### PR TITLE
Update float tests

### DIFF
--- a/packages/protoplugin-test/proto/service.proto
+++ b/packages/protoplugin-test/proto/service.proto
@@ -23,7 +23,7 @@ option (example_file_option) = "Hello";
 message MessageWithOptions {
   option (example_message_option) = 1234;
 
-  int32 foo = 1 [(example_field_option) = 4.5];
+  int32 foo = 1 [(example_field_option) = 1.23];
   string bar = 2;
   oneof qux {
     option (example_oneof_option) = 42;

--- a/packages/protoplugin-test/src/custom-options.test.ts
+++ b/packages/protoplugin-test/src/custom-options.test.ts
@@ -81,7 +81,10 @@ describe("custom options", function () {
           default: {
             const val = findCustomScalarOption(member, 50002, ScalarType.FLOAT);
             if (member.name === "foo") {
-              expect(val).toEqual(4.5);
+              // The custom option value is set to 1.23, but due to the representation
+              // of floating-point numbers in JavaScript, we need to compare the parsed
+              // result to the nearest 32-bit single precision value.
+              expect(val).toEqual(Math.fround(1.23));
             } else {
               expect(val).toBeUndefined();
             }


### PR DESCRIPTION
This updates the custom option unit test for a float value.  Due to https://github.com/bufbuild/protobuf-es/issues/280, it was realized that the parsed value of a float will not always be equal to the exact value set in the proto file.  Therefore, we need to compare to the nearest 32-bit single precision value.