### PR TITLE
makes generated imports look more normal

### DIFF
--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -190,7 +190,7 @@ function elToContent(el: El[], importerPath: string): string {
       const p = names.map(({ name, alias }) =>
         alias == undefined ? name : `${name} as ${alias}`
       );
-      const what = `{${p.join(", ")}}`;
+      const what = `{ ${p.join(", ")} }`;
       if (typeOnly) {
         c.push(`import type ${what} from ${literalString(from)};\n`);
       } else {


### PR DESCRIPTION
The rationale for this change is that we should take the opportunity, when it arises, to make generated code look natural and typical (if possible).  While this isn't a logical change, it's hopefully worthwhile in the pursuit of making the generated outputs feel more normal.

Here's an example:

```diff
- import {Message, proto3} from "@bufbuild/protobuf";
+ import { Message, proto3 } from "@bufbuild/protobuf";
```

Note that this falls in line with [Prettier's default](https://prettier.io/docs/en/options.html#bracket-spacing) as well.  In fact, that's how I found it. I was generating code and trying to aim for a final output that matched prettier's default formatting and this was the only thing that I wasn't able to make match as a downstream consumer of protobuf-es.