### PR TITLE
Point to commonjs in `main` property

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -15,13 +15,13 @@
     "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
-  "main": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.js",
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js",
-    "default": "./dist/esm/index.js"
+    "default": "./dist/cjs/index.js"
   },
   "devDependencies": {
     "typescript": "^4.7.4"


### PR DESCRIPTION
Changing the `main` property to point to the Common JS module entrypoint.  Using ESM forces some workarounds to be needed for libraries like Jest and this seems to cause less friction by default.