### PR TITLE
Fix oneof ADT edge case

### DIFF
--- a/packages/protobuf-test/extra/name-clash.proto
+++ b/packages/protobuf-test/extra/name-clash.proto
@@ -206,8 +206,11 @@ message NoClashOneof {
     }
 }
 message NoClashOneofADT {
-    string case = 1;
-    optional string value = 2;
+    message M {
+        string case = 1;
+        optional string value = 2;
+    }
+    M m = 1;
 }
 // just here as a "namespace" for the enum
 message NoClashEnumWrap {

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -1039,14 +1039,9 @@ export declare class NoClashOneof extends Message$1<NoClashOneof> {
  */
 export declare class NoClashOneofADT extends Message$1<NoClashOneofADT> {
   /**
-   * @generated from field: string case = 1;
+   * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  case: string;
-
-  /**
-   * @generated from field: optional string value = 2;
-   */
-  value?: string;
+  m?: NoClashOneofADT_M;
 
   constructor(data?: PartialMessage$1<NoClashOneofADT>);
 
@@ -1061,6 +1056,35 @@ export declare class NoClashOneofADT extends Message$1<NoClashOneofADT> {
   static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NoClashOneofADT;
 
   static equals(a: NoClashOneofADT | PlainMessage$1<NoClashOneofADT> | undefined, b: NoClashOneofADT | PlainMessage$1<NoClashOneofADT> | undefined): boolean;
+}
+
+/**
+ * @generated from message spec.NoClashOneofADT.M
+ */
+export declare class NoClashOneofADT_M extends Message$1<NoClashOneofADT_M> {
+  /**
+   * @generated from field: string case = 1;
+   */
+  case: string;
+
+  /**
+   * @generated from field: optional string value = 2;
+   */
+  value?: string;
+
+  constructor(data?: PartialMessage$1<NoClashOneofADT_M>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.NoClashOneofADT.M";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NoClashOneofADT_M;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): NoClashOneofADT_M;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NoClashOneofADT_M;
+
+  static equals(a: NoClashOneofADT_M | PlainMessage$1<NoClashOneofADT_M> | undefined, b: NoClashOneofADT_M | PlainMessage$1<NoClashOneofADT_M> | undefined): boolean;
 }
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
@@ -424,9 +424,20 @@ export const NoClashOneof = proto3.makeMessageType(
 export const NoClashOneofADT = proto3.makeMessageType(
   "spec.NoClashOneofADT",
   () => [
+    { no: 1, name: "m", kind: "message", T: NoClashOneofADT_M },
+  ],
+);
+
+/**
+ * @generated from message spec.NoClashOneofADT.M
+ */
+export const NoClashOneofADT_M = proto3.makeMessageType(
+  "spec.NoClashOneofADT.M",
+  () => [
     { no: 1, name: "case", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
   ],
+  {localName: "NoClashOneofADT_M"},
 );
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -1482,14 +1482,9 @@ export class NoClashOneof extends Message$1<NoClashOneof> {
  */
 export class NoClashOneofADT extends Message$1<NoClashOneofADT> {
   /**
-   * @generated from field: string case = 1;
+   * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  case = "";
-
-  /**
-   * @generated from field: optional string value = 2;
-   */
-  value?: string;
+  m?: NoClashOneofADT_M;
 
   constructor(data?: PartialMessage$1<NoClashOneofADT>) {
     super();
@@ -1499,8 +1494,7 @@ export class NoClashOneofADT extends Message$1<NoClashOneofADT> {
   static readonly runtime = proto3;
   static readonly typeName = "spec.NoClashOneofADT";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "case", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 1, name: "m", kind: "message", T: NoClashOneofADT_M },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NoClashOneofADT {
@@ -1517,6 +1511,49 @@ export class NoClashOneofADT extends Message$1<NoClashOneofADT> {
 
   static equals(a: NoClashOneofADT | PlainMessage$1<NoClashOneofADT> | undefined, b: NoClashOneofADT | PlainMessage$1<NoClashOneofADT> | undefined): boolean {
     return proto3.util.equals(NoClashOneofADT, a, b);
+  }
+}
+
+/**
+ * @generated from message spec.NoClashOneofADT.M
+ */
+export class NoClashOneofADT_M extends Message$1<NoClashOneofADT_M> {
+  /**
+   * @generated from field: string case = 1;
+   */
+  case = "";
+
+  /**
+   * @generated from field: optional string value = 2;
+   */
+  value?: string;
+
+  constructor(data?: PartialMessage$1<NoClashOneofADT_M>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "spec.NoClashOneofADT.M";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "case", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NoClashOneofADT_M {
+    return new NoClashOneofADT_M().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): NoClashOneofADT_M {
+    return new NoClashOneofADT_M().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NoClashOneofADT_M {
+    return new NoClashOneofADT_M().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: NoClashOneofADT_M | PlainMessage$1<NoClashOneofADT_M> | undefined, b: NoClashOneofADT_M | PlainMessage$1<NoClashOneofADT_M> | undefined): boolean {
+    return proto3.util.equals(NoClashOneofADT_M, a, b);
   }
 }
 

--- a/packages/protobuf-test/src/name-clash.test.ts
+++ b/packages/protobuf-test/src/name-clash.test.ts
@@ -1,0 +1,35 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { NoClashOneofADT as TS_NoClashOneofADT } from "./gen/ts/extra/name-clash_pb";
+
+describe("message looking like a oneof ADT", () => {
+  test("takes all fields in constructor", () => {
+    const m = new TS_NoClashOneofADT({
+      m: {
+        case: "value",
+        value: "xxx",
+      },
+    });
+    expect(m).toBeDefined();
+  });
+  test("takes partial input in constructor", () => {
+    const m = new TS_NoClashOneofADT({
+      m: {
+        case: "value",
+      },
+    });
+    expect(m).toBeDefined();
+  });
+});

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -159,9 +159,9 @@ type PartialField<F> =
   F extends (Date | Uint8Array | bigint | boolean | string | number) ? F
   : F extends Array<infer U> ? Array<PartialField<U>>
   : F extends ReadonlyArray<infer U> ? ReadonlyArray<PartialField<U>>
+  : F extends Message ? PartialMessage<F>
   : F extends OneofSelectedMessage<infer C, infer V> ? {case: C; value: PartialMessage<V>}
   : F extends { case: string | undefined; value?: unknown; } ? F
-  : F extends Message ? PartialMessage<F>
   : F extends {[key: string|number]: Message<infer U>} ? {[key: string|number]: PartialMessage<U>}
   : F ;
 


### PR DESCRIPTION
The PartialMessage type didn't properly account for oneof ADTs.
If a message happens to define fields `case` and `value` that look like a oneof ADT, PartialMessage didn't accept partial data.

This fixed by changing the order of conditional typing.