### PR TITLE
Simplify type `PlainMessage<T>`

### DIFF
--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -137,10 +137,7 @@ export class Message<T extends Message<T> = AnyMessage> {
  * PlainMessage<T> strips all methods from a message, leaving only fields
  * and oneof groups.
  */
-export type PlainMessage<T extends Message> = {
-  // eslint-disable-next-line @typescript-eslint/ban-types -- we use `Function` to identify methods
-  [P in keyof T as T[P] extends Function ? never : P]: T[P];
-};
+export type PlainMessage<T extends Message> = Omit<T, keyof Message>;
 
 /**
  * PartialMessage<T> constructs a type from a message. The resulting type


### PR DESCRIPTION
Using TypeScript's built-in types, we can simplify `PlainMessage<T>` and remove an `eslint-disable` annotation.