### PR TITLE
Update TypeScript to 4.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-node": "^11.1.0",
         "prettier": "^2.7.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       },
       "engines": {
         "node": ">=16",
@@ -5463,8 +5463,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "license": "Apache-2.0",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5664,7 +5665,7 @@
         "@bufbuild/protobuf": "0.1.0",
         "@bufbuild/protoc-gen-es": "0.1.0",
         "@types/node": "^18.7.14",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "packages/protobuf": {
@@ -5685,7 +5686,7 @@
       "dependencies": {
         "@bufbuild/protobuf": "0.1.0",
         "@types/node": "^18.7.14",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "packages/protobuf-test": {
@@ -5735,7 +5736,7 @@
         "@bufbuild/protobuf": "0.1.0"
       },
       "devDependencies": {
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     }
   },
@@ -6160,7 +6161,7 @@
         "@bufbuild/protobuf": "0.1.0",
         "@bufbuild/protoc-gen-es": "0.1.0",
         "@types/node": "^18.7.14",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "@bufbuild/protobuf": {
@@ -6179,7 +6180,7 @@
       "requires": {
         "@bufbuild/protobuf": "0.1.0",
         "@types/node": "^18.7.14",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "@bufbuild/protobuf-test": {
@@ -6209,7 +6210,7 @@
       "version": "file:packages/protoplugin",
       "requires": {
         "@bufbuild/protobuf": "0.1.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "@esbuild/linux-loong64": {
@@ -9354,7 +9355,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4"
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "prettier": "^2.7.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   }
 }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,6 +13,6 @@
     "@bufbuild/protobuf": "0.1.0",
     "@bufbuild/protoc-gen-es": "0.1.0",
     "@types/node": "^18.7.14",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   }
 }

--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "@bufbuild/protobuf": "0.1.0",
     "@types/node": "^18.7.14",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   }
 }

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -38,7 +38,7 @@
     "@bufbuild/protobuf": "0.1.0"
   },
   "devDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   },
   "files": [
     "dist/**/"


### PR DESCRIPTION
Updates TypeScript version to 4.8.2 as a result of Dependabot run on 9/1.