### PR TITLE
Make wrappers more lenient

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 74,055 b      | 36,960 b | 9,651 b |
+| protobuf-es         | 73,953 b      | 36,801 b | 9,632 b |
 | protobuf-javascript | 370,857 b  | 271,536 b | 43,759 b |

--- a/packages/protobuf-test/extra/wkt-wrappers.proto
+++ b/packages/protobuf-test/extra/wkt-wrappers.proto
@@ -47,5 +47,14 @@ message WrappersMessage {
     repeated google.protobuf.UInt32Value repeated_uint32_value_field = 27;
     repeated google.protobuf.StringValue repeated_string_value_field = 28;
     repeated google.protobuf.BytesValue repeated_bytes_value_field = 29;
+    map<string, google.protobuf.DoubleValue> map_double_value_field = 31;
+    map<string, google.protobuf.BoolValue> map_bool_value_field = 32;
+    map<string, google.protobuf.FloatValue> map_float_value_field = 33;
+    map<string, google.protobuf.Int64Value> map_int64_value_field = 34;
+    map<string, google.protobuf.UInt64Value> map_uint64_value_field = 35;
+    map<string, google.protobuf.Int32Value> map_int32_value_field = 36;
+    map<string, google.protobuf.UInt32Value> map_uint32_value_field = 37;
+    map<string, google.protobuf.StringValue> map_string_value_field = 38;
+    map<string, google.protobuf.BytesValue> map_bytes_value_field = 39;
 
 }

--- a/packages/protobuf-test/src/clone.test.ts
+++ b/packages/protobuf-test/src/clone.test.ts
@@ -25,7 +25,7 @@ import {
 import { WrappersMessage as TS_WrappersMessage } from "./gen/ts/extra/wkt-wrappers_pb.js";
 import { WrappersMessage as JS_WrappersMessage } from "./gen/js/extra/wkt-wrappers_pb.js";
 import { testMT } from "./helpers.js";
-import { protoInt64 } from "@bufbuild/protobuf";
+import { BoolValue, protoInt64 } from "@bufbuild/protobuf";
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
@@ -131,6 +131,14 @@ describe("clone", function () {
       uint32ValueField: 7,
       stringValueField: "a",
       bytesValueField: new Uint8Array([0xff]),
+      repeatedBoolValueField: [
+        new BoolValue({ value: true }),
+        new BoolValue({ value: false }),
+      ],
+      mapBoolValueField: {
+        foo: new BoolValue({ value: true }),
+        bar: new BoolValue({ value: false }),
+      },
     });
     const b = a.clone();
     expect(b).toStrictEqual(a);

--- a/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
@@ -172,6 +172,51 @@ export declare class WrappersMessage extends Message<WrappersMessage> {
    */
   repeatedBytesValueField: BytesValue[];
 
+  /**
+   * @generated from field: map<string, google.protobuf.DoubleValue> map_double_value_field = 31;
+   */
+  mapDoubleValueField: { [key: string]: DoubleValue };
+
+  /**
+   * @generated from field: map<string, google.protobuf.BoolValue> map_bool_value_field = 32;
+   */
+  mapBoolValueField: { [key: string]: BoolValue };
+
+  /**
+   * @generated from field: map<string, google.protobuf.FloatValue> map_float_value_field = 33;
+   */
+  mapFloatValueField: { [key: string]: FloatValue };
+
+  /**
+   * @generated from field: map<string, google.protobuf.Int64Value> map_int64_value_field = 34;
+   */
+  mapInt64ValueField: { [key: string]: Int64Value };
+
+  /**
+   * @generated from field: map<string, google.protobuf.UInt64Value> map_uint64_value_field = 35;
+   */
+  mapUint64ValueField: { [key: string]: UInt64Value };
+
+  /**
+   * @generated from field: map<string, google.protobuf.Int32Value> map_int32_value_field = 36;
+   */
+  mapInt32ValueField: { [key: string]: Int32Value };
+
+  /**
+   * @generated from field: map<string, google.protobuf.UInt32Value> map_uint32_value_field = 37;
+   */
+  mapUint32ValueField: { [key: string]: UInt32Value };
+
+  /**
+   * @generated from field: map<string, google.protobuf.StringValue> map_string_value_field = 38;
+   */
+  mapStringValueField: { [key: string]: StringValue };
+
+  /**
+   * @generated from field: map<string, google.protobuf.BytesValue> map_bytes_value_field = 39;
+   */
+  mapBytesValueField: { [key: string]: BytesValue };
+
   constructor(data?: PartialMessage<WrappersMessage>);
 
   static readonly runtime: typeof proto3;

--- a/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.js
@@ -51,6 +51,15 @@ export const WrappersMessage = proto3.makeMessageType(
     { no: 27, name: "repeated_uint32_value_field", kind: "message", T: UInt32Value, repeated: true },
     { no: 28, name: "repeated_string_value_field", kind: "message", T: StringValue, repeated: true },
     { no: 29, name: "repeated_bytes_value_field", kind: "message", T: BytesValue, repeated: true },
+    { no: 31, name: "map_double_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: DoubleValue} },
+    { no: 32, name: "map_bool_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: BoolValue} },
+    { no: 33, name: "map_float_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: FloatValue} },
+    { no: 34, name: "map_int64_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Int64Value} },
+    { no: 35, name: "map_uint64_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: UInt64Value} },
+    { no: 36, name: "map_int32_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Int32Value} },
+    { no: 37, name: "map_uint32_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: UInt32Value} },
+    { no: 38, name: "map_string_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: StringValue} },
+    { no: 39, name: "map_bytes_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: BytesValue} },
   ],
 );
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.d.ts
@@ -67,7 +67,7 @@ export declare class DoubleValue extends Message<DoubleValue> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: number | DoubleValue): DoubleValue,
+    wrapField(value: number): DoubleValue,
     unwrapField(value: DoubleValue): number,
   };
 
@@ -102,7 +102,7 @@ export declare class FloatValue extends Message<FloatValue> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: number | FloatValue): FloatValue,
+    wrapField(value: number): FloatValue,
     unwrapField(value: FloatValue): number,
   };
 
@@ -137,7 +137,7 @@ export declare class Int64Value extends Message<Int64Value> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: bigint | Int64Value): Int64Value,
+    wrapField(value: bigint): Int64Value,
     unwrapField(value: Int64Value): bigint,
   };
 
@@ -172,7 +172,7 @@ export declare class UInt64Value extends Message<UInt64Value> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: bigint | UInt64Value): UInt64Value,
+    wrapField(value: bigint): UInt64Value,
     unwrapField(value: UInt64Value): bigint,
   };
 
@@ -207,7 +207,7 @@ export declare class Int32Value extends Message<Int32Value> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: number | Int32Value): Int32Value,
+    wrapField(value: number): Int32Value,
     unwrapField(value: Int32Value): number,
   };
 
