### PR TITLE
Adding automated release process

### DIFF
--- a/.github/release-notes-config.json
+++ b/.github/release-notes-config.json
@@ -1,0 +1,4 @@
+{
+  "template": "${{UNCATEGORIZED}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})"
+}

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -1,0 +1,63 @@
+name: Prep release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        type: choice
+        description: "The type of release."
+        required: true
+        options:
+          - major
+          - minor
+          - patch
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          # Fetch full depth so we can get history and compare
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.15.0
+      - name: perpare version
+        id: prepare
+        run: |
+          CURRENT_VERSION=$(cat package.json | jq -r '.version')
+          NEXT_VERSION=$(npx -y semver -i ${{ github.event.inputs.releaseType }} $CURRENT_VERSION)
+          echo "::set-output name=currentVersion::v$CURRENT_VERSION"
+          echo "::set-output name=nextVersion::v$NEXT_VERSION"
+          echo "v$NEXT_VERSION" > version
+      - name: build message
+        uses: mikepenz/release-changelog-builder-action@2ef19db678c29357b2438963a1758eb9fd375a1e
+        id: diff
+        with:
+          # See https://github.com/mikepenz/release-changelog-builder-action#advanced-workflow-specification for configuration options
+          configuration: "release-notes-config.json"
+          fromTag: ${{ steps.prepare.outputs.currentVersion }}
+          toTag: HEAD
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: fail if no PRs to merge
+        if: steps.diff.outputs.pull_requests == ''
+        run: |
+          echo 'No PRs available to release.' >> $GITHUB_STEP_SUMMARY
+          exit 1
+      - name: create pr
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
+        with: 
+          commit-message: "Publishing ${{ steps.prepare.outputs.nextVersion }}"
+          delete-branch: true
+          title: "Prepare release ${{ steps.prepare.outputs.nextVersion }}"
+          body: ${{ steps.diff.outputs.changelog }}
+          labels: "release"
+
+          

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -13,12 +13,12 @@ on:
           - patch
         default: patch
 
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
-  create-pr:
+  gather-change-logs:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
@@ -26,23 +26,12 @@ jobs:
         with:
           # Fetch full depth so we can get history and compare
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.15.0
-      - name: perpare version
-        id: prepare
-        run: |
-          CURRENT_VERSION=$(cat package.json | jq -r '.version')
-          NEXT_VERSION=$(npx -y semver -i ${{ github.event.inputs.releaseType }} $CURRENT_VERSION)
-          echo "::set-output name=currentVersion::v$CURRENT_VERSION"
-          echo "::set-output name=nextVersion::v$NEXT_VERSION"
-          echo "v$NEXT_VERSION" > version
       - name: build message
         uses: mikepenz/release-changelog-builder-action@2ef19db678c29357b2438963a1758eb9fd375a1e
         id: diff
         with:
           # See https://github.com/mikepenz/release-changelog-builder-action#advanced-workflow-specification for configuration options
-          configuration: "release-notes-config.json"
+          configuration: "./.github/release-notes-config.json"
           fromTag: ${{ steps.prepare.outputs.currentVersion }}
           toTag: HEAD
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,13 +40,65 @@ jobs:
         run: |
           echo 'No PRs available to release.' >> $GITHUB_STEP_SUMMARY
           exit 1
+      - name: save changelog to file
+        run: |
+          echo "${{ steps.diff.outputs.changelog }}" > changelog.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: changelog
+          path: changelog.txt
+  create-pr:
+    needs: gather-change-logs
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: prepare version
+        id: prepare
+        run: |
+          CURRENT_VERSION=$(cat packages/protobuf/package.json | jq -r '.version')
+          NEXT_VERSION=$(npx -y semver -i ${{ github.event.inputs.releaseType }} $CURRENT_VERSION)
+          echo "::set-output name=currentVersion::v$CURRENT_VERSION"
+          echo "::set-output name=nextVersion::v$NEXT_VERSION"
+          echo "v$NEXT_VERSION" > version
+      - name: commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git switch -c "prep-release-${{ steps.prepare.outputs.nextVersion }}"
+          git add .
+          git commit -m "Release ${{ steps.prepare.outputs.nextVersion }}"
+          git push -u origin "prep-release-${{ steps.prepare.outputs.nextVersion }}"
+      - uses: actions/download-artifact@v2
+        with:
+          name: changelog
       - name: create pr
