### PR TITLE
Clean up descriptor discrimination

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 74,055 b      | 36,960 b | 9,637 b |
+| protobuf-es         | 74,055 b      | 36,960 b | 9,651 b |
 | protobuf-javascript | 370,857 b  | 271,536 b | 43,759 b |

--- a/packages/protobuf-test/src/descriptor-set.test.ts
+++ b/packages/protobuf-test/src/descriptor-set.test.ts
@@ -37,7 +37,8 @@ describe("DescriptorSet", () => {
     expect(ext?.typeName).toBe("protobuf_unittest.optional_int32_extension");
     expect(ext?.extendee.typeName).toBe(TestAllExtensions.typeName);
     expect(ext?.optional).toBe(true);
-    expect(ext?.kind).toBe("scalar_field");
+    expect(ext?.kind).toBe("extension");
+    expect(ext?.fieldKind).toBe("scalar");
     expect(ext?.scalar).toBe(ScalarType.INT32);
     expect(ext?.toString()).toBe(
       "extension protobuf_unittest.optional_int32_extension"

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -211,17 +211,17 @@ export function createRegistryFromDescriptors(
 interface Resolver extends IMessageTypeRegistry, IEnumTypeRegistry {}
 
 function makeFieldInfo(desc: DescField, resolver: Resolver): PartialFieldInfo {
-  switch (desc.kind) {
-    case "map_field":
+  switch (desc.fieldKind) {
+    case "map":
       return makeMapFieldInfo(desc, resolver);
-    case "message_field":
+    case "message":
       return makeMessageFieldInfo(desc, resolver);
-    case "enum_field": {
+    case "enum": {
       const fi = makeEnumFieldInfo(desc, resolver);
       fi.default = desc.getDefaultValue();
       return fi;
     }
-    case "scalar_field": {
+    case "scalar": {
       const fi = makeScalarFieldInfo(desc);
       fi.default = desc.getDefaultValue();
       return fi;
@@ -230,7 +230,7 @@ function makeFieldInfo(desc: DescField, resolver: Resolver): PartialFieldInfo {
 }
 
 function makeMapFieldInfo(
-  field: DescField & { kind: "map_field" },
+  field: DescField & { fieldKind: "map" },
   resolver: Resolver
 ): PartialFieldInfo {
   const base = {
@@ -280,7 +280,7 @@ function makeMapFieldInfo(
 }
 
 function makeScalarFieldInfo(
-  field: DescField & { kind: "scalar_field" }
+  field: DescField & { fieldKind: "scalar" }
 ): PartialFieldInfo {
   const base = {
     kind: "scalar",
@@ -314,7 +314,7 @@ function makeScalarFieldInfo(
 }
 
 function makeMessageFieldInfo(
-  field: DescField & { kind: "message_field" },
+  field: DescField & { fieldKind: "message" },
   resolver: Resolver
 ): PartialFieldInfo {
   const messageType = resolver.findMessage(field.message.typeName);
@@ -353,7 +353,7 @@ function makeMessageFieldInfo(
 }
 
 function makeEnumFieldInfo(
-  field: DescField & { kind: "enum_field" },
+  field: DescField & { fieldKind: "enum" },
   resolver: Resolver
 ): PartialFieldInfo {
   const enumType = resolver.findEnum(field.enum.typeName);

--- a/packages/protobuf/src/descriptor-set.ts
+++ b/packages/protobuf/src/descriptor-set.ts
@@ -32,6 +32,10 @@ import type { MethodIdempotency, MethodKind } from "./service-type.js";
  * When protobuf sources are compiled, each file is parsed into a
  * google.protobuf.FileDescriptorProto. Those messages describe all parts
  * of the source file that are required to generate code for them.
+ *
+ * DescriptorSet resolves references between the descriptors, hides
+ * implementation details like synthetic map entry messages, and provides
+ * simple access to comments.
  */
 export interface DescriptorSet {
   /**
@@ -58,6 +62,20 @@ export interface DescriptorSet {
    */
   readonly extensions: ReadonlyMap<string, DescExtension>;
 }
+
+/**
+ * A union of all descriptors, discriminated by a `kind` property.
+ */
+export type AnyDesc =
+  | DescFile
+  | DescEnum
+  | DescEnumValue
+  | DescMessage
+  | DescField
+  | DescExtension
+  | DescOneof
+  | DescService
+  | DescMethod;
 
 /**
  * Describes a protobuf source file.
@@ -100,14 +118,17 @@ export interface DescFile {
    * The compiler-generated descriptor.
    */
   readonly proto: FileDescriptorProto;
+
   /**
    * Get comments on the syntax element in the protobuf source.
    */
   getSyntaxComments(): DescComments;
+
   /**
    * Get comments on the package element in the protobuf source.
    */
   getPackageComments(): DescComments;
+
   toString(): string;
 }
 
@@ -149,10 +170,12 @@ export interface DescEnum {
    * The compiler-generated descriptor.
    */
   readonly proto: EnumDescriptorProto;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   toString(): string;
 }
 
@@ -181,15 +204,18 @@ export interface DescEnumValue {
    * The compiler-generated descriptor.
    */
   readonly proto: EnumValueDescriptorProto;
+
   /**
    * Return a string that (closely) matches the definition of the enumeration
    * value in the protobuf source.
    */
   declarationString(): string;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   toString(): string;
 }
 
@@ -250,10 +276,12 @@ export interface DescMessage {
    * The compiler-generated descriptor.
    */
   readonly proto: DescriptorProto;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   toString(): string;
 }
 
@@ -262,6 +290,8 @@ export interface DescMessage {
  */
 export type DescField = DescFieldCommon &
   (DescFieldScalar | DescFieldMessage | DescFieldEnum | DescFieldMap) & {
+    kind: "field";
+
     /**
      * The message this field is declared on.
      */
@@ -273,6 +303,8 @@ export type DescField = DescFieldCommon &
  */
 export type DescExtension = DescFieldCommon &
   (DescFieldScalar | DescFieldMessage | DescFieldEnum | DescFieldMap) & {
+    kind: "extension";
+
     /**
      * The fully qualified name of the extension.
      */
@@ -332,20 +364,23 @@ interface DescFieldCommon {
    * The compiler-generated descriptor.
    */
   readonly proto: FieldDescriptorProto;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   /**
    * Return a string that (closely) matches the definition of the field in the
    * protobuf source.
    */
   declarationString(): string;
+
   toString(): string;
 }
 
 interface DescFieldScalar {
-  readonly kind: "scalar_field";
+  readonly fieldKind: "scalar";
   /**
    * Is the field repeated?
    */
@@ -370,6 +405,7 @@ interface DescFieldScalar {
    * The map value type, if this is a map field.
    */
   readonly mapValue: undefined;
+
   /**
    * Return the default value specified in the protobuf source.
    * Only valid for proto2 syntax.
@@ -384,7 +420,7 @@ interface DescFieldScalar {
 }
 
 interface DescFieldMessage {
-  readonly kind: "message_field";
+  readonly fieldKind: "message";
   /**
    * Is the field repeated?
    */
@@ -412,7 +448,7 @@ interface DescFieldMessage {
 }
 
 interface DescFieldEnum {
-  readonly kind: "enum_field";
+  readonly fieldKind: "enum";
   /**
    * Is the field repeated?
    */
@@ -437,6 +473,7 @@ interface DescFieldEnum {
    * The map value type, if this is a map field.
    */
   readonly mapValue: undefined;
+
   /**
    * Return the default value specified in the protobuf source.
    * Only valid for proto2 syntax.
@@ -451,7 +488,7 @@ interface DescFieldEnum {
 }
 
 interface DescFieldMap {
-  readonly kind: "map_field";
+  readonly fieldKind: "map";
   /**
    * Is the field repeated?
    */
@@ -559,10 +596,12 @@ export interface DescOneof {
    * The compiler-generated descriptor.
    */
   readonly proto: OneofDescriptorProto;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   toString(): string;
 }
 
@@ -595,10 +634,12 @@ export interface DescService {
    * The compiler-generated descriptor.
    */
   readonly proto: ServiceDescriptorProto;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   toString(): string;
 }
 
@@ -639,10 +680,12 @@ export interface DescMethod {
    * The compiler-generated descriptor.
    */
   readonly proto: MethodDescriptorProto;
+
   /**
    * Get comments on the element in the protobuf source.
    */
   getComments(): DescComments;
+
   toString(): string;
 }
 

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -60,6 +60,7 @@ export {
 
 export {
   DescriptorSet,
+  AnyDesc,
   DescFile,
   DescEnum,
   DescEnumValue,

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -67,7 +67,7 @@ export function unwrapField<T extends Message<T>>(
 export function getUnwrappedFieldType(
   field: DescField
 ): ScalarType | undefined {
-  if (field.kind !== "message_field") {
+  if (field.fieldKind !== "message") {
     return undefined;
   }
   if (field.repeated) {

--- a/packages/protobuf/src/private/names.ts
+++ b/packages/protobuf/src/private/names.ts
@@ -40,10 +40,7 @@ export function localName(
     | DescMethod
 ): string {
   switch (desc.kind) {
-    case "enum_field":
-    case "message_field":
-    case "map_field":
-    case "scalar_field":
+    case "field":
       return localFieldName(desc.name, desc.oneof !== undefined);
     case "oneof":
       return localOneofName(desc.name);

--- a/packages/protoc-gen-es/src/javascript.ts
+++ b/packages/protoc-gen-es/src/javascript.ts
@@ -102,11 +102,11 @@ export function generateFieldInfo(schema: Schema, f: GeneratedFile, field: DescF
   if (field.jsonName !== undefined) {
     e.push(`jsonName: "`, field.jsonName, `", `);
   }
-  switch (field.kind) {
-    case "scalar_field":
+  switch (field.fieldKind) {
+    case "scalar":
       e.push(`kind: "scalar", T: `, field.scalar, ` /* ScalarType.`, ScalarType[field.scalar], ` */, `);
       break;
-    case "map_field":
+    case "map":
       e.push(`kind: "map", K: `, field.mapKey, ` /* ScalarType.`, ScalarType[field.mapKey], ` */, `);
       switch (field.mapValue.kind) {
         case "scalar":
@@ -120,10 +120,10 @@ export function generateFieldInfo(schema: Schema, f: GeneratedFile, field: DescF
           break;
       }
       break;
-    case "message_field":
+    case "message":
       e.push(`kind: "message", T: `, field.message, `, `);
       break;
-    case "enum_field":
+    case "enum":
       e.push(`kind: "enum", T: `, protoN, `.getEnumType(`, field.enum, `), `);
       break;
   }

--- a/packages/protoc-gen-es/src/match-wkt.ts
+++ b/packages/protoc-gen-es/src/match-wkt.ts
@@ -37,21 +37,21 @@ type DescWkt =
     }
   | {
       typeName: "google.protobuf.Struct";
-      fields: DescField & { kind: "map_field" };
+      fields: DescField & { fieldKind: "map" };
     }
   | {
       typeName: "google.protobuf.Value";
       kind: DescOneof;
-      nullValue: DescField & { kind: "enum_field" };
+      nullValue: DescField & { fieldKind: "enum" };
       numberValue: DescField;
       stringValue: DescField;
       boolValue: DescField;
-      structValue: DescField & { kind: "message_field" };
-      listValue: DescField & { kind: "message_field" };
+      structValue: DescField & { fieldKind: "message" };
+      listValue: DescField & { fieldKind: "message" };
     }
   | {
       typeName: "google.protobuf.ListValue";
-      values: DescField & { kind: "message_field" };
+      values: DescField & { fieldKind: "message" };
     }
   | {
       typeName: "google.protobuf.FieldMask";
@@ -59,39 +59,39 @@ type DescWkt =
     }
   | {
       typeName: "google.protobuf.DoubleValue";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.FloatValue";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.Int64Value";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.UInt64Value";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.Int32Value";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.UInt32Value";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.BoolValue";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.StringValue";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     }
   | {
       typeName: "google.protobuf.BytesValue";
-      value: DescField & { kind: "scalar_field" };
+      value: DescField & { fieldKind: "scalar" };
     };
 
 export function matchWkt(message: DescMessage): DescWkt | undefined {
@@ -100,13 +100,13 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
       const typeUrl = message.fields.find(
         (f) =>
           f.number == 1 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.STRING
       );
       const value = message.fields.find(
         (f) =>
           f.number == 2 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.BYTES
       );
       if (typeUrl && value) {
@@ -122,13 +122,13 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
       const seconds = message.fields.find(
         (f) =>
           f.number == 1 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.INT64
       );
       const nanos = message.fields.find(
         (f) =>
           f.number == 2 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.INT32
       );
       if (seconds && nanos) {
@@ -144,13 +144,13 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
       const seconds = message.fields.find(
         (f) =>
           f.number == 1 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.INT64
       );
       const nanos = message.fields.find(
         (f) =>
           f.number == 2 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.INT32
       );
       if (seconds && nanos) {
@@ -165,7 +165,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
     case "google.protobuf.Struct": {
       const fields = message.fields.find((f) => f.number == 1 && !f.repeated);
       if (
-        fields?.kind !== "map_field" ||
+        fields?.fieldKind !== "map" ||
         fields.mapValue.kind !== "message" ||
         fields.mapValue.message.typeName !== "google.protobuf.Value"
       ) {
@@ -179,7 +179,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
         (f) => f.number == 1 && f.oneof === kind
       );
       if (
-        nullValue?.kind !== "enum_field" ||
+        nullValue?.fieldKind !== "enum" ||
         nullValue.enum.typeName !== "google.protobuf.NullValue"
       ) {
         return undefined;
@@ -187,21 +187,21 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
       const numberValue = message.fields.find(
         (f) =>
           f.number == 2 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.DOUBLE &&
           f.oneof === kind
       );
       const stringValue = message.fields.find(
         (f) =>
           f.number == 3 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.STRING &&
           f.oneof === kind
       );
       const boolValue = message.fields.find(
         (f) =>
           f.number == 4 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.BOOL &&
           f.oneof === kind
       );
@@ -209,7 +209,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
         (f) => f.number == 5 && f.oneof === kind
       );
       if (
-        structValue?.kind !== "message_field" ||
+        structValue?.fieldKind !== "message" ||
         structValue.message.typeName !== "google.protobuf.Struct"
       ) {
         return undefined;
@@ -218,7 +218,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
         (f) => f.number == 6 && f.oneof === kind
       );
       if (
-        listValue?.kind !== "message_field" ||
+        listValue?.fieldKind !== "message" ||
         listValue.message.typeName !== "google.protobuf.ListValue"
       ) {
         return undefined;
@@ -240,7 +240,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
     case "google.protobuf.ListValue": {
       const values = message.fields.find((f) => f.number == 1 && f.repeated);
       if (
-        values?.kind != "message_field" ||
+        values?.fieldKind != "message" ||
         values.message.typeName !== "google.protobuf.Value"
       ) {
         break;
@@ -251,7 +251,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
       const paths = message.fields.find(
         (f) =>
           f.number == 1 &&
-          f.kind == "scalar_field" &&
+          f.fieldKind == "scalar" &&
           f.scalar === ScalarType.STRING &&
           f.repeated
       );
@@ -275,7 +275,7 @@ export function matchWkt(message: DescMessage): DescWkt | undefined {
       if (!value) {
         break;
       }
-      if (value.kind !== "scalar_field") {
+      if (value.fieldKind !== "scalar") {
         break;
       }
       return { typeName: message.typeName, value };


### PR DESCRIPTION
This extracts a change from #231 that is independently useful:

`DescriptorSet` provides convenient types to work with descriptors. It uses a row of interfaces like `DescMessage`, `DescEnum`, which are discriminated with a `kind` property.

We made a bad call with `DescField`, which needs further discrimination between map fields, message fields, etc.  We added `kind: "map_field"`, `kind: "message_field"`, etc., which makes it cumbersome to identify fields.

This fixes the issue by using `kind: "field"` for `DescField`, and discriminating further with a second discriminator `fieldKind`.

This is a breaking change for anybody inspecting fields from `createDescriptorSet()` or in @bufbuild/protoplugin.