### PR TITLE
Fix names of generated messages without a package

### DIFF
--- a/private/protoplugin/names.go
+++ b/private/protoplugin/names.go
@@ -201,8 +201,10 @@ func makeImportPathRelative(importer string, importPath string) string {
 }
 
 func makeMessageName(message *Message) string {
-	nestedName := strings.TrimPrefix(message.protoTypeName, "."+message.File.Proto.GetPackage()+".")
-	name := strings.ReplaceAll(nestedName, ".", "_")
+	name := message.protoTypeName
+	name = strings.TrimPrefix(name, ".")
+	name = strings.TrimPrefix(name, message.File.Proto.GetPackage()+".")
+	name = strings.ReplaceAll(name, ".", "_")
 	if _, reserved := reservedIdentifiers[name]; reserved {
 		return name + escapeChar
 	}


### PR DESCRIPTION
For `message Example`, we generated `class _Example`, where we should be generating `class Example`.