### PR TITLE
Enable tree-shaking

### DIFF
--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -9,5 +9,5 @@ minify the bundle, and compress it like a web server would usually do.
 
 | code generator    | bundle size             | minified               | compressed         |
 |-------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es       | 160,619 b      | 86,421 b | 15,098 b |
+| protobuf-es       | 72,457 b      | 35,936 b | 9,393 b |
 | google-protobuf   | 368,034 b  | 270,748 b | 43,704 b |

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/bufbuild/protobuf-es.git",
     "directory": "packages/protobuf"
   },
+  "sideEffects": false,
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",


### PR DESCRIPTION
We didn't mark our package as free from side effects. This shaves off a third of our bundle size in a simple use case.

Code size is now in the expected range - best in class:

| code generator    | bundle size             | minified               | compressed         |
|-------------------|------------------------:|-----------------------:|-------------------:|
| protobuf-es       | 72,457 b      | 35,936 b | 9,393 b |
| ts-proto          | 73,318 b  | 36,033 b | 9,613 b |
| protobuf-ts       | 97,516 b  | 45,850 b | 11,452 b |
| google-protobuf   | 368,034 b  | 270,748 b | 43,704 b |
