### PR TITLE
Add a plugin option to keep empty files

### DIFF
--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -124,3 +124,11 @@ By default, we generate JavaScript and TypeScript declaration files, which
 produces the smallest code size. If you prefer to generate TypeScript, use
 `target=ts`.
 
+### `keep_empty_files=true`
+
+By default, [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es) 
+(and all other plugins based on [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin)) 
+omit empty files from the plugin output. This option disables pruning of 
+empty files, to allow for smooth interoperation with Bazel and similar 
+tooling that requires all output files to be declared ahead of time.
+Unless you use Bazel, it is very unlikely that you need this option.

--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -48,8 +48,13 @@ export function createEcmaScriptPlugin(
     name: init.name,
     version: init.version,
     run(req) {
-      const { targets, tsNocheck, bootstrapWkt, rewriteImports } =
-        parseParameter(req.parameter, init.parseOption);
+      const {
+        targets,
+        tsNocheck,
+        bootstrapWkt,
+        rewriteImports,
+        keepEmptyFiles,
+      } = parseParameter(req.parameter, init.parseOption);
       const { schema, toResponse } = createSchema(
         req,
         targets,
@@ -57,7 +62,8 @@ export function createEcmaScriptPlugin(
         init.version,
         tsNocheck,
         bootstrapWkt,
-        rewriteImports
+        rewriteImports,
+        keepEmptyFiles
       );
       generateFn(schema);
       const res = new CodeGeneratorResponse();
@@ -74,6 +80,7 @@ function parseParameter(
   let targets: Target[] = ["js", "dts"];
   let tsNocheck = true;
   let bootstrapWkt = false;
+  let keepEmptyFiles = false;
   const rewriteImports: RewriteImports = [];
   for (const { key, value } of splitParameter(parameter)) {
     switch (key) {
@@ -134,6 +141,21 @@ function parseParameter(
         rewriteImports.push({ pattern, target });
         break;
       }
+      case "keep_empty_files": {
+        switch (value) {
+          case "true":
+          case "1":
+            keepEmptyFiles = true;
+            break;
+          case "false":
+          case "0":
+            keepEmptyFiles = false;
+            break;
+          default:
+            throw new PluginOptionError(`${key}=${value}`);
+        }
+        break;
+      }
       default:
         if (parseOption === undefined) {
           throw new PluginOptionError(`${key}=${value}`);
@@ -146,7 +168,7 @@ function parseParameter(
         break;
     }
   }
-  return { targets, tsNocheck, bootstrapWkt, rewriteImports };
+  return { targets, tsNocheck, bootstrapWkt, rewriteImports, keepEmptyFiles };
 }
 
 function splitParameter(

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -102,7 +102,8 @@ export function createGeneratedFile(
     pluginVersion: string;
     parameter: string | undefined;
     tsNocheck: boolean;
-  }
+  },
+  keepEmpty: boolean
 ): GeneratedFile & GenerateFileToResponse {
   let preamble: string | undefined;
   const el: El[] = [];
@@ -132,7 +133,7 @@ export function createGeneratedFile(
     },
     toResponse(res) {
       let content = elToContent(el, importPath);
-      if (content.length === 0) {
+      if (!keepEmpty && content.length === 0) {
         return;
       }
       if (preamble !== undefined) {

--- a/packages/protoplugin/src/ecmascript/schema.ts
+++ b/packages/protoplugin/src/ecmascript/schema.ts
@@ -89,7 +89,8 @@ export function createSchema(
   pluginVersion: string,
   tsNocheck: boolean,
   bootstrapWkt: boolean,
-  rewriteImports: RewriteImports
+  rewriteImports: RewriteImports,
+  keepEmptyFiles: boolean
 ): SchemaController {
   const descriptorSet = createDescriptorSet(request.protoFile);
   const filesToGenerate = findFilesToGenerate(descriptorSet, request);
@@ -124,7 +125,8 @@ export function createSchema(
           pluginVersion,
           parameter: request.parameter,
           tsNocheck,
-        }
+        },
+        keepEmptyFiles
       );
       generatedFiles.push(genFile);
       return genFile;


### PR DESCRIPTION
By default, protoc-gen-es (and all other plugins based on @bufbuild/protoplugin) omit empty files from the plugin output.

This is reasonable behaviour, because a file without contents is meaningless, and plugin authors often run into a situation where they only find out that they don't have anything to generate deep into some loop, long after they have constructed a file to generate. Users may have protobuf files that only declare services, which does not generate any code with protoc-gen-es.

Unfortunately, some tooling like Bazel requires all output files to be declared ahead of time, which makes it impossible to generate code through Bazel without looking at the contents of the protobuf sources.

All standard base type generators do create files for empty sources files. Most contain somewhat useful code (a file descriptor), in case of the JavaScript generator the files only contain unexported initialization code. But all do create a file.

This adds the plugin option `keep_empty_files=true` to @bufbuild/protoplugin. Bazel users can use this option to ensure that every input file has an output file, even though it may be empty. For all other users, this option is irrelevant.

An alternative to this option would be to generate empty files in protoc-gen-es exclusively. On the upside, we would not need an additional option. On the downside, we would generate meaningless files in some situations, and RPC generators could still not be used in combination with Bazel.