### PR TITLE
Use curated buf build plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
       - name: Cache
         uses: actions/cache@v3
         with:
+          github_token: ${{ github.token }}
+        with:
           path: |
             ~/.tmp
             .tmp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.9.0
-        with:
-          version: 1.1.0
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -11,4 +11,4 @@ server would usually do.
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
 | protobuf-es         | 74,150 b      | 36,975 b | 9,660 b |
-| protobuf-javascript | 370,857 b  | 271,536 b | 43,759 b |
+| protobuf-javascript | 370,614 b  | 271,674 b | 43,786 b |

--- a/packages/protobuf-bench/buf.gen.yaml
+++ b/packages/protobuf-bench/buf.gen.yaml
@@ -3,6 +3,8 @@
 # your choice.
 # Learn more: https://docs.buf.build/configuration/v1/buf-gen-yaml
 version: v1
+managed:
+  enabled: true
 plugins:
   - name: es
     path: packages/protoc-gen-es/bin/protoc-gen-es

--- a/packages/protobuf-bench/buf.gen.yaml
+++ b/packages/protobuf-bench/buf.gen.yaml
@@ -8,6 +8,6 @@ plugins:
     path: packages/protoc-gen-es/bin/protoc-gen-es
     opt: ts_nocheck=false,target=ts
     out: src/gen/protobuf-es
-  - remote: buf.build/protocolbuffers/plugins/js:v3.19.3-1
+  - plugin: buf.build/protocolbuffers/js
     out: src/gen/google-protobuf
     opt: import_style=commonjs

--- a/packages/protobuf-bench/buf.gen.yaml
+++ b/packages/protobuf-bench/buf.gen.yaml
@@ -3,8 +3,6 @@
 # your choice.
 # Learn more: https://docs.buf.build/configuration/v1/buf-gen-yaml
 version: v1
-managed:
-  enabled: true
 plugins:
   - name: es
     path: packages/protoc-gen-es/bin/protoc-gen-es

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/envelope_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/envelope_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/module_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/module_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/plugin_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/plugin_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginConfig', null, global);
 goog.exportSymbol('proto.buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginVersionMapping', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/repository_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/repository_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/role_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/role_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1OrganizationRole', null, global);
 goog.exportSymbol('proto.buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginRole', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/search_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/search_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1SearchFilter', null, global);
 /**

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/user_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/audit/v1alpha1/user_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1UserState', null, global);
 /**

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/breaking/v1/config_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/breaking/v1/config_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.breaking.v1.Config', null, global);
 goog.exportSymbol('proto.buf.alpha.breaking.v1.IDPaths', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/image/v1/image_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/image/v1/image_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_descriptor_pb = require('google-protobuf/google/protobuf/descriptor_pb.js');
 goog.object.extend(proto, google_protobuf_descriptor_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/lint/v1/config_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/lint/v1/config_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.lint.v1.Config', null, global);
 goog.exportSymbol('proto.buf.alpha.lint.v1.IDPaths', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/module/v1alpha1/module_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/module/v1alpha1/module_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_breaking_v1_config_pb = require('../../../../buf/alpha/breaking/v1/config_pb.js');
 goog.object.extend(proto, buf_alpha_breaking_v1_config_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/admin_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/admin_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_organization_pb = require('../../../../buf/alpha/registry/v1alpha1/organization_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_organization_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/audit_logs_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/audit_logs_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/authn_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/authn_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_user_pb = require('../../../../buf/alpha/registry/v1alpha1/user_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_user_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/authz_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/authz_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_role_pb = require('../../../../buf/alpha/registry/v1alpha1/role_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_role_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/display_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/display_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_role_pb = require('../../../../buf/alpha/registry/v1alpha1/role_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_role_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/doc_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/doc_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.registry.v1alpha1.Enum', null, global);
 goog.exportSymbol('proto.buf.alpha.registry.v1alpha1.EnumValue', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/download_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/download_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_module_v1alpha1_module_pb = require('../../../../buf/alpha/module/v1alpha1/module_pb.js');
 goog.object.extend(proto, buf_alpha_module_v1alpha1_module_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/generate_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/generate_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_compiler_plugin_pb = require('google-protobuf/google/protobuf/compiler/plugin_pb.js');
 goog.object.extend(proto, google_protobuf_compiler_plugin_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/image_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/image_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_image_v1_image_pb = require('../../../../buf/alpha/image/v1/image_pb.js');
 goog.object.extend(proto, buf_alpha_image_v1_image_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/jsonschema_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/jsonschema_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.registry.v1alpha1.GetJSONSchemaRequest', null, global);
 goog.exportSymbol('proto.buf.alpha.registry.v1alpha1.GetJSONSchemaResponse', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/module_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/module_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/organization_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/organization_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_role_pb = require('../../../../buf/alpha/registry/v1alpha1/role_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_role_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/owner_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/owner_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_user_pb = require('../../../../buf/alpha/registry/v1alpha1/user_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_user_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/plugin_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/plugin_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_role_pb = require('../../../../buf/alpha/registry/v1alpha1/role_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_role_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/push_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/push_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_module_v1alpha1_module_pb = require('../../../../buf/alpha/module/v1alpha1/module_pb.js');
 goog.object.extend(proto, buf_alpha_module_v1alpha1_module_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/recommendation_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/recommendation_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/reference_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/reference_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_repository_branch_pb = require('../../../../buf/alpha/registry/v1alpha1/repository_branch_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_repository_branch_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_branch_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_branch_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_commit_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_commit_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_repository_tag_pb = require('../../../../buf/alpha/registry/v1alpha1/repository_tag_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_repository_tag_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_role_pb = require('../../../../buf/alpha/registry/v1alpha1/role_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_role_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_tag_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_tag_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_track_commit_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_track_commit_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_track_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/repository_track_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/resolve_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/resolve_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_module_v1alpha1_module_pb = require('../../../../buf/alpha/module/v1alpha1/module_pb.js');
 goog.object.extend(proto, buf_alpha_module_v1alpha1_module_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/role_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/role_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.registry.v1alpha1.OrganizationRole', null, global);
 goog.exportSymbol('proto.buf.alpha.registry.v1alpha1.PluginRole', null, global);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/search_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/search_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_repository_pb = require('../../../../buf/alpha/registry/v1alpha1/repository_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_repository_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/token_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/token_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 goog.object.extend(proto, google_protobuf_timestamp_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/user_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/registry/v1alpha1/user_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 var buf_alpha_registry_v1alpha1_role_pb = require('../../../../buf/alpha/registry/v1alpha1/role_pb.js');
 goog.object.extend(proto, buf_alpha_registry_v1alpha1_role_pb);

--- a/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/rpc/v1alpha1/error_pb.js
+++ b/packages/protobuf-bench/src/gen/google-protobuf/buf/alpha/rpc/v1alpha1/error_pb.js
@@ -13,13 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() {
-  if (this) { return this; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  if (typeof self !== 'undefined') { return self; }
-  return Function('return this')();
-}.call(null));
+var global =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof global !== 'undefined' && global) ||
+    (typeof self !== 'undefined' && self) ||
+    (function () { return this; }).call(null) ||
+    Function('return this')();
 
 goog.exportSymbol('proto.buf.alpha.rpc.v1alpha1.ErrorCode', null, global);
 /**


### PR DESCRIPTION
This switches our `bench` package to use the new curated plugin in the BSR rather than a deprecated remote plugin.