### PR TITLE
Pin Bazel version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,6 +27,14 @@ git fetch upstream
 Make sure that the tests and the linters pass (you'll need `node`, `bazel`,
 `buf`, `bash` and the latest stable Go release installed):
 
+Note that your Bazel installation should be `v5.4.0` or earlier as the version
+of Protocol Buffers in use during our `make` process is incompatible with Bazel
+`v6.0` and above.  If you use [Bazelisk](https://github.com/bazelbuild/bazelisk)
+to manage Bazel installations, then this should be seamless as our Makefile
+uses Bazelisk syntax to invoke Bazel.  However, if you have installed Bazel via
+other means (Homebrew, etc.) then you will have to downgrade to successfully
+run the below command.
+
 ```
 make 
 ```

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ LICENSE_HEADER_YEAR_RANGE := 2021-2022
 LICENSE_HEADER_IGNORES := .tmp\/ node_module\/ packages\/protobuf-conformance\/bin\/conformance_esm.js packages\/protobuf-conformance\/src\/gen\/ packages\/protobuf-test\/src\/gen\/ packages\/protobuf\/src\/google\/varint.ts packages\/protobuf-bench\/src\/gen\/ packages\/protobuf\/dist\/ packages\/protobuf-test\/dist\/ scripts\/ packages\/protoplugin-example/src/protoc-gen-twirp-es.ts
 GOOGLE_PROTOBUF_WKT = google/protobuf/api.proto google/protobuf/any.proto google/protobuf/compiler/plugin.proto google/protobuf/descriptor.proto google/protobuf/duration.proto google/protobuf/descriptor.proto google/protobuf/empty.proto google/protobuf/field_mask.proto google/protobuf/source_context.proto google/protobuf/struct.proto google/protobuf/timestamp.proto google/protobuf/type.proto google/protobuf/wrappers.proto
 GOOGLE_PROTOBUF_VERSION = 21.12
+BAZEL_VERSION = 5.3.0
 TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.4
 
 node_modules: package-lock.json
@@ -28,12 +29,14 @@ $(PB):
 	tar -xzf $(TMP)/protobuf-$(GOOGLE_PROTOBUF_VERSION).tar.gz -C $(TMP)/
 
 $(BIN)/protoc: $(PB)
+	export USE_BAZEL_VERSION=$(BAZEL_VERSION)
 	@mkdir -p $(@D)
 	cd $(PB) && bazel build protoc
 	cp -f $(PB)/bazel-bin/protoc $(@D)
 	@touch $(@)
 
 $(BIN)/conformance_test_runner: $(PB)
+	export USE_BAZEL_VERSION=$(BAZEL_VERSION)
 	@mkdir -p $(@D)
 	cd $(PB) && bazel build test_messages_proto3_proto conformance:conformance_proto conformance:conformance_test conformance:conformance_test_runner
 	cp -f $(PB)/bazel-bin/conformance/conformance_test_runner $(@D)

--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,14 @@ $(PB):
 	tar -xzf $(TMP)/protobuf-$(GOOGLE_PROTOBUF_VERSION).tar.gz -C $(TMP)/
 
 $(BIN)/protoc: $(PB)
-	export USE_BAZEL_VERSION=$(BAZEL_VERSION)
 	@mkdir -p $(@D)
-	cd $(PB) && bazel build protoc
+	cd $(PB) && USE_BAZEL_VERSION=$(BAZEL_VERSION) bazel build protoc
 	cp -f $(PB)/bazel-bin/protoc $(@D)
 	@touch $(@)
 
 $(BIN)/conformance_test_runner: $(PB)
-	export USE_BAZEL_VERSION=$(BAZEL_VERSION)
 	@mkdir -p $(@D)
-	cd $(PB) && bazel build test_messages_proto3_proto conformance:conformance_proto conformance:conformance_test conformance:conformance_test_runner
+	cd $(PB) && USE_BAZEL_VERSION=$(BAZEL_VERSION) bazel build test_messages_proto3_proto conformance:conformance_proto conformance:conformance_test conformance:conformance_test_runner
 	cp -f $(PB)/bazel-bin/conformance/conformance_test_runner $(@D)
 	@touch $(@)
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LICENSE_HEADER_YEAR_RANGE := 2021-2022
 LICENSE_HEADER_IGNORES := .tmp\/ node_module\/ packages\/protobuf-conformance\/bin\/conformance_esm.js packages\/protobuf-conformance\/src\/gen\/ packages\/protobuf-test\/src\/gen\/ packages\/protobuf\/src\/google\/varint.ts packages\/protobuf-bench\/src\/gen\/ packages\/protobuf\/dist\/ packages\/protobuf-test\/dist\/ scripts\/ packages\/protoplugin-example/src/protoc-gen-twirp-es.ts
 GOOGLE_PROTOBUF_WKT = google/protobuf/api.proto google/protobuf/any.proto google/protobuf/compiler/plugin.proto google/protobuf/descriptor.proto google/protobuf/duration.proto google/protobuf/descriptor.proto google/protobuf/empty.proto google/protobuf/field_mask.proto google/protobuf/source_context.proto google/protobuf/struct.proto google/protobuf/timestamp.proto google/protobuf/type.proto google/protobuf/wrappers.proto
 GOOGLE_PROTOBUF_VERSION = 21.12
-BAZEL_VERSION = 5.3.0
+BAZEL_VERSION = 5.4.0
 TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.4
 
 node_modules: package-lock.json


### PR DESCRIPTION
This pins the Bazel version to `5.4.0`, which is a version compatible with our version of Protocol Buffers (`21.12`).  The upgrade to Bazel 6 causes our builds to fail and this ensures that we use `5.4.0` when building.

Note this assumes Bazelisk is being used to enforce the Bazel version.  However, we can't be sure all users are using Bazelisk with their Bazel install.  The contributing docs have been updated to reflect that `5.4.0` is the latest supported version.