### PR TITLE
Fix PlainMessage type to correctly omit functions

### DIFF
--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -16,10 +16,11 @@ import type { PlainMessage } from "@bufbuild/protobuf";
 import { Timestamp as TS_Timestamp } from "./gen/ts/google/protobuf/timestamp_pb";
 
 describe("PlainMessage", () => {
-  test("removes wkt functions", () => {
+  test("removes wkt functions from type system", () => {
     const plainTimestamp: PlainMessage<TS_Timestamp> = TS_Timestamp.now();
-    // We want to test that the type system sees this function as undefined even though it's still actually there.
-    // @ts-expect-error TS2334
+    // We want to test that the type system sees this function as undefined even though it's still actually there.  So
+    // we expect TS error TS2339, but add a simple test so Jest doesn't complain there's no expectations.
+    // @ts-expect-error TS2339
     expect(plainTimestamp.toDate).toBeDefined();
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { PlainMessage } from "@bufbuild/protobuf";
+import { Timestamp as JS_Timestamp } from "./gen/js/google/protobuf/timestamp_pb";
+import { Timestamp as TS_Timestamp } from "./gen/ts/google/protobuf/timestamp_pb";
+
+describe("PlainMessage", () => {
+  describe("toDate", () => {
+    test("JS_Timestamp", () => {
+      const plainTimestamp: PlainMessage<JS_Timestamp> = JS_Timestamp.now();
+      // @ts-expect-error TS2339
+      plainTimestamp.toDate();
+    });
+    test("TS_Timestamp", () => {
+      const plainTimestamp: PlainMessage<TS_Timestamp> = TS_Timestamp.now();
+      // @ts-expect-error TS2339
+      console.log(plainTimestamp.toDate());
+    });
+  });
+});

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -22,17 +22,14 @@ describe("PlainMessage", () => {
     expect(plainTimestamp.nanos).toBeDefined();
   });
   test("removes standard methods from type system", () => {
-    // Methods are removed from the type system.
+    // We want to test that the type system sees this function as undefined even though it's still actually there.  So
+    // we expect TS error  TS2339, but add a simple test so Jest doesn't complain there's no expectations.
     // @ts-expect-error TS2339
-    const toBinary = plainTimestamp.toBinary;
-    // The method property still exists.
-    expect(toBinary).toBeDefined();
+    expect(plainTimestamp.toBinary).toBeDefined();
   });
   test("removes wkt methods from type system", () => {
     // Custom methods of well-known types are removed as well.
     // @ts-expect-error TS2339
-    const toDate = plainTimestamp.toDate;
-    // The method property still exists.
-    expect(toDate).toBeDefined();
+    expect(plainTimestamp.toDate).toBeDefined();
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -13,20 +13,13 @@
 // limitations under the License.
 
 import type { PlainMessage } from "@bufbuild/protobuf";
-import { Timestamp as JS_Timestamp } from "./gen/js/google/protobuf/timestamp_pb";
 import { Timestamp as TS_Timestamp } from "./gen/ts/google/protobuf/timestamp_pb";
 
 describe("PlainMessage", () => {
-  describe("toDate", () => {
-    test("JS_Timestamp", () => {
-      const plainTimestamp: PlainMessage<JS_Timestamp> = JS_Timestamp.now();
-      // @ts-expect-error TS2339
-      plainTimestamp.toDate();
-    });
-    test("TS_Timestamp", () => {
-      const plainTimestamp: PlainMessage<TS_Timestamp> = TS_Timestamp.now();
-      // @ts-expect-error TS2339
-      plainTimestamp.toDate();
-    });
+  test("removes wkt functions", () => {
+    const plainTimestamp: PlainMessage<TS_Timestamp> = TS_Timestamp.now();
+    // We want to test that the type system sees this function as undefined even though it's still actually there.
+    // @ts-expect-error TS2334
+    expect(plainTimestamp.toDate).toBeDefined();
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -13,14 +13,26 @@
 // limitations under the License.
 
 import type { PlainMessage } from "@bufbuild/protobuf";
-import { Timestamp as TS_Timestamp } from "./gen/ts/google/protobuf/timestamp_pb";
+import { Timestamp } from "./gen/ts/google/protobuf/timestamp_pb";
 
 describe("PlainMessage", () => {
-  test("removes wkt functions from type system", () => {
-    const plainTimestamp: PlainMessage<TS_Timestamp> = TS_Timestamp.now();
-    // We want to test that the type system sees this function as undefined even though it's still actually there.  So
-    // we expect TS error TS2339, but add a simple test so Jest doesn't complain there's no expectations.
+  const plainTimestamp: PlainMessage<Timestamp> = Timestamp.now();
+  test("keeps regular fields", () => {
+    // Regular fields are untouched.
+    expect(plainTimestamp.nanos).toBeDefined();
+  });
+  test("removes standard methods from type system", () => {
+    // Methods are removed from the type system.
     // @ts-expect-error TS2339
-    expect(plainTimestamp.toDate).toBeDefined();
+    const toBinary = plainTimestamp.toBinary;
+    // The method property still exists.
+    expect(toBinary).toBeDefined();
+  });
+  test("removes wkt methods from type system", () => {
+    // Custom methods of well-known types are removed as well.
+    // @ts-expect-error TS2339
+    const toDate = plainTimestamp.toDate;
+    // The method property still exists.
+    expect(toDate).toBeDefined();
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -26,7 +26,7 @@ describe("PlainMessage", () => {
     test("TS_Timestamp", () => {
       const plainTimestamp: PlainMessage<TS_Timestamp> = TS_Timestamp.now();
       // @ts-expect-error TS2339
-      console.log(plainTimestamp.toDate());
+      plainTimestamp.toDate();
     });
   });
 });

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -137,7 +137,10 @@ export class Message<T extends Message<T> = AnyMessage> {
  * PlainMessage<T> strips all methods from a message, leaving only fields
  * and oneof groups.
  */
-export type PlainMessage<T extends Message> = Omit<T, keyof Message>;
+export type PlainMessage<T extends Message> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types -- we use `Function` to identify methods
+  [P in keyof T as T[P] extends Function ? never : P]: T[P];
+};
 
 /**
  * PartialMessage<T> constructs a type from a message. The resulting type


### PR DESCRIPTION
This fixes the type declaration so that it correctly removes custom WKT methods.  