### PR TITLE
Add better docs to toJSON

### DIFF
--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -142,9 +142,9 @@ export class Message<T extends Message<T> = AnyMessage> {
    * message type.  As a result, attempting to serialize a message with this
    * type will throw an Error.
    *
-   * This method is protected because users should not need to invoke it
-   * directly -- they should use JSON.stringify or toJsonString for
-   * stringified JSON.  Alternatively, if actual JSON is desired, users should
+   * This method is protected because you should not need to invoke it
+   * directly -- instead use JSON.stringify or toJsonString for
+   * stringified JSON.  Alternatively, if actual JSON is desired, you should
    * use toJson.
    */
   protected toJSON(): JsonValue {

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -142,8 +142,10 @@ export class Message<T extends Message<T> = AnyMessage> {
    * message type.  As a result, attempting to serialize a message with this
    * type will throw an Error.
    *
-   * Note that this method is protected because users should not need to invoke
-   * it directly -- they can use JSON.stringify.
+   * This method is protected because users should not need to invoke it
+   * directly -- they should use JSON.stringify or toJsonString for
+   * stringified JSON.  Alternatively, if actual JSON is desired, users should
+   * use toJson.
    */
   protected toJSON(): JsonValue {
     return this.toJson({


### PR DESCRIPTION
This adds better documentation to the protected `toJSON` method.  Users should use `JSON.stringify` or `toJsonString` if they need stringified JSON.  If they want an actual JSON object, they should use `toJson`.

Also updated release notes to reflect that making `toJSON` protected was a breaking change:  https://github.com/bufbuild/protobuf-es/releases/tag/v0.5.0