### PR TITLE
Scope out "traditional" approach for proto2 extensions

### DIFF
--- a/packages/protobuf-test/extra/proto2-extend.proto
+++ b/packages/protobuf-test/extra/proto2-extend.proto
@@ -1,0 +1,33 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+option go_package = "github.com/bufbuild/extra";
+
+package spec;
+
+message Proto2Extendee {
+  extensions 100 to max;
+  optional string foo = 1;
+  oneof y {
+    int32 a = 3;
+  }
+}
+
+extend Proto2Extendee {
+  // if we just generate like regular fields, this will totally clash with Proto2Extendee.foo
+  optional string foo = 100;
+  repeated string bar = 101;
+}

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -18,11 +18,7 @@ import { proto3 } from "./proto3.js";
 import { proto2 } from "./proto2.js";
 import type { PartialFieldInfo } from "./field.js";
 import type { EnumType, EnumValueInfo } from "./enum.js";
-import type {
-  IEnumTypeRegistry,
-  IMessageTypeRegistry,
-  IServiceTypeRegistry,
-} from "./type-registry.js";
+import type { IEnumTypeRegistry, IMessageTypeRegistry, IServiceTypeRegistry } from "./type-registry.js";
 import type { MethodInfo, ServiceType } from "./service-type.js";
 import { localName } from "./private/names.js";
 import { Timestamp } from "./google/protobuf/timestamp_pb.js";
@@ -30,12 +26,7 @@ import { Duration } from "./google/protobuf/duration_pb.js";
 import { Any } from "./google/protobuf/any_pb.js";
 import { Empty } from "./google/protobuf/empty_pb.js";
 import { FieldMask } from "./google/protobuf/field_mask_pb.js";
-import {
-  ListValue,
-  NullValue,
-  Struct,
-  Value,
-} from "./google/protobuf/struct_pb.js";
+import { ListValue, NullValue, Struct, Value } from "./google/protobuf/struct_pb.js";
 import { getEnumType } from "./private/enum.js";
 import {
   BoolValue,
@@ -46,7 +37,7 @@ import {
   Int64Value,
   StringValue,
   UInt32Value,
-  UInt64Value,
+  UInt64Value
 } from "./google/protobuf/wrappers_pb.js";
 import { FileDescriptorSet } from "./google/protobuf/descriptor_pb.js";
 import type { DescField, DescriptorSet } from "./descriptor-set.js";
@@ -91,7 +82,7 @@ const wkEnums = [getEnumType(NullValue)];
 export function createRegistryFromDescriptors(
   input: DescriptorSet | FileDescriptorSet | Uint8Array,
   replaceWkt = true
-): IMessageTypeRegistry & IEnumTypeRegistry & IServiceTypeRegistry {
+): IMessageTypeRegistry & IEnumTypeRegistry & IServiceTypeRegistry /*& IExtensionRegistry*/ {
   const set: DescriptorSet =
     input instanceof Uint8Array || input instanceof FileDescriptorSet
       ? createDescriptorSet(input)
@@ -99,6 +90,7 @@ export function createRegistryFromDescriptors(
   const enums: Record<string, EnumType | undefined> = {};
   const messages: Record<string, MessageType | undefined> = {};
   const services: Record<string, ServiceType | undefined> = {};
+  // const extensions: Record<string, Extension | undefined> = {};
   if (replaceWkt) {
     for (const mt of wkMessages) {
       messages[mt.typeName] = mt;

--- a/packages/protobuf/src/create-registry.ts
+++ b/packages/protobuf/src/create-registry.ts
@@ -20,23 +20,25 @@ import type {
   IEnumTypeRegistry,
   IServiceTypeRegistry,
 } from "./type-registry.js";
+import type { Extension } from "./extension.js";
 
 /**
  * Create a new registry from the given types.
  */
 export function createRegistry(
-  ...types: Array<MessageType | EnumType | ServiceType>
-): IMessageTypeRegistry & IEnumTypeRegistry & IServiceTypeRegistry {
+  ...types: Array<MessageType | EnumType | ServiceType | Extension>
+): IMessageTypeRegistry & IEnumTypeRegistry & IServiceTypeRegistry /* & IExtensionRegistry */ {
   const messages: Record<string, MessageType> = {};
   const enums: Record<string, EnumType> = {};
   const services: Record<string, ServiceType> = {};
+  const extensions: Record<string, Extension> = {};
   const registry = {
     /**
      * Add a type to the registry. For messages, the types used in message
      * fields are added recursively. For services, the message types used
      * for requests and responses are added recursively.
      */
-    add(type: MessageType | EnumType | ServiceType): void {
+    add(type: MessageType | EnumType | ServiceType | Extension): void {
       if ("fields" in type) {
         if (!this.findMessage(type.typeName)) {
           messages[type.typeName] = type;
@@ -58,6 +60,8 @@ export function createRegistry(
             this.add(method.O);
           }
         }
+      } else if ("extendee" in type) {
+        extensions[type.typeName] = type;
       } else {
         enums[type.typeName] = type;
       }

--- a/packages/protobuf/src/extension.ts
+++ b/packages/protobuf/src/extension.ts
@@ -1,0 +1,88 @@
+import type { FieldInfo, PartialFieldInfo } from "./field.js";
+import { ScalarType } from "./field.js";
+import type { AnyMessage, Message } from "./message.js";
+import type { MessageType } from "./message-type.js";
+import type { IExtensionRegistry } from "./type-registry.js";
+import { Struct } from "./google/protobuf/struct_pb";
+
+export interface Extension<E extends Message<E> = AnyMessage, V = unknown> {
+
+  /**
+   * The fully qualified name of the extension.
+   */
+  readonly typeName: string;
+
+  readonly extendee: MessageType<E>;
+
+  readonly field: FieldInfo;
+
+  // TODO this would be an alternative, but right now, external functions look preferable
+  // isSet(message: E): boolean;
+  // getValue(message: E): V | undefined;
+  // setValue(message: E, value: V): void;
+  // clearValue(message: E): void;
+}
+
+
+// TODO this is an alternative to Extension.getValue() - this _may_ be the better solution
+function getExtensionValue<E extends Message<E>, V>(extension: Extension<E, V>, extendee: Message<E>): V | undefined {
+  return undefined;
+}
+function setExtensionValue<E extends Message<E>, V>(extension: Extension<E, V>, extendee: Message<E>, value: V): void {
+  //
+}
+function clearExtensionValue<E extends Message<E>, V>(extension: Extension<E, V>, extendee: Message<E>): void {
+  //
+}
+function hasExtensionValue<E extends Message<E>, V>(extension: Extension<E, V>, extendee: Message<E>): boolean {
+  //
+}
+
+
+type DistributiveOmit<T, K extends keyof T> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+type PartialExtensionInfo = DistributiveOmit<PartialFieldInfo, "name" | "oneof">;
+
+
+// TODO this one would expect the name of the extension as the `name` in the field info
+// TODO this needs to be a method of the proto2 and proto3 objects, and normalize the field info
+function createExtension4<E extends Message<E> = AnyMessage, V = unknown>(extendee: MessageType<E>, info: PartialFieldInfo): Extension<E, V> {
+
+}
+
+// TODO this one takes the name of the extension as a separate argument, and a special form of FieldInfo
+// TODO this needs to be a method of the proto2 and proto3 objects, and normalize the field info
+function createExtension3<E extends Message<E> = AnyMessage, V = unknown>(typeName: string, extendee: MessageType<E>, field: PartialExtensionInfo): Extension<E, V> {
+
+}
+
+
+// ---
+
+
+const extFoo = createExtension3<Struct, boolean>("foo", Struct, {no: 1, kind: "scalar", T: ScalarType.BOOL, default: "f"});
+
+createExtension3("bar", Struct, {no: 1, kind: "scalar", T: ScalarType.BOOL, default: "f"});
+createExtension4<Struct, boolean>(Struct, {name: "foo", no: 1, kind: "scalar", T: ScalarType.BOOL, default: "f"});
+
+
+function example(m: Struct, bytes: Uint8Array, extensions: IExtensionRegistry) {
+  // TODO do we _need_ an extension registry when for binary I/O? why not simply modify unknown fields in getExtensionValue() etc?
+  m.fromBinary(bytes, {
+    typeRegistry: extensions,
+  });
+  // TODO here we definitely need an extension registry
+  m.toJson({
+    typeRegistry: extensions,
+  })
+  const extFooVal = getExtensionValue(extFoo, m);
+  setExtensionValue(extFoo, m, extFooVal);
+  setExtensionValue(extFoo, m, false);
+  setExtensionValue(extFoo, m, undefined); // TODO this should not accept undefined
+  setExtensionValue(extFoo, m, undefined); // TODO this should not accept undefined
+  if (hasExtensionValue(extFoo, m)) {
+    clearExtensionValue(extFoo, m);
+  }
+}

--- a/packages/protobuf/src/type-registry.ts
+++ b/packages/protobuf/src/type-registry.ts
@@ -15,6 +15,7 @@
 import type { MessageType } from "./message-type.js";
 import type { EnumType } from "./enum.js";
 import type { ServiceType } from "./service-type.js";
+import type { Extension } from "./extension";
 
 /**
  * IMessageTypeRegistry provides look-up for message types.
@@ -44,4 +45,19 @@ export interface IServiceTypeRegistry {
    * Find a service type by its protobuf type name.
    */
   findService(typeName: string): ServiceType | undefined;
+}
+
+/**
+ * IExtensionRegistry provides look-up for extensions.
+ */
+export interface IExtensionRegistry {
+
+  // TODO these methods need to change, according to what's needed for the binary and json format
+
+  findExtensions(extendee: string): Extension[];
+  findExtensionByNumber(no: number, extendee: string): Extension | undefined;
+  /**
+   * Find an extension type by its protobuf type name.
+   */
+  findExtension(typeName: string): Extension | undefined;
 }


### PR DESCRIPTION
This is a starting for full support for proto2 extensions, generating a distinct symbol for each extension field.

Note that it is a very incomplete draft that only investigates the API shape. This may never land.

In contrast to https://github.com/bufbuild/protobuf-es/pull/231, this approach works well for consuming custom options in custom code generators, but requires an extension registry that needs to be populated by the user, and is likely to increase bundle size for users who do not need the feature.