### PR TITLE
Make toJSON private

### DIFF
--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -149,7 +149,7 @@ export class Message<T extends Message<T> = AnyMessage> {
    */
   //  eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //  @ts-ignore
-  private toJSON(): JsonValue {
+  protected toJSON(): JsonValue {
     return this.toJson({
       emitDefaultValues: true,
     });

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -141,8 +141,15 @@ export class Message<T extends Message<T> = AnyMessage> {
    * unpacked, and this is only possible with a type registry to look up the
    * message type.  As a result, attempting to serialize a message with this
    * type will throw an Error.
+   *
+   * Note that this function is private because users should not need to invoke
+   * it directly -- they can use JSON.stringify.  Additionally, if it is public
+   * it shows as part of the Message API to users which can be confusing when
+   * listed with the other toJson method
    */
-  toJSON(): JsonValue {
+  //  eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //  @ts-ignore
+  private toJSON(): JsonValue {
     return this.toJson({
       emitDefaultValues: true,
     });

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -142,13 +142,9 @@ export class Message<T extends Message<T> = AnyMessage> {
    * message type.  As a result, attempting to serialize a message with this
    * type will throw an Error.
    *
-   * Note that this function is private because users should not need to invoke
-   * it directly -- they can use JSON.stringify.  Additionally, if it is public
-   * it shows as part of the Message API to users which can be confusing when
-   * listed with the other toJson method
+   * Note that this function is protected because users should not need to invoke
+   * it directly -- they can use JSON.stringify.
    */
-  //  eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //  @ts-ignore
   protected toJSON(): JsonValue {
     return this.toJson({
       emitDefaultValues: true,

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -142,7 +142,7 @@ export class Message<T extends Message<T> = AnyMessage> {
    * message type.  As a result, attempting to serialize a message with this
    * type will throw an Error.
    *
-   * Note that this function is protected because users should not need to invoke
+   * Note that this method is protected because users should not need to invoke
    * it directly -- they can use JSON.stringify.
    */
   protected toJSON(): JsonValue {


### PR DESCRIPTION
This makes the `toJSON` method on `Message` private.  This is done for two reasons:

- Users should never need to invoke this directly.  They should use `JSON.stringify(msg)` to indirectly invoke it.
- Showing this function as part of the public API of `Message` is confusing when listed with the other `toJson` function.