### PR TITLE
Directly Export PluginInit for Testing

### DIFF
--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -20,7 +20,7 @@ import { transpile } from "./ecmascript/transpile.js";
 import { PluginOptionError } from "./error.js";
 import type { RewriteImports } from "./ecmascript/import-path.js";
 
-interface PluginInit {
+export interface PluginInit {
   /**
    * Name of this code generator plugin.
    */
@@ -84,7 +84,7 @@ interface PluginInit {
   ) => FileInfo[];
 }
 
-type PluginOptionParseFn = (key: string, value: string | undefined) => void;
+export type PluginOptionParseFn = (key: string, value: string | undefined) => void;
 
 /**
  * Create a new code generator plugin for ECMAScript.

--- a/packages/protoplugin/src/index.ts
+++ b/packages/protoplugin/src/index.ts
@@ -16,3 +16,4 @@ export { Plugin } from "./plugin.js";
 export { Schema } from "./ecmascript/schema.js";
 export { runNodeJs } from "./run-node.js";
 export { createEcmaScriptPlugin } from "./create-es-plugin.js";
+export type { PluginInit, PluginOptionParseFn } from "./create-es-plugin.js";


### PR DESCRIPTION
I needed this when writing tests for plugins.  We already indirectly export it:

```ts
type PluginInit = Parameters<typeof createEcmaScriptPlugin>[0]
```

(which, is what I had to do to keep going with my tests)

This PR just makes it directly exported.