### PR TITLE
makes generated imports look more normal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ lint: node_modules $(BUILD)/protobuf $(BUILD)/protobuf-test $(BUILD)/protobuf-co
 
 .PHONY: format
 format: node_modules $(BIN)/git-ls-files-unstaged $(BIN)/license-header ## Format all files, adding license headers
-	npx prettier --write '**/*.{json,js,jsx,ts,tsx,css}' --loglevel error
+	npx prettier --write '**/*.{json,js,jsx,ts,tsx,css,mjs}' --loglevel error
 	$(BIN)/git-ls-files-unstaged | \
 		grep -v $(patsubst %,-e %,$(sort $(LICENSE_HEADER_IGNORES))) | \
 		xargs $(BIN)/license-header \

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -321,7 +321,7 @@ Some of the well-known types provide additional methods for convenience:
 ### Timestamp
 
 ````typescript
-import {Timestamp} from "@bufbuild/protobuf";
+import { Timestamp } from "@bufbuild/protobuf";
 
 // Create an instance from a built-in Date object
 let ts = Timestamp.fromDate(new Date(1938, 0, 10));
@@ -336,8 +336,8 @@ ts.toDate();
 ### Any
 
 ```typescript
-import {Any} from "@bufbuild/protobuf";
-import {Timestamp} from "@bufbuild/protobuf";
+import { Any } from "@bufbuild/protobuf";
+import { Timestamp } from "@bufbuild/protobuf";
 
 // Pack a message:
 let any = Any.pack(message);
@@ -427,7 +427,7 @@ In case you simply want to set a field value, for example from an HTML form inpu
 use the provided conversion utility [`protoInt64`][src-proto-int64]:
 
 ```typescript
-import {protoInt64} from "@bufbuild/protobuf";
+import { protoInt64 } from "@bufbuild/protobuf";
 
 let input: string | number | bigint = "123";
 

--- a/packages/protobuf-bench/report.mjs
+++ b/packages/protobuf-bench/report.mjs
@@ -1,5 +1,5 @@
-import {buildSync} from "esbuild";
-import {brotliCompressSync} from "zlib";
+import { buildSync } from "esbuild";
+import { brotliCompressSync } from "zlib";
 
 const protobufEs = gather("src/entry-protobuf-es.ts");
 const googleProtobuf = gather("src/entry-google-protobuf.js");
