### PR TITLE
Fix doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ pete = Person.fromJsonString('{"name": "pete", "id": 123}');
 ```
 
 To learn more, have a look at a complete [code example](https://github.com/bufbuild/protobuf-es/packages/example), 
-the documentation for the [generated code](https://github.com/bufbuild/protobuf-es/docs/generated_code.md), 
-and the documentation for the [runtime API](https://github.com/bufbuild/protobuf-es/docs/runtime_api.md).
+the documentation for the [generated code](https://github.com/bufbuild/protobuf-es/blob/main/docs/generated_code.md), 
+and the documentation for the [runtime API](https://github.com/bufbuild/protobuf-es/blob/main/docs/runtime_api.md).
 
 
 ### How does this compare to protoc's JavaScript generator?


### PR DESCRIPTION
The links in the main README were missing the branch to point to, and thus would result in a 404.