### PR TITLE
Pin plugin versions

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 74,150 b      | 36,975 b | 9,660 b |
-| protobuf-javascript | 370,614 b  | 271,674 b | 43,786 b |
+| protobuf-es         | 74,150 b      | 36,950 b | 9,642 b |
+| protobuf-javascript | 370,614 b  | 271,672 b | 43,769 b |

--- a/packages/protobuf-bench/buf.gen.yaml
+++ b/packages/protobuf-bench/buf.gen.yaml
@@ -8,6 +8,6 @@ plugins:
     path: packages/protoc-gen-es/bin/protoc-gen-es
     opt: ts_nocheck=false,target=ts
     out: src/gen/protobuf-es
-  - plugin: buf.build/protocolbuffers/js
+  - plugin: buf.build/protocolbuffers/js:v3.21.2
     out: src/gen/google-protobuf
     opt: import_style=commonjs


### PR DESCRIPTION
This pins the usage of the protocolbuffers JS plugin to a specific version, which matches how Connect-Web works also.