@@ -20,38 +20,37 @@ server would usually do.
 | protobuf-javascript | ${googleProtobuf.size}  | ${googleProtobuf.minified} | ${googleProtobuf.compressed} |
 `);
 
-
 function gather(entryPoint) {
-    const bundle = build(entryPoint, false, "esm");
-    const bundleMinified = build(entryPoint, true, "esm");
-    const compressed = compress(bundleMinified);
-    return {
-        entryPoint,
-        size: formatSize(bundle.byteLength),
-        minified: formatSize(bundleMinified.byteLength),
-        compressed: formatSize(compressed.byteLength),
-    };
+  const bundle = build(entryPoint, false, "esm");
+  const bundleMinified = build(entryPoint, true, "esm");
+  const compressed = compress(bundleMinified);
+  return {
+    entryPoint,
+    size: formatSize(bundle.byteLength),
+    minified: formatSize(bundleMinified.byteLength),
+    compressed: formatSize(compressed.byteLength),
+  };
 }
 
 function build(entryPoint, minify, format) {
-    const result = buildSync({
-        entryPoints: [entryPoint],
-        bundle: true,
-        format: format,
-        treeShaking: true,
-        minify: minify,
-        write: false,
-    });
-    if (result.outputFiles.length !== 1) {
-        throw new Error();
-    }
-    return result.outputFiles[0].contents;
+  const result = buildSync({
+    entryPoints: [entryPoint],
+    bundle: true,
+    format: format,
+    treeShaking: true,
+    minify: minify,
+    write: false,
+  });
+  if (result.outputFiles.length !== 1) {
+    throw new Error();
+  }
+  return result.outputFiles[0].contents;
 }
 
 function compress(buf) {
-    return brotliCompressSync(buf);
+  return brotliCompressSync(buf);
 }
 
 function formatSize(bytes) {
-    return new Intl.NumberFormat().format(bytes) + " b";
+  return new Intl.NumberFormat().format(bytes) + " b";
 }

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/envelope_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/envelope_pb.ts
@@ -16,16 +16,16 @@
 // @generated from file buf/alpha/audit/v1alpha1/envelope.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64, Timestamp} from "@bufbuild/protobuf";
-import {BufAlphaRegistryV1Alpha1OrganizationRole, BufAlphaRegistryV1Alpha1PluginRole, BufAlphaRegistryV1Alpha1RepositoryRole, BufAlphaRegistryV1Alpha1ServerRole, BufAlphaRegistryV1Alpha1TemplateRole} from "./role_pb.js";
-import {BufAlphaRegistryV1Alpha1PluginConfig, BufAlphaRegistryV1Alpha1PluginVersionMapping, BufAlphaRegistryV1Alpha1PluginVersionRuntimeLibrary, BufAlphaRegistryV1Alpha1PluginVisibility} from "./plugin_pb.js";
-import {BufAlphaRegistryV1Alpha1RepositoryBranch, BufAlphaRegistryV1Alpha1RepositoryCommit, BufAlphaRegistryV1Alpha1RepositoryTag, BufAlphaRegistryV1Alpha1RepositoryTrack, BufAlphaRegistryV1Alpha1Visibility} from "./repository_pb.js";
-import {ModulePin, ModuleReference} from "../../module/v1alpha1/module_pb.js";
-import {BufAlphaRegistryV1Alpha1LocalModuleReference, BufAlphaRegistryV1Alpha1LocalModuleResolveResult} from "./module_pb.js";
-import {BufAlphaRegistryV1Alpha1SearchFilter} from "./search_pb.js";
-import {BufAlphaRegistryV1Alpha1UserState} from "./user_pb.js";
-import {ErrorCode} from "../../rpc/v1alpha1/error_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
+import { BufAlphaRegistryV1Alpha1OrganizationRole, BufAlphaRegistryV1Alpha1PluginRole, BufAlphaRegistryV1Alpha1RepositoryRole, BufAlphaRegistryV1Alpha1ServerRole, BufAlphaRegistryV1Alpha1TemplateRole } from "./role_pb.js";
+import { BufAlphaRegistryV1Alpha1PluginConfig, BufAlphaRegistryV1Alpha1PluginVersionMapping, BufAlphaRegistryV1Alpha1PluginVersionRuntimeLibrary, BufAlphaRegistryV1Alpha1PluginVisibility } from "./plugin_pb.js";
+import { BufAlphaRegistryV1Alpha1RepositoryBranch, BufAlphaRegistryV1Alpha1RepositoryCommit, BufAlphaRegistryV1Alpha1RepositoryTag, BufAlphaRegistryV1Alpha1RepositoryTrack, BufAlphaRegistryV1Alpha1Visibility } from "./repository_pb.js";
+import { ModulePin, ModuleReference } from "../../module/v1alpha1/module_pb.js";
+import { BufAlphaRegistryV1Alpha1LocalModuleReference, BufAlphaRegistryV1Alpha1LocalModuleResolveResult } from "./module_pb.js";
+import { BufAlphaRegistryV1Alpha1SearchFilter } from "./search_pb.js";
+import { BufAlphaRegistryV1Alpha1UserState } from "./user_pb.js";
+import { ErrorCode } from "../../rpc/v1alpha1/error_pb.js";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.Action

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/module_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/audit/v1alpha1/module.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1ResolvedReferenceType

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/plugin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/plugin_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/audit/v1alpha1/plugin.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginVisibility

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/repository_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/repository_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/audit/v1alpha1/repository.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1Visibility

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/role_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/role_pb.ts
@@ -16,7 +16,7 @@
 // @generated from file buf/alpha/audit/v1alpha1/role.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1ServerRole

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/search_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/search_pb.ts
@@ -16,7 +16,7 @@
 // @generated from file buf/alpha/audit/v1alpha1/search.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1SearchFilter

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/user_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/user_pb.ts
@@ -16,7 +16,7 @@
 // @generated from file buf/alpha/audit/v1alpha1/user.proto (package buf.alpha.audit.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1UserState

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/breaking/v1/config_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/breaking/v1/config_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/breaking/v1/config.proto (package buf.alpha.breaking.v1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * Config represents the breaking change configuration for a module. The rule and category IDs are defined

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/image/v1/image.proto (package buf.alpha.image.v1, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileOptions, Message, proto2, ServiceDescriptorProto, SourceCodeInfo} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileOptions, Message, proto2, ServiceDescriptorProto, SourceCodeInfo } from "@bufbuild/protobuf";
 
 /**
  * Image is an extended FileDescriptorSet.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/lint/v1/config_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/lint/v1/config_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/lint/v1/config.proto (package buf.alpha.lint.v1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * Config represents the lint configuration for a module. The rule and category IDs are defined

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/module/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/module/v1alpha1/module_pb.ts
@@ -16,10 +16,10 @@
 // @generated from file buf/alpha/module/v1alpha1/module.proto (package buf.alpha.module.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
-import {Config} from "../../breaking/v1/config_pb.js";
-import {Config as Config$1} from "../../lint/v1/config_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { Config } from "../../breaking/v1/config_pb.js";
+import { Config as Config$1 } from "../../lint/v1/config_pb.js";
 
 /**
  * Module is a module.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/admin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/admin_pb.ts
@@ -16,12 +16,12 @@
 // @generated from file buf/alpha/registry/v1alpha1/admin.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {User} from "./user_pb.js";
-import {Organization} from "./organization_pb.js";
-import {Repository} from "./repository_pb.js";
-import {Plugin, Template} from "./plugin_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { User } from "./user_pb.js";
+import { Organization } from "./organization_pb.js";
+import { Repository } from "./repository_pb.js";
+import { Plugin, Template } from "./plugin_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.ForceDeleteUserRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/audit_logs_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/audit_logs_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/audit_logs.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
-import {Event} from "../../audit/v1alpha1/envelope_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { Event } from "../../audit/v1alpha1/envelope_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.ListAuditLogsRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authn_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authn_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/authn.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {User} from "./user_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { User } from "./user_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.GetCurrentUserRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authz_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authz_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/authz.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {OrganizationRole, PluginRole, RepositoryRole, TemplateRole} from "./role_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { OrganizationRole, PluginRole, RepositoryRole, TemplateRole } from "./role_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.UserCanCreateOrganizationRepositoryRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/display_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/display_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/display.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {PluginRole, RepositoryRole, TemplateRole} from "./role_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { PluginRole, RepositoryRole, TemplateRole } from "./role_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.DisplayOrganizationElementsRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/doc_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/doc_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/doc.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message as Message$1, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message as Message$1, proto3 } from "@bufbuild/protobuf";
 
 /**
  * GetSourceDirectoryInfoRequest takes an owner, repository, and reference.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/download_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/download_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/download.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {Module} from "../../module/v1alpha1/module_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Module } from "../../module/v1alpha1/module_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.DownloadRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/generate_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/generate_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/generate.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {CodeGeneratorResponse, Message, proto3} from "@bufbuild/protobuf";
-import {Image} from "../../image/v1/image_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { CodeGeneratorResponse, Message, proto3 } from "@bufbuild/protobuf";
+import { Image } from "../../image/v1/image_pb.js";
 
 /**
  * File defines a file with a path and some content.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/image_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/image.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {Image} from "../../image/v1/image_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Image } from "../../image/v1/image_pb.js";
 
 /**
  * ImageMask is used in GetImageRequest to specify which parts of an image 

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/jsonschema_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/jsonschema_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/jsonschema.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.GetJSONSchemaRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/module_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/module.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * LocalModuleReference is a local module reference.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/organization_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/organization_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/organization.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
-import {OrganizationRole, PluginRole, RepositoryRole, TemplateRole} from "./role_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { OrganizationRole, PluginRole, RepositoryRole, TemplateRole } from "./role_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.Organization

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/owner_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/owner_pb.ts
@@ -16,10 +16,10 @@
 // @generated from file buf/alpha/registry/v1alpha1/owner.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {User} from "./user_pb.js";
-import {Organization} from "./organization_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { User } from "./user_pb.js";
+import { Organization } from "./organization_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.Owner

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/plugin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/plugin_pb.ts
@@ -16,11 +16,11 @@
 // @generated from file buf/alpha/registry/v1alpha1/plugin.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {RuntimeLibrary} from "./generate_pb.js";
-import {User} from "./user_pb.js";
-import {PluginRole, TemplateRole} from "./role_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { RuntimeLibrary } from "./generate_pb.js";
+import { User } from "./user_pb.js";
+import { PluginRole, TemplateRole } from "./role_pb.js";
 
 /**
  * PluginVisibility defines the visibility options available

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/push_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/push_pb.ts
@@ -16,10 +16,10 @@
 // @generated from file buf/alpha/registry/v1alpha1/push.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {Module} from "../../module/v1alpha1/module_pb.js";
-import {LocalModulePin} from "./module_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Module } from "../../module/v1alpha1/module_pb.js";
+import { LocalModulePin } from "./module_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.PushRequest

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/recommendation_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/recommendation_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/recommendation.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * RecommendedRepository is the information about a repository needed to link to

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/reference_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/reference_pb.ts
@@ -16,12 +16,12 @@
 // @generated from file buf/alpha/registry/v1alpha1/reference.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {RepositoryBranch} from "./repository_branch_pb.js";
-import {RepositoryTag} from "./repository_tag_pb.js";
-import {RepositoryCommit} from "./repository_commit_pb.js";
-import {RepositoryTrack} from "./repository_track_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { RepositoryBranch } from "./repository_branch_pb.js";
+import { RepositoryTag } from "./repository_tag_pb.js";
+import { RepositoryCommit } from "./repository_commit_pb.js";
+import { RepositoryTrack } from "./repository_track_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.Reference

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_branch_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_branch_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/repository_branch.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.RepositoryBranch

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_commit_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_commit_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/repository_commit.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64, Timestamp} from "@bufbuild/protobuf";
-import {RepositoryTag} from "./repository_tag_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
+import { RepositoryTag } from "./repository_tag_pb.js";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.RepositoryCommit

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_pb.ts
@@ -16,10 +16,10 @@
 // @generated from file buf/alpha/registry/v1alpha1/repository.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
-import {User} from "./user_pb.js";
-import {RepositoryRole} from "./role_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { User } from "./user_pb.js";
+import { RepositoryRole } from "./role_pb.js";
 
 /**
  * @generated from enum buf.alpha.registry.v1alpha1.Visibility

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_tag_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_tag_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/repository_tag.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.RepositoryTag

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_commit_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_commit_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/repository_track_commit.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * RepositoryTrackCommit is the existance of a RepositoryCommit on a RepositoryTrack. Currently its only purpose is

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/repository_track.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.RepositoryTrack

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/resolve_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/resolve_pb.ts
@@ -16,10 +16,10 @@
 // @generated from file buf/alpha/registry/v1alpha1/resolve.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {ModulePin, ModuleReference} from "../../module/v1alpha1/module_pb.js";
-import {LocalModulePin, LocalModuleReference} from "./module_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { ModulePin, ModuleReference } from "../../module/v1alpha1/module_pb.js";
+import { LocalModulePin, LocalModuleReference } from "./module_pb.js";
 
 /**
  * @generated from enum buf.alpha.registry.v1alpha1.ResolvedReferenceType

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/role_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/role_pb.ts
@@ -16,7 +16,7 @@
 // @generated from file buf/alpha/registry/v1alpha1/role.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * The roles that users can have in a Server.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/search_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/search_pb.ts
@@ -16,10 +16,10 @@
 // @generated from file buf/alpha/registry/v1alpha1/search.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {Visibility} from "./repository_pb.js";
-import {PluginVisibility} from "./plugin_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Visibility } from "./repository_pb.js";
+import { PluginVisibility } from "./plugin_pb.js";
 
 /**
  * @generated from enum buf.alpha.registry.v1alpha1.SearchFilter

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/token_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/token_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file buf/alpha/registry/v1alpha1/token.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from message buf.alpha.registry.v1alpha1.Token

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/user_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/user_pb.ts
@@ -16,9 +16,9 @@
 // @generated from file buf/alpha/registry/v1alpha1/user.proto (package buf.alpha.registry.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
-import {OrganizationRole, ServerRole} from "./role_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { OrganizationRole, ServerRole } from "./role_pb.js";
 
 /**
  * @generated from enum buf.alpha.registry.v1alpha1.UserState

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/rpc/v1alpha1/error_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/rpc/v1alpha1/error_pb.ts
@@ -16,7 +16,7 @@
 // @generated from file buf/alpha/rpc/v1alpha1/error.proto (package buf.alpha.rpc.v1alpha1, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * Well defined error codes specified as part of the RPC API.

--- a/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
+++ b/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file conformance/conformance.proto (package conformance, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum conformance.WireFormat

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/test_messages_proto2.proto (package protobuf_test_messages.proto2, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto2.ForeignEnumProto2

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/test_messages_proto3.proto (package protobuf_test_messages.proto3, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Any, BoolValue, BytesValue, DoubleValue, Duration, FieldMask, FloatValue, Int32Value, Int64Value, ListValue, Message, NullValue, proto3, protoInt64, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Any, BoolValue, BytesValue, DoubleValue, Duration, FieldMask, FloatValue, Int32Value, Int64Value, ListValue, Message, NullValue, proto3, protoInt64, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto3.ForeignEnum

--- a/packages/protobuf-example/src/gen/addressbook_pb.ts
+++ b/packages/protobuf-example/src/gen/addressbook_pb.ts
@@ -17,8 +17,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from message example.Person

--- a/packages/protobuf-test/src/gen/js/extra/comments_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/comments_pb.d.ts
@@ -24,8 +24,8 @@
 
 // Comment before package.
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * Leading comment for enum.

--- a/packages/protobuf-test/src/gen/js/extra/comments_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/comments_pb.js
@@ -24,7 +24,7 @@
 
 // Comment before package.
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * Leading comment for enum.

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * The entire enum is deprecated

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * The entire enum is deprecated

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ImplicitlyDeprecatedMessage

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ImplicitlyDeprecatedMessage

--- a/packages/protobuf-test/src/gen/js/extra/enum_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/enum_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/enum.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.AnnotatedEnum

--- a/packages/protobuf-test/src/gen/js/extra/enum_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/enum_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/enum.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.AnnotatedEnum

--- a/packages/protobuf-test/src/gen/js/extra/example_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/example_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/example.proto (package docs, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message docs.Example

--- a/packages/protobuf-test/src/gen/js/extra/example_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/example_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/example.proto (package docs, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message docs.Example

--- a/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-json-names.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.JsonNamesMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-json-names_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/msg-json-names.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.JsonNamesMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-maps_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-maps_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-maps.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.MapsEnum

--- a/packages/protobuf-test/src/gen/js/extra/msg-maps_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-maps_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/msg-maps.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.MapsEnum

--- a/packages/protobuf-test/src/gen/js/extra/msg-message_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-message_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-message.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.MessageFieldMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-message_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-message_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/msg-message.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.MessageFieldMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-oneof.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.OneofEnum

--- a/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/msg-oneof.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.OneofEnum

--- a/packages/protobuf-test/src/gen/js/extra/msg-scalar_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-scalar_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-scalar.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ScalarValuesMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-scalar_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-scalar_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/msg-scalar.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ScalarValuesMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-self-reference_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-self-reference_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-self-reference.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.SelfReferencingMessage

--- a/packages/protobuf-test/src/gen/js/extra/msg-self-reference_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-self-reference_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/msg-self-reference.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.SelfReferencingMessage

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/name-clash.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage as PartialMessage$1, PlainMessage as PlainMessage$1} from "@bufbuild/protobuf";
-import {Message as Message$1, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage as PartialMessage$1, PlainMessage as PlainMessage$1 } from "@bufbuild/protobuf";
+import { Message as Message$1, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ReservedPropertyNames

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/name-clash.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ReservedPropertyNames

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/proto2.proto (package spec, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto2Enum

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/proto2.proto (package spec, syntax proto2)
 /* eslint-disable */
 
-import {proto2, protoInt64} from "@bufbuild/protobuf";
+import { proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto2Enum

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/proto3.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto3Enum

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/proto3.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto3Enum

--- a/packages/protobuf-test/src/gen/js/extra/service-example_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/service-example_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/service-example.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.FailRequest

--- a/packages/protobuf-test/src/gen/js/extra/service-example_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/service-example_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/service-example.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.FailRequest

--- a/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/wkt-wrappers.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, BoolValue, BytesValue, DoubleValue, FieldList, FloatValue, Int32Value, Int64Value, JsonReadOptions, JsonValue, PartialMessage, PlainMessage, StringValue, UInt32Value, UInt64Value} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, BoolValue, BytesValue, DoubleValue, FieldList, FloatValue, Int32Value, Int64Value, JsonReadOptions, JsonValue, PartialMessage, PlainMessage, StringValue, UInt32Value, UInt64Value } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.WrappersMessage

--- a/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.js
@@ -16,7 +16,7 @@
 // @generated from file extra/wkt-wrappers.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import {BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, proto3, StringValue, UInt32Value, UInt64Value} from "@bufbuild/protobuf";
+import { BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, proto3, StringValue, UInt32Value, UInt64Value } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.WrappersMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/any_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/any_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/any.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, MessageType, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, MessageType, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/packages/protobuf-test/src/gen/js/google/protobuf/any_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/any_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/any.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/packages/protobuf-test/src/gen/js/google/protobuf/api_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/api_pb.d.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/api.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {Option, Syntax} from "./type_pb.js";
-import type {SourceContext} from "./source_context_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { Option, Syntax } from "./type_pb.js";
+import type { SourceContext } from "./source_context_pb.js";
 
 /**
  * Api is a light-weight descriptor for an API Interface.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/api_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/api_pb.js
@@ -32,9 +32,9 @@
 // @generated from file google/protobuf/api.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {Option, Syntax} from "./type_pb.js";
-import {SourceContext} from "./source_context_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { Option, Syntax } from "./type_pb.js";
+import { SourceContext } from "./source_context_pb.js";
 
 /**
  * Api is a light-weight descriptor for an API Interface.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/compiler/plugin_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/compiler/plugin_pb.d.ts
@@ -48,9 +48,9 @@
 // @generated from file google/protobuf/compiler/plugin.proto (package google.protobuf.compiler, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {FileDescriptorProto, GeneratedCodeInfo} from "../descriptor_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { FileDescriptorProto, GeneratedCodeInfo } from "../descriptor_pb.js";
 
 /**
  * The version number of protocol compiler.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/compiler/plugin_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/compiler/plugin_pb.js
@@ -48,8 +48,8 @@
 // @generated from file google/protobuf/compiler/plugin.proto (package google.protobuf.compiler, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
-import {FileDescriptorProto, GeneratedCodeInfo} from "../descriptor_pb.js";
+import { proto2 } from "@bufbuild/protobuf";
+import { FileDescriptorProto, GeneratedCodeInfo } from "../descriptor_pb.js";
 
 /**
  * The version number of protocol compiler.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
@@ -40,8 +40,8 @@
 // @generated from file google/protobuf/descriptor.proto (package google.protobuf, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto

--- a/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.js
@@ -40,7 +40,7 @@
 // @generated from file google/protobuf/descriptor.proto (package google.protobuf, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto

--- a/packages/protobuf-test/src/gen/js/google/protobuf/duration_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/duration_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/duration.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * A Duration represents a signed, fixed-length span of time represented

--- a/packages/protobuf-test/src/gen/js/google/protobuf/duration_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/duration_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/duration.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3, protoInt64} from "@bufbuild/protobuf";
+import { proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * A Duration represents a signed, fixed-length span of time represented

--- a/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/empty.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * A generic empty message that you can re-use to avoid defining duplicated

--- a/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/empty_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/empty.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * A generic empty message that you can re-use to avoid defining duplicated

--- a/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/field_mask.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `FieldMask` represents a set of symbolic field paths, for example:

--- a/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/field_mask.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * `FieldMask` represents a set of symbolic field paths, for example:

--- a/packages/protobuf-test/src/gen/js/google/protobuf/source_context_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/source_context_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/source_context.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `SourceContext` represents information about the source of a

--- a/packages/protobuf-test/src/gen/js/google/protobuf/source_context_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/source_context_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/source_context.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * `SourceContext` represents information about the source of a

--- a/packages/protobuf-test/src/gen/js/google/protobuf/struct_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/struct_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/struct.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the

--- a/packages/protobuf-test/src/gen/js/google/protobuf/struct_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/struct_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/struct.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/test_messages_proto2.proto (package protobuf_test_messages.proto2, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto2.ForeignEnumProto2

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.js
@@ -39,7 +39,7 @@
 // @generated from file google/protobuf/test_messages_proto2.proto (package protobuf_test_messages.proto2, syntax proto2)
 /* eslint-disable */
 
-import {proto2, protoInt64} from "@bufbuild/protobuf";
+import { proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto2.ForeignEnumProto2

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/test_messages_proto3.proto (package protobuf_test_messages.proto3, syntax proto3)
 /* eslint-disable */
 
-import type {Any, BinaryReadOptions, BoolValue, BytesValue, DoubleValue, Duration, FieldList, FieldMask, FloatValue, Int32Value, Int64Value, JsonReadOptions, JsonValue, ListValue, NullValue, PartialMessage, PlainMessage, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { Any, BinaryReadOptions, BoolValue, BytesValue, DoubleValue, Duration, FieldList, FieldMask, FloatValue, Int32Value, Int64Value, JsonReadOptions, JsonValue, ListValue, NullValue, PartialMessage, PlainMessage, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto3.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.js
@@ -39,7 +39,7 @@
 // @generated from file google/protobuf/test_messages_proto3.proto (package protobuf_test_messages.proto3, syntax proto3)
 /* eslint-disable */
 
-import {Any, BoolValue, BytesValue, DoubleValue, Duration, FieldMask, FloatValue, Int32Value, Int64Value, ListValue, NullValue, proto3, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
+import { Any, BoolValue, BytesValue, DoubleValue, Duration, FieldMask, FloatValue, Int32Value, Int64Value, ListValue, NullValue, proto3, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto3.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/timestamp_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/timestamp_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/timestamp.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local

--- a/packages/protobuf-test/src/gen/js/google/protobuf/timestamp_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/timestamp_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/timestamp.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3, protoInt64} from "@bufbuild/protobuf";
+import { proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local

--- a/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.d.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/type.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {SourceContext} from "./source_context_pb.js";
-import type {Any} from "./any_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { SourceContext } from "./source_context_pb.js";
+import type { Any } from "./any_pb.js";
 
 /**
  * The syntax in which a protocol buffer element is defined.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.js
@@ -32,9 +32,9 @@
 // @generated from file google/protobuf/type.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {SourceContext} from "./source_context_pb.js";
-import {Any} from "./any_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { SourceContext } from "./source_context_pb.js";
+import { Any } from "./any_pb.js";
 
 /**
  * The syntax in which a protocol buffer element is defined.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_arena_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_arena_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_arena.proto (package proto2_arena_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message proto2_arena_unittest.NestedMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_arena_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_arena_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/unittest_arena.proto (package proto2_arena_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message proto2_arena_unittest.NestedMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -41,8 +41,8 @@
 // We don't put this in a package within proto2 because we need to make sure
 // that the generated code doesn't depend on being in the proto2 namespace.
 
-import type {Any, BinaryReadOptions, FieldList, FileOptions, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { Any, BinaryReadOptions, FieldList, FileOptions, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.MethodOpt1

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.js
@@ -41,7 +41,7 @@
 // We don't put this in a package within proto2 because we need to make sure
 // that the generated code doesn't depend on being in the proto2 namespace.
 
-import {Any, FileOptions, proto2} from "@bufbuild/protobuf";
+import { Any, FileOptions, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.MethodOpt1

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_drop_unknown_fields.proto (package unittest_drop_unknown_fields, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message unittest_drop_unknown_fields.Foo

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_drop_unknown_fields_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/unittest_drop_unknown_fields.proto (package unittest_drop_unknown_fields, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message unittest_drop_unknown_fields.Foo

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.d.ts
@@ -38,9 +38,9 @@
 // @generated from file google/protobuf/unittest_embed_optimize_for.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {TestOptimizedForSize} from "./unittest_optimize_for_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { TestOptimizedForSize } from "./unittest_optimize_for_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestEmbedOptimizedForSize

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.js
@@ -38,8 +38,8 @@
 // @generated from file google/protobuf/unittest_embed_optimize_for.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
-import {TestOptimizedForSize} from "./unittest_optimize_for_pb.js";
+import { proto2 } from "@bufbuild/protobuf";
+import { TestOptimizedForSize } from "./unittest_optimize_for_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestEmbedOptimizedForSize

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_enormous_descriptor_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_enormous_descriptor_pb.d.ts
@@ -40,8 +40,8 @@
 // @generated from file google/protobuf/unittest_enormous_descriptor.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestEnormousDescriptor

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_enormous_descriptor_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_enormous_descriptor_pb.js
@@ -40,7 +40,7 @@
 // @generated from file google/protobuf/unittest_enormous_descriptor.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestEnormousDescriptor

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_lite_pb.d.ts
@@ -36,8 +36,8 @@
 // @generated from file google/protobuf/unittest_import_lite.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest_import.ImportEnumLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_lite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_lite_pb.js
@@ -36,7 +36,7 @@
 // @generated from file google/protobuf/unittest_import_lite.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest_import.ImportEnumLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_pb.d.ts
@@ -43,8 +43,8 @@
 // In test_util.h we do
 // "using namespace unittest_import = protobuf_unittest_import".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest_import.ImportEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_pb.js
@@ -43,7 +43,7 @@
 // In test_util.h we do
 // "using namespace unittest_import = protobuf_unittest_import".
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest_import.ImportEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_lite_pb.d.ts
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_import_public_lite.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest_import.PublicImportMessageLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_lite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_lite_pb.js
@@ -34,7 +34,7 @@
 // @generated from file google/protobuf/unittest_import_public_lite.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest_import.PublicImportMessageLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_pb.d.ts
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_import_public.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest_import.PublicImportMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_pb.js
@@ -34,7 +34,7 @@
 // @generated from file google/protobuf/unittest_import_public.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest_import.PublicImportMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_custom_option_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_custom_option_pb.d.ts
@@ -42,8 +42,8 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.lazy_imports.LazyMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_custom_option_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_custom_option_pb.js
@@ -42,7 +42,7 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.lazy_imports.LazyMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_enum_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_enum_pb.js
@@ -42,7 +42,7 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.lazy_imports.LazyEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_pb.d.ts
@@ -42,9 +42,9 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {LazyMessage} from "./unittest_lazy_dependencies_custom_option_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { LazyMessage } from "./unittest_lazy_dependencies_custom_option_pb.js";
 
 /**
  * @generated from message protobuf_unittest.lazy_imports.ImportedMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lazy_dependencies_pb.js
@@ -42,8 +42,8 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import {proto2} from "@bufbuild/protobuf";
-import {LazyMessage} from "./unittest_lazy_dependencies_custom_option_pb.js";
+import { proto2 } from "@bufbuild/protobuf";
+import { LazyMessage } from "./unittest_lazy_dependencies_custom_option_pb.js";
 
 /**
  * @generated from message protobuf_unittest.lazy_imports.ImportedMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.d.ts
@@ -36,9 +36,9 @@
 // @generated from file google/protobuf/unittest_lite_imports_nonlite.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {TestAllTypes, TestRequired} from "./unittest_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { TestAllTypes, TestRequired } from "./unittest_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestLiteImportsNonlite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.js
@@ -36,8 +36,8 @@
 // @generated from file google/protobuf/unittest_lite_imports_nonlite.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
-import {TestAllTypes, TestRequired} from "./unittest_pb.js";
+import { proto2 } from "@bufbuild/protobuf";
+import { TestAllTypes, TestRequired } from "./unittest_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestLiteImportsNonlite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
@@ -36,10 +36,10 @@
 // @generated from file google/protobuf/unittest_lite.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {ImportEnumLite, ImportMessageLite} from "./unittest_import_lite_pb.js";
-import type {PublicImportMessageLite} from "./unittest_import_public_lite_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { ImportEnumLite, ImportMessageLite } from "./unittest_import_lite_pb.js";
+import type { PublicImportMessageLite } from "./unittest_import_public_lite_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.ForeignEnumLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.js
@@ -36,9 +36,9 @@
 // @generated from file google/protobuf/unittest_lite.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2, protoInt64} from "@bufbuild/protobuf";
-import {ImportEnumLite, ImportMessageLite} from "./unittest_import_lite_pb.js";
-import {PublicImportMessageLite} from "./unittest_import_public_lite_pb.js";
+import { proto2, protoInt64 } from "@bufbuild/protobuf";
+import { ImportEnumLite, ImportMessageLite } from "./unittest_import_lite_pb.js";
+import { PublicImportMessageLite } from "./unittest_import_public_lite_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.ForeignEnumLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
@@ -39,9 +39,9 @@
 // @generated from file google/protobuf/unittest_mset.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {TestMessageSet} from "./unittest_mset_wire_format_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { TestMessageSet } from "./unittest_mset_wire_format_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestMessageSetContainer

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.js
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/unittest_mset.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
-import {TestMessageSet} from "./unittest_mset_wire_format_pb.js";
+import { proto2 } from "@bufbuild/protobuf";
+import { TestMessageSet } from "./unittest_mset_wire_format_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestMessageSetContainer

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.d.ts
@@ -38,8 +38,8 @@
 // @generated from file google/protobuf/unittest_mset_wire_format.proto (package proto2_wireformat_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * A message with message_set_wire_format.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.js
@@ -38,7 +38,7 @@
 // @generated from file google/protobuf/unittest_mset_wire_format.proto (package proto2_wireformat_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * A message with message_set_wire_format.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_field_presence_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_field_presence_pb.d.ts
@@ -34,9 +34,9 @@
 // @generated from file google/protobuf/unittest_no_field_presence.proto (package proto2_nofieldpresence_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {TestAllTypes as TestAllTypes$1, TestRequired} from "./unittest_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { TestAllTypes as TestAllTypes$1, TestRequired } from "./unittest_pb.js";
 
 /**
  * @generated from enum proto2_nofieldpresence_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_field_presence_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_field_presence_pb.js
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_no_field_presence.proto (package proto2_nofieldpresence_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {TestAllTypes as TestAllTypes$1, TestRequired} from "./unittest_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { TestAllTypes as TestAllTypes$1, TestRequired } from "./unittest_pb.js";
 
 /**
  * @generated from enum proto2_nofieldpresence_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_no_generic_services.proto (package protobuf_unittest.no_generic_services_test, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.no_generic_services_test.TestEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.js
@@ -34,7 +34,7 @@
 // @generated from file google/protobuf/unittest_no_generic_services.proto (package protobuf_unittest.no_generic_services_test, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.no_generic_services_test.TestEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
@@ -38,9 +38,9 @@
 // @generated from file google/protobuf/unittest_optimize_for.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {ForeignMessage} from "./unittest_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { ForeignMessage } from "./unittest_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestOptimizedForSize

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.js
@@ -38,8 +38,8 @@
 // @generated from file google/protobuf/unittest_optimize_for.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
-import {ForeignMessage} from "./unittest_pb.js";
+import { proto2 } from "@bufbuild/protobuf";
+import { ForeignMessage } from "./unittest_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestOptimizedForSize

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -44,10 +44,10 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import type {ImportEnum, ImportMessage} from "./unittest_import_pb.js";
-import type {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import type { ImportEnum, ImportMessage } from "./unittest_import_pb.js";
+import type { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.js
@@ -44,9 +44,9 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import {proto2, protoInt64} from "@bufbuild/protobuf";
-import {ImportEnum, ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import { proto2, protoInt64 } from "@bufbuild/protobuf";
+import { ImportEnum, ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum2_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_preserve_unknown_enum2.proto (package proto2_preserve_unknown_enum_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum proto2_preserve_unknown_enum_unittest.MyEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum2_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum2_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/unittest_preserve_unknown_enum2.proto (package proto2_preserve_unknown_enum_unittest, syntax proto2)
 /* eslint-disable */
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum proto2_preserve_unknown_enum_unittest.MyEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_preserve_unknown_enum.proto (package proto3_preserve_unknown_enum_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum proto3_preserve_unknown_enum_unittest.MyEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_preserve_unknown_enum_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/unittest_preserve_unknown_enum.proto (package proto3_preserve_unknown_enum_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum proto3_preserve_unknown_enum_unittest.MyEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_lite_pb.d.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3_arena_lite.proto (package proto3_arena_lite_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {ImportMessage} from "./unittest_import_pb.js";
-import type {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { ImportMessage } from "./unittest_import_pb.js";
+import type { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_arena_lite_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_lite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_lite_pb.js
@@ -32,9 +32,9 @@
 // @generated from file google/protobuf/unittest_proto3_arena_lite.proto (package proto3_arena_lite_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_arena_lite_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.d.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3_arena.proto (package proto3_arena_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {ImportMessage} from "./unittest_import_pb.js";
-import type {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { ImportMessage } from "./unittest_import_pb.js";
+import type { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_arena_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_arena_pb.js
@@ -32,9 +32,9 @@
 // @generated from file google/protobuf/unittest_proto3_arena.proto (package proto3_arena_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_arena_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_lite_pb.d.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3_lite.proto (package proto3_lite_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {ImportMessage} from "./unittest_import_pb.js";
-import type {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { ImportMessage } from "./unittest_import_pb.js";
+import type { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_lite_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_lite_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_lite_pb.js
@@ -32,9 +32,9 @@
 // @generated from file google/protobuf/unittest_proto3_lite.proto (package proto3_lite_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_lite_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_proto3_optional.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestProto3Optional

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.js
@@ -32,7 +32,7 @@
 // @generated from file google/protobuf/unittest_proto3_optional.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
+import { proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestProto3Optional

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3.proto (package proto3_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {ImportMessage} from "./unittest_import_pb.js";
-import type {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { ImportMessage } from "./unittest_import_pb.js";
+import type { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.js
@@ -32,9 +32,9 @@
 // @generated from file google/protobuf/unittest_proto3.proto (package proto3_unittest, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.d.ts
@@ -2,9 +2,9 @@
 // @generated from file google/protobuf/unittest_well_known_types.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {Any, Api, BinaryReadOptions, BoolValue, BytesValue, DoubleValue, Duration, Empty, FieldList, FieldMask, FloatValue, Int32Value, Int64Value, JsonReadOptions, JsonValue, PartialMessage, PlainMessage, SourceContext, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import type {Type} from "./type_pb.js";
+import type { Any, Api, BinaryReadOptions, BoolValue, BytesValue, DoubleValue, Duration, Empty, FieldList, FieldMask, FloatValue, Int32Value, Int64Value, JsonReadOptions, JsonValue, PartialMessage, PlainMessage, SourceContext, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import type { Type } from "./type_pb.js";
 
 /**
  * Test that we can include all well-known types.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.js
@@ -2,8 +2,8 @@
 // @generated from file google/protobuf/unittest_well_known_types.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import {Any, Api, BoolValue, BytesValue, DoubleValue, Duration, Empty, FieldMask, FloatValue, Int32Value, Int64Value, proto3, SourceContext, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
-import {Type} from "./type_pb.js";
+import { Any, Api, BoolValue, BytesValue, DoubleValue, Duration, Empty, FieldMask, FloatValue, Int32Value, Int64Value, proto3, SourceContext, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
+import { Type } from "./type_pb.js";
 
 /**
  * Test that we can include all well-known types.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.d.ts
@@ -42,8 +42,8 @@
 // @generated from file google/protobuf/wrappers.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * Wrapper message for `double`.

--- a/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/wrappers_pb.js
@@ -42,7 +42,7 @@
 // @generated from file google/protobuf/wrappers.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3, ScalarType} from "@bufbuild/protobuf";
+import { proto3, ScalarType } from "@bufbuild/protobuf";
 
 /**
  * Wrapper message for `double`.

--- a/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
@@ -24,8 +24,8 @@
 
 // Comment before package.
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * Leading comment for enum.

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * The entire enum is deprecated

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ImplicitlyDeprecatedMessage

--- a/packages/protobuf-test/src/gen/ts/extra/enum_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/enum_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/enum.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.AnnotatedEnum

--- a/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/example.proto (package docs, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message docs.Example

--- a/packages/protobuf-test/src/gen/ts/extra/msg-json-names_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-json-names_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-json-names.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.JsonNamesMessage

--- a/packages/protobuf-test/src/gen/ts/extra/msg-maps_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-maps_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-maps.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.MapsEnum

--- a/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-message.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.MessageFieldMessage

--- a/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-oneof.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.OneofEnum

--- a/packages/protobuf-test/src/gen/ts/extra/msg-scalar_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-scalar_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-scalar.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ScalarValuesMessage

--- a/packages/protobuf-test/src/gen/ts/extra/msg-self-reference_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-self-reference_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/msg-self-reference.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.SelfReferencingMessage

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/name-clash.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage as PartialMessage$1, PlainMessage as PlainMessage$1} from "@bufbuild/protobuf";
-import {Message as Message$1, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage as PartialMessage$1, PlainMessage as PlainMessage$1 } from "@bufbuild/protobuf";
+import { Message as Message$1, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.ReservedPropertyNames

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/proto2.proto (package spec, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto2Enum

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/proto3.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto3Enum

--- a/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/service-example.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.FailRequest

--- a/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/wkt-wrappers.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, Message, proto3, StringValue, UInt32Value, UInt64Value} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, Message, proto3, StringValue, UInt32Value, UInt64Value } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.WrappersMessage

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/any_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/any_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/any.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, MessageType, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, MessageType, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/api_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/api_pb.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/api.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {Option, Syntax} from "./type_pb.js";
-import {SourceContext} from "./source_context_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Option, Syntax } from "./type_pb.js";
+import { SourceContext } from "./source_context_pb.js";
 
 /**
  * Api is a light-weight descriptor for an API Interface.

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
@@ -48,9 +48,9 @@
 // @generated from file google/protobuf/compiler/plugin.proto (package google.protobuf.compiler, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import {FileDescriptorProto, GeneratedCodeInfo} from "../descriptor_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import { FileDescriptorProto, GeneratedCodeInfo } from "../descriptor_pb.js";
 
 /**
  * The version number of protocol compiler.

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
@@ -40,8 +40,8 @@
 // @generated from file google/protobuf/descriptor.proto (package google.protobuf, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/duration_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/duration_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/duration.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * A Duration represents a signed, fixed-length span of time represented

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/empty_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/empty_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/empty.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * A generic empty message that you can re-use to avoid defining duplicated

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/field_mask.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `FieldMask` represents a set of symbolic field paths, for example:

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/source_context_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/source_context_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/source_context.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `SourceContext` represents information about the source of a

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/struct_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/struct_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/struct.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonObject, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonObject, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/test_messages_proto2.proto (package protobuf_test_messages.proto2, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto2.ForeignEnumProto2

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
@@ -39,8 +39,8 @@
 // @generated from file google/protobuf/test_messages_proto3.proto (package protobuf_test_messages.proto3, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Any, BoolValue, BytesValue, DoubleValue, Duration, FieldMask, FloatValue, Int32Value, Int64Value, ListValue, Message, NullValue, proto3, protoInt64, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Any, BoolValue, BytesValue, DoubleValue, Duration, FieldMask, FloatValue, Int32Value, Int64Value, ListValue, Message, NullValue, proto3, protoInt64, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_test_messages.proto3.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/timestamp_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/timestamp_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/timestamp.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/type.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {SourceContext} from "./source_context_pb.js";
-import {Any} from "./any_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { SourceContext } from "./source_context_pb.js";
+import { Any } from "./any_pb.js";
 
 /**
  * The syntax in which a protocol buffer element is defined.

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_arena_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_arena.proto (package proto2_arena_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message proto2_arena_unittest.NestedMessage

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -41,8 +41,8 @@
 // We don't put this in a package within proto2 because we need to make sure
 // that the generated code doesn't depend on being in the proto2 namespace.
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Any, FileOptions, Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Any, FileOptions, Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.MethodOpt1

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_drop_unknown_fields_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_drop_unknown_fields_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_drop_unknown_fields.proto (package unittest_drop_unknown_fields, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message unittest_drop_unknown_fields.Foo

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
@@ -38,9 +38,9 @@
 // @generated from file google/protobuf/unittest_embed_optimize_for.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import {TestOptimizedForSize} from "./unittest_optimize_for_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import { TestOptimizedForSize } from "./unittest_optimize_for_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestEmbedOptimizedForSize

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
@@ -40,8 +40,8 @@
 // @generated from file google/protobuf/unittest_enormous_descriptor.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestEnormousDescriptor

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
@@ -36,8 +36,8 @@
 // @generated from file google/protobuf/unittest_import_lite.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest_import.ImportEnumLite

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
@@ -43,8 +43,8 @@
 // In test_util.h we do
 // "using namespace unittest_import = protobuf_unittest_import".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest_import.ImportEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_import_public_lite.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest_import.PublicImportMessageLite

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_import_public.proto (package protobuf_unittest_import, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest_import.PublicImportMessage

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_custom_option_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_custom_option_pb.ts
@@ -42,8 +42,8 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.lazy_imports.LazyMessage

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_enum_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_enum_pb.ts
@@ -42,7 +42,7 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import {proto2} from "@bufbuild/protobuf";
+import { proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.lazy_imports.LazyEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_pb.ts
@@ -42,9 +42,9 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import {LazyMessage} from "./unittest_lazy_dependencies_custom_option_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import { LazyMessage } from "./unittest_lazy_dependencies_custom_option_pb.js";
 
 /**
  * @generated from message protobuf_unittest.lazy_imports.ImportedMessage

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
@@ -36,9 +36,9 @@
 // @generated from file google/protobuf/unittest_lite_imports_nonlite.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import {TestAllTypes, TestRequired} from "./unittest_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import { TestAllTypes, TestRequired } from "./unittest_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestLiteImportsNonlite

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
@@ -36,10 +36,10 @@
 // @generated from file google/protobuf/unittest_lite.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2, protoInt64} from "@bufbuild/protobuf";
-import {ImportEnumLite, ImportMessageLite} from "./unittest_import_lite_pb.js";
-import {PublicImportMessageLite} from "./unittest_import_public_lite_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
+import { ImportEnumLite, ImportMessageLite } from "./unittest_import_lite_pb.js";
+import { PublicImportMessageLite } from "./unittest_import_public_lite_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.ForeignEnumLite

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
@@ -39,9 +39,9 @@
 // @generated from file google/protobuf/unittest_mset.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import {TestMessageSet} from "./unittest_mset_wire_format_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import { TestMessageSet } from "./unittest_mset_wire_format_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestMessageSetContainer

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
@@ -38,8 +38,8 @@
 // @generated from file google/protobuf/unittest_mset_wire_format.proto (package proto2_wireformat_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * A message with message_set_wire_format.

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_field_presence_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_field_presence_pb.ts
@@ -34,9 +34,9 @@
 // @generated from file google/protobuf/unittest_no_field_presence.proto (package proto2_nofieldpresence_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
-import {TestAllTypes as TestAllTypes$1, TestRequired} from "./unittest_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { TestAllTypes as TestAllTypes$1, TestRequired } from "./unittest_pb.js";
 
 /**
  * @generated from enum proto2_nofieldpresence_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
@@ -34,8 +34,8 @@
 // @generated from file google/protobuf/unittest_no_generic_services.proto (package protobuf_unittest.no_generic_services_test, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.no_generic_services_test.TestEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
@@ -38,9 +38,9 @@
 // @generated from file google/protobuf/unittest_optimize_for.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
-import {ForeignMessage} from "./unittest_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
+import { ForeignMessage } from "./unittest_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestOptimizedForSize

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -44,10 +44,10 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2, protoInt64} from "@bufbuild/protobuf";
-import {ImportEnum, ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
+import { ImportEnum, ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum2_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_preserve_unknown_enum2.proto (package proto2_preserve_unknown_enum_unittest, syntax proto2)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto2} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum proto2_preserve_unknown_enum_unittest.MyEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_preserve_unknown_enum.proto (package proto3_preserve_unknown_enum_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum proto3_preserve_unknown_enum_unittest.MyEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_lite_pb.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3_arena_lite.proto (package proto3_arena_lite_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_arena_lite_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3_arena.proto (package proto3_arena_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_arena_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_lite_pb.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3_lite.proto (package proto3_lite_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_lite_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
@@ -32,8 +32,8 @@
 // @generated from file google/protobuf/unittest_proto3_optional.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestProto3Optional

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
@@ -32,10 +32,10 @@
 // @generated from file google/protobuf/unittest_proto3.proto (package proto3_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64} from "@bufbuild/protobuf";
-import {ImportMessage} from "./unittest_import_pb.js";
-import {PublicImportMessage} from "./unittest_import_public_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { ImportMessage } from "./unittest_import_pb.js";
+import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
 /**
  * @generated from enum proto3_unittest.ForeignEnum

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
@@ -2,9 +2,9 @@
 // @generated from file google/protobuf/unittest_well_known_types.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Any, Api, BoolValue, BytesValue, DoubleValue, Duration, Empty, FieldMask, FloatValue, Int32Value, Int64Value, Message, proto3, SourceContext, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value} from "@bufbuild/protobuf";
-import {Type} from "./type_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Any, Api, BoolValue, BytesValue, DoubleValue, Duration, Empty, FieldMask, FloatValue, Int32Value, Int64Value, Message, proto3, SourceContext, StringValue, Struct, Timestamp, UInt32Value, UInt64Value, Value } from "@bufbuild/protobuf";
+import { Type } from "./type_pb.js";
 
 /**
  * Test that we can include all well-known types.

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/wrappers_pb.ts
@@ -42,8 +42,8 @@
 // @generated from file google/protobuf/wrappers.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, protoInt64, ScalarType} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, JsonWriteOptions, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, ScalarType } from "@bufbuild/protobuf";
 
 /**
  * Wrapper message for `double`.

--- a/packages/protobuf/src/google/protobuf/any_pb.ts
+++ b/packages/protobuf/src/google/protobuf/any_pb.ts
@@ -16,13 +16,13 @@
 // @generated from file google/protobuf/any.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {proto3} from "../../proto3.js";
-import type {JsonReadOptions, JsonValue, JsonWriteOptions} from "../../json-format.js";
-import type {MessageType} from "../../message-type.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { proto3 } from "../../proto3.js";
+import type { JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
+import type { MessageType } from "../../message-type.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
 
 /**
  * `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/packages/protobuf/src/google/protobuf/api_pb.ts
