### PR TITLE
Fix protoc-gen-twirp-es.ts in the protoplugin-example package

### DIFF
--- a/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
+++ b/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
@@ -67,7 +67,7 @@ function generateTs(schema: Schema) {
             f.print(makeJsDoc(method, "    "));
             f.print("    async ", localName(method), "(request: ", method.input, "): Promise<", method.output, "> {");
             f.print("        const promise = this.request(");
-            f.print("            ", literalString(service.typeName), ", ");
+            f.print("            ", literalString(service.typeName), ",");
             f.print("            ", literalString(method.name), ",");
             f.print('            "application/json",');
             f.print("            request");

--- a/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
+++ b/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
@@ -75,8 +75,8 @@ function generateTs(schema: Schema) {
             f.print("        return promise.then(async (data) =>");
             f.print("             ", method.output, ".fromJson(data as ", JsonValue, ")");
             f.print("        );");
+            f.print("    }");
         }
-        f.print("    }");
       }
       f.print("}");
     }

--- a/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
+++ b/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
@@ -76,10 +76,10 @@ function generateTs(schema: Schema) {
             f.print("             ", method.output, ".fromJson(data as ", JsonValue, ")");
             f.print("        );");
         }
+        f.print("    }");
       }
-      f.print("    }");
+      f.print("}");
     }
-    f.print("}");
   }
 }
 


### PR DESCRIPTION
Fix the following bugs in the sample plugin
- The code to output closing brackets was incorrectly positioned, causing unnecessary files to be generated from protos where no RPCs existed.
- Incorrect positioning of code outputting closing brackets was generating incorrect syntax when multiple RPCs existed.
- Unnecessary spaces were being output.
