### PR TITLE
Fix error message in proto2 binary format

### DIFF
--- a/packages/protobuf-test/src/proto2.test.ts
+++ b/packages/protobuf-test/src/proto2.test.ts
@@ -109,7 +109,7 @@ describeMT(
           stringField: "",
         }).toBinary()
       ).toThrow(
-        `cannot encode field ${messageType.typeName}.enum_field to JSON: required field not set`
+        `cannot encode field ${messageType.typeName}.enum_field to binary: required field not set`
       );
     });
   }

--- a/packages/protobuf/src/private/binary-format-proto2.ts
+++ b/packages/protobuf/src/private/binary-format-proto2.ts
@@ -53,7 +53,7 @@ export function makeBinaryFormatProto2(): BinaryFormat {
             // field is missing a value.
             if (value === undefined && !field.oneof && !field.opt) {
               throw new Error(
-                `cannot encode field ${type.typeName}.${field.name} to JSON: required field not set`
+                `cannot encode field ${type.typeName}.${field.name} to binary: required field not set`
               );
             }
           }


### PR DESCRIPTION
The error message is `cannot encode field ... to JSON`. Obviously that should be `binary`.