+++ b/packages/protobuf/src/google/protobuf/api_pb.ts
@@ -16,14 +16,14 @@
 // @generated from file google/protobuf/api.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {Option, Syntax} from "./type_pb.js";
-import {SourceContext} from "./source_context_pb.js";
-import {proto3} from "../../proto3.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
-import type {JsonReadOptions, JsonValue} from "../../json-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { Option, Syntax } from "./type_pb.js";
+import { SourceContext } from "./source_context_pb.js";
+import { proto3 } from "../../proto3.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
+import type { JsonReadOptions, JsonValue } from "../../json-format.js";
 
 /**
  * Api is a light-weight descriptor for an API Interface.

--- a/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
@@ -32,13 +32,13 @@
 // @generated from file google/protobuf/compiler/plugin.proto (package google.protobuf.compiler, syntax proto2)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../../message.js";
-import {Message} from "../../../message.js";
-import {proto2} from "../../../proto2.js";
-import type {FieldList} from "../../../field-list.js";
-import type {BinaryReadOptions} from "../../../binary-format.js";
-import type {JsonReadOptions, JsonValue} from "../../../json-format.js";
-import {FileDescriptorProto, GeneratedCodeInfo} from "../descriptor_pb.js";
+import type { PartialMessage, PlainMessage } from "../../../message.js";
+import { Message } from "../../../message.js";
+import { proto2 } from "../../../proto2.js";
+import type { FieldList } from "../../../field-list.js";
+import type { BinaryReadOptions } from "../../../binary-format.js";
+import type { JsonReadOptions, JsonValue } from "../../../json-format.js";
+import { FileDescriptorProto, GeneratedCodeInfo } from "../descriptor_pb.js";
 
 /**
  * The version number of protocol compiler.

--- a/packages/protobuf/src/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/google/protobuf/descriptor_pb.ts
@@ -24,12 +24,12 @@
 // @generated from file google/protobuf/descriptor.proto (package google.protobuf, syntax proto2)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {proto2} from "../../proto2.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
-import type {JsonReadOptions, JsonValue} from "../../json-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { proto2 } from "../../proto2.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
+import type { JsonReadOptions, JsonValue } from "../../json-format.js";
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto

--- a/packages/protobuf/src/google/protobuf/duration_pb.ts
+++ b/packages/protobuf/src/google/protobuf/duration_pb.ts
@@ -16,13 +16,13 @@
 // @generated from file google/protobuf/duration.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {protoInt64} from "../../proto-int64.js";
-import {proto3} from "../../proto3.js";
-import type {JsonReadOptions, JsonValue, JsonWriteOptions} from "../../json-format.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { protoInt64 } from "../../proto-int64.js";
+import { proto3 } from "../../proto3.js";
+import type { JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
 
 /**
  * A Duration represents a signed, fixed-length span of time represented

--- a/packages/protobuf/src/google/protobuf/empty_pb.ts
+++ b/packages/protobuf/src/google/protobuf/empty_pb.ts
@@ -16,12 +16,12 @@
 // @generated from file google/protobuf/empty.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {proto3} from "../../proto3.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
-import type {JsonReadOptions, JsonValue} from "../../json-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { proto3 } from "../../proto3.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
+import type { JsonReadOptions, JsonValue } from "../../json-format.js";
 
 /**
  * A generic empty message that you can re-use to avoid defining duplicated

--- a/packages/protobuf/src/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf/src/google/protobuf/field_mask_pb.ts
@@ -16,12 +16,12 @@
 // @generated from file google/protobuf/field_mask.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {proto3} from "../../proto3.js";
-import type {JsonReadOptions, JsonValue, JsonWriteOptions} from "../../json-format.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { proto3 } from "../../proto3.js";
+import type { JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
 
 /**
  * `FieldMask` represents a set of symbolic field paths, for example:

--- a/packages/protobuf/src/google/protobuf/source_context_pb.ts
+++ b/packages/protobuf/src/google/protobuf/source_context_pb.ts
@@ -16,12 +16,12 @@
 // @generated from file google/protobuf/source_context.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {proto3} from "../../proto3.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
-import type {JsonReadOptions, JsonValue} from "../../json-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { proto3 } from "../../proto3.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
+import type { JsonReadOptions, JsonValue } from "../../json-format.js";
 
 /**
  * `SourceContext` represents information about the source of a

--- a/packages/protobuf/src/google/protobuf/struct_pb.ts
+++ b/packages/protobuf/src/google/protobuf/struct_pb.ts
@@ -16,12 +16,12 @@
 // @generated from file google/protobuf/struct.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "../../proto3.js";
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import type {JsonObject, JsonReadOptions, JsonValue, JsonWriteOptions} from "../../json-format.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
+import { proto3 } from "../../proto3.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import type { JsonObject, JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
 
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the

--- a/packages/protobuf/src/google/protobuf/timestamp_pb.ts
+++ b/packages/protobuf/src/google/protobuf/timestamp_pb.ts
@@ -16,13 +16,13 @@
 // @generated from file google/protobuf/timestamp.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {protoInt64} from "../../proto-int64.js";
-import {proto3} from "../../proto3.js";
-import type {JsonReadOptions, JsonValue, JsonWriteOptions} from "../../json-format.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { protoInt64 } from "../../proto-int64.js";
+import { proto3 } from "../../proto3.js";
+import type { JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local

--- a/packages/protobuf/src/google/protobuf/type_pb.ts
+++ b/packages/protobuf/src/google/protobuf/type_pb.ts
@@ -16,14 +16,14 @@
 // @generated from file google/protobuf/type.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import {proto3} from "../../proto3.js";
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {SourceContext} from "./source_context_pb.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
-import type {JsonReadOptions, JsonValue} from "../../json-format.js";
-import {Any} from "./any_pb.js";
+import { proto3 } from "../../proto3.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { SourceContext } from "./source_context_pb.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
+import type { JsonReadOptions, JsonValue } from "../../json-format.js";
+import { Any } from "./any_pb.js";
 
 /**
  * The syntax in which a protocol buffer element is defined.

--- a/packages/protobuf/src/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf/src/google/protobuf/wrappers_pb.ts
@@ -26,14 +26,14 @@
 // @generated from file google/protobuf/wrappers.proto (package google.protobuf, syntax proto3)
 /* eslint-disable */
 