@@ -242,7 +242,7 @@ export declare class UInt32Value extends Message<UInt32Value> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: number | UInt32Value): UInt32Value,
+    wrapField(value: number): UInt32Value,
     unwrapField(value: UInt32Value): number,
   };
 
@@ -277,7 +277,7 @@ export declare class BoolValue extends Message<BoolValue> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: boolean | BoolValue): BoolValue,
+    wrapField(value: boolean): BoolValue,
     unwrapField(value: BoolValue): boolean,
   };
 
@@ -312,7 +312,7 @@ export declare class StringValue extends Message<StringValue> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: string | StringValue): StringValue,
+    wrapField(value: string): StringValue,
     unwrapField(value: StringValue): string,
   };
 
@@ -347,7 +347,7 @@ export declare class BytesValue extends Message<BytesValue> {
   static readonly fields: FieldList;
 
   static readonly fieldWrapper: {
-    wrapField(value: Uint8Array | BytesValue): BytesValue,
+    wrapField(value: Uint8Array): BytesValue,
     unwrapField(value: BytesValue): Uint8Array,
   };
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.js
@@ -77,7 +77,7 @@ DoubleValue.prototype.fromJson = function fromJson(json, options) {
 
 DoubleValue.fieldWrapper = {
   wrapField(value) {
-    return value instanceof DoubleValue ? value : new DoubleValue({value});
+    return new DoubleValue({value});
   },
   unwrapField(value) {
     return value.value;
@@ -117,7 +117,7 @@ FloatValue.prototype.fromJson = function fromJson(json, options) {
 
 FloatValue.fieldWrapper = {
   wrapField(value) {
-    return value instanceof FloatValue ? value : new FloatValue({value});
+    return new FloatValue({value});
   },
   unwrapField(value) {
     return value.value;
@@ -157,7 +157,7 @@ Int64Value.prototype.fromJson = function fromJson(json, options) {
 
 Int64Value.fieldWrapper = {
   wrapField(value) {
-    return value instanceof Int64Value ? value : new Int64Value({value});
+    return new Int64Value({value});
   },
   unwrapField(value) {
     return value.value;
@@ -197,7 +197,7 @@ UInt64Value.prototype.fromJson = function fromJson(json, options) {
 
 UInt64Value.fieldWrapper = {
   wrapField(value) {
-    return value instanceof UInt64Value ? value : new UInt64Value({value});
+    return new UInt64Value({value});
   },
   unwrapField(value) {
     return value.value;
@@ -237,7 +237,7 @@ Int32Value.prototype.fromJson = function fromJson(json, options) {
 
 Int32Value.fieldWrapper = {
   wrapField(value) {
-    return value instanceof Int32Value ? value : new Int32Value({value});
+    return new Int32Value({value});
   },
   unwrapField(value) {
     return value.value;
@@ -277,7 +277,7 @@ UInt32Value.prototype.fromJson = function fromJson(json, options) {
 
 UInt32Value.fieldWrapper = {
   wrapField(value) {
-    return value instanceof UInt32Value ? value : new UInt32Value({value});
+    return new UInt32Value({value});
   },
   unwrapField(value) {
     return value.value;
@@ -317,7 +317,7 @@ BoolValue.prototype.fromJson = function fromJson(json, options) {
 
 BoolValue.fieldWrapper = {
   wrapField(value) {
-    return value instanceof BoolValue ? value : new BoolValue({value});
+    return new BoolValue({value});
   },
   unwrapField(value) {
     return value.value;
@@ -357,7 +357,7 @@ StringValue.prototype.fromJson = function fromJson(json, options) {
 
 StringValue.fieldWrapper = {
   wrapField(value) {
-    return value instanceof StringValue ? value : new StringValue({value});
+    return new StringValue({value});
   },
   unwrapField(value) {
     return value.value;
@@ -397,7 +397,7 @@ BytesValue.prototype.fromJson = function fromJson(json, options) {
 
 BytesValue.fieldWrapper = {
   wrapField(value) {
-    return value instanceof BytesValue ? value : new BytesValue({value});
+    return new BytesValue({value});
   },
   unwrapField(value) {
     return value.value;

--- a/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
@@ -172,6 +172,51 @@ export class WrappersMessage extends Message<WrappersMessage> {
    */
   repeatedBytesValueField: BytesValue[] = [];
 
+  /**
+   * @generated from field: map<string, google.protobuf.DoubleValue> map_double_value_field = 31;
+   */
+  mapDoubleValueField: { [key: string]: DoubleValue } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.BoolValue> map_bool_value_field = 32;
+   */
+  mapBoolValueField: { [key: string]: BoolValue } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.FloatValue> map_float_value_field = 33;
+   */
+  mapFloatValueField: { [key: string]: FloatValue } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.Int64Value> map_int64_value_field = 34;
+   */
+  mapInt64ValueField: { [key: string]: Int64Value } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.UInt64Value> map_uint64_value_field = 35;
+   */
+  mapUint64ValueField: { [key: string]: UInt64Value } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.Int32Value> map_int32_value_field = 36;
+   */
+  mapInt32ValueField: { [key: string]: Int32Value } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.UInt32Value> map_uint32_value_field = 37;
+   */
+  mapUint32ValueField: { [key: string]: UInt32Value } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.StringValue> map_string_value_field = 38;
+   */
+  mapStringValueField: { [key: string]: StringValue } = {};
+
+  /**
+   * @generated from field: map<string, google.protobuf.BytesValue> map_bytes_value_field = 39;
+   */
+  mapBytesValueField: { [key: string]: BytesValue } = {};
+
   constructor(data?: PartialMessage<WrappersMessage>) {
     super();
     proto3.util.initPartial(data, this);
@@ -207,6 +252,15 @@ export class WrappersMessage extends Message<WrappersMessage> {
     { no: 27, name: "repeated_uint32_value_field", kind: "message", T: UInt32Value, repeated: true },
     { no: 28, name: "repeated_string_value_field", kind: "message", T: StringValue, repeated: true },
     { no: 29, name: "repeated_bytes_value_field", kind: "message", T: BytesValue, repeated: true },
+    { no: 31, name: "map_double_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: DoubleValue} },
+    { no: 32, name: "map_bool_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: BoolValue} },
+    { no: 33, name: "map_float_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: FloatValue} },
+    { no: 34, name: "map_int64_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Int64Value} },
+    { no: 35, name: "map_uint64_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: UInt64Value} },
+    { no: 36, name: "map_int32_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Int32Value} },
+    { no: 37, name: "map_uint32_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: UInt32Value} },
+    { no: 38, name: "map_string_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: StringValue} },
+    { no: 39, name: "map_bytes_value_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: BytesValue} },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): WrappersMessage {

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/wrappers_pb.ts
@@ -89,8 +89,8 @@ export class DoubleValue extends Message<DoubleValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | DoubleValue): DoubleValue {
-      return value instanceof DoubleValue ? value : new DoubleValue({value});
+    wrapField(value: number): DoubleValue {
+      return new DoubleValue({value});
     },
     unwrapField(value: DoubleValue): number {
       return value.value;
@@ -158,8 +158,8 @@ export class FloatValue extends Message<FloatValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | FloatValue): FloatValue {
-      return value instanceof FloatValue ? value : new FloatValue({value});
+    wrapField(value: number): FloatValue {
+      return new FloatValue({value});
     },
     unwrapField(value: FloatValue): number {
       return value.value;
@@ -227,8 +227,8 @@ export class Int64Value extends Message<Int64Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: bigint | Int64Value): Int64Value {
-      return value instanceof Int64Value ? value : new Int64Value({value});
+    wrapField(value: bigint): Int64Value {
+      return new Int64Value({value});
     },
     unwrapField(value: Int64Value): bigint {
       return value.value;
@@ -296,8 +296,8 @@ export class UInt64Value extends Message<UInt64Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: bigint | UInt64Value): UInt64Value {
-      return value instanceof UInt64Value ? value : new UInt64Value({value});
+    wrapField(value: bigint): UInt64Value {
+      return new UInt64Value({value});
     },
     unwrapField(value: UInt64Value): bigint {
       return value.value;
@@ -365,8 +365,8 @@ export class Int32Value extends Message<Int32Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | Int32Value): Int32Value {
-      return value instanceof Int32Value ? value : new Int32Value({value});
+    wrapField(value: number): Int32Value {
+      return new Int32Value({value});
     },
     unwrapField(value: Int32Value): number {
       return value.value;
@@ -434,8 +434,8 @@ export class UInt32Value extends Message<UInt32Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | UInt32Value): UInt32Value {
-      return value instanceof UInt32Value ? value : new UInt32Value({value});
+    wrapField(value: number): UInt32Value {
+      return new UInt32Value({value});
     },
     unwrapField(value: UInt32Value): number {
       return value.value;
@@ -503,8 +503,8 @@ export class BoolValue extends Message<BoolValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: boolean | BoolValue): BoolValue {
-      return value instanceof BoolValue ? value : new BoolValue({value});
+    wrapField(value: boolean): BoolValue {
+      return new BoolValue({value});
     },
     unwrapField(value: BoolValue): boolean {
       return value.value;
@@ -572,8 +572,8 @@ export class StringValue extends Message<StringValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: string | StringValue): StringValue {
-      return value instanceof StringValue ? value : new StringValue({value});
+    wrapField(value: string): StringValue {
+      return new StringValue({value});
     },
     unwrapField(value: StringValue): string {
       return value.value;
@@ -641,8 +641,8 @@ export class BytesValue extends Message<BytesValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: Uint8Array | BytesValue): BytesValue {
-      return value instanceof BytesValue ? value : new BytesValue({value});
+    wrapField(value: Uint8Array): BytesValue {
+      return new BytesValue({value});
     },
     unwrapField(value: BytesValue): Uint8Array {
       return value.value;

--- a/packages/protobuf-test/src/mixing-instances.test.ts
+++ b/packages/protobuf-test/src/mixing-instances.test.ts
@@ -1,0 +1,49 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  MessageFieldMessage as TS_MessageFieldMessage,
+  MessageFieldMessage_TestMessage as TS_MessageFieldMessage_TestMessage,
+} from "./gen/ts/extra/msg-message_pb.js";
+import { MessageFieldMessage_TestMessage as JS_MessageFieldMessage_TestMessage } from "./gen/js/extra/msg-message_pb.js";
+
+describe("mixing message instances", () => {
+  const message = new TS_MessageFieldMessage();
+  message.messageField = new JS_MessageFieldMessage_TestMessage({
+    name: "foo",
+  });
+  test("serializes to the binary format", () => {
+    const bytes = message.toBinary();
+    const message2 = TS_MessageFieldMessage.fromBinary(bytes);
+    expect(message2.messageField?.name).toBe("foo");
+  });
+  test("serializes to JSON", () => {
+    const jsonString = message.toJsonString();
+    const message2 = TS_MessageFieldMessage.fromJsonString(jsonString);
+    expect(message2.messageField?.name).toBe("foo");
+  });
+});
+
+describe("mixing message instances in the constructor", () => {
+  test("normalizes by creating a new instance", () => {
+    const test = new JS_MessageFieldMessage_TestMessage({ name: "foo" });
+    const message = new TS_MessageFieldMessage({
+      messageField: test,
+    });
+    expect(message.messageField?.name).toBe("foo");
+    expect(message.messageField).toBeInstanceOf(
+      TS_MessageFieldMessage_TestMessage
+    );
+  });
+});

--- a/packages/protobuf-test/src/wkt-wrappers.test.ts
+++ b/packages/protobuf-test/src/wkt-wrappers.test.ts
@@ -15,58 +15,145 @@
 import { WrappersMessage as TS_WrappersMessage } from "./gen/ts/extra/wkt-wrappers_pb.js";
 import { WrappersMessage as JS_WrappersMessage } from "./gen/js/extra/wkt-wrappers_pb.js";
 import { describeMT } from "./helpers";
-import { protoInt64 } from "@bufbuild/protobuf";
+import { BoolValue, protoInt64 } from "@bufbuild/protobuf";
 
 describeMT(
   { ts: TS_WrappersMessage, js: JS_WrappersMessage },
   (messageType) => {
-    test("wrapper field is unset by default", () => {
-      const w = new messageType();
-      expect(w.doubleValueField).toBeUndefined();
-      expect(w.boolValueField).toBeUndefined();
-      expect(w.floatValueField).toBeUndefined();
-      expect(w.int64ValueField).toBeUndefined();
-      expect(w.uint64ValueField).toBeUndefined();
-      expect(w.int32ValueField).toBeUndefined();
-      expect(w.uint32ValueField).toBeUndefined();
-      expect(w.stringValueField).toBeUndefined();
-      expect(w.bytesValueField).toBeUndefined();
-    });
-    test("unwrapped wrapper field is accepted in constructor", () => {
-      const w = new messageType({
-        doubleValueField: 1.2,
-        boolValueField: true,
-        floatValueField: 1.3,
-        int64ValueField: protoInt64.parse(4),
-        uint64ValueField: protoInt64.parse(5),
-        int32ValueField: 6,
-        uint32ValueField: 7,
-        stringValueField: "a",
-        bytesValueField: new Uint8Array([0xff]),
+    describe("singular fields", () => {
+      test("wrapper field is unset by default", () => {
+        const w = new messageType();
+        expect(w.doubleValueField).toBeUndefined();
+        expect(w.boolValueField).toBeUndefined();
+        expect(w.floatValueField).toBeUndefined();
+        expect(w.int64ValueField).toBeUndefined();
+        expect(w.uint64ValueField).toBeUndefined();
+        expect(w.int32ValueField).toBeUndefined();
+        expect(w.uint32ValueField).toBeUndefined();
+        expect(w.stringValueField).toBeUndefined();
+        expect(w.bytesValueField).toBeUndefined();
       });
-      expect(w.doubleValueField).toBe(1.2);
-      expect(w.boolValueField).toBe(true);
-      expect(w.floatValueField).toBe(1.3);
-      expect(w.int64ValueField).toBe(protoInt64.parse(4));
-      expect(w.uint64ValueField).toBe(protoInt64.parse(5));
-      expect(w.int32ValueField).toBe(6);
-      expect(w.uint32ValueField).toBe(7);
-      expect(w.stringValueField).toBe("a");
-      expect(w.bytesValueField).toStrictEqual(new Uint8Array([0xff]));
-    });
-    test("unset wrapper field is omitted in JSON", () => {
-      const w = new messageType();
-      const got = w.toJsonString();
-      const want = `{}`;
-      expect(got).toBe(want);
-    });
-    test("set wrapper field is not omitted in JSON", () => {
-      const w = new messageType({
-        boolValueField: true,
+      test("unwrapped wrapper field is accepted in constructor", () => {
+        const w = new messageType({
+          doubleValueField: 1.2,
+          boolValueField: true,
+          floatValueField: 1.3,
+          int64ValueField: protoInt64.parse(4),
+          uint64ValueField: protoInt64.parse(5),
+          int32ValueField: 6,
+          uint32ValueField: 7,
+          stringValueField: "a",
+          bytesValueField: new Uint8Array([0xff]),
+        });
+        expect(w.doubleValueField).toBe(1.2);
+        expect(w.boolValueField).toBe(true);
+        expect(w.floatValueField).toBe(1.3);
+        expect(w.int64ValueField).toBe(protoInt64.parse(4));
+        expect(w.uint64ValueField).toBe(protoInt64.parse(5));
+        expect(w.int32ValueField).toBe(6);
+        expect(w.uint32ValueField).toBe(7);
+        expect(w.stringValueField).toBe("a");
+        expect(w.bytesValueField).toStrictEqual(new Uint8Array([0xff]));
       });
-      const got = w.toJsonString();
-      const want = `{"boolValueField":true}`;
-      expect(got).toBe(want);
+      test("unset wrapper field is omitted in JSON", () => {
+        const w = new messageType();
+        const got = w.toJsonString();
+        const want = `{}`;
+        expect(got).toBe(want);
+      });
+      test("set wrapper field is not omitted in JSON", () => {
+        const w = new messageType({
+          boolValueField: true,
+        });
+        const got = w.toJsonString();
+        const want = `{"boolValueField":true}`;
+        expect(got).toBe(want);
+      });
+    });
+    describe("oneof fields", () => {
+      const w = new messageType({
+        oneofFields: {
+          case: "oneofBoolValueField",
+          value: new BoolValue({ value: false }),
+        },
+      });
+      test("construct as expected", () => {
+        expect(w.oneofFields.case).toBe("oneofBoolValueField");
+        expect(w.oneofFields.value?.value).toBe(false);
+      });
+      test("clone as expected", () => {
+        const wClone = w.clone();
+        expect(wClone.oneofFields.case).toBe("oneofBoolValueField");
+        expect(wClone.oneofFields.value?.value).toBe(false);
+      });
+      test("serialize to binary", () => {
+        const wBinary = messageType.fromBinary(w.toBinary());
+        expect(wBinary.oneofFields.case).toBe("oneofBoolValueField");
+        expect(wBinary.oneofFields.value?.value).toBe(false);
+      });
+      test("serialize to JSON", () => {
+        const wJson = messageType.fromJsonString(w.toJsonString());
+        expect(wJson.oneofFields.case).toBe("oneofBoolValueField");
+        expect(wJson.oneofFields.value?.value).toBe(false);
+      });
+    });
+    describe("repeated fields", () => {
+      const w = new messageType({
+        repeatedBoolValueField: [
+          new BoolValue({ value: true }),
+          new BoolValue({ value: false }),
+        ],
+      });
+      test("construct as expected", () => {
+        expect(w.repeatedBoolValueField.length).toBe(2);
+        expect(w.repeatedBoolValueField[0]?.value).toBe(true);
+        expect(w.repeatedBoolValueField[1]?.value).toBe(false);
+      });
+      test("clone as expected", () => {
+        const wClone = w.clone();
+        expect(wClone.repeatedBoolValueField.length).toBe(2);
+        expect(wClone.repeatedBoolValueField[0]?.value).toBe(true);
+        expect(wClone.repeatedBoolValueField[1]?.value).toBe(false);
+      });
+      test("serialize to binary", () => {
+        const wBinary = messageType.fromBinary(w.toBinary());
+        expect(wBinary.repeatedBoolValueField.length).toBe(2);
+        expect(wBinary.repeatedBoolValueField[0]?.value).toBe(true);
+        expect(wBinary.repeatedBoolValueField[1]?.value).toBe(false);
+      });
+      test("serialize to JSON", () => {
+        const wJson = messageType.fromJsonString(w.toJsonString());
+        expect(wJson.repeatedBoolValueField.length).toBe(2);
+        expect(wJson.repeatedBoolValueField[0]?.value).toBe(true);
+        expect(wJson.repeatedBoolValueField[1]?.value).toBe(false);
+      });
+    });
+    describe("map fields", () => {
+      const w = new messageType({
+        mapBoolValueField: {
+          foo: new BoolValue({ value: true }),
+          bar: new BoolValue({ value: false }),
+        },
+      });
+      test("construct as expected", () => {
+        expect(w.mapBoolValueField["foo"].value).toBe(true);
+        expect(w.mapBoolValueField["bar"].value).toBe(false);
+      });
+      test("clone as expected", () => {
+        const wClone = w.clone();
+        expect(wClone.mapBoolValueField["foo"].value).toBe(true);
+        expect(wClone.mapBoolValueField["bar"].value).toBe(false);
+      });
+      test("serialize to binary", () => {
+        const wBinary = messageType.fromBinary(w.toBinary());
+        expect(wBinary.mapBoolValueField["foo"].value).toBe(true);
+        expect(wBinary.mapBoolValueField["bar"].value).toBe(false);
+      });
+      test("serialize to JSON", () => {
+        const wJson = messageType.fromJsonString(w.toJsonString());
+        expect(wJson.mapBoolValueField["foo"].value).toBe(true);
+        expect(wJson.mapBoolValueField["bar"].value).toBe(false);
+      });
     });
   }
 );

--- a/packages/protobuf/src/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf/src/google/protobuf/wrappers_pb.ts
@@ -79,8 +79,8 @@ export class DoubleValue extends Message<DoubleValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | DoubleValue): DoubleValue {
-      return value instanceof DoubleValue ? value : new DoubleValue({value});
+    wrapField(value: number): DoubleValue {
+      return new DoubleValue({value});
     },
     unwrapField(value: DoubleValue): number {
       return value.value;
@@ -148,8 +148,8 @@ export class FloatValue extends Message<FloatValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | FloatValue): FloatValue {
-      return value instanceof FloatValue ? value : new FloatValue({value});
+    wrapField(value: number): FloatValue {
+      return new FloatValue({value});
     },
     unwrapField(value: FloatValue): number {
       return value.value;
@@ -217,8 +217,8 @@ export class Int64Value extends Message<Int64Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: bigint | Int64Value): Int64Value {
-      return value instanceof Int64Value ? value : new Int64Value({value});
+    wrapField(value: bigint): Int64Value {
+      return new Int64Value({value});
     },
     unwrapField(value: Int64Value): bigint {
       return value.value;
@@ -286,8 +286,8 @@ export class UInt64Value extends Message<UInt64Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: bigint | UInt64Value): UInt64Value {
-      return value instanceof UInt64Value ? value : new UInt64Value({value});
+    wrapField(value: bigint): UInt64Value {
+      return new UInt64Value({value});
     },
     unwrapField(value: UInt64Value): bigint {
       return value.value;
@@ -355,8 +355,8 @@ export class Int32Value extends Message<Int32Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | Int32Value): Int32Value {
-      return value instanceof Int32Value ? value : new Int32Value({value});
+    wrapField(value: number): Int32Value {
+      return new Int32Value({value});
     },
     unwrapField(value: Int32Value): number {
       return value.value;
@@ -424,8 +424,8 @@ export class UInt32Value extends Message<UInt32Value> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: number | UInt32Value): UInt32Value {
-      return value instanceof UInt32Value ? value : new UInt32Value({value});
+    wrapField(value: number): UInt32Value {
+      return new UInt32Value({value});
     },
     unwrapField(value: UInt32Value): number {
       return value.value;
@@ -493,8 +493,8 @@ export class BoolValue extends Message<BoolValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: boolean | BoolValue): BoolValue {
-      return value instanceof BoolValue ? value : new BoolValue({value});
+    wrapField(value: boolean): BoolValue {
+      return new BoolValue({value});
     },
     unwrapField(value: BoolValue): boolean {
       return value.value;
@@ -562,8 +562,8 @@ export class StringValue extends Message<StringValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: string | StringValue): StringValue {
-      return value instanceof StringValue ? value : new StringValue({value});
+    wrapField(value: string): StringValue {
+      return new StringValue({value});
     },
     unwrapField(value: StringValue): string {
       return value.value;
@@ -631,8 +631,8 @@ export class BytesValue extends Message<BytesValue> {
   ]);
 
   static readonly fieldWrapper = {
-    wrapField(value: Uint8Array | BytesValue): BytesValue {
-      return value instanceof BytesValue ? value : new BytesValue({value});
+    wrapField(value: Uint8Array): BytesValue {
+      return new BytesValue({value});
     },
     unwrapField(value: BytesValue): Uint8Array {
       return value.value;

--- a/packages/protobuf/src/private/binary-format-common.ts
+++ b/packages/protobuf/src/private/binary-format-common.ts
@@ -24,9 +24,9 @@ import type {
   BinaryWriteOptions,
 } from "../binary-format.js";
 import type { BinaryFormat } from "../binary-format.js";
-import type { Message } from "../message.js";
+import { Message } from "../message.js";
 import { FieldInfo, ScalarType } from "../field.js";
-import { unwrapField, wrapField } from "./field-wrapper.js";
+import { wrapField } from "./field-wrapper.js";
 import { scalarDefaultValue, scalarTypeInfo } from "./scalars.js";
 import { assert } from "./assert.js";
 import type { MessageType } from "../message-type.js";
@@ -152,16 +152,22 @@ export function makeBinaryFormatCommon(): Omit<BinaryFormat, "writeMessage"> {
                 messageType.fromBinary(reader.bytes(), options)
               );
             } else {
-              if (target[localName] instanceof messageType) {
-                (target[localName] as Message).fromBinary(
+              if (target[localName] instanceof Message) {
+                target[localName].fromBinary(reader.bytes(), options);
+              } else {
+                target[localName] = messageType.fromBinary(
                   reader.bytes(),
                   options
                 );
-              } else {
-                target[localName] = unwrapField(
-                  messageType,
-                  messageType.fromBinary(reader.bytes(), options)
-                );
+                if (
+                  messageType.fieldWrapper &&
+                  !field.oneof &&
+                  !field.repeated
+                ) {
+                  target[localName] = messageType.fieldWrapper.unwrapField(
+                    target[localName]
+                  );
+                }
               }
             }
             break;

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { Message } from "../message.js";
+import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { DescField } from "../descriptor-set.js";
 import { ScalarType } from "../field.js";
@@ -23,7 +23,7 @@ import { ScalarType } from "../field.js";
  * A field wrapper unwraps a message to a primitive value that is more
  * ergonomic for use as a message field.
  *
- * Note that this feature exists for google/protobuf/{wrappers,struct}.proto
+ * Note that this feature exists for google/protobuf/wrappers.proto
  * and cannot be used to arbitrarily modify types in generated code.
  */
 export interface FieldWrapper<T extends Message<T> = any, U = any> {
@@ -33,36 +33,22 @@ export interface FieldWrapper<T extends Message<T> = any, U = any> {
 }
 
 /**
- * Wrap field values whose message type has a wrapper.
+ * Wrap a primitive message field value in its corresponding wrapper
+ * message. This function is idempotent.
  */
 export function wrapField<T extends Message<T>>(
   type: MessageType<T>,
   value: any
 ): T {
-  if (value instanceof type) {
-    return value;
+  if (value instanceof Message || !type.fieldWrapper) {
+    return value as T;
   }
-  if (type.fieldWrapper) {
-    return type.fieldWrapper.wrapField(value);
-  }
-  throw new Error(
-    `cannot wrap field value, ${type.typeName} does not define a field wrapper`
-  );
-}
-
-/**
- * Unwrap field values whose message type has a wrapper.
- */
-export function unwrapField<T extends Message<T>>(
-  type: MessageType<T>,
-  value: T
-): any {
-  return type.fieldWrapper ? type.fieldWrapper.unwrapField(value) : value;
+  return type.fieldWrapper.wrapField(value);
 }
 
 /**
  * If the given field uses one of the well-known wrapper types, return
- * the base type it wraps.
+ * the primitive type it wraps.
  */
 export function getUnwrappedFieldType(
   field: DescField

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { setEnumType } from "./enum.js";
-import type {
+import {
   AnyMessage,
   Message,
   PartialMessage,
@@ -222,23 +222,13 @@ function cloneSingularField(
   if (value === undefined) {
     return value;
   }
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- unmatched "map" is unsupported
-  switch (field.kind) {
-    case "enum":
-      return value;
-    case "scalar":
-      if (field.T === ScalarType.BYTES) {
-        const c = new Uint8Array((value as Uint8Array).byteLength);
-        c.set(value as Uint8Array);
-        return c;
-      }
-      return value;
-    case "message":
-      if (field.T.fieldWrapper) {
-        return field.T.fieldWrapper.unwrapField(
-          field.T.fieldWrapper.wrapField(value).clone()
-        );
-      }
-      return (value as Message).clone();
+  if (value instanceof Message) {
+    return value.clone();
   }
+  if (value instanceof Uint8Array) {
+    const c = new Uint8Array(value.byteLength);
+    c.set(value);
+    return c;
+  }
+  return value;
 }

--- a/packages/protoc-gen-es/src/declaration.ts
+++ b/packages/protoc-gen-es/src/declaration.ts
@@ -216,7 +216,7 @@ function generateWktStaticMethods(schema: Schema, f: GeneratedFile, message: Des
     case "google.protobuf.BytesValue": {
       const {typing} = getFieldTyping(ref.value, f);
       f.print("  static readonly fieldWrapper: {")
-      f.print("    wrapField(value: ", typing, " | ", message, "): ", message, ",")
+      f.print("    wrapField(value: ", typing, "): ", message, ",")
       f.print("    unwrapField(value: ", message, "): ", typing, ",")
       f.print("  };")
       f.print()

--- a/packages/protoc-gen-es/src/javascript.ts
+++ b/packages/protoc-gen-es/src/javascript.ts
@@ -557,7 +557,7 @@ function generateWktStaticMethods(schema: Schema, f: GeneratedFile, message: Des
     case "google.protobuf.BytesValue": {
       f.print(message, ".fieldWrapper = {")
       f.print("  wrapField(value) {")
-      f.print("    return value instanceof ", message, " ? value : new ", message, "({value});")
+      f.print("    return new ", message, "({value});")
       f.print("  },")
       f.print("  unwrapField(value) {")
       f.print("    return value.", localName(ref.value), ";")

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -581,8 +581,8 @@ function generateWktStaticMethods(schema: Schema, f: GeneratedFile, message: Des
     case "google.protobuf.BytesValue": {
       const {typing} = getFieldTyping(ref.value, f);
       f.print("  static readonly fieldWrapper = {")
-      f.print("    wrapField(value: ", typing, " | ", message, "): ", message, " {")
-      f.print("      return value instanceof ", message, " ? value : new ", message, "({value});")
+      f.print("    wrapField(value: ", typing, "): ", message, " {")
+      f.print("      return new ", message, "({value});")
       f.print("    },")
       f.print("    unwrapField(value: ", message, "): ", typing, " {")
       f.print("      return value.", localName(ref.value), ";")


### PR DESCRIPTION
Fixes #283 by removing code path that errors. We can easily and reliably determine whether a field is already wrapped by checking if it is `instanceof Message`.