### PR TITLE
Add plugin option `import_extension` to replace the `.js` extension in import paths

### DIFF
--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -124,11 +124,26 @@ By default, we generate JavaScript and TypeScript declaration files, which
 produces the smallest code size. If you prefer to generate TypeScript, use
 `target=ts`.
 
+### `import_extension=.js`
+
+By default, [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es)
+(and all other plugins based on [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin))
+uses a `.js` file extensions in import paths, even in TypeScript files.
+
+This is unintuitive, but necessary for [ECMAScript modules in Node.js](https://www.typescriptlang.org/docs/handbook/esm-node.html).
+Unfortunately, not all bundlers and tools have caught up yet, and Deno 
+requires `.ts`. With this plugin option, you can replace `.js` extensions 
+in import paths with the given value. For example, set
+
+- `import_extension=` to remove the `.js` extension
+- `import_extension=.ts` to replace the `.js` extension with `.ts`
+
+
 ### `keep_empty_files=true`
 
-By default, [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es) 
-(and all other plugins based on [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin)) 
-omit empty files from the plugin output. This option disables pruning of 
-empty files, to allow for smooth interoperation with Bazel and similar 
+By default, [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es)
+(and all other plugins based on [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin))
+omit empty files from the plugin output. This option disables pruning of
+empty files, to allow for smooth interoperation with Bazel and similar
 tooling that requires all output files to be declared ahead of time.
 Unless you use Bazel, it is very unlikely that you need this option.

--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -121,8 +121,8 @@ Multiple values can be given by separating them with `+`, for example
 `target=js+dts`.
 
 By default, we generate JavaScript and TypeScript declaration files, which
-produces the smallest code size. If you prefer to generate TypeScript, use
-`target=ts`.
+produces the smallest code size and is the most compatible with various 
+bundler configurations. If you prefer to generate TypeScript, use `target=ts`.
 
 ### `import_extension=.js`
 

--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -135,7 +135,7 @@ Unfortunately, not all bundlers and tools have caught up yet, and Deno
 requires `.ts`. With this plugin option, you can replace `.js` extensions 
 in import paths with the given value. For example, set
 
-- `import_extension=` to remove the `.js` extension
+- `import_extension=none` to remove the `.js` extension
 - `import_extension=.ts` to replace the `.js` extension with `.ts`
 
 

--- a/packages/protoplugin-test/src/generated-file.test.ts
+++ b/packages/protoplugin-test/src/generated-file.test.ts
@@ -14,7 +14,8 @@
 
 import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
-import { assert, getCodeGeneratorRequest } from "./helpers";
+import { assert, getDescriptorSet } from "./helpers";
+import { CodeGeneratorRequest } from "@bufbuild/protobuf";
 
 /**
  * Generates a single file using the plugin framework and the given print function.
@@ -24,7 +25,7 @@ import { assert, getCodeGeneratorRequest } from "./helpers";
 function generate(
   printFn: (f: GeneratedFile, schema: Schema) => void
 ): string[] {
-  const req = getCodeGeneratorRequest("target=ts", []);
+  const req = new CodeGeneratorRequest({ parameter: "target=ts" });
   const plugin = createEcmaScriptPlugin({
     name: "test-plugin",
     version: "v99.0.0",
@@ -54,10 +55,8 @@ describe("generated file", () => {
     ]);
   });
   it("should print npm import", function () {
-    const lines = generate((f, schema) => {
-      const exampleDesc = schema.allFiles
-        .find((f) => f.name == "proto/person")
-        ?.messages.find((m) => m.typeName == "example.Person");
+    const lines = generate((f) => {
+      const exampleDesc = getDescriptorSet().messages.get("example.Person");
       assert(exampleDesc);
       const Foo = f.import("Foo", "@scope/pkg");
       f.print`${Foo}`;
@@ -91,10 +90,8 @@ describe("generated file", () => {
     ]);
   });
   it("should print descriptor imports", function () {
-    const lines = generate((f, schema) => {
-      const exampleDesc = schema.allFiles
-        .find((f) => f.name == "proto/person")
-        ?.messages.find((m) => m.typeName == "example.Person");
+    const lines = generate((f) => {
+      const exampleDesc = getDescriptorSet().messages.get("example.Person");
       assert(exampleDesc);
       f.print`${exampleDesc}.typeName`;
     });

--- a/packages/protoplugin-test/src/import_extension.test.ts
+++ b/packages/protoplugin-test/src/import_extension.test.ts
@@ -60,6 +60,20 @@ describe("import_extension", function () {
       "Bar",
     ]);
   });
+  test("should be removed with 'none'", () => {
+    const lines = generate(
+      (f) => {
+        const Bar = f.import("Bar", "./foo/bar_pb.js");
+        f.print`${Bar}`;
+      },
+      ["import_extension=none"]
+    );
+    expect(lines).toStrictEqual([
+      'import { Bar } from "./foo/bar_pb";',
+      "",
+      "Bar",
+    ]);
+  });
   test("should be removed with ''", () => {
     const lines = generate(
       (f) => {

--- a/packages/protoplugin-test/src/import_extension.test.ts
+++ b/packages/protoplugin-test/src/import_extension.test.ts
@@ -1,0 +1,91 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
+import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
+import { CodeGeneratorRequest } from "@bufbuild/protobuf";
+
+/**
+ * Generates a single file using the plugin framework and the given print function,
+ * passing the given options to the plugin.
+ * The returned string array represents the generated file content created using printFn.
+ */
+function generate(
+  printFn: (f: GeneratedFile, schema: Schema) => void,
+  options: string[]
+): string[] {
+  const req = new CodeGeneratorRequest({
+    parameter: `target=ts,${options.join(",")}`,
+  });
+  const plugin = createEcmaScriptPlugin({
+    name: "test-plugin",
+    version: "v99.0.0",
+    generateTs: (schema: Schema) => {
+      const f = schema.generateFile("test.ts");
+      printFn(f, schema);
+    },
+  });
+  const res = plugin.run(req);
+  if (res.file.length !== 1) {
+    throw new Error(`no file generated`);
+  }
+
+  const content = res.file[0].content ?? "";
+  return content.trim().split("\n");
+}
+
+describe("import_extension", function () {
+  test("should be replaced with '.ts'", () => {
+    const lines = generate(
+      (f) => {
+        const Bar = f.import("Bar", "./foo/bar_pb.js");
+        f.print`${Bar}`;
+      },
+      ["import_extension=.ts"]
+    );
+    expect(lines).toStrictEqual([
+      'import { Bar } from "./foo/bar_pb.ts";',
+      "",
+      "Bar",
+    ]);
+  });
+  test("should be removed with ''", () => {
+    const lines = generate(
+      (f) => {
+        const Bar = f.import("Bar", "./foo/bar_pb.js");
+        f.print`${Bar}`;
+      },
+      ["import_extension="]
+    );
+    expect(lines).toStrictEqual([
+      'import { Bar } from "./foo/bar_pb";',
+      "",
+      "Bar",
+    ]);
+  });
+  test("should only touch .js import paths", () => {
+    const lines = generate(
+      (f) => {
+        const json = f.import("json", "./foo/bar_pb.json");
+        f.print`${json}`;
+      },
+      ["import_extension=.ts"]
+    );
+    expect(lines).toStrictEqual([
+      'import { json } from "./foo/bar_pb.json";',
+      "",
+      "json",
+    ]);
+  });
+});

--- a/packages/protoplugin-test/src/rewrite_imports.test.ts
+++ b/packages/protoplugin-test/src/rewrite_imports.test.ts
@@ -14,7 +14,8 @@
 
 import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
-import { assert, getCodeGeneratorRequest } from "./helpers";
+import { assert, getDescriptorSet } from "./helpers";
+import { CodeGeneratorRequest } from "@bufbuild/protobuf";
 
 /**
  * Generates a single file using the plugin framework and the given print function,
@@ -26,7 +27,9 @@ function generate(
   printFn: (f: GeneratedFile, schema: Schema) => void,
   options: string[]
 ): string[] {
-  const req = getCodeGeneratorRequest(`target=ts,${options.join(",")}`, []);
+  const req = new CodeGeneratorRequest({
+    parameter: `target=ts,${options.join(",")}`,
+  });
   const plugin = createEcmaScriptPlugin({
     name: "test-plugin",
     version: "v99.0.0",
@@ -76,10 +79,8 @@ describe("rewrite_imports", function () {
   });
   test("should rewrite npm import to other package", () => {
     const lines = generate(
-      (f, schema) => {
-        const exampleDesc = schema.allFiles
-          .find((f) => f.name == "proto/person")
-          ?.messages.find((m) => m.typeName == "example.Person");
+      (f) => {
+        const exampleDesc = getDescriptorSet().messages.get("example.Person");
         assert(exampleDesc);
         const Foo = f.import("Foo", "@scope/pkg");
         f.print`${Foo}`;

--- a/packages/protoplugin-test/src/rewrite_imports.test.ts
+++ b/packages/protoplugin-test/src/rewrite_imports.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
+import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
+import { assert, getCodeGeneratorRequest } from "./helpers";
+
+/**
+ * Generates a single file using the plugin framework and the given print function,
+ * passing the given options to the plugin.
+ * Uses descriptorset.bin for the code generator request.
+ * The returned string array represents the generated file content created using printFn.
+ */
+function generate(
+  printFn: (f: GeneratedFile, schema: Schema) => void,
+  options: string[]
+): string[] {
+  const req = getCodeGeneratorRequest(`target=ts,${options.join(",")}`, []);
+  const plugin = createEcmaScriptPlugin({
+    name: "test-plugin",
+    version: "v99.0.0",
+    generateTs: (schema: Schema) => {
+      const f = schema.generateFile("test.ts");
+      printFn(f, schema);
+    },
+  });
+  const res = plugin.run(req);
+  if (res.file.length !== 1) {
+    throw new Error(`no file generated`);
+  }
+
+  const content = res.file[0].content ?? "";
+  return content.trim().split("\n");
+}
+
+describe("rewrite_imports", function () {
+  test("example works as documented", () => {
+    const lines = generate(
+      (f) => {
+        const Bar = f.import("Bar", "./foo/bar_pb.js");
+        const Baz = f.import("Baz", "./foo/bar/baz_pb.js");
+        f.print`console.log(${Bar}, ${Baz});`;
+      },
+      ["rewrite_imports=./foo/**/*_pb.js:@scope/pkg"]
+    );
+    expect(lines).toStrictEqual([
+      'import { Bar } from "@scope/pkg/foo/bar_pb.js";',
+      'import { Baz } from "@scope/pkg/foo/bar/baz_pb.js";',
+      "",
+      "console.log(Bar, Baz);",
+    ]);
+  });
+  test("should rewrite runtime import to other package", () => {
+    const lines = generate(
+      (f, schema) => {
+        f.print`${schema.runtime.ScalarType}.INT32`;
+      },
+      ["rewrite_imports=@bufbuild/protobuf:@scope/pkg"]
+    );
+    expect(lines).toStrictEqual([
+      'import { ScalarType } from "@scope/pkg";',
+      "",
+      "ScalarType.INT32",
+    ]);
+  });
+  test("should rewrite npm import to other package", () => {
+    const lines = generate(
+      (f, schema) => {
+        const exampleDesc = schema.allFiles
+          .find((f) => f.name == "proto/person")
+          ?.messages.find((m) => m.typeName == "example.Person");
+        assert(exampleDesc);
+        const Foo = f.import("Foo", "@scope/pkg");
+        f.print`${Foo}`;
+      },
+      ["rewrite_imports=@scope/pkg:@other-scope/other-pkg"]
+    );
+    expect(lines).toStrictEqual([
+      'import { Foo } from "@other-scope/other-pkg";',
+      "",
+      "Foo",
+    ]);
+  });
+});

--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -262,7 +262,7 @@ function parseParameter(
         break;
       }
       case "import_extension": {
-        importExtension = value;
+        importExtension = value === "none" ? "" : value;
         break;
       }
       case "keep_empty_files": {

--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { Target } from "./ecmascript";
-import { Schema, createSchema, toResponse } from "./ecmascript/schema.js";
+import { createSchema, Schema, toResponse } from "./ecmascript/schema.js";
 import type { FileInfo } from "./ecmascript/generated-file.js";
 import type { Plugin } from "./plugin.js";
 import { transpile } from "./ecmascript/transpile.js";
@@ -103,6 +103,7 @@ export function createEcmaScriptPlugin(init: PluginInit): Plugin {
         tsNocheck,
         bootstrapWkt,
         rewriteImports,
+        importExtension,
         keepEmptyFiles,
       } = parseParameter(req.parameter, init.parseOption);
       const { schema, getFileInfo } = createSchema(
@@ -113,6 +114,7 @@ export function createEcmaScriptPlugin(init: PluginInit): Plugin {
         tsNocheck,
         bootstrapWkt,
         rewriteImports,
+        importExtension,
         keepEmptyFiles
       );
 
@@ -199,6 +201,7 @@ function parseParameter(
   let bootstrapWkt = false;
   let keepEmptyFiles = false;
   const rewriteImports: RewriteImports = [];
+  let importExtension = ".js";
   for (const { key, value } of splitParameter(parameter)) {
     switch (key) {
       case "target":
@@ -258,6 +261,10 @@ function parseParameter(
         rewriteImports.push({ pattern, target });
         break;
       }
+      case "import_extension": {
+        importExtension = value;
+        break;
+      }
       case "keep_empty_files": {
         switch (value) {
           case "true":
@@ -285,7 +292,14 @@ function parseParameter(
         break;
     }
   }
-  return { targets, tsNocheck, bootstrapWkt, rewriteImports, keepEmptyFiles };
+  return {
+    targets,
+    tsNocheck,
+    bootstrapWkt,
+    rewriteImports,
+    importExtension,
+    keepEmptyFiles,
+  };
 }
 
 function splitParameter(

--- a/packages/protoplugin/src/ecmascript/import-path.ts
+++ b/packages/protoplugin/src/ecmascript/import-path.ts
@@ -58,11 +58,13 @@ const cache = new WeakMap<
 >();
 
 /**
- * Apply import rewrites to the given path.
+ * Apply import rewrites to the given import path, and change all .js extensions
+ * to the given import extension.
  */
 export function rewriteImportPath(
   importPath: string,
-  rewriteImports: RewriteImports
+  rewriteImports: RewriteImports,
+  importExtension: string
 ): string {
   let ri = cache.get(rewriteImports);
   if (ri === undefined) {
@@ -76,10 +78,18 @@ export function rewriteImportPath(
   }
   for (const { pattern, target } of ri) {
     if (pattern.test(importPath)) {
-      return (
-        target.replace(/\/$/, "") + importPath.replace(relativePathRE, "/")
-      );
+      if (relativePathRE.test(importPath)) {
+        importPath =
+          target.replace(/\/$/, "") + importPath.replace(relativePathRE, "/");
+      } else {
+        importPath = target;
+      }
+      break;
     }
+  }
+  if (importExtension != ".js" && importPath.endsWith(".js")) {
+    importPath =
+      importPath.substring(0, importPath.length - 3) + importExtension;
   }
   return importPath;
 }


### PR DESCRIPTION
### `import_extension=.js`

By default, [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es) (and all other plugins based on [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin)) uses a `.js` file extensions in import paths, even in TypeScript files.

This is unintuitive, but necessary for [ECMAScript modules in Node.js](https://www.typescriptlang.org/docs/handbook/esm-node.html). Unfortunately, not all bundlers and tools have caught up yet, and Deno requires `.ts`. With this plugin option, you can replace `.js` extensions in import paths with the given value. For example, set

- `import_extension=` to remove the `.js` extension
- `import_extension=.ts` to replace the `.js` extension with `.ts`