-import type {PartialMessage, PlainMessage} from "../../message.js";
-import {Message} from "../../message.js";
-import {proto3} from "../../proto3.js";
-import type {JsonReadOptions, JsonValue, JsonWriteOptions} from "../../json-format.js";
-import {ScalarType} from "../../field.js";
-import type {FieldList} from "../../field-list.js";
-import type {BinaryReadOptions} from "../../binary-format.js";
-import {protoInt64} from "../../proto-int64.js";
+import type { PartialMessage, PlainMessage } from "../../message.js";
+import { Message } from "../../message.js";
+import { proto3 } from "../../proto3.js";
+import type { JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
+import { ScalarType } from "../../field.js";
+import type { FieldList } from "../../field-list.js";
+import type { BinaryReadOptions } from "../../binary-format.js";
+import { protoInt64 } from "../../proto-int64.js";
 
 /**
  * Wrapper message for `double`.

--- a/packages/protoplugin-example/src/gen/buf/connect/demo/eliza/v1/eliza_pb.ts
+++ b/packages/protoplugin-example/src/gen/buf/connect/demo/eliza/v1/eliza_pb.ts
@@ -17,8 +17,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * SayRequest describes the sentence said to the ELIZA program.

--- a/packages/protoplugin-example/src/gen/buf/connect/demo/eliza/v1/eliza_twirp.ts
+++ b/packages/protoplugin-example/src/gen/buf/connect/demo/eliza/v1/eliza_twirp.ts
@@ -17,8 +17,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {JsonValue, Message} from "@bufbuild/protobuf";
-import {SayRequest, SayResponse} from "./eliza_pb.js";
+import type { JsonValue, Message } from "@bufbuild/protobuf";
+import { SayRequest, SayResponse } from "./eliza_pb.js";
 
 /**
  * ElizaService provides a way to talk to the ELIZA, which is a port of

--- a/packages/protoplugin-test/src/gen/proto/address_book_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/address_book_pb.ts
@@ -17,9 +17,9 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
-import {Person} from "./person_pb.js";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
+import { Person } from "./person_pb.js";
 
 /**
  * Our address book file is just one of these.

--- a/packages/protoplugin-test/src/gen/proto/custom_options_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/custom_options_pb.ts
@@ -17,8 +17,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum example.ServiceStatus

--- a/packages/protoplugin-test/src/gen/proto/person_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/person_pb.ts
@@ -17,8 +17,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3, Timestamp} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * @generated from message example.Person

--- a/packages/protoplugin-test/src/gen/proto/service_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/service_pb.ts
@@ -17,8 +17,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import type {BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage} from "@bufbuild/protobuf";
-import {Message, proto3} from "@bufbuild/protobuf";
+import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum example.EnumWithOptions

--- a/packages/protoplugin-test/src/generated-file.test.ts
+++ b/packages/protoplugin-test/src/generated-file.test.ts
@@ -48,7 +48,7 @@ describe("print with tagged template literal", function () {
       f.print`export function foo(): ${Foo} { return new ${Foo}(); };`;
     });
     expect(lines).toStrictEqual([
-      'import {Foo} from "foo";',
+      'import { Foo } from "foo";',
       "",
       "export function foo(): Foo { return new Foo(); };",
     ]);
@@ -61,7 +61,7 @@ describe("print with tagged template literal", function () {
 };`;
     });
     expect(lines).toStrictEqual([
-      'import {Foo} from "foo";',
+      'import { Foo } from "foo";',
       "",
       "export function foo(): Foo {",
       "  return new Foo();",
@@ -79,7 +79,7 @@ export function foo(): ${Foo} {
 `;
     });
     expect(lines).toStrictEqual([
-      'import {Foo} from "foo";',
+      'import { Foo } from "foo";',
       "",
       "",
       "export function foo(): Foo {",
@@ -99,6 +99,6 @@ export function foo(): ${Foo} {
       const Foo = f.import("Foo", "foo");
       f.print`${Foo}`;
     });
-    expect(lines).toStrictEqual(['import {Foo} from "foo";', "", "Foo"]);
+    expect(lines).toStrictEqual(['import { Foo } from "foo";', "", "Foo"]);
   });
 });

--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -88,7 +88,7 @@ describe("transpile", function () {
       f.print("export const j: ", schema.runtime.JsonValue, " = 1;");
     });
     expect(linesOf("test.ts")).toStrictEqual([
-      'import type {JsonValue} from "@bufbuild/protobuf";',
+      'import type { JsonValue } from "@bufbuild/protobuf";',
       "",
       "export const j: JsonValue = 1;",
     ]);
@@ -158,7 +158,7 @@ describe("transpile", function () {
       f.print("export function foo() { return new ", Foo, "(); };");
     });
     expect(linesOf("test.ts")).toStrictEqual([
-      'import {Foo} from "foo";',
+      'import { Foo } from "foo";',
       "",
       "export function foo() { return new Foo(); };",
     ]);
@@ -176,7 +176,7 @@ describe("transpile", function () {
       f.print("export function foo(): ", Foo, " { return new ", Foo, "(); };");
     });
     expect(linesOf("test.ts")).toStrictEqual([
-      'import {Foo} from "foo";',
+      'import { Foo } from "foo";',
       "",
       "export function foo(): Foo { return new Foo(); };",
     ]);

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -190,7 +190,7 @@ function elToContent(el: El[], importerPath: string): string {
       const p = names.map(({ name, alias }) =>
         alias == undefined ? name : `${name} as ${alias}`
       );
-      const what = `{${p.join(", ")}}`;
+      const what = `{ ${p.join(", ")} }`;
       if (typeOnly) {
         c.push(`import type ${what} from ${literalString(from)};\n`);
       } else {


### PR DESCRIPTION
The rationale for this change is that we should take the opportunity, when it arises, to make generated code look natural and typical (if possible). While this isn't a logical change, it's hopefully worthwhile in the pursuit of making the generated outputs feel more normal.

Here's an example:

```
- import {Message, proto3} from "@bufbuild/protobuf";
+ import { Message, proto3 } from "@bufbuild/protobuf";
```

Note that this falls in line with [Prettier's default](https://prettier.io/docs/en/options.html#bracket-spacing) as well. In fact, that's how I found it. I was generating code and trying to aim for a final output that matched prettier's default formatting and this was the only thing that I wasn't able to make match as a downstream consumer of protobuf-es.