### PR TITLE
Add missing file extension in a test file

### DIFF
--- a/packages/protobuf-test/src/proto-base64.test.ts
+++ b/packages/protobuf-test/src/proto-base64.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import { protoBase64 } from "@bufbuild/protobuf";
-import { User } from "./gen/ts/extra/example_pb";
+import { User } from "./gen/ts/extra/example_pb.js";
 
 /**
  * Inspiration for data source taken from https://github.com/jsdom/abab


### PR DESCRIPTION
A missing file extension in an import in a test file slipped into main. I ran the tests locally and they passed, but CI spotted the missing extension in when "Testing TypeScript Version 4.7.4".

This adds the missing extension. We should double check that local tests cover all things CI covers.