### PR TITLE
Avoid circular imports

### DIFF
--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -9,5 +9,5 @@ minify the bundle, and compress it like a web server would usually do.
 
 | code generator    | bundle size             | minified               | compressed         |
 |-------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es       | 160,617 b      | 86,421 b | 15,136 b |
+| protobuf-es       | 160,619 b      | 86,421 b | 15,098 b |
 | google-protobuf   | 368,034 b  | 270,748 b | 43,704 b |

--- a/packages/protobuf/src/google/protobuf/any_pb.ts
+++ b/packages/protobuf/src/google/protobuf/any_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/any.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, MessageType, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, MessageType, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 
 /**
  * `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/packages/protobuf/src/google/protobuf/api_pb.ts
+++ b/packages/protobuf/src/google/protobuf/api_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/api.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 import {Option, Syntax} from "./type_pb.js";
 import {SourceContext} from "./source_context_pb.js";
 

--- a/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/compiler/plugin.proto (package google.protobuf.compiler, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../../index.js";
-import {Message, proto2} from "../../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../../index-runtime.js";
+import {Message, proto2} from "../../../index-runtime.js";
 import {FileDescriptorProto, GeneratedCodeInfo} from "../descriptor_pb.js";
 
 /**

--- a/packages/protobuf/src/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/google/protobuf/descriptor_pb.ts
@@ -24,8 +24,8 @@
 // @generated from file google/protobuf/descriptor.proto (package google.protobuf, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto2} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto2} from "../../index-runtime.js";
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto

--- a/packages/protobuf/src/google/protobuf/duration_pb.ts
+++ b/packages/protobuf/src/google/protobuf/duration_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/duration.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3, protoInt64} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3, protoInt64} from "../../index-runtime.js";
 
 /**
  * A Duration represents a signed, fixed-length span of time represented

--- a/packages/protobuf/src/google/protobuf/empty_pb.ts
+++ b/packages/protobuf/src/google/protobuf/empty_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/empty.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 
 /**
  * A generic empty message that you can re-use to avoid defining duplicated

--- a/packages/protobuf/src/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf/src/google/protobuf/field_mask_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/field_mask.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 
 /**
  * `FieldMask` represents a set of symbolic field paths, for example:

--- a/packages/protobuf/src/google/protobuf/source_context_pb.ts
+++ b/packages/protobuf/src/google/protobuf/source_context_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/source_context.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 
 /**
  * `SourceContext` represents information about the source of a

--- a/packages/protobuf/src/google/protobuf/struct_pb.ts
+++ b/packages/protobuf/src/google/protobuf/struct_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/struct.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonObject, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonObject, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the

--- a/packages/protobuf/src/google/protobuf/timestamp_pb.ts
+++ b/packages/protobuf/src/google/protobuf/timestamp_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/timestamp.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3, protoInt64} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3, protoInt64} from "../../index-runtime.js";
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local

--- a/packages/protobuf/src/google/protobuf/type_pb.ts
+++ b/packages/protobuf/src/google/protobuf/type_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/type.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, proto3} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, proto3} from "../../index-runtime.js";
 import {SourceContext} from "./source_context_pb.js";
 import {Any} from "./any_pb.js";
 

--- a/packages/protobuf/src/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf/src/google/protobuf/wrappers_pb.ts
@@ -26,8 +26,8 @@
 // @generated from file google/protobuf/wrappers.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index.js";
-import {Message, ScalarType, proto3, protoInt64} from "../../index.js";
+import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "../../index-runtime.js";
+import {Message, ScalarType, proto3, protoInt64} from "../../index-runtime.js";
 
 /**
  * Wrapper message for `double`.

--- a/packages/protobuf/src/index-runtime.ts
+++ b/packages/protobuf/src/index-runtime.ts
@@ -1,0 +1,61 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { proto3 } from "./proto3.js";
+export { proto2 } from "./proto2.js";
+export { protoInt64 } from "./proto-int64.js";
+export { protoBase64 } from "./proto-base64.js";
+
+export {
+  Message,
+  AnyMessage,
+  PartialMessage,
+  PlainMessage,
+} from "./message.js";
+
+export type { FieldInfo } from "./field.js";
+export type { FieldList } from "./field-list.js";
+export { ScalarType } from "./field.js";
+
+export type { MessageType } from "./message-type.js";
+export type { EnumType, EnumValueInfo } from "./enum.js";
+export type {
+  ServiceType,
+  MethodInfo,
+  MethodInfoUnary,
+  MethodInfoServerStreaming,
+  MethodInfoClientStreaming,
+  MethodInfoBiDiStreaming,
+} from "./service-type.js";
+export { MethodKind, MethodIdempotency } from "./service-type.js";
+export { TypeRegistry, IMessageTypeRegistry } from "./type-registry.js";
+export { DescriptorRegistry } from "./descriptor-registry.js";
+export { DescriptorSet } from "./descriptor-set.js";
+
+export { WireType, BinaryWriter, BinaryReader } from "./binary-encoding.js";
+export type { IBinaryReader, IBinaryWriter } from "./binary-encoding.js";
+export type {
+  BinaryFormat,
+  BinaryWriteOptions,
+  BinaryReadOptions,
+} from "./binary-format.js";
+
+export {
+  JsonFormat,
+  JsonObject,
+  JsonValue,
+  JsonReadOptions,
+  JsonWriteOptions,
+  JsonWriteStringOptions,
+} from "./json-format.js";

--- a/packages/protobuf/src/index-wkt.ts
+++ b/packages/protobuf/src/index-wkt.ts
@@ -1,0 +1,27 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ideally, we would export these types with sub-path exports:
+export * from "./google/protobuf/compiler/plugin_pb.js";
+export * from "./google/protobuf/api_pb.js";
+export * from "./google/protobuf/any_pb.js";
+export * from "./google/protobuf/descriptor_pb.js";
+export * from "./google/protobuf/duration_pb.js";
+export * from "./google/protobuf/empty_pb.js";
+export * from "./google/protobuf/field_mask_pb.js";
+export * from "./google/protobuf/source_context_pb.js";
+export * from "./google/protobuf/struct_pb.js";
+export * from "./google/protobuf/timestamp_pb.js";
+export * from "./google/protobuf/type_pb.js";
+export * from "./google/protobuf/wrappers_pb.js";

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -12,64 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { proto3 } from "./proto3.js";
-export { proto2 } from "./proto2.js";
-export { protoInt64 } from "./proto-int64.js";
-export { protoBase64 } from "./proto-base64.js";
-
-export {
-  Message,
-  AnyMessage,
-  PartialMessage,
-  PlainMessage,
-} from "./message.js";
-
-export type { FieldInfo } from "./field.js";
-export type { FieldList } from "./field-list.js";
-export { ScalarType } from "./field.js";
-
-export type { MessageType } from "./message-type.js";
-export type { EnumType, EnumValueInfo } from "./enum.js";
-export type {
-  ServiceType,
-  MethodInfo,
-  MethodInfoUnary,
-  MethodInfoServerStreaming,
-  MethodInfoClientStreaming,
-  MethodInfoBiDiStreaming,
-} from "./service-type.js";
-export { MethodKind, MethodIdempotency } from "./service-type.js";
-export { TypeRegistry, IMessageTypeRegistry } from "./type-registry.js";
-export { DescriptorRegistry } from "./descriptor-registry.js";
-export { DescriptorSet } from "./descriptor-set.js";
-
-export { WireType, BinaryWriter, BinaryReader } from "./binary-encoding.js";
-export type { IBinaryReader, IBinaryWriter } from "./binary-encoding.js";
-export type {
-  BinaryFormat,
-  BinaryWriteOptions,
-  BinaryReadOptions,
-} from "./binary-format.js";
-
-export {
-  JsonFormat,
-  JsonObject,
-  JsonValue,
-  JsonReadOptions,
-  JsonWriteOptions,
-  JsonWriteStringOptions,
-} from "./json-format.js";
-
-// ideally, we would export these types with sub-path exports:
-export * from "./google/protobuf/compiler/plugin_pb.js";
-export * from "./google/protobuf/api_pb.js";
-export * from "./google/protobuf/any_pb.js";
-export * from "./google/protobuf/descriptor_pb.js";
-export * from "./google/protobuf/duration_pb.js";
-export * from "./google/protobuf/empty_pb.js";
-export * from "./google/protobuf/field_mask_pb.js";
-export * from "./google/protobuf/source_context_pb.js";
-export * from "./google/protobuf/struct_pb.js";
-export * from "./google/protobuf/timestamp_pb.js";
-export * from "./google/protobuf/type_pb.js";
-export * from "./google/protobuf/wrappers_pb.js";
+// To avoid circular imports when the wkt import from ./index.js, we
+// use a separate ./index-runtime.js
+export * from "./index-runtime.js";
+export * from "./index-wkt.js";

--- a/private/protoplugin/names.go
+++ b/private/protoplugin/names.go
@@ -124,7 +124,7 @@ var (
 
 	// runtimeImportPath points to the protobuf runtime library when
 	// bootstrapping the well-known types.
-	runtimeImportPathBootstrapWKT = "./index.js"
+	runtimeImportPathBootstrapWKT = "./index-runtime.js"
 
 	// wktSourceToImportPath maps from the path of a well-known types proto
 	// file to the JavaScript import path for the runtime package.


### PR DESCRIPTION
To avoid circular imports when the wkt import from ./index.js, we use a separate ./index-runtime.js

Fixes https://github.com/bufbuild/protobuf-es/issues/64