### PR TITLE
Improve TypeRegistry

### DIFF
--- a/packages/conformance-test/src/conformance.ts
+++ b/packages/conformance-test/src/conformance.ts
@@ -34,7 +34,7 @@ import {
   Value,
 } from "@bufbuild/protobuf";
 
-const typeRegistry = TypeRegistry.fromTypes(
+const typeRegistry = TypeRegistry.from(
   Value,
   Struct,
   FieldMask,

--- a/packages/protobuf-test/src/google/protobuf/any.test.ts
+++ b/packages/protobuf-test/src/google/protobuf/any.test.ts
@@ -15,7 +15,7 @@
 import { Any, Struct, TypeRegistry, Value } from "@bufbuild/protobuf";
 
 describe(Any.typeName, () => {
-  const typeRegistry = TypeRegistry.fromTypes(Struct, Value);
+  const typeRegistry = TypeRegistry.from(Struct, Value);
 
   test(`encodes ${Struct.typeName} to JSON`, () => {
     const str = new Struct({


### PR DESCRIPTION
This changes the behavior of adding types to a TypeRegistry: A common use case for the TypeRegistry is serializing google.protobuf.Any. That typical involves adding the desired types, and the types they use. We can trivially automate the second part of this, making the TypeRegistry more convenient to use.

This also makes the method add() public, and replaces the static methods fromIterable() and fromTypes() with a single from() that takes all supported types as an input, not just message types.