-        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
-        with: 
-          commit-message: "Publishing ${{ steps.prepare.outputs.nextVersion }}"
-          delete-branch: true
-          title: "Prepare release ${{ steps.prepare.outputs.nextVersion }}"
-          body: ${{ steps.diff.outputs.changelog }}
-          labels: "release"
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs')
+            const util = require('util')
+
+            const readFile = util.promisify(fs.readFile)
+
+            const changeLog = await readFile('changelog.txt', 'utf8')
+            const { data: newPr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Prepare release ${{ steps.prepare.outputs.nextVersion }}",
+              body: changeLog,
+              base: "main",
+              head: "prep-release-${{ steps.prepare.outputs.nextVersion }}"
+            })
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: newPr.number,
+              labels: ["release"]
+            })
 
           

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,57 @@
+name: Publish release
+
+on:
+  pull_request_review:
+    types: [edited, submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  perform-release:
+    if: contains(github.event.pull_request.labels.*.name, 'release') && github.event.review.state == 'approved'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          # Fetch full depth so we can get history and compare
+          fetch-depth: 0
+          ref: 'main'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.15.0
+      - name: setup-go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      # The follow step is custom per repo
+      - name: publish
+        id: publish
+        run: |
+          NEXT_VERSION=$(echo "${{ github.event.pull_request.title }}" | awk '{print $NF}')
+          make set-version SET_VERSION=$NEXT_VERSION
+          echo "::set-output name=nextVersion::$NEXT_VERSION"
+      - name: commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          tagging_message: ${{ steps.publish.outputs.nextVersion }}
+      - name: publish to npm
+        run: |
+          make release
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.publish.outputs.nextVersion }}
+          release_name: ${{ steps.publish.outputs.nextVersion }}
+          body: ${{ github.event.pull_request.body }}
+          prerelease: true
+      - name: close PR
+        run: |
+          gh pr close ${{ github.event.pull_request.number }} -d -c "Released!"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -34,9 +34,14 @@ jobs:
           make set-version SET_VERSION=$NEXT_VERSION
           echo "::set-output name=nextVersion::$NEXT_VERSION"
       - name: commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          tagging_message: ${{ steps.publish.outputs.nextVersion }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Release ${{ steps.publish.outputs.nextVersion }}"
+          git tag -a "${{ steps.publish.outputs.nextVersion }}" -m "Release ${{ steps.publish.outputs.nextVersion }}"
+          git push
+          git push --tags
       - name: publish to npm
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -45,14 +50,17 @@ jobs:
           make release
       - name: create release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v6
         with:
-          tag_name: ${{ steps.publish.outputs.nextVersion }}
-          release_name: ${{ steps.publish.outputs.nextVersion }}
-          body: ${{ github.event.pull_request.body }}
-          prerelease: true
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "${{ steps.publish.outputs.nextVersion }}",
+              tag_name: "${{ steps.publish.outputs.nextVersion }}",
+              body: "${{ github.event.pull_request.body }}",
+              prerelease: false
+            })
       - name: close PR
         run: |
           gh pr close ${{ github.event.pull_request.number }} -d -c "Released!"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -38,7 +38,10 @@ jobs:
         with:
           tagging_message: ${{ steps.publish.outputs.nextVersion }}
       - name: publish to npm
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
         run: |
+          npm set //registry.npmjs.org/:_authToken $NPM_PUBLISH_TOKEN
           make release
       - name: create release
         id: create_release

--- a/package-lock.json
+++ b/package-lock.json
@@ -5739,8 +5739,8 @@
       "version": "file:packages/protobuf-test",
       "requires": {
         "@bufbuild/protobuf": "0.0.6",
-        "@types/jest": "*",
-        "jest": "*",
+        "@types/jest": "^28.1.2",
+        "jest": "^28.1.1",
         "typescript": "^4.7.3"
       }
     },


### PR DESCRIPTION
An automated release worklow. Basically adds an action that can be triggered whenever we want to do release.

1. Manually trigger action
2. Approve resulting PR with release notes
3. Github will automatically create the associated release

Todo:
- Add npm auth token so we can do the actual publish.