### PR TITLE
Fix unit test across Node versions

### DIFF
--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -214,7 +214,7 @@ describe("Message.fromJsonString()", function () {
     expect(() =>
       TestAllTypesProto3.fromJsonString("this is not json")
     ).toThrowError(
-      "cannot decode protobuf_test_messages.proto3.TestAllTypesProto3 from JSON"
+      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'? in JSON at position 1$/
     );
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -214,7 +214,7 @@ describe("Message.fromJsonString()", function () {
     expect(() =>
       TestAllTypesProto3.fromJsonString("this is not json")
     ).toThrowError(
-      "cannot decode protobuf_test_messages.proto3.TestAllTypesProto3 from JSON: Unexpected token h in JSON at position 1"
+      "cannot decode protobuf_test_messages.proto3.TestAllTypesProto3 from JSON: Unexpected token 'h', \"this is not json\" is not valid JSON"
     );
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -214,7 +214,7 @@ describe("Message.fromJsonString()", function () {
     expect(() =>
       TestAllTypesProto3.fromJsonString("this is not json")
     ).toThrowError(
-      "cannot decode protobuf_test_messages.proto3.TestAllTypesProto3 from JSON: Unexpected token 'h', \"this is not json\" is not valid JSON"
+      "cannot decode protobuf_test_messages.proto3.TestAllTypesProto3 from JSON"
     );
   });
 });


### PR DESCRIPTION
This fixes a unit test that passed on Node 18.8, but failed on Node 19.2.  The format of the `JSON.parse` message seems to have changed between these versions.  Instead this just tests that it is preceded by the expected Protobuf-ES specific message text.