### PR TITLE
Improve JSON parse error message

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 73,959 b      | 36,839 b | 9,606 b |
+| protobuf-es         | 74,150 b      | 36,975 b | 9,660 b |
 | protobuf-javascript | 370,857 b  | 271,536 b | 43,759 b |

--- a/packages/protobuf-test/src/google/protobuf/struct.test.ts
+++ b/packages/protobuf-test/src/google/protobuf/struct.test.ts
@@ -71,6 +71,14 @@ describe("google.protobuf.Value", () => {
       });
       expect(value.toJsonString()).toBe("true");
     });
+    test("encoding unset value to JSON raises error", () => {
+      // Absence of any variant indicates an error.
+      // See struct.proto
+      const value = new Value();
+      expect(() => value.toJson()).toThrowError(
+        "google.protobuf.Value must have a value"
+      );
+    });
     test("decodes from JSON", () => {
       const value = Value.fromJsonString("true");
       expect(value.kind.case).toBe("boolValue");

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -15,10 +15,10 @@
 import type { PlainMessage } from "@bufbuild/protobuf";
 import { NullValue, protoInt64 } from "@bufbuild/protobuf";
 import {
-  TestAllTypesProto3,
-  TestAllTypesProto3_NestedEnum,
   ForeignEnum,
+  TestAllTypesProto3,
   TestAllTypesProto3_AliasedEnum,
+  TestAllTypesProto3_NestedEnum,
 } from "./gen/ts/google/protobuf/test_messages_proto3_pb.js";
 
 describe("PlainMessage", () => {
@@ -205,5 +205,15 @@ describe("PlainMessage", () => {
     const msg: PlainMessage<TestAllTypesProto3> = new TestAllTypesProto3();
 
     expect(msg).toBeDefined();
+  });
+});
+
+describe("Message.fromJsonString()", function () {
+  test("raises wrapped error on parse error", () => {
+    expect(() =>
+      TestAllTypesProto3.fromJsonString("this is not json")
+    ).toThrowError(
+      "cannot decode protobuf_test_messages.proto3.TestAllTypesProto3 from JSON: Unexpected token h in JSON at position 1"
+    );
   });
 });

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -88,8 +88,17 @@ export class Message<T extends Message<T> = AnyMessage> {
    * Parse a message from a JSON string.
    */
   fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): this {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- assigning to JsonValue is safe here
-    return this.fromJson(JSON.parse(jsonString), options);
+    let json: JsonValue;
+    try {
+      json = JSON.parse(jsonString) as JsonValue;
+    } catch (e) {
+      throw new Error(
+        `cannot decode ${this.getType().typeName} from JSON: ${
+          e instanceof Error ? e.message : String(e)
+        }`
+      );
+    }
+    return this.fromJson(json, options);
   }
 
   /**
@@ -124,7 +133,7 @@ export class Message<T extends Message<T> = AnyMessage> {
   }
 
   /**
-   * Override for serializaton behavior.  This will be invoked when calling
+   * Override for serialization behavior. This will be invoked when calling
    * JSON.stringify on this message (i.e. JSON.stringify(msg)).
    *
    * Note that this will not serialize google.protobuf.Any with a packed


### PR DESCRIPTION
We already provide helpful error messages when JSON input does not have the expected shape. But Message.fromJsonString() does not. This wraps errors raised by JSON.parse(), and adds a prefix with the message type name.

```ts
// currently:
Example.fromJsonString("this is not json") // Unexpected token h in JSON at position 1

// with this PR:
Example.fromJsonString("this is not json") // cannot decode Example from JSON: Unexpected token h in JSON at position 1