### PR TITLE
Add main prop for older webpack support

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -15,6 +15,7 @@
     "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
+  "main": "./dist/esm/index.js",
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {


### PR DESCRIPTION
enables @bufbuild/protobuf to resolve in my Create React App 4.0,  Typescript project.

I'm not sure if there are other ways around this. But in my project it seemed to allow everything to resolve and build with `tsc` when using `target=ts`.
