### PR TITLE
Adds mergePartial util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ test-conformance: $(BIN)/conformance_test_runner $(BUILD)/protobuf-conformance
 		&& BUF_BIGINT_DISABLE=1 $(abspath $(BIN)/conformance_test_runner) --enforce_recommended --failure_list failing_tests_without_bigint.txt --text_format_failure_list failing_tests_text_format.txt bin/conformance_esm.js
 
 .PHONY: test-ts-compat
-test-ts-compat: $(GEN)/protobuf-test node_modules 
+test-ts-compat: $(GEN)/protobuf-test node_modules
 	@for number in $(TS_VERSIONS) ; do \
 		formatted=$$(echo "$${number}" | sed -r 's/[\.]/_/g'); \
 		dirname=packages/protobuf-test/typescript ; \

--- a/packages/protobuf-test/src/merge.test.ts
+++ b/packages/protobuf-test/src/merge.test.ts
@@ -1,0 +1,89 @@
+import { proto3 } from "@bufbuild/protobuf";
+import { it, describe, expect } from "@jest/globals";
+import { RepeatedScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb";
+import { makeMessageTypeDynamic } from "./helpers";
+
+describe("mergePartial", () => {
+  describe("with scalar fields", () => {
+    it("can merge scalar types from left to right", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        doubleField: [0.75],
+      });
+
+      proto3.util.mergePartial(msg, {
+        doubleField: [0.5],
+      });
+
+      expect(msg.doubleField).toEqual([0.5]);
+    });
+
+    it("new value overwrites old value", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        doubleField: [0.75],
+      });
+
+      proto3.util.mergePartial(msg, {
+        doubleField: [0.5],
+      });
+
+      expect(msg.doubleField).toEqual([0.5]);
+    });
+
+    it("new default value overwrites old value", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        doubleField: [0.75],
+      });
+
+      proto3.util.mergePartial(msg, {
+        doubleField: [0],
+      });
+
+      expect(msg.doubleField).toEqual([0]);
+    });
+
+    it("omitted value does not overwrite existing value", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        doubleField: [0.75],
+      });
+
+      proto3.util.mergePartial(msg, {});
+
+      expect(msg.doubleField).toEqual([0.75]);
+    });
+    it("repeated fields are overwritten", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        doubleField: [0.75],
+      });
+
+      proto3.util.mergePartial(msg, {
+        doubleField: [0.5, 0.25],
+      });
+
+      expect(msg.doubleField).toEqual([0.5, 0.25]);
+    });
+
+    it("int64 fields are overritten", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        int64Field: [BigInt(0)],
+      });
+
+      proto3.util.mergePartial(msg, {
+        int64Field: [BigInt(1)],
+      });
+
+      expect(msg.int64Field).toEqual([BigInt(1)]);
+    });
+  });
+});

