### PR TITLE
Respect json_name in messages created from a descriptor set

### DIFF
--- a/packages/protobuf-test/extra/msg-json-names.proto
+++ b/packages/protobuf-test/extra/msg-json-names.proto
@@ -26,5 +26,6 @@ message JsonNamesMessage {
     string c = 5;
     string d = 6 [json_name = "c"];
     string e = 7 [json_name = ""];
+    string f = 8 [json_name = "@type"];
 
 }

--- a/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.d.ts
@@ -58,6 +58,11 @@ export declare class JsonNamesMessage extends Message<JsonNamesMessage> {
    */
   e: string;
 
+  /**
+   * @generated from field: string f = 8 [json_name = "@type"];
+   */
+  f: string;
+
   constructor(data?: PartialMessage<JsonNamesMessage>);
 
   static readonly runtime: typeof proto3;

--- a/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.js
@@ -31,6 +31,7 @@ export const JsonNamesMessage = proto3.makeMessageType(
     { no: 5, name: "c", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "d", jsonName: "c", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 7, name: "e", jsonName: "", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 8, name: "f", jsonName: "@type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ],
 );
 

--- a/packages/protobuf-test/src/gen/ts/extra/msg-json-names_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-json-names_pb.ts
@@ -58,6 +58,11 @@ export class JsonNamesMessage extends Message<JsonNamesMessage> {
    */
   e = "";
 
+  /**
+   * @generated from field: string f = 8 [json_name = "@type"];
+   */
+  f = "";
+
   constructor(data?: PartialMessage<JsonNamesMessage>) {
     super();
     proto3.util.initPartial(data, this);
@@ -73,6 +78,7 @@ export class JsonNamesMessage extends Message<JsonNamesMessage> {
     { no: 5, name: "c", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "d", jsonName: "c", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 7, name: "e", jsonName: "", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 8, name: "f", jsonName: "@type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): JsonNamesMessage {

--- a/packages/protobuf-test/src/msg-json-names.test.ts
+++ b/packages/protobuf-test/src/msg-json-names.test.ts
@@ -32,20 +32,20 @@ describeMT(
       expect(got).toStrictEqual({
         "": "e",
         "@type": "f",
-        "c": "c",
-        "sameJsonName": "b"
+        c: "c",
+        sameJsonName: "b",
       });
     });
     test("json_name clash with Any.@type is not prevented", () => {
       const any = Any.pack(msg);
       const got = any.toJson({
-        typeRegistry: createRegistry(JsonNamesMessage)
+        typeRegistry: createRegistry(JsonNamesMessage),
       });
       expect(got).toStrictEqual({
         "": "e",
         "@type": "type.googleapis.com/spec.JsonNamesMessage",
-        "c": "c",
-        "sameJsonName": "b"
+        c: "c",
+        sameJsonName: "b",
       });
     });
   }

--- a/packages/protobuf-test/src/msg-json-names.test.ts
+++ b/packages/protobuf-test/src/msg-json-names.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describeMT } from "./helpers.js";
+import { JsonNamesMessage as TS_JsonNamesMessage } from "./gen/ts/extra/msg-json-names_pb.js";
+import { JsonNamesMessage as JS_JsonNamesMessage } from "./gen/js/extra/msg-json-names_pb.js";
+import { Any, createRegistry } from "@bufbuild/protobuf";
+
+describeMT(
+  { ts: TS_JsonNamesMessage, js: JS_JsonNamesMessage },
+  (JsonNamesMessage) => {
+    const msg = new JsonNamesMessage();
+    msg.a = "a";
+    msg.b = "b";
+    msg.c = "c";
+    msg.d = "c";
+    msg.e = "e";
+    msg.f = "f";
+    test("serializes as expected", () => {
+      const got = msg.toJson();
+      expect(got).toStrictEqual({
+        "": "e",
+        "@type": "f",
+        "c": "c",
+        "sameJsonName": "b"
+      });
+    });
+    test("json_name clash with Any.@type is not prevented", () => {
+      const any = Any.pack(msg);
+      const got = any.toJson({
+        typeRegistry: createRegistry(JsonNamesMessage)
+      });
+      expect(got).toStrictEqual({
+        "": "e",
+        "@type": "type.googleapis.com/spec.JsonNamesMessage",
+        "c": "c",
+        "sameJsonName": "b"
+      });
+    });
+  }
+);

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -370,8 +370,9 @@ function makeMapFieldInfo(
 ): PartialFieldInfo {
   const base = {
     kind: "map",
-    name: field.name,
     no: field.number,
+    name: field.name,
+    jsonName: field.jsonName,
     K: field.mapKey,
   } as const;
   if (field.mapValue.message) {
@@ -417,9 +418,10 @@ function makeScalarFieldInfo(
   field: DescField & { kind: "scalar_field" }
 ): PartialFieldInfo {
   const base = {
+    kind: "scalar",
     no: field.number,
     name: field.name,
-    kind: "scalar",
+    jsonName: field.jsonName,
     T: field.scalar,
   } as const;
   if (field.repeated) {
@@ -456,9 +458,10 @@ function makeMessageFieldInfo(
     `message "${field.message.typeName}" for ${field.toString()} not found`
   );
   const base = {
+    kind: "message",
     no: field.number,
     name: field.name,
-    kind: "message",
+    jsonName: field.jsonName,
     T: messageType,
   } as const;
   if (field.repeated) {
@@ -494,9 +497,10 @@ function makeEnumFieldInfo(
     `enum "${field.enum.typeName}" for ${field.toString()} not found`
   );
   const base = {
+    kind: "enum",
     no: field.number,
     name: field.name,
-    kind: "enum",
+    jsonName: field.jsonName,
     T: enumType,
   } as const;
   if (field.repeated) {


### PR DESCRIPTION
We have a feature that allows creating a message type at run time from a set of file descriptors. This feature has a bug - it does not respect the json_name field option.

This adds test coverage for this situation, and fixes the issue.