### PR TITLE
Allow `null` in static equals method

### DIFF
--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -34,6 +34,10 @@ describe("equals", function () {
           repeatedMessageField: [{ name: "a" }, { name: "b" }],
         });
       });
+      test("static nullish equals nullish", () => {
+        expect(messageType.equals(undefined, undefined)).toBeTruthy();
+        expect(messageType.equals(null, null)).toBeTruthy();
+      });
       test("same are equal", () => {
         expect(a).toStrictEqual(b);
         expect(a.equals(b)).toBeTruthy();

--- a/packages/protobuf/src/message-type.ts
+++ b/packages/protobuf/src/message-type.ts
@@ -76,9 +76,10 @@ export interface MessageType<T extends Message<T> = AnyMessage> {
 
   /**
    * Returns true if the given arguments have equal field values, recursively.
+   * Will also return true if both messages are `undefined` or `null`.
    */
   equals(
-    a: T | PlainMessage<T> | undefined,
-    b: T | PlainMessage<T> | undefined
+    a: T | PlainMessage<T> | undefined | null,
+    b: T | PlainMessage<T> | undefined | null
   ): boolean;
 }

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -41,7 +41,7 @@ export class Message<T extends Message<T> = AnyMessage> {
   /**
    * Compare with a message of the same type.
    */
-  equals(other: T | PlainMessage<T> | undefined): boolean {
+  equals(other: T | PlainMessage<T> | undefined | null): boolean {
     return this.getType().runtime.util.equals(this.getType(), this, other);
   }
 

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -105,8 +105,8 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
     },
     equals<T extends Message<T>>(
       type: MessageType<T>,
-      a: T | PlainMessage<T> | undefined,
-      b: T | PlainMessage<T> | undefined
+      a: T | PlainMessage<T> | undefined | null,
+      b: T | PlainMessage<T> | undefined | null
     ): boolean {
       if (a === b) {
         return true;

--- a/packages/protobuf/src/private/util.ts
+++ b/packages/protobuf/src/private/util.ts
@@ -56,12 +56,12 @@ export interface Util {
 
   /**
    * Compares two messages of the same type recursively.
-   * Will also return true if both messages are `undefined`.
+   * Will also return true if both messages are `undefined` or `null`.
    */
   equals<T extends Message<T>>(
     type: MessageType,
-    a: T | PlainMessage<T> | undefined,
-    b: T | PlainMessage<T> | undefined
+    a: T | PlainMessage<T> | undefined | null,
+    b: T | PlainMessage<T> | undefined | null
   ): boolean;
 
   /**


### PR DESCRIPTION
So far we're only accepting `undefined`. It's very reasonable to accept `null` as well.