### PR TITLE
Fix type prop issue in conditional exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LICENSE_HEADER_YEAR_RANGE := 2021-2022
 LICENSE_HEADER_IGNORES := .tmp\/ node_module\/ packages\/protobuf-conformance\/bin\/conformance_esm.js packages\/protobuf-conformance\/src\/gen\/ packages\/protobuf-test\/src\/gen\/ packages\/protobuf\/src\/google\/varint.ts packages\/protobuf-bench\/src\/gen\/ packages\/protobuf\/dist\/ packages\/protobuf-test\/dist\/ scripts\/
 GOOGLE_PROTOBUF_WKT = google/protobuf/api.proto google/protobuf/any.proto google/protobuf/compiler/plugin.proto google/protobuf/descriptor.proto google/protobuf/duration.proto google/protobuf/descriptor.proto google/protobuf/empty.proto google/protobuf/field_mask.proto google/protobuf/source_context.proto google/protobuf/struct.proto google/protobuf/timestamp.proto google/protobuf/type.proto google/protobuf/wrappers.proto
 GOOGLE_PROTOBUF_VERSION = 21.5
-TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.8.1-rc
+TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.2
 
 node_modules: package-lock.json
 	npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -4784,10 +4784,36 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ts4_7_4": {
+      "name": "typescript",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ts4_8_1-rc": {
       "name": "typescript",
       "version": "4.8.1-rc",
       "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/ts4_8_2": {
+      "name": "typescript",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5095,7 +5121,9 @@
         "ts4_4_4": "npm:typescript@4.4.4",
         "ts4_5_2": "npm:typescript@4.5.2",
         "ts4_6_4": "npm:typescript@4.6.4",
-        "ts4_8_1-rc": "npm:typescript@4.8.1-rc"
+        "ts4_7_4": "npm:typescript@4.7.4",
+        "ts4_8_1-rc": "npm:typescript@4.8.1-rc",
+        "ts4_8_2": "npm:typescript@4.8.2"
       }
     },
     "packages/protoc-gen-es": {
@@ -5482,7 +5510,9 @@
         "ts4_4_4": "npm:typescript@4.4.4",
         "ts4_5_2": "npm:typescript@4.5.2",
         "ts4_6_4": "npm:typescript@4.6.4",
-        "ts4_8_1-rc": "npm:typescript@4.8.1-rc"
+        "ts4_7_4": "npm:typescript@4.7.4",
+        "ts4_8_1-rc": "npm:typescript@4.8.1-rc",
+        "ts4_8_2": "npm:typescript@4.8.2"
       }
     },
     "@bufbuild/protoc-gen-es": {
@@ -8050,8 +8080,18 @@
     "ts4_6_4": {
       "version": "npm:typescript@4.6.4"
     },
+    "ts4_7_4": {
+      "version": "npm:typescript@4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+    },
     "ts4_8_1-rc": {
       "version": "npm:typescript@4.8.1-rc"
+    },
+    "ts4_8_2": {
+      "version": "npm:typescript@4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -25,7 +25,6 @@
     "ts4_5_2": "npm:typescript@4.5.2",
     "ts4_6_4": "npm:typescript@4.6.4",
     "ts4_7_4": "npm:typescript@4.7.4",
-    "ts4_8_1-rc": "npm:typescript@4.8.1-rc",
     "ts4_8_2": "npm:typescript@4.8.2"
   }
 }

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -17,13 +17,15 @@
     "@bufbuild/protobuf": "0.1.0",
     "@types/jest": "^28.1.6",
     "jest": "^28.1.3",
+    "long": "^5.2.0",
     "ts4_1_2": "npm:typescript@4.1.2",
     "ts4_2_4": "npm:typescript@4.2.4",
     "ts4_3_5": "npm:typescript@4.3.5",
     "ts4_4_4": "npm:typescript@4.4.4",
     "ts4_5_2": "npm:typescript@4.5.2",
     "ts4_6_4": "npm:typescript@4.6.4",
+    "ts4_7_4": "npm:typescript@4.7.4",
     "ts4_8_1-rc": "npm:typescript@4.8.1-rc",
-    "long": "^5.2.0"
+    "ts4_8_2": "npm:typescript@4.8.2"
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_5_2.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_5_2.json
@@ -1,6 +1,6 @@
 {
   "include": ["../src/gen/js/extra/*.js", "../src/gen/ts/extra/*.ts"],
-  // These are the default compiler options for TypeScript v4.5.2, created with `tsc --init` (except skipLibCheck -- see below)
+  // These are the default compiler options for TypeScript v4.5.2, created with `tsc --init` (except where noted)
   "compilerOptions": {
     "target": "es2016",
     "module": "commonjs",

--- a/packages/protobuf-test/typescript/tsconfig.4_6_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_6_4.json
@@ -1,6 +1,6 @@
 {
   "include": ["../src/gen/js/extra/*.js", "../src/gen/ts/extra/*.ts"],
-  // These are the default compiler options for TypeScript v4.6.4, created with `tsc --init` (except skipLibCheck -- see below)
+  // These are the default compiler options for TypeScript v4.6.4, created with `tsc --init` (except where noted)
   "compilerOptions": {
     "target": "es2016",
     "module": "commonjs",

--- a/packages/protobuf-test/typescript/tsconfig.4_7_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_7_4.json
@@ -1,6 +1,6 @@
 {
   "include": ["../src/gen/js/extra/*.js", "../src/gen/ts/extra/*.ts"],
-  // These are the default compiler options for TypeScript v4.8.1-rc, created with `tsc --init` (except skipLibCheck -- see below)
+  // These are the default compiler options for TypeScript v4.7.4, created with `tsc --init` (except where noted)
   "compilerOptions": {
     "target": "es2016",
     "module": "commonjs",
@@ -9,6 +9,7 @@
     "strict": true,
     // To guard against regression and ensure we are remaining backwards compatible, set the skipLibCheck flag to false explicitly.
     "skipLibCheck": false,
+    // To test forward-compatibility, set to NodeNext
     "moduleResolution": "NodeNext"
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_8_1-rc.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_8_1-rc.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     // To guard against regression and ensure we are remaining backwards compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "moduleResolution": "NodeNext"
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_8_2.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_8_2.json
@@ -1,0 +1,15 @@
+{
+  "include": ["../src/gen/js/extra/*.js", "../src/gen/ts/extra/*.ts"],
+  // These are the default compiler options for TypeScript v4.8.2, created with `tsc --init` (except where noted)
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    // To guard against regression and ensure we are remaining backwards compatible, set the skipLibCheck flag to false explicitly.
+    "skipLibCheck": false,
+    // To test forward-compatibility, set to NodeNext
+    "moduleResolution": "NodeNext"
+  }
+}

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -20,7 +20,8 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "types": "./dist/types/index.d.ts"
   },
   "files": [
     "dist/**/"

--- a/packages/protobuf/src/json-format.ts
+++ b/packages/protobuf/src/json-format.ts
@@ -15,7 +15,7 @@
 import type { Message } from "./message.js";
 import type { MessageType } from "./message-type.js";
 import type { ScalarType } from "./field.js";
-import type { IMessageTypeRegistry } from "./type-registry";
+import type { IMessageTypeRegistry } from "./type-registry.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 


### PR DESCRIPTION
Fixes https://github.com/bufbuild/protobuf-es/issues/209

If consumers try to import `protobuf-es` and configure their `tsconfig.json` file to use `moduleResolution: "NodeNext"`, they experience issues resolving our declaration files.  This is because we specify conditional exports and the `NodeNext` module resolution will use this exports map to resolve modules.  Unfortunately, it also uses this to resolve `types`.  Since we didn't specify a `types` property there, declaration files couldn't be found.

For more context:  
- https://github.com/microsoft/TypeScript/issues/48235
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#esm-nodejs

In addition, this modifies our TypeScript tests to test against 4.7.4 and 4.8.2 using `NodeNext` module resolution (usage of this value with anything below 4.7 errors out because it is marked experimental in those versions).

