### PR TITLE
Update protobuf to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PB   =  .tmp/protobuf-$(GOOGLE_PROTOBUF_VERSION)
 LICENSE_HEADER_YEAR_RANGE := 2021-2022
 LICENSE_HEADER_IGNORES := .tmp\/ node_module\/ packages\/protobuf-conformance\/bin\/conformance_esm.js packages\/protobuf-conformance\/src\/gen\/ packages\/protobuf-test\/src\/gen\/ packages\/protobuf\/src\/google\/varint.ts packages\/protobuf-bench\/src\/gen\/ packages\/protobuf\/dist\/ packages\/protobuf-test\/dist\/ scripts\/
 GOOGLE_PROTOBUF_WKT = google/protobuf/api.proto google/protobuf/any.proto google/protobuf/compiler/plugin.proto google/protobuf/descriptor.proto google/protobuf/duration.proto google/protobuf/descriptor.proto google/protobuf/empty.proto google/protobuf/field_mask.proto google/protobuf/source_context.proto google/protobuf/struct.proto google/protobuf/timestamp.proto google/protobuf/type.proto google/protobuf/wrappers.proto
-GOOGLE_PROTOBUF_VERSION = 3.20.1
+GOOGLE_PROTOBUF_VERSION = 21.5
 
 node_modules: package-lock.json
 	npm ci
@@ -34,8 +34,8 @@ $(BIN)/protoc: $(PB)
 
 $(BIN)/conformance_test_runner: $(PB)
 	@mkdir -p $(@D)
-	cd $(PB) && bazel build test_messages_proto3_proto conformance_proto conformance_test conformance_test_runner
-	cp -f $(PB)/bazel-bin/conformance_test_runner $(@D)
+	cd $(PB) && bazel build test_messages_proto3_proto conformance:conformance_proto conformance:conformance_test conformance:conformance_test_runner
+	cp -f $(PB)/bazel-bin/conformance/conformance_test_runner $(@D)
 	@touch $(@)
 
 $(BIN)/license-header: Makefile

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -1097,14 +1097,14 @@ export enum TestAllTypesProto3_AliasedEnum {
   ALIAS_BAZ = 2,
 
   /**
-   * @generated from enum value: QUX = 2;
+   * @generated from enum value: MOO = 2;
    */
-  QUX = 2,
+  MOO = 2,
 
   /**
-   * @generated from enum value: qux = 2;
+   * @generated from enum value: moo = 2;
    */
-  qux = 2,
+  moo = 2,
 
   /**
    * @generated from enum value: bAz = 2;
@@ -1116,8 +1116,8 @@ proto3.util.setEnumType(TestAllTypesProto3_AliasedEnum, "protobuf_test_messages.
   { no: 0, name: "ALIAS_FOO" },
   { no: 1, name: "ALIAS_BAR" },
   { no: 2, name: "ALIAS_BAZ" },
-  { no: 2, name: "QUX" },
-  { no: 2, name: "qux" },
+  { no: 2, name: "MOO" },
+  { no: 2, name: "moo" },
   { no: 2, name: "bAz" },
 ]);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
@@ -1651,8 +1651,8 @@ export declare class UninterpretedOption extends Message<UninterpretedOption> {
  * The name of the uninterpreted option.  Each string represents a segment in
  * a dot-separated name.  is_extension is true iff a segment represents an
  * extension (denoted with parentheses in options specs in .proto files).
- * E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
- * "foo.(bar.baz).qux".
+ * E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+ * "foo.(bar.baz).moo".
  *
  * @generated from message google.protobuf.UninterpretedOption.NamePart
  */
@@ -1825,13 +1825,13 @@ export declare class SourceCodeInfo_Location extends Message<SourceCodeInfo_Loca
    *   // Comment attached to baz.
    *   // Another line attached to baz.
    *
-   *   // Comment attached to qux.
+   *   // Comment attached to moo.
    *   //
-   *   // Another line attached to qux.
-   *   optional double qux = 4;
+   *   // Another line attached to moo.
+   *   optional double moo = 4;
    *
    *   // Detached comment for corge. This is not leading or trailing comments
-   *   // to qux or corge because there are blank lines separating it from
+   *   // to moo or corge because there are blank lines separating it from
    *   // both.
    *
    *   // Detached comment for corge paragraph 2.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.js
@@ -490,8 +490,8 @@ export const UninterpretedOption = proto2.makeMessageType(
  * The name of the uninterpreted option.  Each string represents a segment in
  * a dot-separated name.  is_extension is true iff a segment represents an
  * extension (denoted with parentheses in options specs in .proto files).
- * E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
- * "foo.(bar.baz).qux".
+ * E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+ * "foo.(bar.baz).moo".
  *
  * @generated from message google.protobuf.UninterpretedOption.NamePart
  */

--- a/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.d.ts
@@ -44,7 +44,6 @@ import {Message, proto3} from "@bufbuild/protobuf";
  *       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
  *     }
  *
- * The JSON representation for `Empty` is empty JSON object `{}`.
  *
  * @generated from message google.protobuf.Empty
  */

--- a/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.js
@@ -43,7 +43,6 @@ import {proto3} from "@bufbuild/protobuf";
  *       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
  *     }
  *