--- a/packages/protobuf-test/src/merge.test.ts
+++ b/packages/protobuf-test/src/merge.test.ts
@@ -11,7 +11,7 @@ import { TestAllTypesProto3 as JS_TestAllTypesProto3 } from "./gen/js/google/pro
 
 describe("mergePartial", () => {
   describe("with scalar fields", () => {
-    it("can merge scalar types from left to right", () => {
+    it("can merge repeated scalar types from right to left", () => {
       const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
 
       const msg = new msgType({
@@ -23,6 +23,59 @@ describe("mergePartial", () => {
       });
 
       expect(msg.doubleField).toEqual([0.5]);
+    });
+
+    it("can merge scalar types from right to left", () => {
+      const msgType = makeMessageTypeDynamic(TS_TestAllTypesProto3);
+
+      const msg = new msgType({
+        optionalInt32: 123,
+        fieldname1: 10, // It should merge this field into the new result.
+      });
+
+      proto3.util.mergePartial(msg, {
+        optionalInt32: 125,
+      });
+
+      expect(msg.fieldname1).toEqual(10);
+      expect(msg.optionalInt32).toEqual(125);
+    });
+
+    it("can merge scalar messages", () => {
+      const msgType = makeMessageTypeDynamic(TS_TestAllTypesProto3);
+
+      const m1 = new msgType({
+        optionalInt32: 123,
+        fieldname1: 10, // It should merge this field into the new result.
+      });
+
+      const m2 = new msgType({
+        optionalInt32: 125,
+      });
+
+      proto3.util.mergePartial(m1, m2);
+
+      expect(m1.fieldname1).toEqual(10);
+      expect(m1.optionalInt32).toEqual(125);
+    });
+
+    it("can set field back to default value", () => {
+      const msgType = makeMessageTypeDynamic(TS_TestAllTypesProto3);
+
+      const m1 = new msgType({
+        optionalInt32: 123,
+        fieldname1: 10,
+      });
+
+      const m2 = new msgType({
+        optionalInt32: 0,
+        fieldname1: 0,
+      });
+
+      proto3.util.mergePartial(m1, m2, true);
+
+      expect(m1.fieldname1).toEqual(0);
+      expect(m1.optionalInt32).toEqual(0);
     });
 
     it("new value overwrites old value", () => {
@@ -53,6 +106,20 @@ describe("mergePartial", () => {
       expect(msg.doubleField).toEqual([0]);
     });
 
+    it("new undefined value overwrites keeps old value", () => {
+      const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
+
+      const msg = new msgType({
+        doubleField: [0.75],
+      });
+
+      proto3.util.mergePartial(msg, {
+        doubleField: undefined,
+      });
+
+      expect(msg.doubleField).toEqual([0.75]);
+    });
+
     it("omitted value does not overwrite existing value", () => {
       const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
 
@@ -64,6 +131,7 @@ describe("mergePartial", () => {
 
       expect(msg.doubleField).toEqual([0.75]);
     });
+
     it("repeated fields are overwritten", () => {
       const msgType = makeMessageTypeDynamic(RepeatedScalarValuesMessage);
 
@@ -157,6 +225,7 @@ describe("mergePartial", () => {
       const m = new messageType({
         recursiveMessage: new messageType({
           optionalInt32: 123,
+          fieldname1: 10, // It should merge this field into the new result.
         }),
       });
       expect(m.recursiveMessage?.optionalInt32).toBe(123);
@@ -167,6 +236,7 @@ describe("mergePartial", () => {
       });
 
       expect(m.recursiveMessage?.optionalInt32).toBe(125);
+      expect(m.recursiveMessage?.fieldname1).toBe(10);
     });
 
     it("merges fully-formed message", () => {
@@ -174,6 +244,7 @@ describe("mergePartial", () => {
       const m1 = new messageType({
         recursiveMessage: new messageType({
           optionalInt32: 123,
+          fieldname1: 10, // It should merge this field into the new result.
         }),
       });
       const m2 = new messageType({
@@ -185,6 +256,7 @@ describe("mergePartial", () => {
       expect(m1.recursiveMessage?.optionalInt32).toBe(123);
       proto3.util.mergePartial(m1, m2);
       expect(m1.recursiveMessage?.optionalInt32).toBe(125);
+      expect(m1.recursiveMessage?.fieldname1).toBe(10);
     });
   });
 

--- a/packages/protobuf-test/src/merge.test.ts
+++ b/packages/protobuf-test/src/merge.test.ts
@@ -1,7 +1,12 @@
 import { proto3 } from "@bufbuild/protobuf";
 import { it, describe, expect } from "@jest/globals";
+import { MessageFieldMessage } from "./gen/ts/extra/msg-message_pb";
 import { RepeatedScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb";
 import { makeMessageTypeDynamic } from "./helpers";
+import {
+  TestAllTypesProto3 as TS_TestAllTypesProto3,
+  // TestAllTypesProto3_NestedMessage as TS_TestAllTypesProto3_NestedMessage,
+} from "./gen/ts/google/protobuf/test_messages_proto3_pb.js";
 
 describe("mergePartial", () => {
   describe("with scalar fields", () => {
@@ -84,6 +89,101 @@ describe("mergePartial", () => {
       });
 
       expect(msg.int64Field).toEqual([BigInt(1)]);
+    });
+  });
+
+  describe("with message fields", () => {
+    it("can deep merge message fields recursively", () => {
+      const msgType = makeMessageTypeDynamic(MessageFieldMessage);
+
+      const msg = new msgType({
+        messageField: {
+          name: "foo",
+        },
+        repeatedMessageField: [
+          {
+            name: "bar",
+          },
+          {
+            name: "baz",
+          },
+        ],
+      });
+
+      proto3.util.mergePartial(msg, {
+        messageField: {
+          name: "qux",
+        },
+        repeatedMessageField: [
+          {
+            name: "new-bar",
+          },
+          {
+            name: "baz",
+          },
+        ],
+      });
+
+      expect(msg.messageField).toEqual({ name: "qux" });
+      expect(msg.repeatedMessageField).toEqual([
+        {
+          name: "new-bar",
+        },
+        {
+          name: "baz",
+        },
+      ]);
+    });
+
+    it("keeps original value if source field is undefined", () => {
+      const msgType = makeMessageTypeDynamic(MessageFieldMessage);
+
+      const msg = new msgType({
+        messageField: {
+          name: "foo",
+        },
+      });
+
+      proto3.util.mergePartial(msg, {
+        messageField: undefined,
+      });
+
+      expect(msg.messageField).toEqual({ name: "foo" });
+    });
+
+    it("merges recursive messages", () => {
+      const messageType = makeMessageTypeDynamic(TS_TestAllTypesProto3);
+      const m = new messageType({
+        recursiveMessage: new messageType({
+          optionalInt32: 123,
+        }),
+      });
+      expect(m.recursiveMessage?.optionalInt32).toBe(123);
+      proto3.util.mergePartial(m, {
+        recursiveMessage: new messageType({
+          optionalInt32: 125,
+        }),
+      });
+
+      expect(m.recursiveMessage?.optionalInt32).toBe(125);
+    });
+
+    it("merges fully formed messages", () => {
+      const messageType = makeMessageTypeDynamic(TS_TestAllTypesProto3);
+      const m1 = new messageType({
+        recursiveMessage: new messageType({
+          optionalInt32: 123,
+        }),
+      });
+      const m2 = new messageType({
+        recursiveMessage: new messageType({
+          optionalInt32: 125,
+        }),
+      });
+
+      expect(m1.recursiveMessage?.optionalInt32).toBe(123);
+      proto3.util.mergePartial(m1, m2);
+      expect(m1.recursiveMessage?.optionalInt32).toBe(125);
     });
   });
 });

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -229,6 +229,24 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
           case "enum":
             t[localName] = s[localName];
             break;
+
+          case "message":
+            const mt = member.T;
+            if (member.repeated) {
+              t[localName] = (s[localName] as any[]).map((val) =>
+                val instanceof mt ? val : new mt(val)
+              );
+            } else if (s[localName] === undefined) {
+              t[localName] = new mt(s[localName]); // nothing to merge with
+            } else {
+              const val = s[localName];
+              if (mt.fieldWrapper) {
+                t[localName] = val;
+              } else {
+                this.mergePartial(t[localName], val);
+              }
+            }
+            break;
         }
       }
     },

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -279,7 +279,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             if (member.repeated) {
               t[localName] = (s[localName] as any[]).map((val) => {
                 let newVal = val instanceof mt ? val : new mt(val);
-                this.mergePartial(newVal, val);
+                this.mergePartial(newVal, val, useDefaults);
                 return newVal;
               });
             } else if (s[localName] === undefined) {

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -286,7 +286,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
               t[localName] = new mt(); // nothing to merge with
             } else {
               const val = s[localName];
-              this.mergePartial(t[localName], val);
+              this.mergePartial(t[localName], val, useDefaults);
             }
             break;
         }

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -208,6 +208,30 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
       }
       return target;
     },
+    mergePartial<T extends Message<T>>(
+      target: T,
+      source: PartialMessage<T>
+    ): void {
+      if (source === undefined) {
+        return;
+      }
+      const type = target.getType();
+      for (const member of type.fields.byMember()) {
+        const localName = member.localName,
+          t = target as AnyMessage,
+          s = source as PartialMessage<AnyMessage>;
+        if (s[localName] === undefined) {
+          continue;
+        }
+
+        switch (member.kind) {
+          case "scalar":
+          case "enum":
+            t[localName] = s[localName];
+            break;
+        }
+      }
+    },
   };
 }
 

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -225,6 +225,22 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
         }
 
         switch (member.kind) {
+          case "oneof":
+            const sk = s[localName].case;
+            if (sk === undefined) {
+              continue;
+            }
+            const sourceField = member.findField(sk);
+            let val = s[localName].value;
+            if (
+              sourceField &&
+              sourceField.kind == "message" &&
+              !(val instanceof sourceField.T)
+            ) {
+              val = new sourceField.T(val);
+            }
+            t[localName] = { case: sk, value: val };
+            break;
           case "scalar":
           case "enum":
             t[localName] = s[localName];

--- a/packages/protobuf/src/private/util.ts
+++ b/packages/protobuf/src/private/util.ts
@@ -76,6 +76,7 @@ export interface Util {
    */
   mergePartial<T extends Message<T>>(
     target: T,
-    source: PartialMessage<T>
+    source: PartialMessage<T>,
+    useDefaults?: boolean
   ): void;
 }

--- a/packages/protobuf/src/private/util.ts
+++ b/packages/protobuf/src/private/util.ts
@@ -70,4 +70,12 @@ export interface Util {
    * Create a deep copy.
    */
   clone<T extends Message<T>>(message: T): T;
+
+  /**
+   * Partially update a message with the given values.
+   */
+  mergePartial<T extends Message<T>>(
+    target: T,
+    source: PartialMessage<T>
+  ): void;
 }


### PR DESCRIPTION
Implements mergePartial, loosely based on initPartial, except it allows recursively merging nested messages without replacing fields on the LHS that were initialised to zero on the RHS. 

### Notes:

There's a few things that need work: 
- how to handle fieldWrappers? 
- how to handle default values overwriting values on the LHS when the RHS is a message.

Opening for discussion.