### PR TITLE
Made test resilient against multiple node versions

### DIFF
--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -216,7 +216,7 @@ describe("Message.fromJsonString()", function () {
     expect(() =>
       TestAllTypesProto3.fromJsonString("this is not json")
     ).toThrowError(
-      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'?,? (in JSON at position 1|\"this is not json\" is not valid JSON)$/
+      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'?,? (in JSON at position 1|"this is not json" is not valid JSON)$/
     );
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -216,7 +216,7 @@ describe("Message.fromJsonString()", function () {
     expect(() =>
       TestAllTypesProto3.fromJsonString("this is not json")
     ).toThrowError(
-      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'?,? (in JSON at position 1|"this is not json" is not valid JSON)$/
+      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'?/
     );
   });
 });

--- a/packages/protobuf-test/src/message.test.ts
+++ b/packages/protobuf-test/src/message.test.ts
@@ -211,10 +211,12 @@ describe("PlainMessage", () => {
 
 describe("Message.fromJsonString()", function () {
   test("raises wrapped error on parse error", () => {
+    // The regex is so that this test passes in Node 18 and Node 19.
+    // The error message text changed across major versions.
     expect(() =>
       TestAllTypesProto3.fromJsonString("this is not json")
     ).toThrowError(
-      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'? in JSON at position 1$/
+      /^cannot decode protobuf_test_messages\.proto3\.TestAllTypesProto3 from JSON: Unexpected token '?h'?,? (in JSON at position 1|\"this is not json\" is not valid JSON)$/
     );
   });
 });


### PR DESCRIPTION
Added an additional OR condition for testing the error message across Node 18 and 19.  The error message for `JSON.parse` seems to have changed in Node 19.