### PR TITLE
allow async code generators

### DIFF
--- a/packages/protoplugin-test/src/create-es-plugin.test.ts
+++ b/packages/protoplugin-test/src/create-es-plugin.test.ts
@@ -64,7 +64,7 @@ function generateDts(schema: Schema) {
   generateFile(schema, "_proto.dts");
 }
 
-function verifyOutFiles(
+async function verifyOutFiles(
   plugin: Plugin,
   fixture: OutFixture,
   req?: CodeGeneratorRequest
@@ -76,7 +76,7 @@ function verifyOutFiles(
       "proto/address_book.proto",
       "proto/person.proto",
     ]);
-  const resp = plugin.run(req);
+  const resp = await plugin.run(req);
 
   // The total expected files is the sum of the lengths of the arrays in the
   // given fixture.
@@ -109,48 +109,48 @@ describe("all generators with variant target outs", function () {
       generateDts,
     });
   });
-  test("all targets", () => {
-    verifyOutFiles(protocGenEs, {
+  test("all targets", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
       dts: ["proto/person_proto.dts", "proto/address_book_proto.dts"],
     });
   });
-  test("ts+js", () => {
-    verifyOutFiles(protocGenEs, {
+  test("ts+js", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
     });
   });
-  test("ts+dts", () => {
-    verifyOutFiles(protocGenEs, {
+  test("ts+dts", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
       dts: ["proto/person_proto.dts", "proto/address_book_proto.dts"],
     });
   });
-  test("ts", () => {
-    verifyOutFiles(protocGenEs, {
+  test("ts", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
     });
   });
-  test("js", () => {
+  test("js", async () => {
     // Note the TS generator was not run because we only specified js+dts
     // and provided a generator for both, so there was no need for TS files
-    verifyOutFiles(protocGenEs, {
+    await verifyOutFiles(protocGenEs, {
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
     });
   });
-  test("dts", () => {
+  test("dts", async () => {
     // Note the TS generator was not run because we only specified js+dts
     // and provided a generator for both, so there was no need for TS files
-    verifyOutFiles(protocGenEs, {
+    await verifyOutFiles(protocGenEs, {
       dts: ["proto/person_proto.dts", "proto/address_book_proto.dts"],
     });
   });
-  test("js+dts", () => {
+  test("js+dts", async () => {
     // Note the TS generator was not run because we only specified js+dts
     // and provided a generator for both, so there was no need for TS files
-    verifyOutFiles(protocGenEs, {
+    await verifyOutFiles(protocGenEs, {
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
       dts: ["proto/person_proto.dts", "proto/address_book_proto.dts"],
     });
@@ -172,46 +172,46 @@ describe("no declaration generator with variant target outs", function () {
   // generates.  Our custom generateDts above uses 'dts'.  A better approach
   // would be to use a spy and verify which functions are being called, but
   // Jest currently has an issue with importing the Jest object in TypeScript
-  test("all targets", () => {
-    verifyOutFiles(protocGenEs, {
+  test("all targets", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
       dts: ["proto/person_proto.d.ts", "proto/address_book_proto.d.ts"],
     });
   });
-  test("ts+js", () => {
-    verifyOutFiles(protocGenEs, {
+  test("ts+js", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
     });
   });
-  test("ts+dts", () => {
-    verifyOutFiles(protocGenEs, {
+  test("ts+dts", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
       dts: ["proto/person_proto.d.ts", "proto/address_book_proto.d.ts"],
     });
   });
-  test("ts", () => {
-    verifyOutFiles(protocGenEs, {
+  test("ts", async () => {
+    await verifyOutFiles(protocGenEs, {
       ts: ["proto/person_proto.ts", "proto/address_book_proto.ts"],
     });
   });
-  test("js", () => {
-    verifyOutFiles(protocGenEs, {
+  test("js", async () => {
+    await verifyOutFiles(protocGenEs, {
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
     });
   });
-  test("dts", () => {
-    verifyOutFiles(protocGenEs, {
+  test("dts", async () => {
+    await verifyOutFiles(protocGenEs, {
       dts: ["proto/person_proto.d.ts", "proto/address_book_proto.d.ts"],
     });
   });
-  test("js+dts", () => {
+  test("js+dts", async () => {
     // Note that even though we only requested js+dts, the TS generator
     // ran also because we need it to emit the declaration files.  However,
     // there should be no TS files in the generated output since ts was
-    // not specified as a target out.
-    verifyOutFiles(protocGenEs, {
+    // not specified as a async target out.
+    await verifyOutFiles(protocGenEs, {
       js: ["proto/person_proto.js", "proto/address_book_proto.js"],
       dts: ["proto/person_proto.d.ts", "proto/address_book_proto.d.ts"],
     });
@@ -219,7 +219,7 @@ describe("no declaration generator with variant target outs", function () {
 });
 
 describe("only request one file to generate with variant target outs", function () {
-  test("all targets with all generators", () => {
+  test("all targets with all generators", async () => {
     const req = getCodeGeneratorRequest("target=ts+js+dts", [
       "proto/address_book.proto",
     ]);
@@ -230,7 +230,7 @@ describe("only request one file to generate with variant target outs", function 
       generateJs,
       generateDts,
     });
-    verifyOutFiles(
+    await verifyOutFiles(
       protocGenEs,
       {
         ts: ["proto/address_book_proto.ts"],
@@ -240,7 +240,7 @@ describe("only request one file to generate with variant target outs", function 
       req
     );
   });
-  test("all targets with no dts generator", () => {
+  test("all targets with no dts generator", async () => {
     const req = getCodeGeneratorRequest("target=ts+js+dts", [
       "proto/address_book.proto",
     ]);
@@ -250,7 +250,7 @@ describe("only request one file to generate with variant target outs", function 
       generateTs,
       generateJs,
     });
-    verifyOutFiles(
+    await verifyOutFiles(
       protocGenEs,
       {
         ts: ["proto/address_book_proto.ts"],
@@ -260,7 +260,7 @@ describe("only request one file to generate with variant target outs", function 
       req
     );
   });
-  test("all targets with no js or dts generator", () => {
+  test("all targets with no js or dts generator", async () => {
     const req = getCodeGeneratorRequest("target=ts+js+dts", [
       "proto/address_book.proto",
     ]);
@@ -269,7 +269,7 @@ describe("only request one file to generate with variant target outs", function 
       version: "v0.1.0",
       generateTs,
     });
-    verifyOutFiles(
+    await verifyOutFiles(
       protocGenEs,
       {
         ts: ["proto/address_book_proto.ts"],

--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -20,9 +20,9 @@ import type { Schema } from "@bufbuild/protoplugin/ecmascript";
  * Creates a plugin with the given function to generate TypeScript,
  * runs the plugin, and returns a function to retrieve output files.
  */
-function transpile(
+async function transpile(
   genTs: (schema: Schema) => void
-): (name: string) => string[] {
+): Promise<(name: string) => string[]> {
   const req = new CodeGeneratorRequest({
     parameter: `target=ts+js+dts`,
   });
@@ -31,7 +31,8 @@ function transpile(
     version: "v99.0.0",
     generateTs: genTs,
   });
-  const res = plugin.run(req);
+  const res = await plugin.run(req);
+
   return function linesOf(filename: string): string[] {
     const file = res.file.find((f) => f.name === filename);
     if (!file) {
@@ -43,8 +44,8 @@ function transpile(
 }
 
 describe("transpile", function () {
-  test("ECMAScript types", () => {
-    const linesOf = transpile((schema) => {
+  test("ECMAScript types", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       f.print("export const p = Promise.resolve(true);");
     });
@@ -56,8 +57,8 @@ describe("transpile", function () {
     ]);
   });
 
-  test("TypeScript built-in types", () => {
-    const linesOf = transpile((schema) => {
+  test("TypeScript built-in types", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       f.print("export const n: ReturnType<typeof parseInt> = 1;");
     });
@@ -69,8 +70,8 @@ describe("transpile", function () {
     ]);
   });
 
-  test("DOM types", () => {
-    const linesOf = transpile((schema) => {
+  test("DOM types", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       f.print("export const h = new Headers();");
     });
@@ -82,8 +83,8 @@ describe("transpile", function () {
     ]);
   });
 
-  test("runtime types", () => {
-    const linesOf = transpile((schema) => {
+  test("runtime types", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       f.print("export const j: ", schema.runtime.JsonValue, " = 1;");
     });
@@ -98,8 +99,8 @@ describe("transpile", function () {
     ]);
   });
 
-  test("file preamble", () => {
-    const linesOf = transpile((schema) => {
+  test("file preamble", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       f.preamble({
         kind: "file",
@@ -151,8 +152,8 @@ describe("transpile", function () {
     ]);
   });
 
-  test("unknown type is not inferred correctly", () => {
-    const linesOf = transpile((schema) => {
+  test("unknown type is not inferred correctly", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       const Foo = f.import("Foo", "foo");
       f.print("export function foo() { return new ", Foo, "(); };");
@@ -169,8 +170,8 @@ describe("transpile", function () {
     ]);
   });
 
-  test("unknown type can be typed explicitly", () => {
-    const linesOf = transpile((schema) => {
+  test("unknown type can be typed explicitly", async () => {
+    const linesOf = await transpile((schema) => {
       const f = schema.generateFile("test.ts");
       const Foo = f.import("Foo", "foo");
       f.print("export function foo(): ", Foo, " { return new ", Foo, "(); };");

--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -43,7 +43,7 @@ interface PluginInit {
    *
    * Note that this is required to be provided for plugin initialization.
    */
-  generateTs: (schema: Schema, target: "ts") => void;
+  generateTs: (schema: Schema, target: "ts") => Promise<void> | void;
 
   /**
    * A optional function which will generate JavaScript files based on proto
@@ -55,7 +55,7 @@ interface PluginInit {
    * JavaScript files.  If not, the plugin framework will transpile the files
    * itself.
    */
-  generateJs?: (schema: Schema, target: "js") => void;
+  generateJs?: (schema: Schema, target: "js") => Promise<void> | void;
 
   /**
    * A optional function which will generate TypeScript declaration files
@@ -67,7 +67,7 @@ interface PluginInit {
    * declaration files.  If not, the plugin framework will transpile the files
    * itself.
    */
-  generateDts?: (schema: Schema, target: "dts") => void;
+  generateDts?: (schema: Schema, target: "dts") => Promise<void> | void;
 
   /**
    * A optional function which will transpile a given set of files.
@@ -97,7 +97,7 @@ export function createEcmaScriptPlugin(init: PluginInit): Plugin {
   return {
     name: init.name,
     version: init.version,
-    run(req) {
+    async run(req) {
       const {
         targets,
         tsNocheck,
@@ -132,7 +132,7 @@ export function createEcmaScriptPlugin(init: PluginInit): Plugin {
         (targetJs && !init.generateJs) ||
         (targetDts && !init.generateDts)
       ) {
-        init.generateTs(schema, "ts");
+        await init.generateTs(schema, "ts");
 
         // Save off the generated TypeScript files so that we can pass these
         // to the transpilation process if necessary.  We do not want to pass
@@ -149,7 +149,7 @@ export function createEcmaScriptPlugin(init: PluginInit): Plugin {
 
       if (targetJs) {
         if (init.generateJs) {
-          init.generateJs(schema, "js");
+          await init.generateJs(schema, "js");
         } else {
           transpileJs = true;
         }
@@ -157,7 +157,7 @@ export function createEcmaScriptPlugin(init: PluginInit): Plugin {
 
       if (targetDts) {
         if (init.generateDts) {
-          init.generateDts(schema, "dts");
+          await init.generateDts(schema, "dts");
         } else {
           transpileDts = true;
         }

--- a/packages/protoplugin/src/plugin.ts
+++ b/packages/protoplugin/src/plugin.ts
@@ -34,5 +34,5 @@ export interface Plugin {
   /**
    * Run this plugin for the given request.
    */
-  run(request: CodeGeneratorRequest): CodeGeneratorResponse;
+  run(request: CodeGeneratorRequest): Promise<CodeGeneratorResponse>;
 }

--- a/packages/protoplugin/src/run-node.ts
+++ b/packages/protoplugin/src/run-node.ts
@@ -42,9 +42,9 @@ export function runNodeJs(plugin: Plugin): void {
     return;
   }
   readBytes(process.stdin)
-    .then((data) => {
+    .then(async (data) => {
       const req = CodeGeneratorRequest.fromBinary(data);
-      const res = plugin.run(req);
+      const res = await plugin.run(req);
       return writeBytes(process.stdout, res.toBinary());
     })
     .then(() => process.exit(0))


### PR DESCRIPTION
I am writing a code generator for generating tests for another code generator (lol). I want to ingest test cases by reading a file with `readline` using `AsyncIterator` (test cases encoded from https://github.com/bufbuild/protoc-gen-validate/tree/main/tests/harness in jsond format (line by line)).

In general, I think we should allow this because why not? :-)  