### PR TITLE
Fix Github Action configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.9.0
-      - name: Cache
-        uses: actions/cache@v3
         with:
           github_token: ${{ github.token }}
+      - name: Cache
+        uses: actions/cache@v3
         with:
           path: |
             ~/.tmp


### PR DESCRIPTION
This fixes the Github Action. config so that the token is used on `buf-setup-action`.  