### PR TITLE
Revert "git-ignore platform-specific packages"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ node_modules
 /testdata/gen/**/*.js
 /testdata/gen/**/*.ts
 /testdata/gen/**/**.d.ts
-/packages/protoc-gen-es/bin/protoc-gen-es
-/packages/protoc-gen-es-*
+/packages/protoc-gen-es*/bin/protoc-gen-es*
 /packages/*/dist
 /packages/protobuf-test/descriptorset.bin
 /.cache

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ $(GOLANGCI_LINT_DEP):
 # (We need --force so NPM doesn't bail on the platform-specific
 # packages in the workspace)
 node_modules: package-lock.json
-	npm ci
+	npm ci --force
 
 
 # Our code generator protoc-gen-es generates message and enum types
@@ -185,7 +185,8 @@ clean: ## Delete build artifacts and installed dependencies
 	cd $(TEST_DIR); npm run clean
 	cd $(BENCHCODESIZE_DIR); npm run clean
 	[ -n "$(CACHE_DIR)" ] && rm -rf $(CACHE_DIR)/*
-	rm -rf node_modules packages/protoc-gen-es/bin/* packages/protoc-gen-es-*
+	rm -rf node_modules
+	rm -rf packages/protoc-gen-*/bin/*
 
 build: $(RUNTIME_BUILD) $(TEST_BUILD) $(CONFORMANCE_BUILD) $(PROTOC_GEN_ES_BIN) $(EXAMPLE_BUILD) ## Build
 
@@ -224,7 +225,7 @@ set-version: ## Set a new version in for the project, i.e. make set-version SET_
 	node make/scripts/update-go-version-file.js cmd/protoc-gen-es/version.go $(SET_VERSION)
 	node make/scripts/set-workspace-version.js $(SET_VERSION)
 	rm package-lock.json
-	npm i
+	npm i -f
 	$(MAKE) all
 
 # Some builds need code generation, some code generation needs builds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5516,7 +5516,6 @@
         "x64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -5536,7 +5535,6 @@
         "arm64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -5556,7 +5554,6 @@
         "x64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -5576,7 +5573,6 @@
         "arm64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -5596,7 +5592,6 @@
         "ia32"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -5616,7 +5611,6 @@
         "x64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -5636,7 +5630,6 @@
         "arm"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -5656,7 +5649,6 @@
         "arm64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -5676,7 +5668,6 @@
         "x64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -5696,7 +5687,6 @@
         "x64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -5716,7 +5706,6 @@
         "ia32"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -5736,7 +5725,6 @@
         "x64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -5756,7 +5744,6 @@
         "arm64"
       ],
       "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],

--- a/packages/protoc-gen-es-darwin-64/package.json
+++ b/packages/protoc-gen-es-darwin-64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-darwin-64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (darwin / x64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/packages/protoc-gen-es-darwin-arm64/package.json
+++ b/packages/protoc-gen-es-darwin-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-darwin-arm64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (darwin / arm64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/packages/protoc-gen-es-freebsd-64/package.json
+++ b/packages/protoc-gen-es-freebsd-64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-freebsd-64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (freebsd / x64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "freebsd"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/packages/protoc-gen-es-freebsd-arm64/package.json
+++ b/packages/protoc-gen-es-freebsd-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-freebsd-arm64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (freebsd / arm64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "freebsd"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/packages/protoc-gen-es-linux-32/package.json
+++ b/packages/protoc-gen-es-linux-32/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-linux-32",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (linux / ia32)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ia32"
+  ]
+}

--- a/packages/protoc-gen-es-linux-64/package.json
+++ b/packages/protoc-gen-es-linux-64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-linux-64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (linux / x64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/packages/protoc-gen-es-linux-arm/package.json
+++ b/packages/protoc-gen-es-linux-arm/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-linux-arm",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (linux / arm)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm"
+  ]
+}

--- a/packages/protoc-gen-es-linux-arm64/package.json
+++ b/packages/protoc-gen-es-linux-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-linux-arm64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (linux / arm64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/packages/protoc-gen-es-netbsd-64/package.json
+++ b/packages/protoc-gen-es-netbsd-64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-netbsd-64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (netbsd / x64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "netbsd"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/packages/protoc-gen-es-openbsd-64/package.json
+++ b/packages/protoc-gen-es-openbsd-64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-openbsd-64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (openbsd / x64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "openbsd"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/packages/protoc-gen-es-windows-32/package.json
+++ b/packages/protoc-gen-es-windows-32/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-windows-32",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (win32 / ia32)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "ia32"
+  ]
+}

--- a/packages/protoc-gen-es-windows-64/package.json
+++ b/packages/protoc-gen-es-windows-64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-windows-64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (win32 / x64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/packages/protoc-gen-es-windows-arm64/package.json
+++ b/packages/protoc-gen-es-windows-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bufbuild/protoc-gen-es-windows-arm64",
+  "version": "0.0.2-alpha.3",
+  "description": "protoc-gen-es (win32 / arm64)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufbuild/protobuf-es.git"
+  },
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^0.0.2-alpha.3"
+  },
+  "peerDependenciesMeta": {
+    "@bufbuild/protobuf": {
+      "optional": true
+    }
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}


### PR DESCRIPTION
This reverts commit cd131eb4a55886201cb57df0d4343e57d1eb9ff7 from https://github.com/bufbuild/protobuf-es/pull/68.

We can't ignore the packages because we use them (indirectly) in the example. Why, npm? :persevere:

