### PR TITLE
Make tsNocheck works correctly

### DIFF
--- a/packages/protoplugin/src/ecmascript/gencommon.ts
+++ b/packages/protoplugin/src/ecmascript/gencommon.ts
@@ -69,7 +69,7 @@ export function makeFilePreamble(
   builder.push(`syntax ${file.syntax})\n`);
   builder.push("/* eslint-disable */\n");
   if (tsNoCheck) {
-    builder.push("/* @ts-nocheck */\n");
+    builder.push("// @ts-nocheck\n");
   }
   builder.push("\n");
   writeLeadingComments(file.getPackageComments());


### PR DESCRIPTION
`/* @ts-nocheck */` won't disable type check. `// @ts-nocheck` is the correct syntax.