- * The JSON representation for `Empty` is empty JSON object `{}`.
  *
  * @generated from message google.protobuf.Empty
  */

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
@@ -921,14 +921,14 @@ export declare enum TestAllTypesProto3_AliasedEnum {
   ALIAS_BAZ = 2,
 
   /**
-   * @generated from enum value: QUX = 2;
+   * @generated from enum value: MOO = 2;
    */
-  QUX = 2,
+  MOO = 2,
 
   /**
-   * @generated from enum value: qux = 2;
+   * @generated from enum value: moo = 2;
    */
-  qux = 2,
+  moo = 2,
 
   /**
    * @generated from enum value: bAz = 2;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.js
@@ -243,8 +243,8 @@ export const TestAllTypesProto3_AliasedEnum = proto3.makeEnum(
     {no: 0, name: "ALIAS_FOO"},
     {no: 1, name: "ALIAS_BAR"},
     {no: 2, name: "ALIAS_BAZ"},
-    {no: 2, name: "QUX"},
-    {no: 2, name: "qux"},
+    {no: 2, name: "MOO"},
+    {no: 2, name: "moo"},
     {no: 2, name: "bAz"},
   ],
 );

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -461,9 +461,9 @@ export declare class ComplexOptionType2_ComplexOptionType4 extends Message<Compl
  */
 export declare class ComplexOptionType3 extends Message<ComplexOptionType3> {
   /**
-   * @generated from field: optional int32 qux = 1;
+   * @generated from field: optional int32 moo = 1;
    */
-  qux?: number;
+  moo?: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.js
@@ -235,7 +235,7 @@ export const ComplexOptionType2_ComplexOptionType4 = proto2.makeMessageType(
 export const ComplexOptionType3 = proto2.makeMessageType(
   "protobuf_unittest.ComplexOptionType3",
   () => [
-    { no: 1, name: "qux", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "moo", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
     { no: 2, name: "complexoptiontype5", kind: "message", T: ComplexOptionType3_ComplexOptionType5, opt: true },
   ],
 );

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.d.ts
@@ -138,8 +138,8 @@ export declare enum FooWithExtraFields_NestedEnum {
   BAZ = 2,
 
   /**
-   * @generated from enum value: QUX = 3;
+   * @generated from enum value: MOO = 3;
    */
-  QUX = 3,
+  MOO = 3,
 }
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.js
@@ -78,7 +78,7 @@ export const FooWithExtraFields_NestedEnum = proto3.makeEnum(
     {no: 0, name: "FOO"},
     {no: 1, name: "BAR"},
     {no: 2, name: "BAZ"},
-    {no: 3, name: "QUX"},
+    {no: 3, name: "MOO"},
   ],
 );
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
@@ -227,6 +227,11 @@ export declare class TestAllTypesLite extends Message<TestAllTypesLite> {
   optionalLazyMessage?: TestAllTypesLite_NestedMessage;
 
   /**
+   * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypesLite_NestedMessage;
+
+  /**
    * Repeated
    *
    * @generated from field: repeated int32 repeated_int32 = 31;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.js
@@ -107,6 +107,7 @@ export const TestAllTypesLite = proto2.makeMessageType(
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessageLite, opt: true },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypesLite_NestedMessage, opt: true },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypesLite_NestedMessage, opt: true },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },
     { no: 33, name: "repeated_uint32", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -795,6 +795,11 @@ export declare class TestAllTypes extends Message<TestAllTypes> {
   optionalLazyMessage?: TestAllTypes_NestedMessage;
 
   /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+
+  /**
    * Repeated
    *
    * @generated from field: repeated int32 repeated_int32 = 31;
@@ -3834,9 +3839,9 @@ export declare class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
  */
 export declare class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> {
   /**
-   * @generated from field: optional int64 qux_int = 1;
+   * @generated from field: optional int64 moo_int = 1;
    */
-  quxInt?: bigint;
+  mooInt?: bigint;
 
   /**
    * @generated from field: repeated int32 corge_int = 2;
@@ -4561,6 +4566,58 @@ export declare class TestCommentInjectionMessage extends Message<TestCommentInje
 }
 
 /**
+ * Used to check that the c++ code generator re-orders messages to reduce
+ * padding.
+ *
+ * @generated from message protobuf_unittest.TestMessageSize
+ */
+export declare class TestMessageSize extends Message<TestMessageSize> {
+  /**
+   * @generated from field: optional bool m1 = 1;
+   */
+  m1?: boolean;
+
+  /**
+   * @generated from field: optional int64 m2 = 2;
+   */
+  m2?: bigint;
+
+  /**
+   * @generated from field: optional bool m3 = 3;
+   */
+  m3?: boolean;
+
+  /**
+   * @generated from field: optional string m4 = 4;
+   */
+  m4?: string;
+
+  /**
+   * @generated from field: optional int32 m5 = 5;
+   */
+  m5?: number;
+
+  /**
+   * @generated from field: optional int64 m6 = 6;
+   */
+  m6?: bigint;
+
+  constructor(data?: PartialMessage<TestMessageSize>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestMessageSize";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestMessageSize;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestMessageSize;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestMessageSize;
+
+  static equals(a: TestMessageSize | PlainMessage<TestMessageSize> | undefined, b: TestMessageSize | PlainMessage<TestMessageSize> | undefined): boolean;
+}
+
+/**
  * Test that RPC services work.
  *
  * @generated from message protobuf_unittest.FooRequest
@@ -5080,5 +5137,628 @@ export declare class TestExtensionRangeSerialize extends Message<TestExtensionRa
   static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestExtensionRangeSerialize;
 
   static equals(a: TestExtensionRangeSerialize | PlainMessage<TestExtensionRangeSerialize> | undefined, b: TestExtensionRangeSerialize | PlainMessage<TestExtensionRangeSerialize> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32Simple
+ */
+export declare class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple> {
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  constructor(data?: PartialMessage<TestVerifyInt32Simple>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyInt32Simple";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyInt32Simple;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyInt32Simple;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyInt32Simple;
+
+  static equals(a: TestVerifyInt32Simple | PlainMessage<TestVerifyInt32Simple> | undefined, b: TestVerifyInt32Simple | PlainMessage<TestVerifyInt32Simple> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32
+ */
+export declare class TestVerifyInt32 extends Message<TestVerifyInt32> {
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyInt32>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyInt32";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyInt32;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyInt32;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyInt32;
+
+  static equals(a: TestVerifyInt32 | PlainMessage<TestVerifyInt32> | undefined, b: TestVerifyInt32 | PlainMessage<TestVerifyInt32> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyMostlyInt32
+ */
+export declare class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32> {
+  /**
+   * @generated from field: optional int64 optional_int64_30 = 30;
+   */
+  optionalInt6430?: bigint;
+
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_3 = 3;
+   */
+  optionalInt323?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_4 = 4;
+   */
+  optionalInt324?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyMostlyInt32>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyMostlyInt32";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyMostlyInt32;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32;
+
+  static equals(a: TestVerifyMostlyInt32 | PlainMessage<TestVerifyMostlyInt32> | undefined, b: TestVerifyMostlyInt32 | PlainMessage<TestVerifyMostlyInt32> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber
+ */
+export declare class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVerifyMostlyInt32BigFieldNumber> {
+  /**
+   * @generated from field: optional int64 optional_int64_30 = 30;
+   */
+  optionalInt6430?: bigint;
+
+  /**
+   * @generated from field: optional int32 optional_int32_300 = 300;
+   */
+  optionalInt32300?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_3 = 3;
+   */
+  optionalInt323?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_4 = 4;
+   */
+  optionalInt324?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyMostlyInt32BigFieldNumber>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyMostlyInt32BigFieldNumber;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32BigFieldNumber;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32BigFieldNumber;
+
+  static equals(a: TestVerifyMostlyInt32BigFieldNumber | PlainMessage<TestVerifyMostlyInt32BigFieldNumber> | undefined, b: TestVerifyMostlyInt32BigFieldNumber | PlainMessage<TestVerifyMostlyInt32BigFieldNumber> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32Simple
+ */
+export declare class TestVerifyUint32Simple extends Message<TestVerifyUint32Simple> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  constructor(data?: PartialMessage<TestVerifyUint32Simple>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyUint32Simple";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyUint32Simple;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyUint32Simple;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyUint32Simple;
+
+  static equals(a: TestVerifyUint32Simple | PlainMessage<TestVerifyUint32Simple> | undefined, b: TestVerifyUint32Simple | PlainMessage<TestVerifyUint32Simple> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32
+ */
+export declare class TestVerifyUint32 extends Message<TestVerifyUint32> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyUint32>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyUint32";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyUint32;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyUint32;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyUint32;
+
+  static equals(a: TestVerifyUint32 | PlainMessage<TestVerifyUint32> | undefined, b: TestVerifyUint32 | PlainMessage<TestVerifyUint32> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyOneUint32
+ */
+export declare class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyOneUint32>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyOneUint32";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyOneUint32;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyOneUint32;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyOneUint32;
+
+  static equals(a: TestVerifyOneUint32 | PlainMessage<TestVerifyOneUint32> | undefined, b: TestVerifyOneUint32 | PlainMessage<TestVerifyOneUint32> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyOneInt32BigFieldNumber
+ */
+export declare class TestVerifyOneInt32BigFieldNumber extends Message<TestVerifyOneInt32BigFieldNumber> {
+  /**
+   * @generated from field: optional int32 optional_int32_65 = 65;
+   */
+  optionalInt3265?: number;
+
+  /**
+   * @generated from field: optional int64 optional_int64_1 = 1;
+   */
+  optionalInt641?: bigint;
+
+  /**
+   * @generated from field: optional int64 optional_int64_2 = 2;
+   */
+  optionalInt642?: bigint;
+
+  /**
+   * @generated from field: optional int64 optional_int64_63 = 63;
+   */
+  optionalInt6463?: bigint;
+
+  /**
+   * @generated from field: optional int64 optional_int64_64 = 64;
+   */
+  optionalInt6464?: bigint;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyOneInt32BigFieldNumber>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyOneInt32BigFieldNumber";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyOneInt32BigFieldNumber;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyOneInt32BigFieldNumber;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyOneInt32BigFieldNumber;
+
+  static equals(a: TestVerifyOneInt32BigFieldNumber | PlainMessage<TestVerifyOneInt32BigFieldNumber> | undefined, b: TestVerifyOneInt32BigFieldNumber | PlainMessage<TestVerifyOneInt32BigFieldNumber> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32BigFieldNumber
+ */
+export declare class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt32BigFieldNumber> {
+  /**
+   * @generated from field: optional int32 optional_int32_1000 = 1000;
+   */
+  optionalInt321000?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_65 = 65;
+   */
+  optionalInt3265?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyInt32BigFieldNumber>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyInt32BigFieldNumber";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyInt32BigFieldNumber;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyInt32BigFieldNumber;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyInt32BigFieldNumber;
+
+  static equals(a: TestVerifyInt32BigFieldNumber | PlainMessage<TestVerifyInt32BigFieldNumber> | undefined, b: TestVerifyInt32BigFieldNumber | PlainMessage<TestVerifyInt32BigFieldNumber> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32BigFieldNumber
+ */
+export declare class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUint32BigFieldNumber> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1000 = 1000;
+   */
+  optionalUint321000?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_65 = 65;
+   */
+  optionalUint3265?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[];
+
+  constructor(data?: PartialMessage<TestVerifyUint32BigFieldNumber>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyUint32BigFieldNumber";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyUint32BigFieldNumber;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyUint32BigFieldNumber;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyUint32BigFieldNumber;
+
+  static equals(a: TestVerifyUint32BigFieldNumber | PlainMessage<TestVerifyUint32BigFieldNumber> | undefined, b: TestVerifyUint32BigFieldNumber | PlainMessage<TestVerifyUint32BigFieldNumber> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32
+ */
+export declare class TestVerifyBigFieldNumberUint32 extends Message<TestVerifyBigFieldNumberUint32> {
+  /**
+   * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
+   */
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+
+  constructor(data?: PartialMessage<TestVerifyBigFieldNumberUint32>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyBigFieldNumberUint32";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyBigFieldNumberUint32;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32;
+
+  static equals(a: TestVerifyBigFieldNumberUint32 | PlainMessage<TestVerifyBigFieldNumberUint32> | undefined, b: TestVerifyBigFieldNumberUint32 | PlainMessage<TestVerifyBigFieldNumberUint32> | undefined): boolean;
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested
+ */
+export declare class TestVerifyBigFieldNumberUint32_Nested extends Message<TestVerifyBigFieldNumberUint32_Nested> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_5000 = 5000;
+   */
+  optionalUint325000?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_1000 = 1000;
+   */
+  optionalUint321000?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_66 = 66;
+   */
+  optionalUint3266?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_65 = 65;
+   */
+  optionalUint3265?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
+   */
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;
+   */
+  repeatedNested: TestVerifyBigFieldNumberUint32_Nested[];
+
+  constructor(data?: PartialMessage<TestVerifyBigFieldNumberUint32_Nested>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyBigFieldNumberUint32_Nested;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32_Nested;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32_Nested;
+
+  static equals(a: TestVerifyBigFieldNumberUint32_Nested | PlainMessage<TestVerifyBigFieldNumberUint32_Nested> | undefined, b: TestVerifyBigFieldNumberUint32_Nested | PlainMessage<TestVerifyBigFieldNumberUint32_Nested> | undefined): boolean;
 }
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.js
@@ -239,6 +239,7 @@ export const TestAllTypes = proto2.makeMessageType(
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessage, opt: true },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypes_NestedMessage, opt: true },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypes_NestedMessage, opt: true },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },
     { no: 33, name: "repeated_uint32", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },
@@ -1294,7 +1295,7 @@ export const TestOneof2_FooGroup = proto2.makeMessageType(
 export const TestOneof2_NestedMessage = proto2.makeMessageType(
   "protobuf_unittest.TestOneof2.NestedMessage",
   () => [
-    { no: 1, name: "qux_int", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 1, name: "moo_int", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
     { no: 2, name: "corge_int", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
   ],
   {localName: "TestOneof2_NestedMessage"},
@@ -1554,6 +1555,24 @@ export const TestCommentInjectionMessage = proto2.makeMessageType(
 );
 
 /**
+ * Used to check that the c++ code generator re-orders messages to reduce
+ * padding.
+ *
+ * @generated from message protobuf_unittest.TestMessageSize
+ */
+export const TestMessageSize = proto2.makeMessageType(
+  "protobuf_unittest.TestMessageSize",
+  () => [
+    { no: 1, name: "m1", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 2, name: "m2", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 3, name: "m3", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 4, name: "m4", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 5, name: "m5", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 6, name: "m6", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+  ],
+);
+
+/**
  * Test that RPC services work.
  *
  * @generated from message protobuf_unittest.FooRequest
@@ -1738,5 +1757,193 @@ export const TestExtensionRangeSerialize = proto2.makeMessageType(
     { no: 7, name: "foo_three", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
     { no: 13, name: "foo_four", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
   ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32Simple
+ */
+export const TestVerifyInt32Simple = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyInt32Simple",
+  () => [
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32
+ */
+export const TestVerifyInt32 = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyInt32",
+  () => [
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyMostlyInt32
+ */
+export const TestVerifyMostlyInt32 = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyMostlyInt32",
+  () => [
+    { no: 30, name: "optional_int64_30", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 3, name: "optional_int32_3", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "optional_int32_4", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber
+ */
+export const TestVerifyMostlyInt32BigFieldNumber = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber",
+  () => [
+    { no: 30, name: "optional_int64_30", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 300, name: "optional_int32_300", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 3, name: "optional_int32_3", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "optional_int32_4", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32Simple
+ */
+export const TestVerifyUint32Simple = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyUint32Simple",
+  () => [
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32
+ */
+export const TestVerifyUint32 = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyUint32",
+  () => [
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyOneUint32
+ */
+export const TestVerifyOneUint32 = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyOneUint32",
+  () => [
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyOneInt32BigFieldNumber
+ */
+export const TestVerifyOneInt32BigFieldNumber = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyOneInt32BigFieldNumber",
+  () => [
+    { no: 65, name: "optional_int32_65", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "optional_int64_1", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 2, name: "optional_int64_2", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 63, name: "optional_int64_63", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 64, name: "optional_int64_64", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32BigFieldNumber
+ */
+export const TestVerifyInt32BigFieldNumber = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyInt32BigFieldNumber",
+  () => [
+    { no: 1000, name: "optional_int32_1000", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 65, name: "optional_int32_65", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32BigFieldNumber
+ */
+export const TestVerifyUint32BigFieldNumber = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyUint32BigFieldNumber",
+  () => [
+    { no: 1000, name: "optional_uint32_1000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 65, name: "optional_uint32_65", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32
+ */
+export const TestVerifyBigFieldNumberUint32 = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyBigFieldNumberUint32",
+  () => [
+    { no: 1, name: "optional_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, opt: true },
+  ],
+);
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested
+ */
+export const TestVerifyBigFieldNumberUint32_Nested = proto2.makeMessageType(
+  "protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested",
+  () => [
+    { no: 5000, name: "optional_uint32_5000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 1000, name: "optional_uint32_1000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 66, name: "optional_uint32_66", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 65, name: "optional_uint32_65", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 9, name: "optional_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, opt: true },
+    { no: 10, name: "repeated_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, repeated: true },
+  ],
+  {localName: "TestVerifyBigFieldNumberUint32_Nested"},
 );
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.d.ts
@@ -194,6 +194,11 @@ export declare class TestAllTypes extends Message<TestAllTypes> {
   optionalLazyMessage?: TestAllTypes_NestedMessage;
 
   /**
+   * @generated from field: proto3_arena_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+
+  /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
   optionalLazyImportMessage?: ImportMessage;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.js
@@ -82,6 +82,7 @@ export const TestAllTypes = proto3.makeMessageType(
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessage },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
     { no: 115, name: "optional_lazy_import_message", kind: "message", T: ImportMessage },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
@@ -194,6 +194,11 @@ export declare class TestAllTypes extends Message<TestAllTypes> {
   optionalLazyMessage?: TestAllTypes_NestedMessage;
 
   /**
+   * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+
+  /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
   optionalLazyImportMessage?: ImportMessage;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.js
@@ -82,6 +82,7 @@ export const TestAllTypes = proto3.makeMessageType(
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessage },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
     { no: 115, name: "optional_lazy_import_message", kind: "message", T: ImportMessage },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
@@ -2079,8 +2079,8 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
  * The name of the uninterpreted option.  Each string represents a segment in
  * a dot-separated name.  is_extension is true iff a segment represents an
  * extension (denoted with parentheses in options specs in .proto files).
- * E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
- * "foo.(bar.baz).qux".
+ * E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+ * "foo.(bar.baz).moo".
  *
  * @generated from message google.protobuf.UninterpretedOption.NamePart
  */
@@ -2280,13 +2280,13 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
    *   // Comment attached to baz.
    *   // Another line attached to baz.
    *
-   *   // Comment attached to qux.
+   *   // Comment attached to moo.
    *   //
-   *   // Another line attached to qux.
-   *   optional double qux = 4;
+   *   // Another line attached to moo.
+   *   optional double moo = 4;
    *
    *   // Detached comment for corge. This is not leading or trailing comments
-   *   // to qux or corge because there are blank lines separating it from
+   *   // to moo or corge because there are blank lines separating it from
    *   // both.
    *
    *   // Detached comment for corge paragraph 2.

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/empty_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/empty_pb.ts
@@ -44,7 +44,6 @@ import {Message, proto3} from "@bufbuild/protobuf";
  *       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
  *     }
  *
- * The JSON representation for `Empty` is empty JSON object `{}`.
  *
  * @generated from message google.protobuf.Empty
  */

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
@@ -1097,14 +1097,14 @@ export enum TestAllTypesProto3_AliasedEnum {
   ALIAS_BAZ = 2,
 
   /**
-   * @generated from enum value: QUX = 2;
+   * @generated from enum value: MOO = 2;
    */
-  QUX = 2,
+  MOO = 2,
 
   /**
-   * @generated from enum value: qux = 2;
+   * @generated from enum value: moo = 2;
    */
-  qux = 2,
+  moo = 2,
 
   /**
    * @generated from enum value: bAz = 2;
@@ -1116,8 +1116,8 @@ proto3.util.setEnumType(TestAllTypesProto3_AliasedEnum, "protobuf_test_messages.
   { no: 0, name: "ALIAS_FOO" },
   { no: 1, name: "ALIAS_BAR" },
   { no: 2, name: "ALIAS_BAZ" },
-  { no: 2, name: "QUX" },
-  { no: 2, name: "qux" },
+  { no: 2, name: "MOO" },
+  { no: 2, name: "moo" },
   { no: 2, name: "bAz" },
 ]);
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -672,9 +672,9 @@ export class ComplexOptionType2_ComplexOptionType4 extends Message<ComplexOption
  */
 export class ComplexOptionType3 extends Message<ComplexOptionType3> {
   /**
-   * @generated from field: optional int32 qux = 1;
+   * @generated from field: optional int32 moo = 1;
    */
-  qux?: number;
+  moo?: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
@@ -689,7 +689,7 @@ export class ComplexOptionType3 extends Message<ComplexOptionType3> {
   static readonly runtime = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOptionType3";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
-    { no: 1, name: "qux", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "moo", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
     { no: 2, name: "complexoptiontype5", kind: "message", T: ComplexOptionType3_ComplexOptionType5, opt: true },
   ]);
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_drop_unknown_fields_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_drop_unknown_fields_pb.ts
@@ -173,15 +173,15 @@ export enum FooWithExtraFields_NestedEnum {
   BAZ = 2,
 
   /**
-   * @generated from enum value: QUX = 3;
+   * @generated from enum value: MOO = 3;
    */
-  QUX = 3,
+  MOO = 3,
 }
 // Retrieve enum metadata with: proto3.getEnumType(FooWithExtraFields_NestedEnum)
 proto3.util.setEnumType(FooWithExtraFields_NestedEnum, "unittest_drop_unknown_fields.FooWithExtraFields.NestedEnum", [
   { no: 0, name: "FOO" },
   { no: 1, name: "BAR" },
   { no: 2, name: "BAZ" },
-  { no: 3, name: "QUX" },
+  { no: 3, name: "MOO" },
 ]);
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
@@ -242,6 +242,11 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
   optionalLazyMessage?: TestAllTypesLite_NestedMessage;
 
   /**
+   * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypesLite_NestedMessage;
+
+  /**
    * Repeated
    *
    * @generated from field: repeated int32 repeated_int32 = 31;
@@ -554,6 +559,7 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessageLite, opt: true },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypesLite_NestedMessage, opt: true },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypesLite_NestedMessage, opt: true },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },
     { no: 33, name: "repeated_uint32", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -923,6 +923,11 @@ export class TestAllTypes extends Message<TestAllTypes> {
   optionalLazyMessage?: TestAllTypes_NestedMessage;
 
   /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+
+  /**
    * Repeated
    *
    * @generated from field: repeated int32 repeated_int32 = 31;
@@ -1216,6 +1221,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessage, opt: true },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypes_NestedMessage, opt: true },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypes_NestedMessage, opt: true },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },
     { no: 33, name: "repeated_uint32", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },
@@ -5192,9 +5198,9 @@ export class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
  */
 export class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> {
   /**
-   * @generated from field: optional int64 qux_int = 1;
+   * @generated from field: optional int64 moo_int = 1;
    */
-  quxInt?: bigint;
+  mooInt?: bigint;
 
   /**
    * @generated from field: repeated int32 corge_int = 2;
@@ -5209,7 +5215,7 @@ export class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> 
   static readonly runtime = proto2;
   static readonly typeName = "protobuf_unittest.TestOneof2.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
-    { no: 1, name: "qux_int", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 1, name: "moo_int", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
     { no: 2, name: "corge_int", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
   ]);
 
@@ -6207,6 +6213,76 @@ export class TestCommentInjectionMessage extends Message<TestCommentInjectionMes
 }
 
 /**
+ * Used to check that the c++ code generator re-orders messages to reduce
+ * padding.
+ *
+ * @generated from message protobuf_unittest.TestMessageSize
+ */
+export class TestMessageSize extends Message<TestMessageSize> {
+  /**
+   * @generated from field: optional bool m1 = 1;
+   */
+  m1?: boolean;
+
+  /**
+   * @generated from field: optional int64 m2 = 2;
+   */
+  m2?: bigint;
+
+  /**
+   * @generated from field: optional bool m3 = 3;
+   */
+  m3?: boolean;
+
+  /**
+   * @generated from field: optional string m4 = 4;
+   */
+  m4?: string;
+
+  /**
+   * @generated from field: optional int32 m5 = 5;
+   */
+  m5?: number;
+
+  /**
+   * @generated from field: optional int64 m6 = 6;
+   */
+  m6?: bigint;
+
+  constructor(data?: PartialMessage<TestMessageSize>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestMessageSize";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "m1", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 2, name: "m2", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 3, name: "m3", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 4, name: "m4", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 5, name: "m5", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 6, name: "m6", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestMessageSize {
+    return new TestMessageSize().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestMessageSize {
+    return new TestMessageSize().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestMessageSize {
+    return new TestMessageSize().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestMessageSize | PlainMessage<TestMessageSize> | undefined, b: TestMessageSize | PlainMessage<TestMessageSize> | undefined): boolean {
+    return proto2.util.equals(TestMessageSize, a, b);
+  }
+}
+
+/**
  * Test that RPC services work.
  *
  * @generated from message protobuf_unittest.FooRequest
@@ -6958,6 +7034,852 @@ export class TestExtensionRangeSerialize extends Message<TestExtensionRangeSeria
 
   static equals(a: TestExtensionRangeSerialize | PlainMessage<TestExtensionRangeSerialize> | undefined, b: TestExtensionRangeSerialize | PlainMessage<TestExtensionRangeSerialize> | undefined): boolean {
     return proto2.util.equals(TestExtensionRangeSerialize, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32Simple
+ */
+export class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple> {
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  constructor(data?: PartialMessage<TestVerifyInt32Simple>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyInt32Simple";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyInt32Simple {
+    return new TestVerifyInt32Simple().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyInt32Simple {
+    return new TestVerifyInt32Simple().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyInt32Simple {
+    return new TestVerifyInt32Simple().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyInt32Simple | PlainMessage<TestVerifyInt32Simple> | undefined, b: TestVerifyInt32Simple | PlainMessage<TestVerifyInt32Simple> | undefined): boolean {
+    return proto2.util.equals(TestVerifyInt32Simple, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32
+ */
+export class TestVerifyInt32 extends Message<TestVerifyInt32> {
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyInt32>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyInt32";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyInt32 {
+    return new TestVerifyInt32().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyInt32 {
+    return new TestVerifyInt32().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyInt32 {
+    return new TestVerifyInt32().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyInt32 | PlainMessage<TestVerifyInt32> | undefined, b: TestVerifyInt32 | PlainMessage<TestVerifyInt32> | undefined): boolean {
+    return proto2.util.equals(TestVerifyInt32, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyMostlyInt32
+ */
+export class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32> {
+  /**
+   * @generated from field: optional int64 optional_int64_30 = 30;
+   */
+  optionalInt6430?: bigint;
+
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_3 = 3;
+   */
+  optionalInt323?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_4 = 4;
+   */
+  optionalInt324?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyMostlyInt32>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyMostlyInt32";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 30, name: "optional_int64_30", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 3, name: "optional_int32_3", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "optional_int32_4", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyMostlyInt32 {
+    return new TestVerifyMostlyInt32().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32 {
+    return new TestVerifyMostlyInt32().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32 {
+    return new TestVerifyMostlyInt32().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyMostlyInt32 | PlainMessage<TestVerifyMostlyInt32> | undefined, b: TestVerifyMostlyInt32 | PlainMessage<TestVerifyMostlyInt32> | undefined): boolean {
+    return proto2.util.equals(TestVerifyMostlyInt32, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber
+ */
+export class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVerifyMostlyInt32BigFieldNumber> {
+  /**
+   * @generated from field: optional int64 optional_int64_30 = 30;
+   */
+  optionalInt6430?: bigint;
+
+  /**
+   * @generated from field: optional int32 optional_int32_300 = 300;
+   */
+  optionalInt32300?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_3 = 3;
+   */
+  optionalInt323?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_4 = 4;
+   */
+  optionalInt324?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyMostlyInt32BigFieldNumber>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 30, name: "optional_int64_30", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 300, name: "optional_int32_300", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 3, name: "optional_int32_3", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "optional_int32_4", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyMostlyInt32BigFieldNumber {
+    return new TestVerifyMostlyInt32BigFieldNumber().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32BigFieldNumber {
+    return new TestVerifyMostlyInt32BigFieldNumber().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyMostlyInt32BigFieldNumber {
+    return new TestVerifyMostlyInt32BigFieldNumber().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyMostlyInt32BigFieldNumber | PlainMessage<TestVerifyMostlyInt32BigFieldNumber> | undefined, b: TestVerifyMostlyInt32BigFieldNumber | PlainMessage<TestVerifyMostlyInt32BigFieldNumber> | undefined): boolean {
+    return proto2.util.equals(TestVerifyMostlyInt32BigFieldNumber, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32Simple
+ */
+export class TestVerifyUint32Simple extends Message<TestVerifyUint32Simple> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  constructor(data?: PartialMessage<TestVerifyUint32Simple>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyUint32Simple";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyUint32Simple {
+    return new TestVerifyUint32Simple().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyUint32Simple {
+    return new TestVerifyUint32Simple().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyUint32Simple {
+    return new TestVerifyUint32Simple().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyUint32Simple | PlainMessage<TestVerifyUint32Simple> | undefined, b: TestVerifyUint32Simple | PlainMessage<TestVerifyUint32Simple> | undefined): boolean {
+    return proto2.util.equals(TestVerifyUint32Simple, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32
+ */
+export class TestVerifyUint32 extends Message<TestVerifyUint32> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyUint32>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyUint32";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyUint32 {
+    return new TestVerifyUint32().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyUint32 {
+    return new TestVerifyUint32().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyUint32 {
+    return new TestVerifyUint32().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyUint32 | PlainMessage<TestVerifyUint32> | undefined, b: TestVerifyUint32 | PlainMessage<TestVerifyUint32> | undefined): boolean {
+    return proto2.util.equals(TestVerifyUint32, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyOneUint32
+ */
+export class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyOneUint32>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyOneUint32";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyOneUint32 {
+    return new TestVerifyOneUint32().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyOneUint32 {
+    return new TestVerifyOneUint32().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyOneUint32 {
+    return new TestVerifyOneUint32().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyOneUint32 | PlainMessage<TestVerifyOneUint32> | undefined, b: TestVerifyOneUint32 | PlainMessage<TestVerifyOneUint32> | undefined): boolean {
+    return proto2.util.equals(TestVerifyOneUint32, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyOneInt32BigFieldNumber
+ */
+export class TestVerifyOneInt32BigFieldNumber extends Message<TestVerifyOneInt32BigFieldNumber> {
+  /**
+   * @generated from field: optional int32 optional_int32_65 = 65;
+   */
+  optionalInt3265?: number;
+
+  /**
+   * @generated from field: optional int64 optional_int64_1 = 1;
+   */
+  optionalInt641?: bigint;
+
+  /**
+   * @generated from field: optional int64 optional_int64_2 = 2;
+   */
+  optionalInt642?: bigint;
+
+  /**
+   * @generated from field: optional int64 optional_int64_63 = 63;
+   */
+  optionalInt6463?: bigint;
+
+  /**
+   * @generated from field: optional int64 optional_int64_64 = 64;
+   */
+  optionalInt6464?: bigint;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyOneInt32BigFieldNumber>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyOneInt32BigFieldNumber";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 65, name: "optional_int32_65", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "optional_int64_1", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 2, name: "optional_int64_2", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 63, name: "optional_int64_63", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 64, name: "optional_int64_64", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyOneInt32BigFieldNumber {
+    return new TestVerifyOneInt32BigFieldNumber().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyOneInt32BigFieldNumber {
+    return new TestVerifyOneInt32BigFieldNumber().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyOneInt32BigFieldNumber {
+    return new TestVerifyOneInt32BigFieldNumber().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyOneInt32BigFieldNumber | PlainMessage<TestVerifyOneInt32BigFieldNumber> | undefined, b: TestVerifyOneInt32BigFieldNumber | PlainMessage<TestVerifyOneInt32BigFieldNumber> | undefined): boolean {
+    return proto2.util.equals(TestVerifyOneInt32BigFieldNumber, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyInt32BigFieldNumber
+ */
+export class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt32BigFieldNumber> {
+  /**
+   * @generated from field: optional int32 optional_int32_1000 = 1000;
+   */
+  optionalInt321000?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_65 = 65;
+   */
+  optionalInt3265?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_1 = 1;
+   */
+  optionalInt321?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_2 = 2;
+   */
+  optionalInt322?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_63 = 63;
+   */
+  optionalInt3263?: number;
+
+  /**
+   * @generated from field: optional int32 optional_int32_64 = 64;
+   */
+  optionalInt3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyInt32BigFieldNumber>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyInt32BigFieldNumber";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1000, name: "optional_int32_1000", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 65, name: "optional_int32_65", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 2, name: "optional_int32_2", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 63, name: "optional_int32_63", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 64, name: "optional_int32_64", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyInt32BigFieldNumber {
+    return new TestVerifyInt32BigFieldNumber().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyInt32BigFieldNumber {
+    return new TestVerifyInt32BigFieldNumber().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyInt32BigFieldNumber {
+    return new TestVerifyInt32BigFieldNumber().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyInt32BigFieldNumber | PlainMessage<TestVerifyInt32BigFieldNumber> | undefined, b: TestVerifyInt32BigFieldNumber | PlainMessage<TestVerifyInt32BigFieldNumber> | undefined): boolean {
+    return proto2.util.equals(TestVerifyInt32BigFieldNumber, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyUint32BigFieldNumber
+ */
+export class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUint32BigFieldNumber> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_1000 = 1000;
+   */
+  optionalUint321000?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_65 = 65;
+   */
+  optionalUint3265?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
+   */
+  optionalAllTypes?: TestAllTypes;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
+   */
+  repeatedAllTypes: TestAllTypes[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyUint32BigFieldNumber>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyUint32BigFieldNumber";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1000, name: "optional_uint32_1000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 65, name: "optional_uint32_65", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 9, name: "optional_all_types", kind: "message", T: TestAllTypes, opt: true },
+    { no: 10, name: "repeated_all_types", kind: "message", T: TestAllTypes, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyUint32BigFieldNumber {
+    return new TestVerifyUint32BigFieldNumber().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyUint32BigFieldNumber {
+    return new TestVerifyUint32BigFieldNumber().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyUint32BigFieldNumber {
+    return new TestVerifyUint32BigFieldNumber().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyUint32BigFieldNumber | PlainMessage<TestVerifyUint32BigFieldNumber> | undefined, b: TestVerifyUint32BigFieldNumber | PlainMessage<TestVerifyUint32BigFieldNumber> | undefined): boolean {
+    return proto2.util.equals(TestVerifyUint32BigFieldNumber, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32
+ */
+export class TestVerifyBigFieldNumberUint32 extends Message<TestVerifyBigFieldNumberUint32> {
+  /**
+   * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
+   */
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+
+  constructor(data?: PartialMessage<TestVerifyBigFieldNumberUint32>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyBigFieldNumberUint32";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 1, name: "optional_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyBigFieldNumberUint32 {
+    return new TestVerifyBigFieldNumberUint32().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32 {
+    return new TestVerifyBigFieldNumberUint32().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32 {
+    return new TestVerifyBigFieldNumberUint32().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyBigFieldNumberUint32 | PlainMessage<TestVerifyBigFieldNumberUint32> | undefined, b: TestVerifyBigFieldNumberUint32 | PlainMessage<TestVerifyBigFieldNumberUint32> | undefined): boolean {
+    return proto2.util.equals(TestVerifyBigFieldNumberUint32, a, b);
+  }
+}
+
+/**
+ * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested
+ */
+export class TestVerifyBigFieldNumberUint32_Nested extends Message<TestVerifyBigFieldNumberUint32_Nested> {
+  /**
+   * @generated from field: optional uint32 optional_uint32_5000 = 5000;
+   */
+  optionalUint325000?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_1000 = 1000;
+   */
+  optionalUint321000?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_66 = 66;
+   */
+  optionalUint3266?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_65 = 65;
+   */
+  optionalUint3265?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_1 = 1;
+   */
+  optionalUint321?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_2 = 2;
+   */
+  optionalUint322?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_63 = 63;
+   */
+  optionalUint3263?: number;
+
+  /**
+   * @generated from field: optional uint32 optional_uint32_64 = 64;
+   */
+  optionalUint3264?: number;
+
+  /**
+   * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
+   */
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+
+  /**
+   * @generated from field: repeated protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;
+   */
+  repeatedNested: TestVerifyBigFieldNumberUint32_Nested[] = [];
+
+  constructor(data?: PartialMessage<TestVerifyBigFieldNumberUint32_Nested>) {
+    super();
+    proto2.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto2;
+  static readonly typeName = "protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested";
+  static readonly fields: FieldList = proto2.util.newFieldList(() => [
+    { no: 5000, name: "optional_uint32_5000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 1000, name: "optional_uint32_1000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 66, name: "optional_uint32_66", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 65, name: "optional_uint32_65", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 2, name: "optional_uint32_2", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 63, name: "optional_uint32_63", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 64, name: "optional_uint32_64", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
+    { no: 9, name: "optional_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, opt: true },
+    { no: 10, name: "repeated_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TestVerifyBigFieldNumberUint32_Nested {
+    return new TestVerifyBigFieldNumberUint32_Nested().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32_Nested {
+    return new TestVerifyBigFieldNumberUint32_Nested().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): TestVerifyBigFieldNumberUint32_Nested {
+    return new TestVerifyBigFieldNumberUint32_Nested().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: TestVerifyBigFieldNumberUint32_Nested | PlainMessage<TestVerifyBigFieldNumberUint32_Nested> | undefined, b: TestVerifyBigFieldNumberUint32_Nested | PlainMessage<TestVerifyBigFieldNumberUint32_Nested> | undefined): boolean {
+    return proto2.util.equals(TestVerifyBigFieldNumberUint32_Nested, a, b);
   }
 }
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
@@ -201,6 +201,11 @@ export class TestAllTypes extends Message<TestAllTypes> {
   optionalLazyMessage?: TestAllTypes_NestedMessage;
 
   /**
+   * @generated from field: proto3_arena_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+
+  /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
   optionalLazyImportMessage?: ImportMessage;
@@ -460,6 +465,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessage },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
     { no: 115, name: "optional_lazy_import_message", kind: "message", T: ImportMessage },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
@@ -201,6 +201,11 @@ export class TestAllTypes extends Message<TestAllTypes> {
   optionalLazyMessage?: TestAllTypes_NestedMessage;
 
   /**
+   * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
+   */
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+
+  /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
   optionalLazyImportMessage?: ImportMessage;
@@ -383,6 +388,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     { no: 25, name: "optional_cord", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 26, name: "optional_public_import_message", kind: "message", T: PublicImportMessage },
     { no: 27, name: "optional_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
+    { no: 28, name: "optional_unverified_lazy_message", kind: "message", T: TestAllTypes_NestedMessage },
     { no: 115, name: "optional_lazy_import_message", kind: "message", T: ImportMessage },
     { no: 31, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
     { no: 32, name: "repeated_int64", kind: "scalar", T: 3 /* ScalarType.INT64 */, repeated: true },

--- a/packages/protobuf/src/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/google/protobuf/descriptor_pb.ts
@@ -2067,8 +2067,8 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
  * The name of the uninterpreted option.  Each string represents a segment in
  * a dot-separated name.  is_extension is true iff a segment represents an
  * extension (denoted with parentheses in options specs in .proto files).
- * E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
- * "foo.(bar.baz).qux".
+ * E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+ * "foo.(bar.baz).moo".
  *
  * @generated from message google.protobuf.UninterpretedOption.NamePart
  */
@@ -2268,13 +2268,13 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
    *   // Comment attached to baz.
    *   // Another line attached to baz.
    *
-   *   // Comment attached to qux.
+   *   // Comment attached to moo.
    *   //
-   *   // Another line attached to qux.
-   *   optional double qux = 4;
+   *   // Another line attached to moo.
+   *   optional double moo = 4;
    *
    *   // Detached comment for corge. This is not leading or trailing comments
-   *   // to qux or corge because there are blank lines separating it from
+   *   // to moo or corge because there are blank lines separating it from
    *   // both.
    *
    *   // Detached comment for corge paragraph 2.

--- a/packages/protobuf/src/google/protobuf/empty_pb.ts
+++ b/packages/protobuf/src/google/protobuf/empty_pb.ts
@@ -32,7 +32,6 @@ import type {JsonReadOptions, JsonValue} from "../../json-format.js";
  *       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
  *     }
  *
- * The JSON representation for `Empty` is empty JSON object `{}`.
  *
  * @generated from message google.protobuf.Empty
  */


### PR DESCRIPTION
This updates protobuf-es to the latest version ([21.5](https://github.com/protocolbuffers/protobuf/releases/tag/v21.5)), which at press time is the most current version.

The only notable changes affecting protobuf-es are the rearrangement of the conformance tests, which were moved to a `conformance/` directory.  

Test run results match currently `main` branch:

```bash
Test Suites: 27 passed, 27 total
Tests:       300 passed, 300 total
Snapshots:   0 total
Time:        2.365 s, estimated 3 s
Ran all test suites.
.tmp/bin/conformance_test_runner --enforce_recommended \
                --failure_list packages/protobuf-conformance/conformance_failing_tests.txt \
                --text_format_failure_list packages/protobuf-conformance/conformance_failing_tests_text_format.txt \
                packages/protobuf-conformance/bin/conformance_esm.js                                                                                                                                                                       [0/1880]

CONFORMANCE TEST BEGIN ====================================

CONFORMANCE SUITE PASSED: 2016 successes, 0 skipped, 1 expected failures, 0 unexpected failures.


CONFORMANCE TEST BEGIN ====================================

CONFORMANCE SUITE PASSED: 0 successes, 8 skipped, 112 expected failures, 0 unexpected failures.
```