### PR TITLE
fix map equality

### DIFF
--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { MapsMessage as TS_MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
+import { MapsMessage as JS_MapsMessage } from "./gen/js/extra/msg-maps_pb.js";
 import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage as JS_MessageFieldMessage } from "./gen/js/extra/msg-message_pb.js";
 import { ScalarValuesMessage as TS_ScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb.js";
@@ -96,4 +98,18 @@ describe("equals", function () {
       });
     }
   );
+
+  describeMT({ ts: TS_MapsMessage, js: JS_MapsMessage }, (messageType) => {
+    test("added key not equal", () => {
+      expect(
+        new messageType({
+          strStrField: { a: "b" },
+        }).equals(
+          new messageType({
+            strStrField: { a: "b", c: "d" },
+          })
+        )
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -164,7 +164,10 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             throw new Error(`oneof cannot contain ${s.kind}`);
           case "map":
             const keys = Object.keys(va);
-            if (keys.some((k) => vb[k] === undefined)) {
+            if (
+              keys.some((k) => vb[k] === undefined) ||
+              Object.keys(vb).some((k) => va[k] === undefined)
+            ) {
               return false;
             }
             switch (m.V.kind) {


### PR DESCRIPTION
Fix map equality when keys are added to the second map.

Fixes #304 