### PR TITLE
Allow optional fields to be explicitly set to `undefined`

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 74,150 b      | 36,950 b | 9,642 b |
+| protobuf-es         | 74,150 b      | 36,950 b | 9,636 b |
 | protobuf-javascript | 370,614 b  | 271,672 b | 43,769 b |

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/envelope_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/envelope_pb.ts
@@ -2452,7 +2452,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateTokenInfo extends Message<Actio
   /**
    * @generated from field: google.protobuf.Timestamp expire_time = 2;
    */
-  expireTime?: Timestamp;
+  expireTime?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<ActionBufAlphaRegistryV1Alpha1CreateTokenInfo>) {
     super();
@@ -2964,7 +2964,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateRepositoryTrackInfo extends Mes
   /**
    * @generated from field: buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1RepositoryTrack track = 1;
    */
-  track?: BufAlphaRegistryV1Alpha1RepositoryTrack;
+  track?: BufAlphaRegistryV1Alpha1RepositoryTrack | undefined;
 
   constructor(data?: PartialMessage<ActionBufAlphaRegistryV1Alpha1CreateRepositoryTrackInfo>) {
     super();
@@ -3104,7 +3104,7 @@ export class Event extends Message<Event> {
    *
    * @generated from field: google.protobuf.Timestamp event_time = 3;
    */
-  eventTime?: Timestamp;
+  eventTime?: Timestamp | undefined;
 
   /**
    * The name of the service to which the request belongs.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/module_pb.ts
@@ -89,7 +89,7 @@ export class BufAlphaRegistryV1Alpha1LocalModulePin extends Message<BufAlphaRegi
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 7;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<BufAlphaRegistryV1Alpha1LocalModulePin>) {
     super();
@@ -180,12 +180,12 @@ export class BufAlphaRegistryV1Alpha1LocalModuleResolveResult extends Message<Bu
   /**
    * @generated from field: buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1LocalModuleReference reference = 1;
    */
-  reference?: BufAlphaRegistryV1Alpha1LocalModuleReference;
+  reference?: BufAlphaRegistryV1Alpha1LocalModuleReference | undefined;
 
   /**
    * @generated from field: buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1LocalModulePin pin = 2;
    */
-  pin?: BufAlphaRegistryV1Alpha1LocalModulePin;
+  pin?: BufAlphaRegistryV1Alpha1LocalModulePin | undefined;
 
   /**
    * @generated from field: buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1ResolvedReferenceType resolved_reference_type = 3;

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/repository_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/repository_pb.ts
@@ -57,7 +57,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryBranch extends Message<BufAlphaRe
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * Field number '3' reserved for the update_time.
@@ -114,7 +114,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryTag extends Message<BufAlphaRegis
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * Field number '3' reserved for the update_time.
@@ -177,7 +177,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryCommit extends Message<BufAlphaRe
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * @generated from field: string digest = 3;
@@ -256,7 +256,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryTrack extends Message<BufAlphaReg
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * Field number '3' reserved for the update_time.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
@@ -76,12 +76,12 @@ export class ImageFile extends Message<ImageFile> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  package?: string | undefined;
 
   /**
    * @generated from field: repeated string dependency = 3;
@@ -121,17 +121,17 @@ export class ImageFile extends Message<ImageFile> {
   /**
    * @generated from field: optional google.protobuf.FileOptions options = 8;
    */
-  options?: FileOptions;
+  options?: FileOptions | undefined;
 
   /**
    * @generated from field: optional google.protobuf.SourceCodeInfo source_code_info = 9;
    */
-  sourceCodeInfo?: SourceCodeInfo;
+  sourceCodeInfo?: SourceCodeInfo | undefined;
 
   /**
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  syntax?: string | undefined;
 
   /**
    * buf_extension contains buf-specific extensions to FileDescriptorProtos.
@@ -143,7 +143,7 @@ export class ImageFile extends Message<ImageFile> {
    *
    * @generated from field: optional buf.alpha.image.v1.ImageFileExtension buf_extension = 8042;
    */
-  bufExtension?: ImageFileExtension;
+  bufExtension?: ImageFileExtension | undefined;
 
   constructor(data?: PartialMessage<ImageFile>) {
     super();
@@ -212,7 +212,7 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
    *
    * @generated from field: optional bool is_import = 1;
    */
-  isImport?: boolean;
+  isImport?: boolean | undefined;
 
   /**
    * ModuleInfo contains information about the Buf module this file belongs to.
@@ -221,7 +221,7 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
    *
    * @generated from field: optional buf.alpha.image.v1.ModuleInfo module_info = 2;
    */
-  moduleInfo?: ModuleInfo;
+  moduleInfo?: ModuleInfo | undefined;
 
   /**
    * is_syntax_unspecified denotes whether the file did not have a syntax
@@ -239,7 +239,7 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
    *
    * @generated from field: optional bool is_syntax_unspecified = 3;
    */
-  isSyntaxUnspecified?: boolean;
+  isSyntaxUnspecified?: boolean | undefined;
 
   /**
    * unused_dependency are the indexes within the dependency field on
@@ -297,7 +297,7 @@ export class ModuleInfo extends Message<ModuleInfo> {
    *
    * @generated from field: optional buf.alpha.image.v1.ModuleName name = 1;
    */
-  name?: ModuleName;
+  name?: ModuleName | undefined;
 
   /**
    * commit is the repository commit.
@@ -306,7 +306,7 @@ export class ModuleInfo extends Message<ModuleInfo> {
    *
    * @generated from field: optional string commit = 2;
    */
-  commit?: string;
+  commit?: string | undefined;
 
   constructor(data?: PartialMessage<ModuleInfo>) {
     super();
@@ -348,17 +348,17 @@ export class ModuleName extends Message<ModuleName> {
   /**
    * @generated from field: optional string remote = 1;
    */
-  remote?: string;
+  remote?: string | undefined;
 
   /**
    * @generated from field: optional string owner = 2;
    */
-  owner?: string;
+  owner?: string | undefined;
 
   /**
    * @generated from field: optional string repository = 3;
    */
-  repository?: string;
+  repository?: string | undefined;
 
   constructor(data?: PartialMessage<ModuleName>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/module/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/module/v1alpha1/module_pb.ts
@@ -61,14 +61,14 @@ export class Module extends Message<Module> {
    *
    * @generated from field: buf.alpha.breaking.v1.Config breaking_config = 4;
    */
-  breakingConfig?: Config;
+  breakingConfig?: Config | undefined;
 
   /**
    * lint_config is the lint configuration set for the module.
    *
    * @generated from field: buf.alpha.lint.v1.Config lint_config = 5;
    */
-  lintConfig?: Config$1;
+  lintConfig?: Config$1 | undefined;
 
   constructor(data?: PartialMessage<Module>) {
     super();
@@ -250,7 +250,7 @@ export class ModulePin extends Message<ModulePin> {
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 7;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<ModulePin>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/admin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/admin_pb.ts
@@ -69,7 +69,7 @@ export class ForceDeleteUserResponse extends Message<ForceDeleteUserResponse> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   /**
    * The deleted organizations.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/audit_logs_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/audit_logs_pb.ts
@@ -50,7 +50,7 @@ export class ListAuditLogsRequest extends Message<ListAuditLogsRequest> {
    *
    * @generated from field: google.protobuf.Timestamp start_time = 4;
    */
-  startTime?: Timestamp;
+  startTime?: Timestamp | undefined;
 
   /**
    * Optionally specifies an end time for the query.
@@ -61,7 +61,7 @@ export class ListAuditLogsRequest extends Message<ListAuditLogsRequest> {
    *
    * @generated from field: google.protobuf.Timestamp end_time = 5;
    */
-  endTime?: Timestamp;
+  endTime?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<ListAuditLogsRequest>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authn_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authn_pb.ts
@@ -58,7 +58,7 @@ export class GetCurrentUserResponse extends Message<GetCurrentUserResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   constructor(data?: PartialMessage<GetCurrentUserResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/doc_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/doc_pb.ts
@@ -79,7 +79,7 @@ export class GetSourceDirectoryInfoResponse extends Message$1<GetSourceDirectory
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.FileInfo root = 1;
    */
-  root?: FileInfo;
+  root?: FileInfo | undefined;
 
   constructor(data?: PartialMessage<GetSourceDirectoryInfoResponse>) {
     super();
@@ -464,7 +464,7 @@ export class GetModuleDocumentationResponse extends Message$1<GetModuleDocumenta
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.ModuleDocumentation module_documentation = 1;
    */
-  moduleDocumentation?: ModuleDocumentation;
+  moduleDocumentation?: ModuleDocumentation | undefined;
 
   constructor(data?: PartialMessage<GetModuleDocumentationResponse>) {
     super();
@@ -612,7 +612,7 @@ export class GetPackageDocumentationResponse extends Message$1<GetPackageDocumen
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.PackageDocumentation package_documentation = 1;
    */
-  packageDocumentation?: PackageDocumentation;
+  packageDocumentation?: PackageDocumentation | undefined;
 
   constructor(data?: PartialMessage<GetPackageDocumentationResponse>) {
     super();
@@ -832,7 +832,7 @@ export class Service extends Message$1<Service> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Location location = 6;
    */
-  location?: Location;
+  location?: Location | undefined;
 
   /**
    * @generated from field: repeated buf.alpha.registry.v1alpha1.Method methods = 7;
@@ -897,12 +897,12 @@ export class Method extends Message$1<Method> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.MethodRequestResponse request = 3;
    */
-  request?: MethodRequestResponse;
+  request?: MethodRequestResponse | undefined;
 
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.MethodRequestResponse response = 4;
    */
-  response?: MethodRequestResponse;
+  response?: MethodRequestResponse | undefined;
 
   constructor(data?: PartialMessage<Method>) {
     super();
@@ -965,7 +965,7 @@ export class MethodRequestResponse extends Message$1<MethodRequestResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Message message = 4;
    */
-  message?: Message;
+  message?: Message | undefined;
 
   /**
    * import_module_ref is included if the request or response is an imported type.
@@ -973,7 +973,7 @@ export class MethodRequestResponse extends Message$1<MethodRequestResponse> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.ImportModuleRef import_module_ref = 5;
    */
-  importModuleRef?: ImportModuleRef;
+  importModuleRef?: ImportModuleRef | undefined;
 
   constructor(data?: PartialMessage<MethodRequestResponse>) {
     super();
@@ -1052,7 +1052,7 @@ export class Enum extends Message$1<Enum> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Location location = 6;
    */
-  location?: Location;
+  location?: Location | undefined;
 
   /**
    * @generated from field: repeated buf.alpha.registry.v1alpha1.EnumValue values = 7;
@@ -1270,7 +1270,7 @@ export class Message extends Message$1<Message> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Location location = 8;
    */
-  location?: Location;
+  location?: Location | undefined;
 
   /**
    * @generated from field: repeated buf.alpha.registry.v1alpha1.Field message_extensions = 9;
@@ -1461,7 +1461,7 @@ export class Field extends Message$1<Field> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.MapEntry map_entry = 7;
    */
-  mapEntry?: MapEntry;
+  mapEntry?: MapEntry | undefined;
 
   /**
    * import_module_ref is included if the field is an imported type.
@@ -1469,7 +1469,7 @@ export class Field extends Message$1<Field> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.ImportModuleRef import_module_ref = 8;
    */
-  importModuleRef?: ImportModuleRef;
+  importModuleRef?: ImportModuleRef | undefined;
 
   /**
    * Extendee is the name of the type that is being extended if the field is an extension.
@@ -1548,7 +1548,7 @@ export class MapEntry extends Message$1<MapEntry> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.ImportModuleRef value_import_module_ref = 4;
    */
-  valueImportModuleRef?: ImportModuleRef;
+  valueImportModuleRef?: ImportModuleRef | undefined;
 
   constructor(data?: PartialMessage<MapEntry>) {
     super();
@@ -1614,7 +1614,7 @@ export class FileExtension extends Message$1<FileExtension> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Location location = 4;
    */
-  location?: Location;
+  location?: Location | undefined;
 
   /**
    * fields are all the fields that are associated with the extension.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/download_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/download_pb.ts
@@ -76,7 +76,7 @@ export class DownloadResponse extends Message<DownloadResponse> {
   /**
    * @generated from field: buf.alpha.module.v1alpha1.Module module = 1;
    */
-  module?: Module;
+  module?: Module | undefined;
 
   constructor(data?: PartialMessage<DownloadResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/generate_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/generate_pb.ts
@@ -205,7 +205,7 @@ export class GeneratePluginsRequest extends Message<GeneratePluginsRequest> {
    *
    * @generated from field: buf.alpha.image.v1.Image image = 1;
    */
-  image?: Image;
+  image?: Image | undefined;
 
   /**
    * The array of plugins to use.
@@ -327,7 +327,7 @@ export class GenerateTemplateRequest extends Message<GenerateTemplateRequest> {
    *
    * @generated from field: buf.alpha.image.v1.Image image = 1;
    */
-  image?: Image;
+  image?: Image | undefined;
 
   /**
    * The owner of the template which identifies the

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/image_pb.ts
@@ -163,7 +163,7 @@ export class GetImageResponse extends Message<GetImageResponse> {
   /**
    * @generated from field: buf.alpha.image.v1.Image image = 1;
    */
-  image?: Image;
+  image?: Image | undefined;
 
   constructor(data?: PartialMessage<GetImageResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/module_pb.ts
@@ -110,7 +110,7 @@ export class LocalModulePin extends Message<LocalModulePin> {
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 7;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<LocalModulePin>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/organization_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/organization_pb.ts
@@ -36,14 +36,14 @@ export class Organization extends Message<Organization> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * mutable
    *
    * @generated from field: google.protobuf.Timestamp update_time = 3;
    */
-  updateTime?: Timestamp;
+  updateTime?: Timestamp | undefined;
 
   /**
    * unique, mutable
@@ -93,7 +93,7 @@ export class OrganizationMembership extends Message<OrganizationMembership> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Organization organization = 1;
    */
-  organization?: Organization;
+  organization?: Organization | undefined;
 
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.OrganizationRole organization_role = 2;
@@ -173,7 +173,7 @@ export class GetOrganizationResponse extends Message<GetOrganizationResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Organization organization = 1;
    */
-  organization?: Organization;
+  organization?: Organization | undefined;
 
   constructor(data?: PartialMessage<GetOrganizationResponse>) {
     super();
@@ -247,7 +247,7 @@ export class GetOrganizationByNameResponse extends Message<GetOrganizationByName
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Organization organization = 1;
    */
-  organization?: Organization;
+  organization?: Organization | undefined;
 
   constructor(data?: PartialMessage<GetOrganizationByNameResponse>) {
     super();
@@ -523,7 +523,7 @@ export class CreateOrganizationResponse extends Message<CreateOrganizationRespon
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Organization organization = 1;
    */
-  organization?: Organization;
+  organization?: Organization | undefined;
 
   constructor(data?: PartialMessage<CreateOrganizationResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/owner_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/owner_pb.ts
@@ -121,7 +121,7 @@ export class GetOwnerByNameResponse extends Message<GetOwnerByNameResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Owner owner = 1;
    */
-  owner?: Owner;
+  owner?: Owner | undefined;
 
   constructor(data?: PartialMessage<GetOwnerByNameResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/plugin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/plugin_pb.ts
@@ -528,7 +528,7 @@ export class PluginContributor extends Message<PluginContributor> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   /**
    * The ID of the plugin which the role belongs to.
@@ -590,7 +590,7 @@ export class TemplateContributor extends Message<TemplateContributor> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   /**
    * The ID of the template which the role belongs to.
@@ -1011,7 +1011,7 @@ export class GetPluginVersionResponse extends Message<GetPluginVersionResponse> 
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.PluginVersion plugin_version = 1;
    */
-  pluginVersion?: PluginVersion;
+  pluginVersion?: PluginVersion | undefined;
 
   constructor(data?: PartialMessage<GetPluginVersionResponse>) {
     super();
@@ -1223,7 +1223,7 @@ export class CreatePluginResponse extends Message<CreatePluginResponse> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.Plugin plugin = 1;
    */
-  plugin?: Plugin;
+  plugin?: Plugin | undefined;
 
   constructor(data?: PartialMessage<CreatePluginResponse>) {
     super();
@@ -1307,7 +1307,7 @@ export class GetPluginResponse extends Message<GetPluginResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Plugin plugin = 1;
    */
-  plugin?: Plugin;
+  plugin?: Plugin | undefined;
 
   constructor(data?: PartialMessage<GetPluginResponse>) {
     super();
@@ -1822,7 +1822,7 @@ export class GetTemplateResponse extends Message<GetTemplateResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Template template = 1;
    */
-  template?: Template;
+  template?: Template | undefined;
 
   constructor(data?: PartialMessage<GetTemplateResponse>) {
     super();
@@ -2114,7 +2114,7 @@ export class GetTemplateVersionResponse extends Message<GetTemplateVersionRespon
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.TemplateVersion template_version = 1;
    */
-  templateVersion?: TemplateVersion;
+  templateVersion?: TemplateVersion | undefined;
 
   constructor(data?: PartialMessage<GetTemplateVersionResponse>) {
     super();
@@ -2438,7 +2438,7 @@ export class CreateTemplateResponse extends Message<CreateTemplateResponse> {
    *
    * @generated from field: buf.alpha.registry.v1alpha1.Template template = 1;
    */
-  template?: Template;
+  template?: Template | undefined;
 
   constructor(data?: PartialMessage<CreateTemplateResponse>) {
     super();
@@ -2620,7 +2620,7 @@ export class CreateTemplateVersionResponse extends Message<CreateTemplateVersion
    *
    * @generated from field: buf.alpha.registry.v1alpha1.TemplateVersion template_version = 1;
    */
-  templateVersion?: TemplateVersion;
+  templateVersion?: TemplateVersion | undefined;
 
   constructor(data?: PartialMessage<CreateTemplateVersionResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/push_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/push_pb.ts
@@ -43,7 +43,7 @@ export class PushRequest extends Message<PushRequest> {
   /**
    * @generated from field: buf.alpha.module.v1alpha1.Module module = 4;
    */
-  module?: Module;
+  module?: Module | undefined;
 
   /**
    * Optional; if provided, the provided tags
@@ -102,7 +102,7 @@ export class PushResponse extends Message<PushResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.LocalModulePin local_module_pin = 5;
    */
-  localModulePin?: LocalModulePin;
+  localModulePin?: LocalModulePin | undefined;
 
   constructor(data?: PartialMessage<PushResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/recommendation_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/recommendation_pb.ts
@@ -39,7 +39,7 @@ export class RecommendedRepository extends Message<RecommendedRepository> {
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 3;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * @generated from field: string description = 4;

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/reference_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/reference_pb.ts
@@ -157,7 +157,7 @@ export class GetReferenceByNameResponse extends Message<GetReferenceByNameRespon
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Reference reference = 1;
    */
-  reference?: Reference;
+  reference?: Reference | undefined;
 
   constructor(data?: PartialMessage<GetReferenceByNameResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_branch_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_branch_pb.ts
@@ -35,7 +35,7 @@ export class RepositoryBranch extends Message<RepositoryBranch> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * We reserve field number '3' for the update_time.
@@ -147,7 +147,7 @@ export class CreateRepositoryBranchResponse extends Message<CreateRepositoryBran
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryBranch repository_branch = 1;
    */
-  repositoryBranch?: RepositoryBranch;
+  repositoryBranch?: RepositoryBranch | undefined;
 
   constructor(data?: PartialMessage<CreateRepositoryBranchResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_commit_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_commit_pb.ts
@@ -36,7 +36,7 @@ export class RepositoryCommit extends Message<RepositoryCommit> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * The digest of the commit.
@@ -413,7 +413,7 @@ export class GetRepositoryCommitByReferenceResponse extends Message<GetRepositor
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryCommit repository_commit = 1;
    */
-  repositoryCommit?: RepositoryCommit;
+  repositoryCommit?: RepositoryCommit | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryCommitByReferenceResponse>) {
     super();
@@ -513,7 +513,7 @@ export class GetRepositoryCommitBySequenceIdResponse extends Message<GetReposito
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryCommit repository_commit = 1;
    */
-  repositoryCommit?: RepositoryCommit;
+  repositoryCommit?: RepositoryCommit | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryCommitBySequenceIdResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_pb.ts
@@ -63,14 +63,14 @@ export class Repository extends Message<Repository> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * mutable
    *
    * @generated from field: google.protobuf.Timestamp update_time = 3;
    */
-  updateTime?: Timestamp;
+  updateTime?: Timestamp | undefined;
 
   /**
    * unique, mutable
@@ -162,7 +162,7 @@ export class RepositoryContributor extends Message<RepositoryContributor> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   /**
    * The ID of the for which the role belongs to.
@@ -338,7 +338,7 @@ export class GetRepositoryResponse extends Message<GetRepositoryResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Repository repository = 1;
    */
-  repository?: Repository;
+  repository?: Repository | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryResponse>) {
     super();
@@ -412,7 +412,7 @@ export class GetRepositoryByFullNameResponse extends Message<GetRepositoryByFull
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Repository repository = 1;
    */
-  repository?: Repository;
+  repository?: Repository | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryByFullNameResponse>) {
     super();
@@ -894,7 +894,7 @@ export class CreateRepositoryByFullNameResponse extends Message<CreateRepository
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Repository repository = 1;
    */
-  repository?: Repository;
+  repository?: Repository | undefined;
 
   constructor(data?: PartialMessage<CreateRepositoryByFullNameResponse>) {
     super();
@@ -1119,7 +1119,7 @@ export class DeprecateRepositoryByNameResponse extends Message<DeprecateReposito
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Repository repository = 1;
    */
-  repository?: Repository;
+  repository?: Repository | undefined;
 
   constructor(data?: PartialMessage<DeprecateRepositoryByNameResponse>) {
     super();
@@ -1199,7 +1199,7 @@ export class UndeprecateRepositoryByNameResponse extends Message<UndeprecateRepo
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Repository repository = 1;
    */
-  repository?: Repository;
+  repository?: Repository | undefined;
 
   constructor(data?: PartialMessage<UndeprecateRepositoryByNameResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_tag_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_tag_pb.ts
@@ -35,7 +35,7 @@ export class RepositoryTag extends Message<RepositoryTag> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * We reserve field number '3' for the update_time.
@@ -154,7 +154,7 @@ export class CreateRepositoryTagResponse extends Message<CreateRepositoryTagResp
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryTag repository_tag = 1;
    */
-  repositoryTag?: RepositoryTag;
+  repositoryTag?: RepositoryTag | undefined;
 
   constructor(data?: PartialMessage<CreateRepositoryTagResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_commit_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_commit_pb.ts
@@ -34,7 +34,7 @@ export class RepositoryTrackCommit extends Message<RepositoryTrackCommit> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * immutable
@@ -138,7 +138,7 @@ export class GetRepositoryTrackCommitByRepositoryCommitResponse extends Message<
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryTrackCommit repository_track_commit = 1;
    */
-  repositoryTrackCommit?: RepositoryTrackCommit;
+  repositoryTrackCommit?: RepositoryTrackCommit | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryTrackCommitByRepositoryCommitResponse>) {
     super();
@@ -328,7 +328,7 @@ export class GetRepositoryTrackCommitByReferenceResponse extends Message<GetRepo
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryTrackCommit repository_track_commit = 1;
    */
-  repositoryTrackCommit?: RepositoryTrackCommit;
+  repositoryTrackCommit?: RepositoryTrackCommit | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryTrackCommitByReferenceResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_pb.ts
@@ -35,7 +35,7 @@ export class RepositoryTrack extends Message<RepositoryTrack> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * We reserve field number '3' for the update_time.
@@ -130,7 +130,7 @@ export class CreateRepositoryTrackResponse extends Message<CreateRepositoryTrack
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryTrack repository_track = 1;
    */
-  repositoryTrack?: RepositoryTrack;
+  repositoryTrack?: RepositoryTrack | undefined;
 
   constructor(data?: PartialMessage<CreateRepositoryTrackResponse>) {
     super();
@@ -404,7 +404,7 @@ export class GetRepositoryTrackByNameResponse extends Message<GetRepositoryTrack
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.RepositoryTrack repository_track = 1;
    */
-  repositoryTrack?: RepositoryTrack;
+  repositoryTrack?: RepositoryTrack | undefined;
 
   constructor(data?: PartialMessage<GetRepositoryTrackByNameResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/resolve_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/resolve_pb.ts
@@ -196,14 +196,14 @@ export class LocalModuleResolveResult extends Message<LocalModuleResolveResult> 
    *
    * @generated from field: buf.alpha.registry.v1alpha1.LocalModuleReference reference = 1;
    */
-  reference?: LocalModuleReference;
+  reference?: LocalModuleReference | undefined;
 
   /**
    * The pin the reference resolved to.
    *
    * @generated from field: buf.alpha.registry.v1alpha1.LocalModulePin pin = 2;
    */
-  pin?: LocalModulePin;
+  pin?: LocalModulePin | undefined;
 
   /**
    * The type the reference resolved as.

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/token_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/token_pb.ts
@@ -31,12 +31,12 @@ export class Token extends Message<Token> {
   /**
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp expire_time = 3;
    */
-  expireTime?: Timestamp;
+  expireTime?: Timestamp | undefined;
 
   /**
    * @generated from field: string note = 4;
@@ -89,7 +89,7 @@ export class CreateTokenRequest extends Message<CreateTokenRequest> {
    *
    * @generated from field: google.protobuf.Timestamp expire_time = 2;
    */
-  expireTime?: Timestamp;
+  expireTime?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<CreateTokenRequest>) {
     super();
@@ -203,7 +203,7 @@ export class GetTokenResponse extends Message<GetTokenResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.Token token = 1;
    */
-  token?: Token;
+  token?: Token | undefined;
 
   constructor(data?: PartialMessage<GetTokenResponse>) {
     super();

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/user_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/user_pb.ts
@@ -62,14 +62,14 @@ export class User extends Message<User> {
    *
    * @generated from field: google.protobuf.Timestamp create_time = 2;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * mutable
    *
    * @generated from field: google.protobuf.Timestamp update_time = 3;
    */
-  updateTime?: Timestamp;
+  updateTime?: Timestamp | undefined;
 
   /**
    * unique, mutable
@@ -126,7 +126,7 @@ export class OrganizationUser extends Message<OrganizationUser> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   /**
    * The ID of the organization for which the role belongs to.
@@ -216,7 +216,7 @@ export class CreateUserResponse extends Message<CreateUserResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   constructor(data?: PartialMessage<CreateUserResponse>) {
     super();
@@ -290,7 +290,7 @@ export class GetUserResponse extends Message<GetUserResponse> {
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   constructor(data?: PartialMessage<GetUserResponse>) {
     super();
@@ -364,7 +364,7 @@ export class GetUserByUsernameResponse extends Message<GetUserByUsernameResponse
   /**
    * @generated from field: buf.alpha.registry.v1alpha1.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 
   constructor(data?: PartialMessage<GetUserByUsernameResponse>) {
     super();

--- a/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
+++ b/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
@@ -254,7 +254,7 @@ export class ConformanceRequest extends Message<ConformanceRequest> {
    *
    * @generated from field: conformance.JspbEncodingConfig jspb_encoding_options = 6;
    */
-  jspbEncodingOptions?: JspbEncodingConfig;
+  jspbEncodingOptions?: JspbEncodingConfig | undefined;
 
   /**
    * This can be used in json and text format. If true, testee should print

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -85,112 +85,112 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesProto2_NestedEnum;
+  optionalNestedEnum?: TestAllTypesProto2_NestedEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignEnumProto2 optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumProto2;
+  optionalForeignEnum?: ForeignEnumProto2 | undefined;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece?: string | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -602,84 +602,84 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * default values
    *
    * @generated from field: optional int32 default_int32 = 241 [default = -123456789];
    */
-  defaultInt32?: number;
+  defaultInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 default_int64 = 242 [default = -9123456789123456789];
    */
-  defaultInt64?: bigint;
+  defaultInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 243 [default = 2123456789];
    */
-  defaultUint32?: number;
+  defaultUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 244 [default = 10123456789123456789];
    */
-  defaultUint64?: bigint;
+  defaultUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 245 [default = -123456789];
    */
-  defaultSint32?: number;
+  defaultSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 246 [default = -9123456789123456789];
    */
-  defaultSint64?: bigint;
+  defaultSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 247 [default = 2123456789];
    */
-  defaultFixed32?: number;
+  defaultFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 248 [default = 10123456789123456789];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 249 [default = -123456789];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float default_float = 251 [default = 9e+09];
    */
-  defaultFloat?: number;
+  defaultFloat?: number | undefined;
 
   /**
    * @generated from field: optional double default_double = 252 [default = 7e+22];
    */
-  defaultDouble?: number;
+  defaultDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool default_bool = 253 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string default_string = 254 [default = "Rosebud"];
    */
-  defaultString?: string;
+  defaultString?: string | undefined;
 
   /**
    * @generated from field: optional bytes default_bytes = 255 [default = "joshua"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes?: Uint8Array | undefined;
 
   /**
    * Test field-name-to-JSON-name convention.
@@ -687,92 +687,92 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 fieldname1 = 401;
    */
-  fieldname1?: number;
+  fieldname1?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_name2 = 402;
    */
-  fieldName2?: number;
+  fieldName2?: number | undefined;
 
   /**
    * @generated from field: optional int32 _field_name3 = 403;
    */
-  FieldName3?: number;
+  FieldName3?: number | undefined;
 
   /**
    * @generated from field: optional int32 field__name4_ = 404;
    */
-  fieldName4?: number;
+  fieldName4?: number | undefined;
 
   /**
    * @generated from field: optional int32 field0name5 = 405;
    */
-  field0name5?: number;
+  field0name5?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_0_name6 = 406;
    */
-  field0Name6?: number;
+  field0Name6?: number | undefined;
 
   /**
    * @generated from field: optional int32 fieldName7 = 407;
    */
-  fieldName7?: number;
+  fieldName7?: number | undefined;
 
   /**
    * @generated from field: optional int32 FieldName8 = 408;
    */
-  FieldName8?: number;
+  FieldName8?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_Name9 = 409;
    */
-  fieldName9?: number;
+  fieldName9?: number | undefined;
 
   /**
    * @generated from field: optional int32 Field_Name10 = 410;
    */
-  FieldName10?: number;
+  FieldName10?: number | undefined;
 
   /**
    * @generated from field: optional int32 FIELD_NAME11 = 411;
    */
-  FIELDNAME11?: number;
+  FIELDNAME11?: number | undefined;
 
   /**
    * @generated from field: optional int32 FIELD_name12 = 412;
    */
-  FIELDName12?: number;
+  FIELDName12?: number | undefined;
 
   /**
    * @generated from field: optional int32 __field_name13 = 413;
    */
-  FieldName13?: number;
+  FieldName13?: number | undefined;
 
   /**
    * @generated from field: optional int32 __Field_name14 = 414;
    */
-  FieldName14?: number;
+  FieldName14?: number | undefined;
 
   /**
    * @generated from field: optional int32 field__name15 = 415;
    */
-  fieldName15?: number;
+  fieldName15?: number | undefined;
 
   /**
    * @generated from field: optional int32 field__Name16 = 416;
    */
-  fieldName16?: number;
+  fieldName16?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_name17__ = 417;
    */
-  fieldName17?: number;
+  fieldName17?: number | undefined;
 
   /**
    * @generated from field: optional int32 Field_name18__ = 418;
    */
-  FieldName18?: number;
+  FieldName18?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2>) {
     super();
@@ -975,12 +975,12 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_NestedMessage>) {
     super();
@@ -1020,12 +1020,12 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
   /**
    * @generated from field: optional int32 group_int32 = 202;
    */
-  groupInt32?: number;
+  groupInt32?: number | undefined;
 
   /**
    * @generated from field: optional uint32 group_uint32 = 203;
    */
-  groupUint32?: number;
+  groupUint32?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_Data>) {
     super();
@@ -1096,7 +1096,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  str?: string | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension1>) {
     super();
@@ -1133,7 +1133,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
   /**
    * @generated from field: optional int32 i = 9;
    */
-  i?: number;
+  i?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension2>) {
     super();
@@ -1170,7 +1170,7 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c?: number | undefined;
 
   constructor(data?: PartialMessage<ForeignMessageProto2>) {
     super();
@@ -1207,27 +1207,27 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   /**
    * @generated from field: optional int32 optional_int32 = 1001;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional string optional_string = 1002;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 1011;
@@ -1274,7 +1274,7 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<UnknownToTestAllTypes_OptionalGroup>) {
     super();
@@ -1393,7 +1393,7 @@ export class OneStringProto2 extends Message<OneStringProto2> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  data?: string | undefined;
 
   constructor(data?: PartialMessage<OneStringProto2>) {
     super();

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -160,12 +160,12 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -195,7 +195,7 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -615,47 +615,47 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -705,32 +705,32 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: Struct;
+  optionalStruct?: Struct | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -1133,7 +1133,7 @@ export class TestAllTypesProto3_NestedMessage extends Message<TestAllTypesProto3
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto3_NestedMessage>) {
     super();

--- a/packages/protobuf-example/src/gen/addressbook_pb.ts
+++ b/packages/protobuf-example/src/gen/addressbook_pb.ts
@@ -49,7 +49,7 @@ export class Person extends Message<Person> {
   /**
    * @generated from field: google.protobuf.Timestamp last_updated = 5;
    */
-  lastUpdated?: Timestamp;
+  lastUpdated?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<Person>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
@@ -41,7 +41,7 @@ export class User extends Message<User> {
   /**
    * @generated from field: docs.User manager = 4;
    */
-  manager?: User;
+  manager?: User | undefined;
 
   /**
    * @generated from field: repeated string locations = 5;

--- a/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
@@ -26,7 +26,7 @@ export class MessageFieldMessage extends Message<MessageFieldMessage> {
   /**
    * @generated from field: spec.MessageFieldMessage.TestMessage message_field = 1;
    */
-  messageField?: MessageFieldMessage_TestMessage;
+  messageField?: MessageFieldMessage_TestMessage | undefined;
 
   /**
    * @generated from field: repeated spec.MessageFieldMessage.TestMessage repeated_message_field = 2;

--- a/packages/protobuf-test/src/gen/ts/extra/msg-self-reference_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-self-reference_pb.ts
@@ -26,7 +26,7 @@ export class SelfReferencingMessage extends Message<SelfReferencingMessage> {
   /**
    * @generated from field: spec.SelfReferencingMessage self = 1;
    */
-  self?: SelfReferencingMessage;
+  self?: SelfReferencingMessage | undefined;
 
   /**
    * @generated from field: repeated spec.SelfReferencingMessage self_list = 2;

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -1484,7 +1484,7 @@ export class NoClashOneofADT extends Message$1<NoClashOneofADT> {
   /**
    * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  m?: NoClashOneofADT_M;
+  m?: NoClashOneofADT_M | undefined;
 
   constructor(data?: PartialMessage$1<NoClashOneofADT>) {
     super();
@@ -1526,7 +1526,7 @@ export class NoClashOneofADT_M extends Message$1<NoClashOneofADT_M> {
   /**
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value?: string | undefined;
 
   constructor(data?: PartialMessage$1<NoClashOneofADT_M>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -193,22 +193,22 @@ export class Proto2OptionalMessage extends Message<Proto2OptionalMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: optional bytes bytes_field = 2;
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional spec.Proto2Enum enum_field = 3;
    */
-  enumField?: Proto2Enum;
+  enumField?: Proto2Enum | undefined;
 
   /**
    * @generated from field: optional spec.Proto2ChildMessage message_field = 4;
    */
-  messageField?: Proto2ChildMessage;
+  messageField?: Proto2ChildMessage | undefined;
 
   constructor(data?: PartialMessage<Proto2OptionalMessage>) {
     super();
@@ -248,22 +248,22 @@ export class Proto2RequiredMessage extends Message<Proto2RequiredMessage> {
   /**
    * @generated from field: required string string_field = 1;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: required bytes bytes_field = 2;
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: required spec.Proto2Enum enum_field = 3;
    */
-  enumField?: Proto2Enum;
+  enumField?: Proto2Enum | undefined;
 
   /**
    * @generated from field: required spec.Proto2ChildMessage message_field = 4;
    */
-  messageField?: Proto2ChildMessage;
+  messageField?: Proto2ChildMessage | undefined;
 
   constructor(data?: PartialMessage<Proto2RequiredMessage>) {
     super();
@@ -303,22 +303,22 @@ export class Proto2RequiredDefaultsMessage extends Message<Proto2RequiredDefault
   /**
    * @generated from field: required string string_field = 1 [default = "hello \" *\/ "];
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: required bytes bytes_field = 2 [default = "\000x\\x\\"x\'AAAAAA\010\014\n\r\t\013"];
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: required spec.Proto2Enum enum_field = 3 [default = PROTO2_ENUM_YES];
    */
-  enumField?: Proto2Enum;
+  enumField?: Proto2Enum | undefined;
 
   /**
    * @generated from field: required spec.Proto2ChildMessage message_field = 4;
    */
-  messageField?: Proto2ChildMessage;
+  messageField?: Proto2ChildMessage | undefined;
 
   constructor(data?: PartialMessage<Proto2RequiredDefaultsMessage>) {
     super();
@@ -358,42 +358,42 @@ export class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage> {
   /**
    * @generated from field: optional string string_field = 1 [default = "hello \" *\/ "];
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: optional bytes bytes_field = 2 [default = "\000x\\x\\"x\'AAAAAA\010\014\n\r\t\013"];
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional int32 int32_field = 3 [default = 128];
    */
-  int32Field?: number;
+  int32Field?: number | undefined;
 
   /**
    * @generated from field: optional int64 int46_field = 4 [default = -256];
    */
-  int46Field?: bigint;
+  int46Field?: bigint | undefined;
 
   /**
    * @generated from field: optional float float_field = 5 [default = -512.13];
    */
-  floatField?: number;
+  floatField?: number | undefined;
 
   /**
    * @generated from field: optional bool bool_field = 6 [default = true];
    */
-  boolField?: boolean;
+  boolField?: boolean | undefined;
 
   /**
    * @generated from field: optional spec.Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];
    */
-  enumField?: Proto2Enum;
+  enumField?: Proto2Enum | undefined;
 
   /**
    * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
    */
-  messageField?: Proto2ChildMessage;
+  messageField?: Proto2ChildMessage | undefined;
 
   constructor(data?: PartialMessage<Proto2DefaultsMessage>) {
     super();
@@ -437,7 +437,7 @@ export class Proto2ChildMessage extends Message<Proto2ChildMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   constructor(data?: PartialMessage<Proto2ChildMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -199,22 +199,22 @@ export class Proto3OptionalMessage extends Message<Proto3OptionalMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: optional bytes bytes_field = 2;
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional spec.Proto3Enum enum_field = 3;
    */
-  enumField?: Proto3Enum;
+  enumField?: Proto3Enum | undefined;
 
   /**
    * @generated from field: optional spec.Proto3OptionalMessage message_field = 4;
    */
-  messageField?: Proto3OptionalMessage;
+  messageField?: Proto3OptionalMessage | undefined;
 
   constructor(data?: PartialMessage<Proto3OptionalMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
@@ -26,47 +26,47 @@ export class WrappersMessage extends Message<WrappersMessage> {
   /**
    * @generated from field: google.protobuf.DoubleValue double_value_field = 1;
    */
-  doubleValueField?: number;
+  doubleValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_value_field = 2;
    */
-  boolValueField?: boolean;
+  boolValueField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_value_field = 3;
    */
-  floatValueField?: number;
+  floatValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_value_field = 4;
    */
-  int64ValueField?: bigint;
+  int64ValueField?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_value_field = 5;
    */
-  uint64ValueField?: bigint;
+  uint64ValueField?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_value_field = 6;
    */
-  int32ValueField?: number;
+  int32ValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_value_field = 7;
    */
-  uint32ValueField?: number;
+  uint32ValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue string_value_field = 8;
    */
-  stringValueField?: string;
+  stringValueField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_value_field = 9;
    */
-  bytesValueField?: Uint8Array;
+  bytesValueField?: Uint8Array | undefined;
 
   /**
    * @generated from oneof spec.WrappersMessage.oneof_fields

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/api_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/api_pb.ts
@@ -106,7 +106,7 @@ export class Api extends Message<Api> {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * Included interfaces. See [Mixin][].

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
@@ -61,17 +61,17 @@ export class Version extends Message<Version> {
   /**
    * @generated from field: optional int32 major = 1;
    */
-  major?: number;
+  major?: number | undefined;
 
   /**
    * @generated from field: optional int32 minor = 2;
    */
-  minor?: number;
+  minor?: number | undefined;
 
   /**
    * @generated from field: optional int32 patch = 3;
    */
-  patch?: number;
+  patch?: number | undefined;
 
   /**
    * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
@@ -79,7 +79,7 @@ export class Version extends Message<Version> {
    *
    * @generated from field: optional string suffix = 4;
    */
-  suffix?: string;
+  suffix?: string | undefined;
 
   constructor(data?: PartialMessage<Version>) {
     super();
@@ -132,7 +132,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
    *
    * @generated from field: optional string parameter = 2;
    */
-  parameter?: string;
+  parameter?: string | undefined;
 
   /**
    * FileDescriptorProtos for all files in files_to_generate and everything
@@ -159,7 +159,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
    *
    * @generated from field: optional google.protobuf.compiler.Version compiler_version = 3;
    */
-  compilerVersion?: Version;
+  compilerVersion?: Version | undefined;
 
   constructor(data?: PartialMessage<CodeGeneratorRequest>) {
     super();
@@ -210,7 +210,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional string error = 1;
    */
-  error?: string;
+  error?: string | undefined;
 
   /**
    * A bitmask of supported features that the code generator supports.
@@ -218,7 +218,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional uint64 supported_features = 2;
    */
-  supportedFeatures?: bigint;
+  supportedFeatures?: bigint | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.compiler.CodeGeneratorResponse.File file = 15;
@@ -298,7 +298,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * If non-empty, indicates that the named file should already exist, and the
@@ -341,14 +341,14 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string insertion_point = 2;
    */
-  insertionPoint?: string;
+  insertionPoint?: string | undefined;
 
   /**
    * The file contents.
    *
    * @generated from field: optional string content = 15;
    */
-  content?: string;
+  content?: string | undefined;
 
   /**
    * Information describing the file content being inserted. If an insertion
@@ -357,7 +357,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional google.protobuf.GeneratedCodeInfo generated_code_info = 16;
    */
-  generatedCodeInfo?: GeneratedCodeInfo;
+  generatedCodeInfo?: GeneratedCodeInfo | undefined;
 
   constructor(data?: PartialMessage<CodeGeneratorResponse_File>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
@@ -94,14 +94,14 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    *
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  package?: string | undefined;
 
   /**
    * Names of files imported by this file.
@@ -150,7 +150,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.FileOptions options = 8;
    */
-  options?: FileOptions;
+  options?: FileOptions | undefined;
 
   /**
    * This field contains optional information about the original source code.
@@ -160,7 +160,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional google.protobuf.SourceCodeInfo source_code_info = 9;
    */
-  sourceCodeInfo?: SourceCodeInfo;
+  sourceCodeInfo?: SourceCodeInfo | undefined;
 
   /**
    * The syntax of the proto file.
@@ -168,7 +168,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  syntax?: string | undefined;
 
   constructor(data?: PartialMessage<FileDescriptorProto>) {
     super();
@@ -218,7 +218,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto field = 2;
@@ -253,7 +253,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.MessageOptions options = 7;
    */
-  options?: MessageOptions;
+  options?: MessageOptions | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9;
@@ -314,19 +314,19 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start?: number | undefined;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
    */
-  options?: ExtensionRangeOptions;
+  options?: ExtensionRangeOptions | undefined;
 
   constructor(data?: PartialMessage<DescriptorProto_ExtensionRange>) {
     super();
@@ -371,14 +371,14 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start?: number | undefined;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end?: number | undefined;
 
   constructor(data?: PartialMessage<DescriptorProto_ReservedRange>) {
     super();
@@ -457,17 +457,17 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional int32 number = 3;
    */
-  number?: number;
+  number?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Label label = 4;
    */
-  label?: FieldDescriptorProto_Label;
+  label?: FieldDescriptorProto_Label | undefined;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
@@ -475,7 +475,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Type type = 5;
    */
-  type?: FieldDescriptorProto_Type;
+  type?: FieldDescriptorProto_Type | undefined;
 
   /**
    * For message and enum types, this is the name of the type.  If the name
@@ -486,7 +486,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string type_name = 6;
    */
-  typeName?: string;
+  typeName?: string | undefined;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
@@ -494,7 +494,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string extendee = 2;
    */
-  extendee?: string;
+  extendee?: string | undefined;
 
   /**
    * For numeric types, contains the original text representation of the value.
@@ -504,7 +504,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string default_value = 7;
    */
-  defaultValue?: string;
+  defaultValue?: string | undefined;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
@@ -512,7 +512,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional int32 oneof_index = 9;
    */
-  oneofIndex?: number;
+  oneofIndex?: number | undefined;
 
   /**
    * JSON name of this field. The value is set by protocol compiler. If the
@@ -522,12 +522,12 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string json_name = 10;
    */
-  jsonName?: string;
+  jsonName?: string | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
    */
-  options?: FieldOptions;
+  options?: FieldOptions | undefined;
 
   /**
    * If true, this is a proto3 "optional". When a proto3 field is optional, it
@@ -554,7 +554,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional bool proto3_optional = 17;
    */
-  proto3Optional?: boolean;
+  proto3Optional?: boolean | undefined;
 
   constructor(data?: PartialMessage<FieldDescriptorProto>) {
     super();
@@ -769,12 +769,12 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
    */
-  options?: OneofOptions;
+  options?: OneofOptions | undefined;
 
   constructor(data?: PartialMessage<OneofDescriptorProto>) {
     super();
@@ -814,7 +814,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.EnumValueDescriptorProto value = 2;
@@ -824,7 +824,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.EnumOptions options = 3;
    */
-  options?: EnumOptions;
+  options?: EnumOptions | undefined;
 
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
@@ -891,14 +891,14 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start?: number | undefined;
 
   /**
    * Inclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end?: number | undefined;
 
   constructor(data?: PartialMessage<EnumDescriptorProto_EnumReservedRange>) {
     super();
@@ -938,17 +938,17 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional int32 number = 2;
    */
-  number?: number;
+  number?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
    */
-  options?: EnumValueOptions;
+  options?: EnumValueOptions | undefined;
 
   constructor(data?: PartialMessage<EnumValueDescriptorProto>) {
     super();
@@ -989,7 +989,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.MethodDescriptorProto method = 2;
@@ -999,7 +999,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.ServiceOptions options = 3;
    */
-  options?: ServiceOptions;
+  options?: ServiceOptions | undefined;
 
   constructor(data?: PartialMessage<ServiceDescriptorProto>) {
     super();
@@ -1040,7 +1040,7 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -1048,31 +1048,31 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
    *
    * @generated from field: optional string input_type = 2;
    */
-  inputType?: string;
+  inputType?: string | undefined;
 
   /**
    * @generated from field: optional string output_type = 3;
    */
-  outputType?: string;
+  outputType?: string | undefined;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
    */
-  options?: MethodOptions;
+  options?: MethodOptions | undefined;
 
   /**
    * Identifies if client streams multiple client messages
    *
    * @generated from field: optional bool client_streaming = 5 [default = false];
    */
-  clientStreaming?: boolean;
+  clientStreaming?: boolean | undefined;
 
   /**
    * Identifies if server streams multiple server messages
    *
    * @generated from field: optional bool server_streaming = 6 [default = false];
    */
-  serverStreaming?: boolean;
+  serverStreaming?: boolean | undefined;
 
   constructor(data?: PartialMessage<MethodDescriptorProto>) {
     super();
@@ -1119,7 +1119,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_package = 1;
    */
-  javaPackage?: string;
+  javaPackage?: string | undefined;
 
   /**
    * Controls the name of the wrapper Java class generated for the .proto file.
@@ -1130,7 +1130,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_outer_classname = 8;
    */
-  javaOuterClassname?: string;
+  javaOuterClassname?: string | undefined;
 
   /**
    * If enabled, then the Java code generator will generate a separate .java
@@ -1142,7 +1142,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_multiple_files = 10 [default = false];
    */
-  javaMultipleFiles?: boolean;
+  javaMultipleFiles?: boolean | undefined;
 
   /**
    * This option does nothing.
@@ -1150,7 +1150,7 @@ export class FileOptions extends Message<FileOptions> {
    * @generated from field: optional bool java_generate_equals_and_hash = 20 [deprecated = true];
    * @deprecated
    */
-  javaGenerateEqualsAndHash?: boolean;
+  javaGenerateEqualsAndHash?: boolean | undefined;
 
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -1162,12 +1162,12 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_string_check_utf8 = 27 [default = false];
    */
-  javaStringCheckUtf8?: boolean;
+  javaStringCheckUtf8?: boolean | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9 [default = SPEED];
    */
-  optimizeFor?: FileOptions_OptimizeMode;
+  optimizeFor?: FileOptions_OptimizeMode | undefined;
 
   /**
    * Sets the Go package where structs generated from this .proto will be
@@ -1178,7 +1178,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string go_package = 11;
    */
-  goPackage?: string;
+  goPackage?: string | undefined;
 
   /**
    * Should generic services be generated in each language?  "Generic" services
@@ -1194,22 +1194,22 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_generic_services = 16 [default = false];
    */
-  ccGenericServices?: boolean;
+  ccGenericServices?: boolean | undefined;
 
   /**
    * @generated from field: optional bool java_generic_services = 17 [default = false];
    */
-  javaGenericServices?: boolean;
+  javaGenericServices?: boolean | undefined;
 
   /**
    * @generated from field: optional bool py_generic_services = 18 [default = false];
    */
-  pyGenericServices?: boolean;
+  pyGenericServices?: boolean | undefined;
 
   /**
    * @generated from field: optional bool php_generic_services = 42 [default = false];
    */
-  phpGenericServices?: boolean;
+  phpGenericServices?: boolean | undefined;
 
   /**
    * Is this file deprecated?
@@ -1219,7 +1219,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool deprecated = 23 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
@@ -1227,7 +1227,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_enable_arenas = 31 [default = true];
    */
-  ccEnableArenas?: boolean;
+  ccEnableArenas?: boolean | undefined;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
@@ -1235,14 +1235,14 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string objc_class_prefix = 36;
    */
-  objcClassPrefix?: string;
+  objcClassPrefix?: string | undefined;
 
   /**
    * Namespace for generated classes; defaults to the package.
    *
    * @generated from field: optional string csharp_namespace = 37;
    */
-  csharpNamespace?: string;
+  csharpNamespace?: string | undefined;
 
   /**
    * By default Swift generators will take the proto package and CamelCase it
@@ -1252,7 +1252,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string swift_prefix = 39;
    */
-  swiftPrefix?: string;
+  swiftPrefix?: string | undefined;
 
   /**
    * Sets the php class prefix which is prepended to all php generated classes
@@ -1260,7 +1260,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_class_prefix = 40;
    */
-  phpClassPrefix?: string;
+  phpClassPrefix?: string | undefined;
 
   /**
    * Use this option to change the namespace of php generated classes. Default
@@ -1269,7 +1269,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_namespace = 41;
    */
-  phpNamespace?: string;
+  phpNamespace?: string | undefined;
 
   /**
    * Use this option to change the namespace of php generated metadata classes.
@@ -1278,7 +1278,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_metadata_namespace = 44;
    */
-  phpMetadataNamespace?: string;
+  phpMetadataNamespace?: string | undefined;
 
   /**
    * Use this option to change the package of ruby generated classes. Default
@@ -1287,7 +1287,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string ruby_package = 45;
    */
-  rubyPackage?: string;
+  rubyPackage?: string | undefined;
 
   /**
    * The parser stores options it doesn't recognize here.
@@ -1407,7 +1407,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool message_set_wire_format = 1 [default = false];
    */
-  messageSetWireFormat?: boolean;
+  messageSetWireFormat?: boolean | undefined;
 
   /**
    * Disables the generation of the standard "descriptor()" accessor, which can
@@ -1416,7 +1416,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool no_standard_descriptor_accessor = 2 [default = false];
    */
-  noStandardDescriptorAccessor?: boolean;
+  noStandardDescriptorAccessor?: boolean | undefined;
 
   /**
    * Is this message deprecated?
@@ -1426,7 +1426,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * Whether the message is an automatically generated map entry type for the
@@ -1453,7 +1453,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool map_entry = 7;
    */
-  mapEntry?: boolean;
+  mapEntry?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1506,7 +1506,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.CType ctype = 1 [default = STRING];
    */
-  ctype?: FieldOptions_CType;
+  ctype?: FieldOptions_CType | undefined;
 
   /**
    * The packed option can be enabled for repeated primitive fields to enable
@@ -1517,7 +1517,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool packed = 2;
    */
-  packed?: boolean;
+  packed?: boolean | undefined;
 
   /**
    * The jstype option determines the JavaScript type used for values of the
@@ -1534,7 +1534,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL];
    */
-  jstype?: FieldOptions_JSType;
+  jstype?: FieldOptions_JSType | undefined;
 
   /**
    * Should this field be parsed lazily?  Lazy applies only to message-type
@@ -1574,7 +1574,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool lazy = 5 [default = false];
    */
-  lazy?: boolean;
+  lazy?: boolean | undefined;
 
   /**
    * unverified_lazy does no correctness checks on the byte stream. This should
@@ -1583,7 +1583,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool unverified_lazy = 15 [default = false];
    */
-  unverifiedLazy?: boolean;
+  unverifiedLazy?: boolean | undefined;
 
   /**
    * Is this field deprecated?
@@ -1593,14 +1593,14 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * For Google-internal migration only. Do not use.
    *
    * @generated from field: optional bool weak = 10 [default = false];
    */
-  weak?: boolean;
+  weak?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1753,7 +1753,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool allow_alias = 2;
    */
-  allowAlias?: boolean;
+  allowAlias?: boolean | undefined;
 
   /**
    * Is this enum deprecated?
@@ -1763,7 +1763,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1814,7 +1814,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool deprecated = 1 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1864,7 +1864,7 @@ export class ServiceOptions extends Message<ServiceOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1914,12 +1914,12 @@ export class MethodOptions extends Message<MethodOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
    */
-  idempotencyLevel?: MethodOptions_IdempotencyLevel;
+  idempotencyLevel?: MethodOptions_IdempotencyLevel | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2014,32 +2014,32 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
    *
    * @generated from field: optional string identifier_value = 3;
    */
-  identifierValue?: string;
+  identifierValue?: string | undefined;
 
   /**
    * @generated from field: optional uint64 positive_int_value = 4;
    */
-  positiveIntValue?: bigint;
+  positiveIntValue?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 negative_int_value = 5;
    */
-  negativeIntValue?: bigint;
+  negativeIntValue?: bigint | undefined;
 
   /**
    * @generated from field: optional double double_value = 6;
    */
-  doubleValue?: number;
+  doubleValue?: number | undefined;
 
   /**
    * @generated from field: optional bytes string_value = 7;
    */
-  stringValue?: Uint8Array;
+  stringValue?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional string aggregate_value = 8;
    */
-  aggregateValue?: string;
+  aggregateValue?: string | undefined;
 
   constructor(data?: PartialMessage<UninterpretedOption>) {
     super();
@@ -2088,12 +2088,12 @@ export class UninterpretedOption_NamePart extends Message<UninterpretedOption_Na
   /**
    * @generated from field: required string name_part = 1;
    */
-  namePart?: string;
+  namePart?: string | undefined;
 
   /**
    * @generated from field: required bool is_extension = 2;
    */
-  isExtension?: boolean;
+  isExtension?: boolean | undefined;
 
   constructor(data?: PartialMessage<UninterpretedOption_NamePart>) {
     super();
@@ -2303,12 +2303,12 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
    *
    * @generated from field: optional string leading_comments = 3;
    */
-  leadingComments?: string;
+  leadingComments?: string | undefined;
 
   /**
    * @generated from field: optional string trailing_comments = 4;
    */
-  trailingComments?: string;
+  trailingComments?: string | undefined;
 
   /**
    * @generated from field: repeated string leading_detached_comments = 6;
@@ -2408,7 +2408,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional string source_file = 2;
    */
-  sourceFile?: string;
+  sourceFile?: string | undefined;
 
   /**
    * Identifies the starting offset in bytes in the generated code
@@ -2416,7 +2416,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 begin = 3;
    */
-  begin?: number;
+  begin?: number | undefined;
 
   /**
    * Identifies the ending offset in bytes in the generated code that
@@ -2425,7 +2425,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 end = 4;
    */
-  end?: number;
+  end?: number | undefined;
 
   constructor(data?: PartialMessage<GeneratedCodeInfo_Annotation>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
@@ -85,112 +85,112 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesProto2_NestedEnum;
+  optionalNestedEnum?: TestAllTypesProto2_NestedEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignEnumProto2 optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumProto2;
+  optionalForeignEnum?: ForeignEnumProto2 | undefined;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece?: string | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -602,84 +602,84 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * default values
    *
    * @generated from field: optional int32 default_int32 = 241 [default = -123456789];
    */
-  defaultInt32?: number;
+  defaultInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 default_int64 = 242 [default = -9123456789123456789];
    */
-  defaultInt64?: bigint;
+  defaultInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 243 [default = 2123456789];
    */
-  defaultUint32?: number;
+  defaultUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 244 [default = 10123456789123456789];
    */
-  defaultUint64?: bigint;
+  defaultUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 245 [default = -123456789];
    */
-  defaultSint32?: number;
+  defaultSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 246 [default = -9123456789123456789];
    */
-  defaultSint64?: bigint;
+  defaultSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 247 [default = 2123456789];
    */
-  defaultFixed32?: number;
+  defaultFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 248 [default = 10123456789123456789];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 249 [default = -123456789];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float default_float = 251 [default = 9e+09];
    */
-  defaultFloat?: number;
+  defaultFloat?: number | undefined;
 
   /**
    * @generated from field: optional double default_double = 252 [default = 7e+22];
    */
-  defaultDouble?: number;
+  defaultDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool default_bool = 253 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string default_string = 254 [default = "Rosebud"];
    */
-  defaultString?: string;
+  defaultString?: string | undefined;
 
   /**
    * @generated from field: optional bytes default_bytes = 255 [default = "joshua"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes?: Uint8Array | undefined;
 
   /**
    * Test field-name-to-JSON-name convention.
@@ -687,92 +687,92 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 fieldname1 = 401;
    */
-  fieldname1?: number;
+  fieldname1?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_name2 = 402;
    */
-  fieldName2?: number;
+  fieldName2?: number | undefined;
 
   /**
    * @generated from field: optional int32 _field_name3 = 403;
    */
-  FieldName3?: number;
+  FieldName3?: number | undefined;
 
   /**
    * @generated from field: optional int32 field__name4_ = 404;
    */
-  fieldName4?: number;
+  fieldName4?: number | undefined;
 
   /**
    * @generated from field: optional int32 field0name5 = 405;
    */
-  field0name5?: number;
+  field0name5?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_0_name6 = 406;
    */
-  field0Name6?: number;
+  field0Name6?: number | undefined;
 
   /**
    * @generated from field: optional int32 fieldName7 = 407;
    */
-  fieldName7?: number;
+  fieldName7?: number | undefined;
 
   /**
    * @generated from field: optional int32 FieldName8 = 408;
    */
-  FieldName8?: number;
+  FieldName8?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_Name9 = 409;
    */
-  fieldName9?: number;
+  fieldName9?: number | undefined;
 
   /**
    * @generated from field: optional int32 Field_Name10 = 410;
    */
-  FieldName10?: number;
+  FieldName10?: number | undefined;
 
   /**
    * @generated from field: optional int32 FIELD_NAME11 = 411;
    */
-  FIELDNAME11?: number;
+  FIELDNAME11?: number | undefined;
 
   /**
    * @generated from field: optional int32 FIELD_name12 = 412;
    */
-  FIELDName12?: number;
+  FIELDName12?: number | undefined;
 
   /**
    * @generated from field: optional int32 __field_name13 = 413;
    */
-  FieldName13?: number;
+  FieldName13?: number | undefined;
 
   /**
    * @generated from field: optional int32 __Field_name14 = 414;
    */
-  FieldName14?: number;
+  FieldName14?: number | undefined;
 
   /**
    * @generated from field: optional int32 field__name15 = 415;
    */
-  fieldName15?: number;
+  fieldName15?: number | undefined;
 
   /**
    * @generated from field: optional int32 field__Name16 = 416;
    */
-  fieldName16?: number;
+  fieldName16?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_name17__ = 417;
    */
-  fieldName17?: number;
+  fieldName17?: number | undefined;
 
   /**
    * @generated from field: optional int32 Field_name18__ = 418;
    */
-  FieldName18?: number;
+  FieldName18?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2>) {
     super();
@@ -975,12 +975,12 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_NestedMessage>) {
     super();
@@ -1020,12 +1020,12 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
   /**
    * @generated from field: optional int32 group_int32 = 202;
    */
-  groupInt32?: number;
+  groupInt32?: number | undefined;
 
   /**
    * @generated from field: optional uint32 group_uint32 = 203;
    */
-  groupUint32?: number;
+  groupUint32?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_Data>) {
     super();
@@ -1096,7 +1096,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  str?: string | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension1>) {
     super();
@@ -1133,7 +1133,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
   /**
    * @generated from field: optional int32 i = 9;
    */
-  i?: number;
+  i?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension2>) {
     super();
@@ -1170,7 +1170,7 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c?: number | undefined;
 
   constructor(data?: PartialMessage<ForeignMessageProto2>) {
     super();
@@ -1207,27 +1207,27 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   /**
    * @generated from field: optional int32 optional_int32 = 1001;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional string optional_string = 1002;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 1011;
@@ -1274,7 +1274,7 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<UnknownToTestAllTypes_OptionalGroup>) {
     super();
@@ -1393,7 +1393,7 @@ export class OneStringProto2 extends Message<OneStringProto2> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  data?: string | undefined;
 
   constructor(data?: PartialMessage<OneStringProto2>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
@@ -160,12 +160,12 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -195,7 +195,7 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -615,47 +615,47 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -705,32 +705,32 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: Struct;
+  optionalStruct?: Struct | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -1133,7 +1133,7 @@ export class TestAllTypesProto3_NestedMessage extends Message<TestAllTypesProto3
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesProto3_NestedMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
@@ -102,7 +102,7 @@ export class Type extends Message<Type> {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -495,7 +495,7 @@ export class Enum extends Message<Enum> {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -618,7 +618,7 @@ export class Option extends Message<Option> {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value?: Any | undefined;
 
   constructor(data?: PartialMessage<Option>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_arena_pb.ts
@@ -42,7 +42,7 @@ export class NestedMessage extends Message<NestedMessage> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  d?: number | undefined;
 
   constructor(data?: PartialMessage<NestedMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -88,7 +88,7 @@ export class TestMessageWithCustomOptions extends Message<TestMessageWithCustomO
   /**
    * @generated from field: optional string field1 = 1;
    */
-  field1?: string;
+  field1?: string | undefined;
 
   /**
    * @generated from oneof protobuf_unittest.TestMessageWithCustomOptions.AnOneof
@@ -527,17 +527,17 @@ export class ComplexOptionType1 extends Message<ComplexOptionType1> {
   /**
    * @generated from field: optional int32 foo = 1;
    */
-  foo?: number;
+  foo?: number | undefined;
 
   /**
    * @generated from field: optional int32 foo2 = 2;
    */
-  foo2?: number;
+  foo2?: number | undefined;
 
   /**
    * @generated from field: optional int32 foo3 = 3;
    */
-  foo3?: number;
+  foo3?: number | undefined;
 
   /**
    * @generated from field: repeated int32 foo4 = 4;
@@ -582,17 +582,17 @@ export class ComplexOptionType2 extends Message<ComplexOptionType2> {
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType1 bar = 1;
    */
-  bar?: ComplexOptionType1;
+  bar?: ComplexOptionType1 | undefined;
 
   /**
    * @generated from field: optional int32 baz = 2;
    */
-  baz?: number;
+  baz?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
    */
-  fred?: ComplexOptionType2_ComplexOptionType4;
+  fred?: ComplexOptionType2_ComplexOptionType4 | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.ComplexOptionType2.ComplexOptionType4 barney = 4;
@@ -637,7 +637,7 @@ export class ComplexOptionType2_ComplexOptionType4 extends Message<ComplexOption
   /**
    * @generated from field: optional int32 waldo = 1;
    */
-  waldo?: number;
+  waldo?: number | undefined;
 
   constructor(data?: PartialMessage<ComplexOptionType2_ComplexOptionType4>) {
     super();
@@ -674,12 +674,12 @@ export class ComplexOptionType3 extends Message<ComplexOptionType3> {
   /**
    * @generated from field: optional int32 moo = 1;
    */
-  moo?: number;
+  moo?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
    */
-  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5;
+  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5 | undefined;
 
   constructor(data?: PartialMessage<ComplexOptionType3>) {
     super();
@@ -717,7 +717,7 @@ export class ComplexOptionType3_ComplexOptionType5 extends Message<ComplexOption
   /**
    * @generated from field: optional int32 plugh = 3;
    */
-  plugh?: number;
+  plugh?: number | undefined;
 
   constructor(data?: PartialMessage<ComplexOptionType3_ComplexOptionType5>) {
     super();
@@ -754,7 +754,7 @@ export class ComplexOpt6 extends Message<ComplexOpt6> {
   /**
    * @generated from field: optional int32 xyzzy = 7593951;
    */
-  xyzzy?: number;
+  xyzzy?: number | undefined;
 
   constructor(data?: PartialMessage<ComplexOpt6>) {
     super();
@@ -855,7 +855,7 @@ export class AggregateMessageSetElement extends Message<AggregateMessageSetEleme
   /**
    * @generated from field: optional string s = 1;
    */
-  s?: string;
+  s?: string | undefined;
 
   constructor(data?: PartialMessage<AggregateMessageSetElement>) {
     super();
@@ -894,40 +894,40 @@ export class Aggregate extends Message<Aggregate> {
   /**
    * @generated from field: optional int32 i = 1;
    */
-  i?: number;
+  i?: number | undefined;
 
   /**
    * @generated from field: optional string s = 2;
    */
-  s?: string;
+  s?: string | undefined;
 
   /**
    * A nested object
    *
    * @generated from field: optional protobuf_unittest.Aggregate sub = 3;
    */
-  sub?: Aggregate;
+  sub?: Aggregate | undefined;
 
   /**
    * To test the parsing of extensions inside aggregate values
    *
    * @generated from field: optional google.protobuf.FileOptions file = 4;
    */
-  file?: FileOptions;
+  file?: FileOptions | undefined;
 
   /**
    * An embedded message set
    *
    * @generated from field: optional protobuf_unittest.AggregateMessageSet mset = 5;
    */
-  mset?: AggregateMessageSet;
+  mset?: AggregateMessageSet | undefined;
 
   /**
    * An any
    *
    * @generated from field: optional google.protobuf.Any any = 6;
    */
-  any?: Any;
+  any?: Any | undefined;
 
   constructor(data?: PartialMessage<Aggregate>) {
     super();
@@ -969,7 +969,7 @@ export class AggregateMessage extends Message<AggregateMessage> {
   /**
    * @generated from field: optional int32 fieldname = 1;
    */
-  fieldname?: number;
+  fieldname?: number | undefined;
 
   constructor(data?: PartialMessage<AggregateMessage>) {
     super();
@@ -1053,7 +1053,7 @@ export class NestedOptionType_NestedMessage extends Message<NestedOptionType_Nes
   /**
    * @generated from field: optional int32 nested_field = 1;
    */
-  nestedField?: number;
+  nestedField?: number | undefined;
 
   constructor(data?: PartialMessage<NestedOptionType_NestedMessage>) {
     super();
@@ -1093,7 +1093,7 @@ export class OldOptionType extends Message<OldOptionType> {
   /**
    * @generated from field: required protobuf_unittest.OldOptionType.TestEnum value = 1;
    */
-  value?: OldOptionType_TestEnum;
+  value?: OldOptionType_TestEnum | undefined;
 
   constructor(data?: PartialMessage<OldOptionType>) {
     super();
@@ -1146,7 +1146,7 @@ export class NewOptionType extends Message<NewOptionType> {
   /**
    * @generated from field: required protobuf_unittest.NewOptionType.TestEnum value = 1;
    */
-  value?: NewOptionType_TestEnum;
+  value?: NewOptionType_TestEnum | undefined;
 
   constructor(data?: PartialMessage<NewOptionType>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
@@ -52,7 +52,7 @@ export class TestEmbedOptimizedForSize extends Message<TestEmbedOptimizedForSize
    *
    * @generated from field: optional protobuf_unittest.TestOptimizedForSize optional_message = 1;
    */
-  optionalMessage?: TestOptimizedForSize;
+  optionalMessage?: TestOptimizedForSize | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestOptimizedForSize repeated_message = 2;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
@@ -50,5002 +50,5002 @@ export class TestEnormousDescriptor extends Message<TestEnormousDescriptor> {
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1 = 1 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_2 = 2 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_3 = 3 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_4 = 4 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_5 = 5 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_6 = 6 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_7 = 7 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_8 = 8 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_9 = 9 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_10 = 10 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_11 = 11 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_12 = 12 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_13 = 13 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_14 = 14 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_15 = 15 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_16 = 16 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_17 = 17 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_18 = 18 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_19 = 19 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_20 = 20 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_21 = 21 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_22 = 22 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_23 = 23 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_24 = 24 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_25 = 25 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_26 = 26 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_27 = 27 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_28 = 28 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_29 = 29 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_30 = 30 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_31 = 31 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_32 = 32 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_33 = 33 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_34 = 34 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_35 = 35 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_36 = 36 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_37 = 37 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_38 = 38 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_39 = 39 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_40 = 40 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_41 = 41 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_42 = 42 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_43 = 43 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_44 = 44 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_45 = 45 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_46 = 46 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_47 = 47 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_48 = 48 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_49 = 49 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_50 = 50 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_51 = 51 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_52 = 52 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_53 = 53 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_54 = 54 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_55 = 55 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_56 = 56 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_57 = 57 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_58 = 58 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_59 = 59 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_60 = 60 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_61 = 61 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_62 = 62 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_63 = 63 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_64 = 64 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_65 = 65 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_66 = 66 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_67 = 67 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_68 = 68 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_69 = 69 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_70 = 70 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_71 = 71 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_72 = 72 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_73 = 73 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_74 = 74 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_75 = 75 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_76 = 76 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_77 = 77 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_78 = 78 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_79 = 79 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_80 = 80 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_81 = 81 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_82 = 82 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_83 = 83 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_84 = 84 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_85 = 85 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_86 = 86 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_87 = 87 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_88 = 88 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_89 = 89 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_90 = 90 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_91 = 91 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_92 = 92 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_93 = 93 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_94 = 94 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_95 = 95 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_96 = 96 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_97 = 97 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_98 = 98 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_99 = 99 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_100 = 100 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_101 = 101 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_102 = 102 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_103 = 103 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_104 = 104 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_105 = 105 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_106 = 106 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_107 = 107 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_108 = 108 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_109 = 109 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_110 = 110 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_111 = 111 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_112 = 112 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_113 = 113 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_114 = 114 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_115 = 115 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_116 = 116 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_117 = 117 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_118 = 118 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_119 = 119 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_120 = 120 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_121 = 121 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_122 = 122 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_123 = 123 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_124 = 124 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_125 = 125 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_126 = 126 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_127 = 127 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_128 = 128 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_129 = 129 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_130 = 130 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_131 = 131 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_132 = 132 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_133 = 133 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_134 = 134 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_135 = 135 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_136 = 136 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_137 = 137 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_138 = 138 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_139 = 139 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_140 = 140 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_141 = 141 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_142 = 142 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_143 = 143 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_144 = 144 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_145 = 145 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_146 = 146 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_147 = 147 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_148 = 148 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_149 = 149 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_150 = 150 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_151 = 151 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_152 = 152 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_153 = 153 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_154 = 154 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_155 = 155 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_156 = 156 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_157 = 157 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_158 = 158 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_159 = 159 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_160 = 160 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_161 = 161 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_162 = 162 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_163 = 163 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_164 = 164 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_165 = 165 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_166 = 166 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_167 = 167 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_168 = 168 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_169 = 169 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_170 = 170 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_171 = 171 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_172 = 172 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_173 = 173 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_174 = 174 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_175 = 175 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_176 = 176 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_177 = 177 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_178 = 178 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_179 = 179 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_180 = 180 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_181 = 181 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_182 = 182 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_183 = 183 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_184 = 184 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_185 = 185 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_186 = 186 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_187 = 187 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_188 = 188 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_189 = 189 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_190 = 190 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_191 = 191 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_192 = 192 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_193 = 193 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_194 = 194 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_195 = 195 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_196 = 196 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_197 = 197 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_198 = 198 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_199 = 199 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_200 = 200 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_201 = 201 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_202 = 202 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_203 = 203 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_204 = 204 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_205 = 205 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_206 = 206 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_207 = 207 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_208 = 208 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_209 = 209 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_210 = 210 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_211 = 211 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_212 = 212 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_213 = 213 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_214 = 214 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_215 = 215 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_216 = 216 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_217 = 217 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_218 = 218 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_219 = 219 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_220 = 220 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_221 = 221 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_222 = 222 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_223 = 223 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_224 = 224 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_225 = 225 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_226 = 226 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_227 = 227 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_228 = 228 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_229 = 229 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_230 = 230 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_231 = 231 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_232 = 232 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_233 = 233 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_234 = 234 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_235 = 235 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_236 = 236 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_237 = 237 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_238 = 238 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_239 = 239 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_240 = 240 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_241 = 241 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_242 = 242 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_243 = 243 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_244 = 244 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_245 = 245 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_246 = 246 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_247 = 247 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_248 = 248 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_249 = 249 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_250 = 250 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_251 = 251 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_252 = 252 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_253 = 253 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_254 = 254 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_255 = 255 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_256 = 256 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_257 = 257 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_258 = 258 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_259 = 259 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_260 = 260 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_261 = 261 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_262 = 262 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_263 = 263 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_264 = 264 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_265 = 265 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_266 = 266 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_267 = 267 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_268 = 268 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_269 = 269 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_270 = 270 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_271 = 271 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_272 = 272 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_273 = 273 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_274 = 274 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_275 = 275 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_276 = 276 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_277 = 277 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_278 = 278 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_279 = 279 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_280 = 280 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_281 = 281 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_282 = 282 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_283 = 283 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_284 = 284 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_285 = 285 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_286 = 286 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_287 = 287 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_288 = 288 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_289 = 289 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_290 = 290 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_291 = 291 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_292 = 292 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_293 = 293 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_294 = 294 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_295 = 295 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_296 = 296 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_297 = 297 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_298 = 298 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_299 = 299 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_300 = 300 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_301 = 301 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_302 = 302 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_303 = 303 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_304 = 304 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_305 = 305 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_306 = 306 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_307 = 307 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_308 = 308 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_309 = 309 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_310 = 310 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_311 = 311 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_312 = 312 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_313 = 313 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_314 = 314 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_315 = 315 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_316 = 316 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_317 = 317 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_318 = 318 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_319 = 319 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_320 = 320 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_321 = 321 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_322 = 322 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_323 = 323 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_324 = 324 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_325 = 325 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_326 = 326 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_327 = 327 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_328 = 328 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_329 = 329 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_330 = 330 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_331 = 331 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_332 = 332 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_333 = 333 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_334 = 334 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_335 = 335 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_336 = 336 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_337 = 337 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_338 = 338 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_339 = 339 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_340 = 340 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_341 = 341 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_342 = 342 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_343 = 343 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_344 = 344 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_345 = 345 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_346 = 346 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_347 = 347 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_348 = 348 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_349 = 349 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_350 = 350 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_351 = 351 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_352 = 352 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_353 = 353 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_354 = 354 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_355 = 355 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_356 = 356 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_357 = 357 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_358 = 358 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_359 = 359 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_360 = 360 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_361 = 361 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_362 = 362 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_363 = 363 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_364 = 364 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_365 = 365 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_366 = 366 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_367 = 367 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_368 = 368 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_369 = 369 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_370 = 370 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_371 = 371 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_372 = 372 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_373 = 373 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_374 = 374 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_375 = 375 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_376 = 376 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_377 = 377 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_378 = 378 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_379 = 379 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_380 = 380 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_381 = 381 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_382 = 382 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_383 = 383 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_384 = 384 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_385 = 385 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_386 = 386 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_387 = 387 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_388 = 388 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_389 = 389 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_390 = 390 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_391 = 391 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_392 = 392 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_393 = 393 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_394 = 394 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_395 = 395 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_396 = 396 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_397 = 397 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_398 = 398 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_399 = 399 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_400 = 400 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_401 = 401 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_402 = 402 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_403 = 403 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_404 = 404 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_405 = 405 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_406 = 406 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_407 = 407 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_408 = 408 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_409 = 409 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_410 = 410 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_411 = 411 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_412 = 412 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_413 = 413 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_414 = 414 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_415 = 415 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_416 = 416 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_417 = 417 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_418 = 418 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_419 = 419 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_420 = 420 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_421 = 421 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_422 = 422 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_423 = 423 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_424 = 424 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_425 = 425 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_426 = 426 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_427 = 427 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_428 = 428 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_429 = 429 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_430 = 430 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_431 = 431 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_432 = 432 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_433 = 433 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_434 = 434 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_435 = 435 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_436 = 436 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_437 = 437 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_438 = 438 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_439 = 439 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_440 = 440 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_441 = 441 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_442 = 442 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_443 = 443 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_444 = 444 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_445 = 445 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_446 = 446 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_447 = 447 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_448 = 448 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_449 = 449 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_450 = 450 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_451 = 451 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_452 = 452 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_453 = 453 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_454 = 454 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_455 = 455 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_456 = 456 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_457 = 457 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_458 = 458 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_459 = 459 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_460 = 460 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_461 = 461 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_462 = 462 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_463 = 463 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_464 = 464 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_465 = 465 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_466 = 466 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_467 = 467 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_468 = 468 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_469 = 469 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_470 = 470 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_471 = 471 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_472 = 472 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_473 = 473 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_474 = 474 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_475 = 475 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_476 = 476 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_477 = 477 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_478 = 478 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_479 = 479 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_480 = 480 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_481 = 481 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_482 = 482 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_483 = 483 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_484 = 484 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_485 = 485 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_486 = 486 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_487 = 487 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_488 = 488 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_489 = 489 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_490 = 490 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_491 = 491 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_492 = 492 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_493 = 493 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_494 = 494 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_495 = 495 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_496 = 496 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_497 = 497 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_498 = 498 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_499 = 499 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_500 = 500 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_501 = 501 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_502 = 502 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_503 = 503 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_504 = 504 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_505 = 505 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_506 = 506 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_507 = 507 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_508 = 508 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_509 = 509 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_510 = 510 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_511 = 511 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_512 = 512 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_513 = 513 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_514 = 514 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_515 = 515 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_516 = 516 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_517 = 517 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_518 = 518 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_519 = 519 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_520 = 520 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_521 = 521 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_522 = 522 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_523 = 523 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_524 = 524 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_525 = 525 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_526 = 526 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_527 = 527 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_528 = 528 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_529 = 529 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_530 = 530 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_531 = 531 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_532 = 532 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_533 = 533 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_534 = 534 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_535 = 535 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_536 = 536 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_537 = 537 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_538 = 538 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_539 = 539 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_540 = 540 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_541 = 541 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_542 = 542 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_543 = 543 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_544 = 544 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_545 = 545 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_546 = 546 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_547 = 547 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_548 = 548 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_549 = 549 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_550 = 550 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_551 = 551 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_552 = 552 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_553 = 553 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_554 = 554 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_555 = 555 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_556 = 556 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_557 = 557 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_558 = 558 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_559 = 559 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_560 = 560 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_561 = 561 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_562 = 562 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_563 = 563 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_564 = 564 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_565 = 565 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_566 = 566 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_567 = 567 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_568 = 568 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_569 = 569 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_570 = 570 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_571 = 571 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_572 = 572 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_573 = 573 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_574 = 574 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_575 = 575 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_576 = 576 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_577 = 577 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_578 = 578 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_579 = 579 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_580 = 580 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_581 = 581 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_582 = 582 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_583 = 583 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_584 = 584 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_585 = 585 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_586 = 586 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_587 = 587 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_588 = 588 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_589 = 589 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_590 = 590 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_591 = 591 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_592 = 592 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_593 = 593 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_594 = 594 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_595 = 595 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_596 = 596 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_597 = 597 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_598 = 598 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_599 = 599 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_600 = 600 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_601 = 601 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_602 = 602 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_603 = 603 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_604 = 604 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_605 = 605 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_606 = 606 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_607 = 607 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_608 = 608 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_609 = 609 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_610 = 610 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_611 = 611 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_612 = 612 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_613 = 613 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_614 = 614 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_615 = 615 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_616 = 616 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_617 = 617 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_618 = 618 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_619 = 619 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_620 = 620 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_621 = 621 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_622 = 622 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_623 = 623 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_624 = 624 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_625 = 625 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_626 = 626 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_627 = 627 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_628 = 628 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_629 = 629 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_630 = 630 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_631 = 631 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_632 = 632 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_633 = 633 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_634 = 634 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_635 = 635 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_636 = 636 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_637 = 637 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_638 = 638 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_639 = 639 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_640 = 640 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_641 = 641 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_642 = 642 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_643 = 643 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_644 = 644 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_645 = 645 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_646 = 646 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_647 = 647 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_648 = 648 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_649 = 649 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_650 = 650 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_651 = 651 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_652 = 652 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_653 = 653 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_654 = 654 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_655 = 655 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_656 = 656 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_657 = 657 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_658 = 658 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_659 = 659 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_660 = 660 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_661 = 661 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_662 = 662 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_663 = 663 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_664 = 664 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_665 = 665 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_666 = 666 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_667 = 667 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_668 = 668 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_669 = 669 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_670 = 670 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_671 = 671 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_672 = 672 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_673 = 673 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_674 = 674 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_675 = 675 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_676 = 676 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_677 = 677 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_678 = 678 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_679 = 679 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_680 = 680 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_681 = 681 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_682 = 682 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_683 = 683 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_684 = 684 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_685 = 685 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_686 = 686 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_687 = 687 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_688 = 688 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_689 = 689 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_690 = 690 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_691 = 691 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_692 = 692 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_693 = 693 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_694 = 694 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_695 = 695 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_696 = 696 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_697 = 697 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_698 = 698 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_699 = 699 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_700 = 700 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_701 = 701 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_702 = 702 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_703 = 703 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_704 = 704 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_705 = 705 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_706 = 706 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_707 = 707 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_708 = 708 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_709 = 709 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_710 = 710 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_711 = 711 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_712 = 712 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_713 = 713 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_714 = 714 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_715 = 715 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_716 = 716 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_717 = 717 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_718 = 718 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_719 = 719 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_720 = 720 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_721 = 721 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_722 = 722 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_723 = 723 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_724 = 724 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_725 = 725 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_726 = 726 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_727 = 727 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_728 = 728 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_729 = 729 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_730 = 730 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_731 = 731 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_732 = 732 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_733 = 733 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_734 = 734 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_735 = 735 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_736 = 736 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_737 = 737 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_738 = 738 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_739 = 739 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_740 = 740 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_741 = 741 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_742 = 742 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_743 = 743 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_744 = 744 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_745 = 745 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_746 = 746 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_747 = 747 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_748 = 748 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_749 = 749 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_750 = 750 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_751 = 751 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_752 = 752 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_753 = 753 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_754 = 754 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_755 = 755 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_756 = 756 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_757 = 757 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_758 = 758 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_759 = 759 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_760 = 760 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_761 = 761 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_762 = 762 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_763 = 763 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_764 = 764 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_765 = 765 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_766 = 766 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_767 = 767 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_768 = 768 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_769 = 769 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_770 = 770 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_771 = 771 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_772 = 772 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_773 = 773 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_774 = 774 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_775 = 775 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_776 = 776 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_777 = 777 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_778 = 778 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_779 = 779 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_780 = 780 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_781 = 781 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_782 = 782 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_783 = 783 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_784 = 784 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_785 = 785 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_786 = 786 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_787 = 787 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_788 = 788 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_789 = 789 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_790 = 790 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_791 = 791 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_792 = 792 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_793 = 793 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_794 = 794 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_795 = 795 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_796 = 796 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_797 = 797 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_798 = 798 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_799 = 799 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_800 = 800 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_801 = 801 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_802 = 802 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_803 = 803 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_804 = 804 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_805 = 805 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_806 = 806 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_807 = 807 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_808 = 808 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_809 = 809 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_810 = 810 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_811 = 811 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_812 = 812 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_813 = 813 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_814 = 814 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_815 = 815 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_816 = 816 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_817 = 817 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_818 = 818 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_819 = 819 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_820 = 820 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_821 = 821 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_822 = 822 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_823 = 823 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_824 = 824 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_825 = 825 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_826 = 826 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_827 = 827 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_828 = 828 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_829 = 829 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_830 = 830 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_831 = 831 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_832 = 832 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_833 = 833 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_834 = 834 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_835 = 835 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_836 = 836 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_837 = 837 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_838 = 838 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_839 = 839 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_840 = 840 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_841 = 841 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_842 = 842 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_843 = 843 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_844 = 844 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_845 = 845 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_846 = 846 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_847 = 847 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_848 = 848 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_849 = 849 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_850 = 850 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_851 = 851 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_852 = 852 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_853 = 853 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_854 = 854 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_855 = 855 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_856 = 856 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_857 = 857 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_858 = 858 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_859 = 859 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_860 = 860 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_861 = 861 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_862 = 862 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_863 = 863 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_864 = 864 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_865 = 865 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_866 = 866 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_867 = 867 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_868 = 868 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_869 = 869 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_870 = 870 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_871 = 871 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_872 = 872 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_873 = 873 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_874 = 874 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_875 = 875 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_876 = 876 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_877 = 877 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_878 = 878 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_879 = 879 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_880 = 880 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_881 = 881 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_882 = 882 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_883 = 883 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_884 = 884 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_885 = 885 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_886 = 886 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_887 = 887 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_888 = 888 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_889 = 889 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_890 = 890 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_891 = 891 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_892 = 892 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_893 = 893 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_894 = 894 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_895 = 895 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_896 = 896 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_897 = 897 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_898 = 898 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_899 = 899 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_900 = 900 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_901 = 901 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_902 = 902 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_903 = 903 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_904 = 904 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_905 = 905 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_906 = 906 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_907 = 907 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_908 = 908 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_909 = 909 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_910 = 910 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_911 = 911 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_912 = 912 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_913 = 913 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_914 = 914 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_915 = 915 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_916 = 916 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_917 = 917 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_918 = 918 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_919 = 919 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_920 = 920 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_921 = 921 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_922 = 922 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_923 = 923 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_924 = 924 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_925 = 925 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_926 = 926 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_927 = 927 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_928 = 928 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_929 = 929 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_930 = 930 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_931 = 931 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_932 = 932 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_933 = 933 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_934 = 934 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_935 = 935 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_936 = 936 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_937 = 937 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_938 = 938 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_939 = 939 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_940 = 940 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_941 = 941 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_942 = 942 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_943 = 943 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_944 = 944 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_945 = 945 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_946 = 946 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_947 = 947 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_948 = 948 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_949 = 949 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_950 = 950 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_951 = 951 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_952 = 952 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_953 = 953 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_954 = 954 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_955 = 955 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_956 = 956 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_957 = 957 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_958 = 958 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_959 = 959 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_960 = 960 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_961 = 961 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_962 = 962 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_963 = 963 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_964 = 964 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_965 = 965 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_966 = 966 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_967 = 967 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_968 = 968 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_969 = 969 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_970 = 970 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_971 = 971 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_972 = 972 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_973 = 973 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_974 = 974 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_975 = 975 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_976 = 976 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_977 = 977 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_978 = 978 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_979 = 979 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_980 = 980 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_981 = 981 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_982 = 982 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_983 = 983 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_984 = 984 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_985 = 985 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_986 = 986 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_987 = 987 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_988 = 988 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_989 = 989 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_990 = 990 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_991 = 991 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_992 = 992 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_993 = 993 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_994 = 994 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_995 = 995 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_996 = 996 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_997 = 997 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_998 = 998 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_999 = 999 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999?: string | undefined;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1000 = 1000 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000?: string | undefined;
 
   constructor(data?: PartialMessage<TestEnormousDescriptor>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
@@ -72,7 +72,7 @@ export class ImportMessageLite extends Message<ImportMessageLite> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  d?: number | undefined;
 
   constructor(data?: PartialMessage<ImportMessageLite>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
@@ -107,7 +107,7 @@ export class ImportMessage extends Message<ImportMessage> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  d?: number | undefined;
 
   constructor(data?: PartialMessage<ImportMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
@@ -44,7 +44,7 @@ export class PublicImportMessageLite extends Message<PublicImportMessageLite> {
   /**
    * @generated from field: optional int32 e = 1;
    */
-  e?: number;
+  e?: number | undefined;
 
   constructor(data?: PartialMessage<PublicImportMessageLite>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
@@ -44,7 +44,7 @@ export class PublicImportMessage extends Message<PublicImportMessage> {
   /**
    * @generated from field: optional int32 e = 1;
    */
-  e?: number;
+  e?: number | undefined;
 
   constructor(data?: PartialMessage<PublicImportMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_custom_option_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_custom_option_pb.ts
@@ -52,7 +52,7 @@ export class LazyMessage extends Message<LazyMessage> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<LazyMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_pb.ts
@@ -53,7 +53,7 @@ export class ImportedMessage extends Message<ImportedMessage> {
   /**
    * @generated from field: optional protobuf_unittest.lazy_imports.LazyMessage lazy_message = 1;
    */
-  lazyMessage?: LazyMessage;
+  lazyMessage?: LazyMessage | undefined;
 
   constructor(data?: PartialMessage<ImportedMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
@@ -47,14 +47,14 @@ export class TestLiteImportsNonlite extends Message<TestLiteImportsNonlite> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes message = 1;
    */
-  message?: TestAllTypes;
+  message?: TestAllTypes | undefined;
 
   /**
    * Verifies that transitive required fields generates valid code.
    *
    * @generated from field: optional protobuf_unittest.TestRequired message_with_required = 2;
    */
-  messageWithRequired?: TestRequired;
+  messageWithRequired?: TestRequired | undefined;
 
   constructor(data?: PartialMessage<TestLiteImportsNonlite>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
@@ -112,139 +112,139 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.OptionalGroup optionalgroup = 16;
    */
-  optionalgroup?: TestAllTypesLite_OptionalGroup;
+  optionalgroup?: TestAllTypesLite_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesLite_NestedMessage;
+  optionalNestedMessage?: TestAllTypesLite_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessageLite optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageLite;
+  optionalForeignMessage?: ForeignMessageLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportMessageLite optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessageLite;
+  optionalImportMessage?: ImportMessageLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesLite_NestedEnum;
+  optionalNestedEnum?: TestAllTypesLite_NestedEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumLite;
+  optionalForeignEnum?: ForeignEnumLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnumLite optional_import_enum = 23;
    */
-  optionalImportEnum?: ImportEnumLite;
+  optionalImportEnum?: ImportEnumLite | undefined;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece?: string | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * Defined in unittest_import_public.proto
    *
    * @generated from field: optional protobuf_unittest_import.PublicImportMessageLite optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessageLite;
+  optionalPublicImportMessage?: PublicImportMessageLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypesLite_NestedMessage;
+  optionalLazyMessage?: TestAllTypesLite_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypesLite_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypesLite_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -378,102 +378,102 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 default_int32 = 61 [default = 41];
    */
-  defaultInt32?: number;
+  defaultInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 default_int64 = 62 [default = 42];
    */
-  defaultInt64?: bigint;
+  defaultInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 63 [default = 43];
    */
-  defaultUint32?: number;
+  defaultUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 64 [default = 44];
    */
-  defaultUint64?: bigint;
+  defaultUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 65 [default = -45];
    */
-  defaultSint32?: number;
+  defaultSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 66 [default = 46];
    */
-  defaultSint64?: bigint;
+  defaultSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 67 [default = 47];
    */
-  defaultFixed32?: number;
+  defaultFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 68 [default = 48];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 69 [default = 49];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 70 [default = -50];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float default_float = 71 [default = 51.5];
    */
-  defaultFloat?: number;
+  defaultFloat?: number | undefined;
 
   /**
    * @generated from field: optional double default_double = 72 [default = 52000];
    */
-  defaultDouble?: number;
+  defaultDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool default_bool = 73 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string default_string = 74 [default = "hello"];
    */
-  defaultString?: string;
+  defaultString?: string | undefined;
 
   /**
    * @generated from field: optional bytes default_bytes = 75 [default = "world"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedEnum default_nested_enum = 81 [default = BAR];
    */
-  defaultNestedEnum?: TestAllTypesLite_NestedEnum;
+  defaultNestedEnum?: TestAllTypesLite_NestedEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite default_foreign_enum = 82 [default = FOREIGN_LITE_BAR];
    */
-  defaultForeignEnum?: ForeignEnumLite;
+  defaultForeignEnum?: ForeignEnumLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnumLite default_import_enum = 83 [default = IMPORT_LITE_BAR];
    */
-  defaultImportEnum?: ImportEnumLite;
+  defaultImportEnum?: ImportEnumLite | undefined;
 
   /**
    * @generated from field: optional string default_string_piece = 84 [default = "abc"];
    */
-  defaultStringPiece?: string;
+  defaultStringPiece?: string | undefined;
 
   /**
    * @generated from field: optional string default_cord = 85 [default = "123"];
    */
-  defaultCord?: string;
+  defaultCord?: string | undefined;
 
   /**
    * For oneof test
@@ -523,7 +523,7 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 deceptively_named_list = 116;
    */
-  deceptivelyNamedList?: number;
+  deceptivelyNamedList?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesLite>) {
     super();
@@ -664,12 +664,12 @@ export class TestAllTypesLite_NestedMessage extends Message<TestAllTypesLite_Nes
   /**
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 
   /**
    * @generated from field: optional int64 cc = 2;
    */
-  cc?: bigint;
+  cc?: bigint | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesLite_NestedMessage>) {
     super();
@@ -707,7 +707,7 @@ export class TestAllTypesLite_NestedMessage2 extends Message<TestAllTypesLite_Ne
   /**
    * @generated from field: optional int32 dd = 1;
    */
-  dd?: number;
+  dd?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesLite_NestedMessage2>) {
     super();
@@ -744,7 +744,7 @@ export class TestAllTypesLite_OptionalGroup extends Message<TestAllTypesLite_Opt
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesLite_OptionalGroup>) {
     super();
@@ -781,7 +781,7 @@ export class TestAllTypesLite_RepeatedGroup extends Message<TestAllTypesLite_Rep
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypesLite_RepeatedGroup>) {
     super();
@@ -818,7 +818,7 @@ export class ForeignMessageLite extends Message<ForeignMessageLite> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c?: number | undefined;
 
   constructor(data?: PartialMessage<ForeignMessageLite>) {
     super();
@@ -1001,7 +1001,7 @@ export class OptionalGroup_extension_lite extends Message<OptionalGroup_extensio
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<OptionalGroup_extension_lite>) {
     super();
@@ -1038,7 +1038,7 @@ export class RepeatedGroup_extension_lite extends Message<RepeatedGroup_extensio
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<RepeatedGroup_extension_lite>) {
     super();
@@ -1141,25 +1141,25 @@ export class TestDeprecatedLite extends Message<TestDeprecatedLite> {
    * @generated from field: optional int32 deprecated_field = 1 [deprecated = true];
    * @deprecated
    */
-  deprecatedField?: number;
+  deprecatedField?: number | undefined;
 
   /**
    * @generated from field: required int32 deprecated_field2 = 2 [deprecated = true];
    * @deprecated
    */
-  deprecatedField2?: number;
+  deprecatedField2?: number | undefined;
 
   /**
    * @generated from field: optional string deprecated_field3 = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedField3?: string;
+  deprecatedField3?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDeprecatedLite deprecated_field4 = 4 [deprecated = true];
    * @deprecated
    */
-  deprecatedField4?: TestDeprecatedLite;
+  deprecatedField4?: TestDeprecatedLite | undefined;
 
   constructor(data?: PartialMessage<TestDeprecatedLite>) {
     super();
@@ -1201,12 +1201,12 @@ export class TestParsingMergeLite extends Message<TestParsingMergeLite> {
   /**
    * @generated from field: required protobuf_unittest.TestAllTypesLite required_all_types = 1;
    */
-  requiredAllTypes?: TestAllTypesLite;
+  requiredAllTypes?: TestAllTypesLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite optional_all_types = 2;
    */
-  optionalAllTypes?: TestAllTypesLite;
+  optionalAllTypes?: TestAllTypesLite | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypesLite repeated_all_types = 3;
@@ -1216,7 +1216,7 @@ export class TestParsingMergeLite extends Message<TestParsingMergeLite> {
   /**
    * @generated from field: optional protobuf_unittest.TestParsingMergeLite.OptionalGroup optionalgroup = 10;
    */
-  optionalgroup?: TestParsingMergeLite_OptionalGroup;
+  optionalgroup?: TestParsingMergeLite_OptionalGroup | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestParsingMergeLite.RepeatedGroup repeatedgroup = 20;
@@ -1335,7 +1335,7 @@ export class TestParsingMergeLite_RepeatedFieldsGenerator_Group1 extends Message
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite field1 = 11;
    */
-  field1?: TestAllTypesLite;
+  field1?: TestAllTypesLite | undefined;
 
   constructor(data?: PartialMessage<TestParsingMergeLite_RepeatedFieldsGenerator_Group1>) {
     super();
@@ -1372,7 +1372,7 @@ export class TestParsingMergeLite_RepeatedFieldsGenerator_Group2 extends Message
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite field1 = 21;
    */
-  field1?: TestAllTypesLite;
+  field1?: TestAllTypesLite | undefined;
 
   constructor(data?: PartialMessage<TestParsingMergeLite_RepeatedFieldsGenerator_Group2>) {
     super();
@@ -1409,7 +1409,7 @@ export class TestParsingMergeLite_OptionalGroup extends Message<TestParsingMerge
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite optional_group_all_types = 11;
    */
-  optionalGroupAllTypes?: TestAllTypesLite;
+  optionalGroupAllTypes?: TestAllTypesLite | undefined;
 
   constructor(data?: PartialMessage<TestParsingMergeLite_OptionalGroup>) {
     super();
@@ -1446,7 +1446,7 @@ export class TestParsingMergeLite_RepeatedGroup extends Message<TestParsingMerge
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite repeated_group_all_types = 21;
    */
-  repeatedGroupAllTypes?: TestAllTypesLite;
+  repeatedGroupAllTypes?: TestAllTypesLite | undefined;
 
   constructor(data?: PartialMessage<TestParsingMergeLite_RepeatedGroup>) {
     super();
@@ -1486,7 +1486,7 @@ export class TestMergeExceptionLite extends Message<TestMergeExceptionLite> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllExtensionsLite all_extensions = 1;
    */
-  allExtensions?: TestAllExtensionsLite;
+  allExtensions?: TestAllExtensionsLite | undefined;
 
   constructor(data?: PartialMessage<TestMergeExceptionLite>) {
     super();
@@ -1590,12 +1590,12 @@ export class V1MessageLite extends Message<V1MessageLite> {
   /**
    * @generated from field: required int32 int_field = 1;
    */
-  intField?: number;
+  intField?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.V1EnumLite enum_field = 2 [default = V1_FIRST];
    */
-  enumField?: V1EnumLite;
+  enumField?: V1EnumLite | undefined;
 
   constructor(data?: PartialMessage<V1MessageLite>) {
     super();
@@ -1633,12 +1633,12 @@ export class V2MessageLite extends Message<V2MessageLite> {
   /**
    * @generated from field: required int32 int_field = 1;
    */
-  intField?: number;
+  intField?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.V2EnumLite enum_field = 2 [default = V2_FIRST];
    */
-  enumField?: V2EnumLite;
+  enumField?: V2EnumLite | undefined;
 
   constructor(data?: PartialMessage<V2MessageLite>) {
     super();
@@ -1676,12 +1676,12 @@ export class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbersLite> 
   /**
    * @generated from field: optional int32 optional_int32 = 536870000;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int32 fixed_32 = 536870001;
    */
-  fixed32?: number;
+  fixed32?: number | undefined;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 536870002 [packed = false];
@@ -1696,27 +1696,27 @@ export class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbersLite> 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite optional_enum = 536870004;
    */
-  optionalEnum?: ForeignEnumLite;
+  optionalEnum?: ForeignEnumLite | undefined;
 
   /**
    * @generated from field: optional string optional_string = 536870005;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 536870006;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessageLite optional_message = 536870007;
    */
-  optionalMessage?: ForeignMessageLite;
+  optionalMessage?: ForeignMessageLite | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestHugeFieldNumbersLite.OptionalGroup optionalgroup = 536870008;
    */
-  optionalgroup?: TestHugeFieldNumbersLite_OptionalGroup;
+  optionalgroup?: TestHugeFieldNumbersLite_OptionalGroup | undefined;
 
   /**
    * @generated from field: map<string, string> string_string_map = 536870010;
@@ -1800,7 +1800,7 @@ export class TestHugeFieldNumbersLite_OptionalGroup extends Message<TestHugeFiel
   /**
    * @generated from field: optional int32 group_a = 536870009;
    */
-  groupA?: number;
+  groupA?: number | undefined;
 
   constructor(data?: PartialMessage<TestHugeFieldNumbersLite_OptionalGroup>) {
     super();
@@ -2190,12 +2190,12 @@ export class RecursiveMessage extends Message<RecursiveMessage> {
   /**
    * @generated from field: optional protobuf_unittest.RecursiveMessage recurse = 1;
    */
-  recurse?: RecursiveMessage;
+  recurse?: RecursiveMessage | undefined;
 
   /**
    * @generated from field: optional bytes payload = 2;
    */
-  payload?: Uint8Array;
+  payload?: Uint8Array | undefined;
 
   constructor(data?: PartialMessage<RecursiveMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
@@ -50,7 +50,7 @@ export class TestMessageSetContainer extends Message<TestMessageSetContainer> {
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet?: TestMessageSet | undefined;
 
   constructor(data?: PartialMessage<TestMessageSetContainer>) {
     super();
@@ -87,12 +87,12 @@ export class NestedTestMessageSetContainer extends Message<NestedTestMessageSetC
   /**
    * @generated from field: optional protobuf_unittest.TestMessageSetContainer container = 1;
    */
-  container?: TestMessageSetContainer;
+  container?: TestMessageSetContainer | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.NestedTestMessageSetContainer child = 2;
    */
-  child?: NestedTestMessageSetContainer;
+  child?: NestedTestMessageSetContainer | undefined;
 
   constructor(data?: PartialMessage<NestedTestMessageSetContainer>) {
     super();
@@ -130,17 +130,17 @@ export class TestMessageSetExtension1 extends Message<TestMessageSetExtension1> 
   /**
    * @generated from field: optional int32 i = 15;
    */
-  i?: number;
+  i?: number | undefined;
 
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
    */
-  recursive?: TestMessageSet;
+  recursive?: TestMessageSet | undefined;
 
   /**
    * @generated from field: optional string test_aliasing = 17;
    */
-  testAliasing?: string;
+  testAliasing?: string | undefined;
 
   constructor(data?: PartialMessage<TestMessageSetExtension1>) {
     super();
@@ -179,7 +179,7 @@ export class TestMessageSetExtension2 extends Message<TestMessageSetExtension2> 
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  str?: string | undefined;
 
   constructor(data?: PartialMessage<TestMessageSetExtension2>) {
     super();
@@ -216,12 +216,12 @@ export class NestedTestInt extends Message<NestedTestInt> {
   /**
    * @generated from field: optional fixed32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.NestedTestInt child = 2;
    */
-  child?: NestedTestInt;
+  child?: NestedTestInt | undefined;
 
   constructor(data?: PartialMessage<NestedTestInt>) {
     super();
@@ -259,7 +259,7 @@ export class TestMessageSetExtension3 extends Message<TestMessageSetExtension3> 
   /**
    * @generated from field: optional protobuf_unittest.NestedTestInt msg = 35;
    */
-  msg?: NestedTestInt;
+  msg?: NestedTestInt | undefined;
 
   constructor(data?: PartialMessage<TestMessageSetExtension3>) {
     super();
@@ -335,12 +335,12 @@ export class RawMessageSet_Item extends Message<RawMessageSet_Item> {
   /**
    * @generated from field: required int32 type_id = 2;
    */
-  typeId?: number;
+  typeId?: number | undefined;
 
   /**
    * @generated from field: required bytes message = 3;
    */
-  message?: Uint8Array;
+  message?: Uint8Array | undefined;
 
   constructor(data?: PartialMessage<RawMessageSet_Item>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
@@ -81,7 +81,7 @@ export class TestMessageSetWireFormatContainer extends Message<TestMessageSetWir
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet?: TestMessageSet | undefined;
 
   constructor(data?: PartialMessage<TestMessageSetWireFormatContainer>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_field_presence_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_field_presence_pb.ts
@@ -153,17 +153,17 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: proto2_nofieldpresence_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_nofieldpresence_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest.TestAllTypes optional_proto2_message = 20;
    */
-  optionalProto2Message?: TestAllTypes$1;
+  optionalProto2Message?: TestAllTypes$1 | undefined;
 
   /**
    * @generated from field: proto2_nofieldpresence_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -192,7 +192,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: proto2_nofieldpresence_unittest.TestAllTypes.NestedMessage optional_lazy_message = 30;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -487,7 +487,7 @@ export class TestProto2Required extends Message<TestProto2Required> {
   /**
    * @generated from field: protobuf_unittest.TestRequired proto2 = 1;
    */
-  proto2?: TestRequired;
+  proto2?: TestRequired | undefined;
 
   constructor(data?: PartialMessage<TestProto2Required>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
@@ -58,7 +58,7 @@ export class TestMessage extends Message<TestMessage> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
@@ -49,12 +49,12 @@ export class TestOptimizedForSize extends Message<TestOptimizedForSize> {
   /**
    * @generated from field: optional int32 i = 1;
    */
-  i?: number;
+  i?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage msg = 19;
    */
-  msg?: ForeignMessage;
+  msg?: ForeignMessage | undefined;
 
   /**
    * @generated from oneof protobuf_unittest.TestOptimizedForSize.foo
@@ -111,7 +111,7 @@ export class TestRequiredOptimizedForSize extends Message<TestRequiredOptimizedF
   /**
    * @generated from field: required int32 x = 1;
    */
-  x?: number;
+  x?: number | undefined;
 
   constructor(data?: PartialMessage<TestRequiredOptimizedForSize>) {
     super();
@@ -148,7 +148,7 @@ export class TestOptionalOptimizedForSize extends Message<TestOptionalOptimizedF
   /**
    * @generated from field: optional protobuf_unittest.TestRequiredOptimizedForSize o = 1;
    */
-  o?: TestRequiredOptimizedForSize;
+  o?: TestRequiredOptimizedForSize | undefined;
 
   constructor(data?: PartialMessage<TestOptionalOptimizedForSize>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -793,139 +793,139 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.OptionalGroup optionalgroup = 16;
    */
-  optionalgroup?: TestAllTypes_OptionalGroup;
+  optionalgroup?: TestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypes_NestedEnum;
+  optionalNestedEnum?: TestAllTypes_NestedEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnum;
+  optionalForeignEnum?: ForeignEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnum optional_import_enum = 23;
    */
-  optionalImportEnum?: ImportEnum;
+  optionalImportEnum?: ImportEnum | undefined;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece?: string | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * Defined in unittest_import_public.proto
    *
    * @generated from field: optional protobuf_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -1059,102 +1059,102 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 default_int32 = 61 [default = 41];
    */
-  defaultInt32?: number;
+  defaultInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 default_int64 = 62 [default = 42];
    */
-  defaultInt64?: bigint;
+  defaultInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 63 [default = 43];
    */
-  defaultUint32?: number;
+  defaultUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 64 [default = 44];
    */
-  defaultUint64?: bigint;
+  defaultUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 65 [default = -45];
    */
-  defaultSint32?: number;
+  defaultSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 66 [default = 46];
    */
-  defaultSint64?: bigint;
+  defaultSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 67 [default = 47];
    */
-  defaultFixed32?: number;
+  defaultFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 68 [default = 48];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 69 [default = 49];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 70 [default = -50];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float default_float = 71 [default = 51.5];
    */
-  defaultFloat?: number;
+  defaultFloat?: number | undefined;
 
   /**
    * @generated from field: optional double default_double = 72 [default = 52000];
    */
-  defaultDouble?: number;
+  defaultDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool default_bool = 73 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string default_string = 74 [default = "hello"];
    */
-  defaultString?: string;
+  defaultString?: string | undefined;
 
   /**
    * @generated from field: optional bytes default_bytes = 75 [default = "world"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedEnum default_nested_enum = 81 [default = BAR];
    */
-  defaultNestedEnum?: TestAllTypes_NestedEnum;
+  defaultNestedEnum?: TestAllTypes_NestedEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum default_foreign_enum = 82 [default = FOREIGN_BAR];
    */
-  defaultForeignEnum?: ForeignEnum;
+  defaultForeignEnum?: ForeignEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnum default_import_enum = 83 [default = IMPORT_BAR];
    */
-  defaultImportEnum?: ImportEnum;
+  defaultImportEnum?: ImportEnum | undefined;
 
   /**
    * @generated from field: optional string default_string_piece = 84 [default = "abc"];
    */
-  defaultStringPiece?: string;
+  defaultStringPiece?: string | undefined;
 
   /**
    * @generated from field: optional string default_cord = 85 [default = "123"];
    */
-  defaultCord?: string;
+  defaultCord?: string | undefined;
 
   /**
    * For oneof test
@@ -1335,7 +1335,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypes_NestedMessage>) {
     super();
@@ -1372,7 +1372,7 @@ export class TestAllTypes_OptionalGroup extends Message<TestAllTypes_OptionalGro
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypes_OptionalGroup>) {
     super();
@@ -1409,7 +1409,7 @@ export class TestAllTypes_RepeatedGroup extends Message<TestAllTypes_RepeatedGro
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestAllTypes_RepeatedGroup>) {
     super();
@@ -1448,12 +1448,12 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
   /**
    * @generated from field: optional protobuf_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.NestedTestAllTypes repeated_child = 3;
@@ -1463,12 +1463,12 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
   /**
    * @generated from field: optional protobuf_unittest.NestedTestAllTypes lazy_child = 4;
    */
-  lazyChild?: NestedTestAllTypes;
+  lazyChild?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes eager_child = 5;
    */
-  eagerChild?: TestAllTypes;
+  eagerChild?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<NestedTestAllTypes>) {
     super();
@@ -1510,7 +1510,7 @@ export class TestDeprecatedFields extends Message<TestDeprecatedFields> {
    * @generated from field: optional int32 deprecated_int32 = 1 [deprecated = true];
    * @deprecated
    */
-  deprecatedInt32?: number;
+  deprecatedInt32?: number | undefined;
 
   /**
    * @generated from oneof protobuf_unittest.TestDeprecatedFields.oneof_fields
@@ -1595,12 +1595,12 @@ export class ForeignMessage extends Message<ForeignMessage> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c?: number | undefined;
 
   /**
    * @generated from field: optional int32 d = 2;
    */
-  d?: number;
+  d?: number | undefined;
 
   constructor(data?: PartialMessage<ForeignMessage>) {
     super();
@@ -1700,7 +1700,7 @@ export class OptionalGroup_extension extends Message<OptionalGroup_extension> {
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<OptionalGroup_extension>) {
     super();
@@ -1737,7 +1737,7 @@ export class RepeatedGroup_extension extends Message<RepeatedGroup_extension> {
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<RepeatedGroup_extension>) {
     super();
@@ -1774,12 +1774,12 @@ export class TestGroup extends Message<TestGroup> {
   /**
    * @generated from field: optional protobuf_unittest.TestGroup.OptionalGroup optionalgroup = 16;
    */
-  optionalgroup?: TestGroup_OptionalGroup;
+  optionalgroup?: TestGroup_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnum;
+  optionalForeignEnum?: ForeignEnum | undefined;
 
   constructor(data?: PartialMessage<TestGroup>) {
     super();
@@ -1817,7 +1817,7 @@ export class TestGroup_OptionalGroup extends Message<TestGroup_OptionalGroup> {
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestGroup_OptionalGroup>) {
     super();
@@ -1916,7 +1916,7 @@ export class TestNestedExtension_OptionalGroup_extension extends Message<TestNes
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestNestedExtension_OptionalGroup_extension>) {
     super();
@@ -1953,17 +1953,17 @@ export class TestChildExtension extends Message<TestChildExtension> {
   /**
    * @generated from field: optional string a = 1;
    */
-  a?: string;
+  a?: string | undefined;
 
   /**
    * @generated from field: optional string b = 2;
    */
-  b?: string;
+  b?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllExtensions optional_extension = 3;
    */
-  optionalExtension?: TestAllExtensions;
+  optionalExtension?: TestAllExtensions | undefined;
 
   constructor(data?: PartialMessage<TestChildExtension>) {
     super();
@@ -2005,17 +2005,17 @@ export class TestChildExtensionData extends Message<TestChildExtensionData> {
   /**
    * @generated from field: optional string a = 1;
    */
-  a?: string;
+  a?: string | undefined;
 
   /**
    * @generated from field: optional string b = 2;
    */
-  b?: string;
+  b?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
    */
-  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData;
+  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData | undefined;
 
   constructor(data?: PartialMessage<TestChildExtensionData>) {
     super();
@@ -2054,7 +2054,7 @@ export class TestChildExtensionData_NestedTestAllExtensionsData extends Message<
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData.NestedDynamicExtensions dynamic = 409707008;
    */
-  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
+  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions | undefined;
 
   constructor(data?: PartialMessage<TestChildExtensionData_NestedTestAllExtensionsData>) {
     super();
@@ -2091,12 +2091,12 @@ export class TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExt
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  b?: number | undefined;
 
   constructor(data?: PartialMessage<TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions>) {
     super();
@@ -2134,12 +2134,12 @@ export class TestNestedChildExtension extends Message<TestNestedChildExtension> 
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtension child = 2;
    */
-  child?: TestChildExtension;
+  child?: TestChildExtension | undefined;
 
   constructor(data?: PartialMessage<TestNestedChildExtension>) {
     super();
@@ -2180,12 +2180,12 @@ export class TestNestedChildExtensionData extends Message<TestNestedChildExtensi
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData child = 2;
    */
-  child?: TestChildExtensionData;
+  child?: TestChildExtensionData | undefined;
 
   constructor(data?: PartialMessage<TestNestedChildExtensionData>) {
     super();
@@ -2229,17 +2229,17 @@ export class TestRequired extends Message<TestRequired> {
   /**
    * @generated from field: required int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy2 = 2;
    */
-  dummy2?: number;
+  dummy2?: number | undefined;
 
   /**
    * @generated from field: required int32 b = 3;
    */
-  b?: number;
+  b?: number | undefined;
 
   /**
    * Pad the field count to 32 so that we can test that IsInitialized()
@@ -2247,159 +2247,159 @@ export class TestRequired extends Message<TestRequired> {
    *
    * @generated from field: optional int32 dummy4 = 4;
    */
-  dummy4?: number;
+  dummy4?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy5 = 5;
    */
-  dummy5?: number;
+  dummy5?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy6 = 6;
    */
-  dummy6?: number;
+  dummy6?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy7 = 7;
    */
-  dummy7?: number;
+  dummy7?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy8 = 8;
    */
-  dummy8?: number;
+  dummy8?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy9 = 9;
    */
-  dummy9?: number;
+  dummy9?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy10 = 10;
    */
-  dummy10?: number;
+  dummy10?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy11 = 11;
    */
-  dummy11?: number;
+  dummy11?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy12 = 12;
    */
-  dummy12?: number;
+  dummy12?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy13 = 13;
    */
-  dummy13?: number;
+  dummy13?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy14 = 14;
    */
-  dummy14?: number;
+  dummy14?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy15 = 15;
    */
-  dummy15?: number;
+  dummy15?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy16 = 16;
    */
-  dummy16?: number;
+  dummy16?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy17 = 17;
    */
-  dummy17?: number;
+  dummy17?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy18 = 18;
    */
-  dummy18?: number;
+  dummy18?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy19 = 19;
    */
-  dummy19?: number;
+  dummy19?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy20 = 20;
    */
-  dummy20?: number;
+  dummy20?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy21 = 21;
    */
-  dummy21?: number;
+  dummy21?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy22 = 22;
    */
-  dummy22?: number;
+  dummy22?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy23 = 23;
    */
-  dummy23?: number;
+  dummy23?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy24 = 24;
    */
-  dummy24?: number;
+  dummy24?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy25 = 25;
    */
-  dummy25?: number;
+  dummy25?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy26 = 26;
    */
-  dummy26?: number;
+  dummy26?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy27 = 27;
    */
-  dummy27?: number;
+  dummy27?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy28 = 28;
    */
-  dummy28?: number;
+  dummy28?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy29 = 29;
    */
-  dummy29?: number;
+  dummy29?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy30 = 30;
    */
-  dummy30?: number;
+  dummy30?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy31 = 31;
    */
-  dummy31?: number;
+  dummy31?: number | undefined;
 
   /**
    * @generated from field: optional int32 dummy32 = 32;
    */
-  dummy32?: number;
+  dummy32?: number | undefined;
 
   /**
    * @generated from field: required int32 c = 33;
    */
-  c?: number;
+  c?: number | undefined;
 
   /**
    * Add an optional child message to make this non-trivial for go/pdlazy.
    *
    * @generated from field: optional protobuf_unittest.ForeignMessage optional_foreign = 34;
    */
-  optionalForeign?: ForeignMessage;
+  optionalForeign?: ForeignMessage | undefined;
 
   constructor(data?: PartialMessage<TestRequired>) {
     super();
@@ -2469,7 +2469,7 @@ export class TestRequiredForeign extends Message<TestRequiredForeign> {
   /**
    * @generated from field: optional protobuf_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage?: TestRequired | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestRequired repeated_message = 2;
@@ -2479,7 +2479,7 @@ export class TestRequiredForeign extends Message<TestRequiredForeign> {
   /**
    * @generated from field: optional int32 dummy = 3;
    */
-  dummy?: number;
+  dummy?: number | undefined;
 
   constructor(data?: PartialMessage<TestRequiredForeign>) {
     super();
@@ -2518,7 +2518,7 @@ export class TestRequiredMessage extends Message<TestRequiredMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage?: TestRequired | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestRequired repeated_message = 2;
@@ -2528,7 +2528,7 @@ export class TestRequiredMessage extends Message<TestRequiredMessage> {
   /**
    * @generated from field: required protobuf_unittest.TestRequired required_message = 3;
    */
-  requiredMessage?: TestRequired;
+  requiredMessage?: TestRequired | undefined;
 
   constructor(data?: PartialMessage<TestRequiredMessage>) {
     super();
@@ -2567,17 +2567,17 @@ export class TestNestedRequiredForeign extends Message<TestNestedRequiredForeign
   /**
    * @generated from field: optional protobuf_unittest.TestNestedRequiredForeign child = 1;
    */
-  child?: TestNestedRequiredForeign;
+  child?: TestNestedRequiredForeign | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestRequiredForeign payload = 2;
    */
-  payload?: TestRequiredForeign;
+  payload?: TestRequiredForeign | undefined;
 
   /**
    * @generated from field: optional int32 dummy = 3;
    */
-  dummy?: number;
+  dummy?: number | undefined;
 
   constructor(data?: PartialMessage<TestNestedRequiredForeign>) {
     super();
@@ -2618,7 +2618,7 @@ export class TestForeignNested extends Message<TestForeignNested> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedMessage foreign_nested = 1;
    */
-  foreignNested?: TestAllTypes_NestedMessage;
+  foreignNested?: TestAllTypes_NestedMessage | undefined;
 
   constructor(data?: PartialMessage<TestForeignNested>) {
     super();
@@ -2755,7 +2755,7 @@ export class TestPickleNestedMessage_NestedMessage extends Message<TestPickleNes
   /**
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 
   constructor(data?: PartialMessage<TestPickleNestedMessage_NestedMessage>) {
     super();
@@ -2792,7 +2792,7 @@ export class TestPickleNestedMessage_NestedMessage_NestedNestedMessage extends M
   /**
    * @generated from field: optional int32 cc = 1;
    */
-  cc?: number;
+  cc?: number | undefined;
 
   constructor(data?: PartialMessage<TestPickleNestedMessage_NestedMessage_NestedNestedMessage>) {
     super();
@@ -2865,12 +2865,12 @@ export class TestReallyLargeTagNumber extends Message<TestReallyLargeTagNumber> 
    *
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional int32 bb = 268435455;
    */
-  bb?: number;
+  bb?: number | undefined;
 
   constructor(data?: PartialMessage<TestReallyLargeTagNumber>) {
     super();
@@ -2908,12 +2908,12 @@ export class TestRecursiveMessage extends Message<TestRecursiveMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestRecursiveMessage a = 1;
    */
-  a?: TestRecursiveMessage;
+  a?: TestRecursiveMessage | undefined;
 
   /**
    * @generated from field: optional int32 i = 2;
    */
-  i?: number;
+  i?: number | undefined;
 
   constructor(data?: PartialMessage<TestRecursiveMessage>) {
     super();
@@ -2953,12 +2953,12 @@ export class TestMutualRecursionA extends Message<TestMutualRecursionA> {
   /**
    * @generated from field: optional protobuf_unittest.TestMutualRecursionB bb = 1;
    */
-  bb?: TestMutualRecursionB;
+  bb?: TestMutualRecursionB | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestMutualRecursionA.SubGroup subgroup = 2;
    */
-  subgroup?: TestMutualRecursionA_SubGroup;
+  subgroup?: TestMutualRecursionA_SubGroup | undefined;
 
   constructor(data?: PartialMessage<TestMutualRecursionA>) {
     super();
@@ -2996,7 +2996,7 @@ export class TestMutualRecursionA_SubMessage extends Message<TestMutualRecursion
   /**
    * @generated from field: optional protobuf_unittest.TestMutualRecursionB b = 1;
    */
-  b?: TestMutualRecursionB;
+  b?: TestMutualRecursionB | undefined;
 
   constructor(data?: PartialMessage<TestMutualRecursionA_SubMessage>) {
     super();
@@ -3035,12 +3035,12 @@ export class TestMutualRecursionA_SubGroup extends Message<TestMutualRecursionA_
    *
    * @generated from field: optional protobuf_unittest.TestMutualRecursionA.SubMessage sub_message = 3;
    */
-  subMessage?: TestMutualRecursionA_SubMessage;
+  subMessage?: TestMutualRecursionA_SubMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes not_in_this_scc = 4;
    */
-  notInThisScc?: TestAllTypes;
+  notInThisScc?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestMutualRecursionA_SubGroup>) {
     super();
@@ -3078,12 +3078,12 @@ export class TestMutualRecursionB extends Message<TestMutualRecursionB> {
   /**
    * @generated from field: optional protobuf_unittest.TestMutualRecursionA a = 1;
    */
-  a?: TestMutualRecursionA;
+  a?: TestMutualRecursionA | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32 = 2;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   constructor(data?: PartialMessage<TestMutualRecursionB>) {
     super();
@@ -3121,7 +3121,7 @@ export class TestIsInitialized extends Message<TestIsInitialized> {
   /**
    * @generated from field: optional protobuf_unittest.TestIsInitialized.SubMessage sub_message = 1;
    */
-  subMessage?: TestIsInitialized_SubMessage;
+  subMessage?: TestIsInitialized_SubMessage | undefined;
 
   constructor(data?: PartialMessage<TestIsInitialized>) {
     super();
@@ -3158,7 +3158,7 @@ export class TestIsInitialized_SubMessage extends Message<TestIsInitialized_SubM
   /**
    * @generated from field: optional protobuf_unittest.TestIsInitialized.SubMessage.SubGroup subgroup = 1;
    */
-  subgroup?: TestIsInitialized_SubMessage_SubGroup;
+  subgroup?: TestIsInitialized_SubMessage_SubGroup | undefined;
 
   constructor(data?: PartialMessage<TestIsInitialized_SubMessage>) {
     super();
@@ -3195,7 +3195,7 @@ export class TestIsInitialized_SubMessage_SubGroup extends Message<TestIsInitial
   /**
    * @generated from field: required int32 i = 2;
    */
-  i?: number;
+  i?: number | undefined;
 
   constructor(data?: PartialMessage<TestIsInitialized_SubMessage_SubGroup>) {
     super();
@@ -3241,17 +3241,17 @@ export class TestDupFieldNumber extends Message<TestDupFieldNumber> {
    *
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDupFieldNumber.Foo foo = 2;
    */
-  foo?: TestDupFieldNumber_Foo;
+  foo?: TestDupFieldNumber_Foo | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDupFieldNumber.Bar bar = 3;
    */
-  bar?: TestDupFieldNumber_Bar;
+  bar?: TestDupFieldNumber_Bar | undefined;
 
   constructor(data?: PartialMessage<TestDupFieldNumber>) {
     super();
@@ -3290,7 +3290,7 @@ export class TestDupFieldNumber_Foo extends Message<TestDupFieldNumber_Foo> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestDupFieldNumber_Foo>) {
     super();
@@ -3327,7 +3327,7 @@ export class TestDupFieldNumber_Bar extends Message<TestDupFieldNumber_Bar> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a?: number | undefined;
 
   constructor(data?: PartialMessage<TestDupFieldNumber_Bar>) {
     super();
@@ -3366,7 +3366,7 @@ export class TestEagerMessage extends Message<TestEagerMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestEagerMessage>) {
     super();
@@ -3403,7 +3403,7 @@ export class TestLazyMessage extends Message<TestLazyMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestLazyMessage>) {
     super();
@@ -3440,17 +3440,17 @@ export class TestEagerMaybeLazy extends Message<TestEagerMaybeLazy> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes message_foo = 1;
    */
-  messageFoo?: TestAllTypes;
+  messageFoo?: TestAllTypes | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes message_bar = 2;
    */
-  messageBar?: TestAllTypes;
+  messageBar?: TestAllTypes | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestEagerMaybeLazy.NestedMessage message_baz = 3;
    */
-  messageBaz?: TestEagerMaybeLazy_NestedMessage;
+  messageBaz?: TestEagerMaybeLazy_NestedMessage | undefined;
 
   constructor(data?: PartialMessage<TestEagerMaybeLazy>) {
     super();
@@ -3489,7 +3489,7 @@ export class TestEagerMaybeLazy_NestedMessage extends Message<TestEagerMaybeLazy
   /**
    * @generated from field: optional protobuf_unittest.TestPackedTypes packed = 1;
    */
-  packed?: TestPackedTypes;
+  packed?: TestPackedTypes | undefined;
 
   constructor(data?: PartialMessage<TestEagerMaybeLazy_NestedMessage>) {
     super();
@@ -3528,7 +3528,7 @@ export class TestNestedMessageHasBits extends Message<TestNestedMessageHasBits> 
   /**
    * @generated from field: optional protobuf_unittest.TestNestedMessageHasBits.NestedMessage optional_nested_message = 1;
    */
-  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage;
+  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage | undefined;
 
   constructor(data?: PartialMessage<TestNestedMessageHasBits>) {
     super();
@@ -3611,32 +3611,32 @@ export class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldNames> {
   /**
    * @generated from field: optional int32 PrimitiveField = 1;
    */
-  PrimitiveField?: number;
+  PrimitiveField?: number | undefined;
 
   /**
    * @generated from field: optional string StringField = 2;
    */
-  StringField?: string;
+  StringField?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum EnumField = 3;
    */
-  EnumField?: ForeignEnum;
+  EnumField?: ForeignEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage MessageField = 4;
    */
-  MessageField?: ForeignMessage;
+  MessageField?: ForeignMessage | undefined;
 
   /**
    * @generated from field: optional string StringPieceField = 5;
    */
-  StringPieceField?: string;
+  StringPieceField?: string | undefined;
 
   /**
    * @generated from field: optional string CordField = 6;
    */
-  CordField?: string;
+  CordField?: string | undefined;
 
   /**
    * @generated from field: repeated int32 RepeatedPrimitiveField = 7;
@@ -3717,22 +3717,22 @@ export class TestFieldOrderings extends Message<TestFieldOrderings> {
   /**
    * @generated from field: optional string my_string = 11;
    */
-  myString?: string;
+  myString?: string | undefined;
 
   /**
    * @generated from field: optional int64 my_int = 1;
    */
-  myInt?: bigint;
+  myInt?: bigint | undefined;
 
   /**
    * @generated from field: optional float my_float = 101;
    */
-  myFloat?: number;
+  myFloat?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
    */
-  optionalNestedMessage?: TestFieldOrderings_NestedMessage;
+  optionalNestedMessage?: TestFieldOrderings_NestedMessage | undefined;
 
   constructor(data?: PartialMessage<TestFieldOrderings>) {
     super();
@@ -3772,7 +3772,7 @@ export class TestFieldOrderings_NestedMessage extends Message<TestFieldOrderings
   /**
    * @generated from field: optional int64 oo = 2;
    */
-  oo?: bigint;
+  oo?: bigint | undefined;
 
   /**
    * The field name "b" fails to compile in proto1 because it conflicts with
@@ -3781,7 +3781,7 @@ export class TestFieldOrderings_NestedMessage extends Message<TestFieldOrderings
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 
   constructor(data?: PartialMessage<TestFieldOrderings_NestedMessage>) {
     super();
@@ -3819,7 +3819,7 @@ export class TestExtensionOrderings1 extends Message<TestExtensionOrderings1> {
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  myString?: string | undefined;
 
   constructor(data?: PartialMessage<TestExtensionOrderings1>) {
     super();
@@ -3856,7 +3856,7 @@ export class TestExtensionOrderings2 extends Message<TestExtensionOrderings2> {
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  myString?: string | undefined;
 
   constructor(data?: PartialMessage<TestExtensionOrderings2>) {
     super();
@@ -3893,7 +3893,7 @@ export class TestExtensionOrderings2_TestExtensionOrderings3 extends Message<Tes
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  myString?: string | undefined;
 
   constructor(data?: PartialMessage<TestExtensionOrderings2_TestExtensionOrderings3>) {
     super();
@@ -3930,37 +3930,37 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
   /**
    * @generated from field: optional bytes escaped_bytes = 1 [default = "\000\001\007\010\014\n\r\t\013\\\'\\"\376"];
    */
-  escapedBytes?: Uint8Array;
+  escapedBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional uint32 large_uint32 = 2 [default = 4294967295];
    */
-  largeUint32?: number;
+  largeUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 large_uint64 = 3 [default = 18446744073709551615];
    */
-  largeUint64?: bigint;
+  largeUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional int32 small_int32 = 4 [default = -2147483647];
    */
-  smallInt32?: number;
+  smallInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 small_int64 = 5 [default = -9223372036854775807];
    */
-  smallInt64?: bigint;
+  smallInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional int32 really_small_int32 = 21 [default = -2147483648];
    */
-  reallySmallInt32?: number;
+  reallySmallInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 really_small_int64 = 22 [default = -9223372036854775808];
    */
-  reallySmallInt64?: bigint;
+  reallySmallInt64?: bigint | undefined;
 
   /**
    * The default value here is UTF-8 for "\u1234".  (We could also just type
@@ -3969,78 +3969,78 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
    *
    * @generated from field: optional string utf8_string = 6 [default = "ሴ"];
    */
-  utf8String?: string;
+  utf8String?: string | undefined;
 
   /**
    * Tests for single-precision floating-point values.
    *
    * @generated from field: optional float zero_float = 7 [default = 0];
    */
-  zeroFloat?: number;
+  zeroFloat?: number | undefined;
 
   /**
    * @generated from field: optional float one_float = 8 [default = 1];
    */
-  oneFloat?: number;
+  oneFloat?: number | undefined;
 
   /**
    * @generated from field: optional float small_float = 9 [default = 1.5];
    */
-  smallFloat?: number;
+  smallFloat?: number | undefined;
 
   /**
    * @generated from field: optional float negative_one_float = 10 [default = -1];
    */
-  negativeOneFloat?: number;
+  negativeOneFloat?: number | undefined;
 
   /**
    * @generated from field: optional float negative_float = 11 [default = -1.5];
    */
-  negativeFloat?: number;
+  negativeFloat?: number | undefined;
 
   /**
    * Using exponents
    *
    * @generated from field: optional float large_float = 12 [default = 2e+08];
    */
-  largeFloat?: number;
+  largeFloat?: number | undefined;
 
   /**
    * @generated from field: optional float small_negative_float = 13 [default = -8e-28];
    */
-  smallNegativeFloat?: number;
+  smallNegativeFloat?: number | undefined;
 
   /**
    * Text for nonfinite floating-point values.
    *
    * @generated from field: optional double inf_double = 14 [default = inf];
    */
-  infDouble?: number;
+  infDouble?: number | undefined;
 
   /**
    * @generated from field: optional double neg_inf_double = 15 [default = -inf];
    */
-  negInfDouble?: number;
+  negInfDouble?: number | undefined;
 
   /**
    * @generated from field: optional double nan_double = 16 [default = nan];
    */
-  nanDouble?: number;
+  nanDouble?: number | undefined;
 
   /**
    * @generated from field: optional float inf_float = 17 [default = inf];
    */
-  infFloat?: number;
+  infFloat?: number | undefined;
 
   /**
    * @generated from field: optional float neg_inf_float = 18 [default = -inf];
    */
-  negInfFloat?: number;
+  negInfFloat?: number | undefined;
 
   /**
    * @generated from field: optional float nan_float = 19 [default = nan];
    */
-  nanFloat?: number;
+  nanFloat?: number | undefined;
 
   /**
    * Tests for C++ trigraphs.
@@ -4051,34 +4051,34 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
    *
    * @generated from field: optional string cpp_trigraph = 20 [default = "? ? ?? ?? ??? ??/ ??-"];
    */
-  cppTrigraph?: string;
+  cppTrigraph?: string | undefined;
 
   /**
    * String defaults containing the character '\000'
    *
    * @generated from field: optional string string_with_zero = 23 [default = "hel lo"];
    */
-  stringWithZero?: string;
+  stringWithZero?: string | undefined;
 
   /**
    * @generated from field: optional bytes bytes_with_zero = 24 [default = "wor\000ld"];
    */
-  bytesWithZero?: Uint8Array;
+  bytesWithZero?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional string string_piece_with_zero = 25 [default = "ab c"];
    */
-  stringPieceWithZero?: string;
+  stringPieceWithZero?: string | undefined;
 
   /**
    * @generated from field: optional string cord_with_zero = 26 [default = "12 3"];
    */
-  cordWithZero?: string;
+  cordWithZero?: string | undefined;
 
   /**
    * @generated from field: optional string replacement_string = 27 [default = "${unknown}"];
    */
-  replacementString?: string;
+  replacementString?: string | undefined;
 
   constructor(data?: PartialMessage<TestExtremeDefaultValues>) {
     super();
@@ -4141,7 +4141,7 @@ export class SparseEnumMessage extends Message<SparseEnumMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestSparseEnum sparse_enum = 1;
    */
-  sparseEnum?: TestSparseEnum;
+  sparseEnum?: TestSparseEnum | undefined;
 
   constructor(data?: PartialMessage<SparseEnumMessage>) {
     super();
@@ -4180,7 +4180,7 @@ export class OneString extends Message<OneString> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  data?: string | undefined;
 
   constructor(data?: PartialMessage<OneString>) {
     super();
@@ -4254,7 +4254,7 @@ export class OneBytes extends Message<OneBytes> {
   /**
    * @generated from field: optional bytes data = 1;
    */
-  data?: Uint8Array;
+  data?: Uint8Array | undefined;
 
   constructor(data?: PartialMessage<OneBytes>) {
     super();
@@ -4328,162 +4328,162 @@ export class ManyOptionalString extends Message<ManyOptionalString> {
   /**
    * @generated from field: optional string str1 = 1;
    */
-  str1?: string;
+  str1?: string | undefined;
 
   /**
    * @generated from field: optional string str2 = 2;
    */
-  str2?: string;
+  str2?: string | undefined;
 
   /**
    * @generated from field: optional string str3 = 3;
    */
-  str3?: string;
+  str3?: string | undefined;
 
   /**
    * @generated from field: optional string str4 = 4;
    */
-  str4?: string;
+  str4?: string | undefined;
 
   /**
    * @generated from field: optional string str5 = 5;
    */
-  str5?: string;
+  str5?: string | undefined;
 
   /**
    * @generated from field: optional string str6 = 6;
    */
-  str6?: string;
+  str6?: string | undefined;
 
   /**
    * @generated from field: optional string str7 = 7;
    */
-  str7?: string;
+  str7?: string | undefined;
 
   /**
    * @generated from field: optional string str8 = 8;
    */
-  str8?: string;
+  str8?: string | undefined;
 
   /**
    * @generated from field: optional string str9 = 9;
    */
-  str9?: string;
+  str9?: string | undefined;
 
   /**
    * @generated from field: optional string str10 = 10;
    */
-  str10?: string;
+  str10?: string | undefined;
 
   /**
    * @generated from field: optional string str11 = 11;
    */
-  str11?: string;
+  str11?: string | undefined;
 
   /**
    * @generated from field: optional string str12 = 12;
    */
-  str12?: string;
+  str12?: string | undefined;
 
   /**
    * @generated from field: optional string str13 = 13;
    */
-  str13?: string;
+  str13?: string | undefined;
 
   /**
    * @generated from field: optional string str14 = 14;
    */
-  str14?: string;
+  str14?: string | undefined;
 
   /**
    * @generated from field: optional string str15 = 15;
    */
-  str15?: string;
+  str15?: string | undefined;
 
   /**
    * @generated from field: optional string str16 = 16;
    */
-  str16?: string;
+  str16?: string | undefined;
 
   /**
    * @generated from field: optional string str17 = 17;
    */
-  str17?: string;
+  str17?: string | undefined;
 
   /**
    * @generated from field: optional string str18 = 18;
    */
-  str18?: string;
+  str18?: string | undefined;
 
   /**
    * @generated from field: optional string str19 = 19;
    */
-  str19?: string;
+  str19?: string | undefined;
 
   /**
    * @generated from field: optional string str20 = 20;
    */
-  str20?: string;
+  str20?: string | undefined;
 
   /**
    * @generated from field: optional string str21 = 21;
    */
-  str21?: string;
+  str21?: string | undefined;
 
   /**
    * @generated from field: optional string str22 = 22;
    */
-  str22?: string;
+  str22?: string | undefined;
 
   /**
    * @generated from field: optional string str23 = 23;
    */
-  str23?: string;
+  str23?: string | undefined;
 
   /**
    * @generated from field: optional string str24 = 24;
    */
-  str24?: string;
+  str24?: string | undefined;
 
   /**
    * @generated from field: optional string str25 = 25;
    */
-  str25?: string;
+  str25?: string | undefined;
 
   /**
    * @generated from field: optional string str26 = 26;
    */
-  str26?: string;
+  str26?: string | undefined;
 
   /**
    * @generated from field: optional string str27 = 27;
    */
-  str27?: string;
+  str27?: string | undefined;
 
   /**
    * @generated from field: optional string str28 = 28;
    */
-  str28?: string;
+  str28?: string | undefined;
 
   /**
    * @generated from field: optional string str29 = 29;
    */
-  str29?: string;
+  str29?: string | undefined;
 
   /**
    * @generated from field: optional string str30 = 30;
    */
-  str30?: string;
+  str30?: string | undefined;
 
   /**
    * @generated from field: optional string str31 = 31;
    */
-  str31?: string;
+  str31?: string | undefined;
 
   /**
    * @generated from field: optional string str32 = 32;
    */
-  str32?: string;
+  str32?: string | undefined;
 
   constructor(data?: PartialMessage<ManyOptionalString>) {
     super();
@@ -4553,7 +4553,7 @@ export class Int32Message extends Message<Int32Message> {
   /**
    * @generated from field: optional int32 data = 1;
    */
-  data?: number;
+  data?: number | undefined;
 
   constructor(data?: PartialMessage<Int32Message>) {
     super();
@@ -4590,7 +4590,7 @@ export class Uint32Message extends Message<Uint32Message> {
   /**
    * @generated from field: optional uint32 data = 1;
    */
-  data?: number;
+  data?: number | undefined;
 
   constructor(data?: PartialMessage<Uint32Message>) {
     super();
@@ -4627,7 +4627,7 @@ export class Int64Message extends Message<Int64Message> {
   /**
    * @generated from field: optional int64 data = 1;
    */
-  data?: bigint;
+  data?: bigint | undefined;
 
   constructor(data?: PartialMessage<Int64Message>) {
     super();
@@ -4664,7 +4664,7 @@ export class Uint64Message extends Message<Uint64Message> {
   /**
    * @generated from field: optional uint64 data = 1;
    */
-  data?: bigint;
+  data?: bigint | undefined;
 
   constructor(data?: PartialMessage<Uint64Message>) {
     super();
@@ -4701,7 +4701,7 @@ export class BoolMessage extends Message<BoolMessage> {
   /**
    * @generated from field: optional bool data = 1;
    */
-  data?: boolean;
+  data?: boolean | undefined;
 
   constructor(data?: PartialMessage<BoolMessage>) {
     super();
@@ -4804,12 +4804,12 @@ export class TestOneof_FooGroup extends Message<TestOneof_FooGroup> {
   /**
    * @generated from field: optional int32 a = 5;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional string b = 6;
    */
-  b?: string;
+  b?: string | undefined;
 
   constructor(data?: PartialMessage<TestOneof_FooGroup>) {
     super();
@@ -4847,22 +4847,22 @@ export class TestOneofBackwardsCompatible extends Message<TestOneofBackwardsComp
   /**
    * @generated from field: optional int32 foo_int = 1;
    */
-  fooInt?: number;
+  fooInt?: number | undefined;
 
   /**
    * @generated from field: optional string foo_string = 2;
    */
-  fooString?: string;
+  fooString?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes foo_message = 3;
    */
-  fooMessage?: TestAllTypes;
+  fooMessage?: TestAllTypes | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestOneofBackwardsCompatible.FooGroup foogroup = 4;
    */
-  foogroup?: TestOneofBackwardsCompatible_FooGroup;
+  foogroup?: TestOneofBackwardsCompatible_FooGroup | undefined;
 
   constructor(data?: PartialMessage<TestOneofBackwardsCompatible>) {
     super();
@@ -4902,12 +4902,12 @@ export class TestOneofBackwardsCompatible_FooGroup extends Message<TestOneofBack
   /**
    * @generated from field: optional int32 a = 5;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional string b = 6;
    */
-  b?: string;
+  b?: string | undefined;
 
   constructor(data?: PartialMessage<TestOneofBackwardsCompatible_FooGroup>) {
     super();
@@ -5069,12 +5069,12 @@ export class TestOneof2 extends Message<TestOneof2> {
   /**
    * @generated from field: optional int32 baz_int = 18;
    */
-  bazInt?: number;
+  bazInt?: number | undefined;
 
   /**
    * @generated from field: optional string baz_string = 19 [default = "BAZ"];
    */
-  bazString?: string;
+  bazString?: string | undefined;
 
   constructor(data?: PartialMessage<TestOneof2>) {
     super();
@@ -5157,12 +5157,12 @@ export class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
   /**
    * @generated from field: optional int32 a = 9;
    */
-  a?: number;
+  a?: number | undefined;
 
   /**
    * @generated from field: optional string b = 10;
    */
-  b?: string;
+  b?: string | undefined;
 
   constructor(data?: PartialMessage<TestOneof2_FooGroup>) {
     super();
@@ -5200,7 +5200,7 @@ export class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> 
   /**
    * @generated from field: optional int64 moo_int = 1;
    */
-  mooInt?: bigint;
+  mooInt?: bigint | undefined;
 
   /**
    * @generated from field: repeated int32 corge_int = 2;
@@ -5300,7 +5300,7 @@ export class TestRequiredOneof_NestedMessage extends Message<TestRequiredOneof_N
   /**
    * @generated from field: required double required_double = 1;
    */
-  requiredDouble?: number;
+  requiredDouble?: number | undefined;
 
   constructor(data?: PartialMessage<TestRequiredOneof_NestedMessage>) {
     super();
@@ -5636,27 +5636,27 @@ export class TestDynamicExtensions extends Message<TestDynamicExtensions> {
   /**
    * @generated from field: optional fixed32 scalar_extension = 2000;
    */
-  scalarExtension?: number;
+  scalarExtension?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum enum_extension = 2001;
    */
-  enumExtension?: ForeignEnum;
+  enumExtension?: ForeignEnum | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDynamicExtensions.DynamicEnumType dynamic_enum_extension = 2002;
    */
-  dynamicEnumExtension?: TestDynamicExtensions_DynamicEnumType;
+  dynamicEnumExtension?: TestDynamicExtensions_DynamicEnumType | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage message_extension = 2003;
    */
-  messageExtension?: ForeignMessage;
+  messageExtension?: ForeignMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDynamicExtensions.DynamicMessageType dynamic_message_extension = 2004;
    */
-  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType;
+  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType | undefined;
 
   /**
    * @generated from field: repeated string repeated_extension = 2005;
@@ -5735,7 +5735,7 @@ export class TestDynamicExtensions_DynamicMessageType extends Message<TestDynami
   /**
    * @generated from field: optional int32 dynamic_field = 2100;
    */
-  dynamicField?: number;
+  dynamicField?: number | undefined;
 
   constructor(data?: PartialMessage<TestDynamicExtensions_DynamicMessageType>) {
     super();
@@ -5852,12 +5852,12 @@ export class TestParsingMerge extends Message<TestParsingMerge> {
   /**
    * @generated from field: required protobuf_unittest.TestAllTypes required_all_types = 1;
    */
-  requiredAllTypes?: TestAllTypes;
+  requiredAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 2;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 3;
@@ -5867,7 +5867,7 @@ export class TestParsingMerge extends Message<TestParsingMerge> {
   /**
    * @generated from field: optional protobuf_unittest.TestParsingMerge.OptionalGroup optionalgroup = 10;
    */
-  optionalgroup?: TestParsingMerge_OptionalGroup;
+  optionalgroup?: TestParsingMerge_OptionalGroup | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestParsingMerge.RepeatedGroup repeatedgroup = 20;
@@ -5992,7 +5992,7 @@ export class TestParsingMerge_RepeatedFieldsGenerator_Group1 extends Message<Tes
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes field1 = 11;
    */
-  field1?: TestAllTypes;
+  field1?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestParsingMerge_RepeatedFieldsGenerator_Group1>) {
     super();
@@ -6029,7 +6029,7 @@ export class TestParsingMerge_RepeatedFieldsGenerator_Group2 extends Message<Tes
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes field1 = 21;
    */
-  field1?: TestAllTypes;
+  field1?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestParsingMerge_RepeatedFieldsGenerator_Group2>) {
     super();
@@ -6066,7 +6066,7 @@ export class TestParsingMerge_OptionalGroup extends Message<TestParsingMerge_Opt
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_group_all_types = 11;
    */
-  optionalGroupAllTypes?: TestAllTypes;
+  optionalGroupAllTypes?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestParsingMerge_OptionalGroup>) {
     super();
@@ -6103,7 +6103,7 @@ export class TestParsingMerge_RepeatedGroup extends Message<TestParsingMerge_Rep
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes repeated_group_all_types = 21;
    */
-  repeatedGroupAllTypes?: TestAllTypes;
+  repeatedGroupAllTypes?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<TestParsingMerge_RepeatedGroup>) {
     super();
@@ -6143,7 +6143,7 @@ export class TestMergeException extends Message<TestMergeException> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllExtensions all_extensions = 1;
    */
-  allExtensions?: TestAllExtensions;
+  allExtensions?: TestAllExtensions | undefined;
 
   constructor(data?: PartialMessage<TestMergeException>) {
     super();
@@ -6182,7 +6182,7 @@ export class TestCommentInjectionMessage extends Message<TestCommentInjectionMes
    *
    * @generated from field: optional string a = 1 [default = "*\/ <- Neither should this."];
    */
-  a?: string;
+  a?: string | undefined;
 
   constructor(data?: PartialMessage<TestCommentInjectionMessage>) {
     super();
@@ -6222,32 +6222,32 @@ export class TestMessageSize extends Message<TestMessageSize> {
   /**
    * @generated from field: optional bool m1 = 1;
    */
-  m1?: boolean;
+  m1?: boolean | undefined;
 
   /**
    * @generated from field: optional int64 m2 = 2;
    */
-  m2?: bigint;
+  m2?: bigint | undefined;
 
   /**
    * @generated from field: optional bool m3 = 3;
    */
-  m3?: boolean;
+  m3?: boolean | undefined;
 
   /**
    * @generated from field: optional string m4 = 4;
    */
-  m4?: string;
+  m4?: string | undefined;
 
   /**
    * @generated from field: optional int32 m5 = 5;
    */
-  m5?: number;
+  m5?: number | undefined;
 
   /**
    * @generated from field: optional int64 m6 = 6;
    */
-  m6?: bigint;
+  m6?: bigint | undefined;
 
   constructor(data?: PartialMessage<TestMessageSize>) {
     super();
@@ -6477,37 +6477,37 @@ export class TestJsonName extends Message<TestJsonName> {
   /**
    * @generated from field: optional int32 field_name1 = 1;
    */
-  fieldName1?: number;
+  fieldName1?: number | undefined;
 
   /**
    * @generated from field: optional int32 fieldName2 = 2;
    */
-  fieldName2?: number;
+  fieldName2?: number | undefined;
 
   /**
    * @generated from field: optional int32 FieldName3 = 3;
    */
-  FieldName3?: number;
+  FieldName3?: number | undefined;
 
   /**
    * @generated from field: optional int32 _field_name4 = 4;
    */
-  FieldName4?: number;
+  FieldName4?: number | undefined;
 
   /**
    * @generated from field: optional int32 FIELD_NAME5 = 5;
    */
-  FIELDNAME5?: number;
+  FIELDNAME5?: number | undefined;
 
   /**
    * @generated from field: optional int32 field_name6 = 6 [json_name = "@type"];
    */
-  fieldName6?: number;
+  fieldName6?: number | undefined;
 
   /**
    * @generated from field: optional int32 fieldname7 = 7;
    */
-  fieldname7?: number;
+  fieldname7?: number | undefined;
 
   constructor(data?: PartialMessage<TestJsonName>) {
     super();
@@ -6550,12 +6550,12 @@ export class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> {
   /**
    * @generated from field: optional int32 optional_int32 = 536870000;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int32 fixed_32 = 536870001;
    */
-  fixed32?: number;
+  fixed32?: number | undefined;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 536870002 [packed = false];
@@ -6570,27 +6570,27 @@ export class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> {
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_enum = 536870004;
    */
-  optionalEnum?: ForeignEnum;
+  optionalEnum?: ForeignEnum | undefined;
 
   /**
    * @generated from field: optional string optional_string = 536870005;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 536870006;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage optional_message = 536870007;
    */
-  optionalMessage?: ForeignMessage;
+  optionalMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestHugeFieldNumbers.OptionalGroup optionalgroup = 536870008;
    */
-  optionalgroup?: TestHugeFieldNumbers_OptionalGroup;
+  optionalgroup?: TestHugeFieldNumbers_OptionalGroup | undefined;
 
   /**
    * @generated from field: map<string, string> string_string_map = 536870010;
@@ -6674,7 +6674,7 @@ export class TestHugeFieldNumbers_OptionalGroup extends Message<TestHugeFieldNum
   /**
    * @generated from field: optional int32 group_a = 536870009;
    */
-  groupA?: number;
+  groupA?: number | undefined;
 
   constructor(data?: PartialMessage<TestHugeFieldNumbers_OptionalGroup>) {
     super();
@@ -6711,47 +6711,47 @@ export class TestExtensionInsideTable extends Message<TestExtensionInsideTable> 
   /**
    * @generated from field: optional int32 field1 = 1;
    */
-  field1?: number;
+  field1?: number | undefined;
 
   /**
    * @generated from field: optional int32 field2 = 2;
    */
-  field2?: number;
+  field2?: number | undefined;
 
   /**
    * @generated from field: optional int32 field3 = 3;
    */
-  field3?: number;
+  field3?: number | undefined;
 
   /**
    * @generated from field: optional int32 field4 = 4;
    */
-  field4?: number;
+  field4?: number | undefined;
 
   /**
    * @generated from field: optional int32 field6 = 6;
    */
-  field6?: number;
+  field6?: number | undefined;
 
   /**
    * @generated from field: optional int32 field7 = 7;
    */
-  field7?: number;
+  field7?: number | undefined;
 
   /**
    * @generated from field: optional int32 field8 = 8;
    */
-  field8?: number;
+  field8?: number | undefined;
 
   /**
    * @generated from field: optional int32 field9 = 9;
    */
-  field9?: number;
+  field9?: number | undefined;
 
   /**
    * @generated from field: optional int32 field10 = 10;
    */
-  field10?: number;
+  field10?: number | undefined;
 
   constructor(data?: PartialMessage<TestExtensionInsideTable>) {
     super();
@@ -6798,7 +6798,7 @@ export class TestNestedGroupExtensionOuter extends Message<TestNestedGroupExtens
   /**
    * @generated from field: optional protobuf_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup layer1optionalgroup = 1;
    */
-  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
+  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup | undefined;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter>) {
     super();
@@ -6878,7 +6878,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGro
   /**
    * @generated from field: optional string another_field = 6;
    */
-  anotherField?: string;
+  anotherField?: string | undefined;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGroup>) {
     super();
@@ -6915,7 +6915,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOpti
   /**
    * @generated from field: optional string but_why_tho = 5;
    */
-  butWhyTho?: string;
+  butWhyTho?: string | undefined;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOptionalRepeatedGroup>) {
     super();
@@ -6952,7 +6952,7 @@ export class TestNestedGroupExtensionInnerExtension extends Message<TestNestedGr
   /**
    * @generated from field: optional string inner_name = 1;
    */
-  innerName?: string;
+  innerName?: string | undefined;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionInnerExtension>) {
     super();
@@ -6989,22 +6989,22 @@ export class TestExtensionRangeSerialize extends Message<TestExtensionRangeSeria
   /**
    * @generated from field: optional int32 foo_one = 1;
    */
-  fooOne?: number;
+  fooOne?: number | undefined;
 
   /**
    * @generated from field: optional int32 foo_two = 6;
    */
-  fooTwo?: number;
+  fooTwo?: number | undefined;
 
   /**
    * @generated from field: optional int32 foo_three = 7;
    */
-  fooThree?: number;
+  fooThree?: number | undefined;
 
   /**
    * @generated from field: optional int32 foo_four = 13;
    */
-  fooFour?: number;
+  fooFour?: number | undefined;
 
   constructor(data?: PartialMessage<TestExtensionRangeSerialize>) {
     super();
@@ -7044,22 +7044,22 @@ export class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple> {
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264?: number | undefined;
 
   constructor(data?: PartialMessage<TestVerifyInt32Simple>) {
     super();
@@ -7099,27 +7099,27 @@ export class TestVerifyInt32 extends Message<TestVerifyInt32> {
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7166,42 +7166,42 @@ export class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32> {
   /**
    * @generated from field: optional int64 optional_int64_30 = 30;
    */
-  optionalInt6430?: bigint;
+  optionalInt6430?: bigint | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_3 = 3;
    */
-  optionalInt323?: number;
+  optionalInt323?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_4 = 4;
    */
-  optionalInt324?: number;
+  optionalInt324?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7251,47 +7251,47 @@ export class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVerifyMostl
   /**
    * @generated from field: optional int64 optional_int64_30 = 30;
    */
-  optionalInt6430?: bigint;
+  optionalInt6430?: bigint | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_300 = 300;
    */
-  optionalInt32300?: number;
+  optionalInt32300?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_3 = 3;
    */
-  optionalInt323?: number;
+  optionalInt323?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_4 = 4;
    */
-  optionalInt324?: number;
+  optionalInt324?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7342,22 +7342,22 @@ export class TestVerifyUint32Simple extends Message<TestVerifyUint32Simple> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264?: number | undefined;
 
   constructor(data?: PartialMessage<TestVerifyUint32Simple>) {
     super();
@@ -7397,27 +7397,27 @@ export class TestVerifyUint32 extends Message<TestVerifyUint32> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7464,27 +7464,27 @@ export class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7531,32 +7531,32 @@ export class TestVerifyOneInt32BigFieldNumber extends Message<TestVerifyOneInt32
   /**
    * @generated from field: optional int32 optional_int32_65 = 65;
    */
-  optionalInt3265?: number;
+  optionalInt3265?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_1 = 1;
    */
-  optionalInt641?: bigint;
+  optionalInt641?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_2 = 2;
    */
-  optionalInt642?: bigint;
+  optionalInt642?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_63 = 63;
    */
-  optionalInt6463?: bigint;
+  optionalInt6463?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_64 = 64;
    */
-  optionalInt6464?: bigint;
+  optionalInt6464?: bigint | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7604,37 +7604,37 @@ export class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt32BigFie
   /**
    * @generated from field: optional int32 optional_int32_1000 = 1000;
    */
-  optionalInt321000?: number;
+  optionalInt321000?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_65 = 65;
    */
-  optionalInt3265?: number;
+  optionalInt3265?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263?: number | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7683,37 +7683,37 @@ export class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUint32BigF
   /**
    * @generated from field: optional uint32 optional_uint32_1000 = 1000;
    */
-  optionalUint321000?: number;
+  optionalUint321000?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_65 = 65;
    */
-  optionalUint3265?: number;
+  optionalUint3265?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestAllTypes repeated_all_types = 10;
@@ -7762,7 +7762,7 @@ export class TestVerifyBigFieldNumberUint32 extends Message<TestVerifyBigFieldNu
   /**
    * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested | undefined;
 
   constructor(data?: PartialMessage<TestVerifyBigFieldNumberUint32>) {
     super();
@@ -7799,47 +7799,47 @@ export class TestVerifyBigFieldNumberUint32_Nested extends Message<TestVerifyBig
   /**
    * @generated from field: optional uint32 optional_uint32_5000 = 5000;
    */
-  optionalUint325000?: number;
+  optionalUint325000?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1000 = 1000;
    */
-  optionalUint321000?: number;
+  optionalUint321000?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_66 = 66;
    */
-  optionalUint3266?: number;
+  optionalUint3266?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_65 = 65;
    */
-  optionalUint3265?: number;
+  optionalUint3265?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263?: number | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264?: number | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested | undefined;
 
   /**
    * @generated from field: repeated protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum2_pb.ts
@@ -68,7 +68,7 @@ export class MyMessage extends Message<MyMessage> {
   /**
    * @generated from field: optional proto2_preserve_unknown_enum_unittest.MyEnum e = 1;
    */
-  e?: MyEnum;
+  e?: MyEnum | undefined;
 
   /**
    * @generated from field: repeated proto2_preserve_unknown_enum_unittest.MyEnum repeated_e = 2;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_lite_pb.ts
@@ -156,17 +156,17 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: proto3_arena_lite_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_lite_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_lite_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -193,12 +193,12 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: protobuf_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_lite_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -746,12 +746,12 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
   /**
    * @generated from field: proto3_arena_lite_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto3_arena_lite_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<NestedTestAllTypes>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
@@ -156,17 +156,17 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: proto3_arena_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -193,22 +193,22 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: protobuf_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_arena_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
-  optionalLazyImportMessage?: ImportMessage;
+  optionalLazyImportMessage?: ImportMessage | undefined;
 
   /**
    * Repeated
@@ -292,77 +292,77 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 proto3_optional_int32 = 116;
    */
-  proto3OptionalInt32?: number;
+  proto3OptionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 proto3_optional_int64 = 117;
    */
-  proto3OptionalInt64?: bigint;
+  proto3OptionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 proto3_optional_uint32 = 118;
    */
-  proto3OptionalUint32?: number;
+  proto3OptionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 proto3_optional_uint64 = 119;
    */
-  proto3OptionalUint64?: bigint;
+  proto3OptionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 proto3_optional_sint32 = 120;
    */
-  proto3OptionalSint32?: number;
+  proto3OptionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 proto3_optional_sint64 = 121;
    */
-  proto3OptionalSint64?: bigint;
+  proto3OptionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 proto3_optional_fixed32 = 122;
    */
-  proto3OptionalFixed32?: number;
+  proto3OptionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 proto3_optional_fixed64 = 123;
    */
-  proto3OptionalFixed64?: bigint;
+  proto3OptionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 proto3_optional_sfixed32 = 124;
    */
-  proto3OptionalSfixed32?: number;
+  proto3OptionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 proto3_optional_sfixed64 = 125;
    */
-  proto3OptionalSfixed64?: bigint;
+  proto3OptionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float proto3_optional_float = 126;
    */
-  proto3OptionalFloat?: number;
+  proto3OptionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double proto3_optional_double = 127;
    */
-  proto3OptionalDouble?: number;
+  proto3OptionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool proto3_optional_bool = 128;
    */
-  proto3OptionalBool?: boolean;
+  proto3OptionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string proto3_optional_string = 129;
    */
-  proto3OptionalString?: string;
+  proto3OptionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes proto3_optional_bytes = 130;
    */
-  proto3OptionalBytes?: Uint8Array;
+  proto3OptionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated proto3_arena_unittest.TestAllTypes.NestedMessage repeated_nested_message = 48;
@@ -850,12 +850,12 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
   /**
    * @generated from field: proto3_arena_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto3_arena_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto3_arena_unittest.NestedTestAllTypes repeated_child = 3;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_lite_pb.ts
@@ -156,17 +156,17 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: proto3_lite_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_lite_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto3_lite_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -193,12 +193,12 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: protobuf_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto3_lite_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -746,12 +746,12 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
   /**
    * @generated from field: proto3_lite_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto3_lite_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<NestedTestAllTypes>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
@@ -44,97 +44,97 @@ export class TestProto3Optional extends Message<TestProto3Optional> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 16;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestProto3Optional.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestProto3Optional_NestedMessage;
+  optionalNestedMessage?: TestProto3Optional_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestProto3Optional.NestedMessage lazy_nested_message = 19;
    */
-  lazyNestedMessage?: TestProto3Optional_NestedMessage;
+  lazyNestedMessage?: TestProto3Optional_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestProto3Optional.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestProto3Optional_NestedEnum;
+  optionalNestedEnum?: TestProto3Optional_NestedEnum | undefined;
 
   /**
    * Add some non-optional fields to verify we can mix them.
@@ -247,7 +247,7 @@ export class TestProto3Optional_NestedMessage extends Message<TestProto3Optional
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 
   constructor(data?: PartialMessage<TestProto3Optional_NestedMessage>) {
     super();
@@ -284,12 +284,12 @@ export class TestProto3OptionalMessage extends Message<TestProto3OptionalMessage
   /**
    * @generated from field: protobuf_unittest.TestProto3OptionalMessage.NestedMessage nested_message = 1;
    */
-  nestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  nestedMessage?: TestProto3OptionalMessage_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_unittest.TestProto3OptionalMessage.NestedMessage optional_nested_message = 2;
    */
-  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage | undefined;
 
   constructor(data?: PartialMessage<TestProto3OptionalMessage>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
@@ -156,17 +156,17 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: optional proto3_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -193,22 +193,22 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: protobuf_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
-  optionalLazyImportMessage?: ImportMessage;
+  optionalLazyImportMessage?: ImportMessage | undefined;
 
   /**
    * Repeated
@@ -758,12 +758,12 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
   /**
    * @generated from field: proto3_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   constructor(data?: PartialMessage<NestedTestAllTypes>) {
     super();

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
@@ -17,99 +17,99 @@ export class TestWellKnownTypes extends Message<TestWellKnownTypes> {
   /**
    * @generated from field: google.protobuf.Any any_field = 1;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Api api_field = 2;
    */
-  apiField?: Api;
+  apiField?: Api | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 3;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 4;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 5;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.SourceContext source_context_field = 6;
    */
-  sourceContextField?: SourceContext;
+  sourceContextField?: SourceContext | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 7;
    */
-  structField?: Struct;
+  structField?: Struct | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 8;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.Type type_field = 9;
    */
-  typeField?: Type;
+  typeField?: Type | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue double_field = 10;
    */
-  doubleField?: number;
+  doubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_field = 11;
    */
-  floatField?: number;
+  floatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_field = 12;
    */
-  int64Field?: bigint;
+  int64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_field = 13;
    */
-  uint64Field?: bigint;
+  uint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_field = 14;
    */
-  int32Field?: number;
+  int32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_field = 15;
    */
-  uint32Field?: number;
+  uint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_field = 16;
    */
-  boolField?: boolean;
+  boolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue string_field = 17;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_field = 18;
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * Part of struct, but useful to be able to test separately
    *
    * @generated from field: google.protobuf.Value value_field = 19;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 
   constructor(data?: PartialMessage<TestWellKnownTypes>) {
     super();

--- a/packages/protobuf/src/google/protobuf/api_pb.ts
+++ b/packages/protobuf/src/google/protobuf/api_pb.ts
@@ -94,7 +94,7 @@ export class Api extends Message<Api> {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * Included interfaces. See [Mixin][].

--- a/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
@@ -49,17 +49,17 @@ export class Version extends Message<Version> {
   /**
    * @generated from field: optional int32 major = 1;
    */
-  major?: number;
+  major?: number | undefined;
 
   /**
    * @generated from field: optional int32 minor = 2;
    */
-  minor?: number;
+  minor?: number | undefined;
 
   /**
    * @generated from field: optional int32 patch = 3;
    */
-  patch?: number;
+  patch?: number | undefined;
 
   /**
    * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
@@ -67,7 +67,7 @@ export class Version extends Message<Version> {
    *
    * @generated from field: optional string suffix = 4;
    */
-  suffix?: string;
+  suffix?: string | undefined;
 
   constructor(data?: PartialMessage<Version>) {
     super();
@@ -120,7 +120,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
    *
    * @generated from field: optional string parameter = 2;
    */
-  parameter?: string;
+  parameter?: string | undefined;
 
   /**
    * FileDescriptorProtos for all files in files_to_generate and everything
@@ -147,7 +147,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
    *
    * @generated from field: optional google.protobuf.compiler.Version compiler_version = 3;
    */
-  compilerVersion?: Version;
+  compilerVersion?: Version | undefined;
 
   constructor(data?: PartialMessage<CodeGeneratorRequest>) {
     super();
@@ -198,7 +198,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional string error = 1;
    */
-  error?: string;
+  error?: string | undefined;
 
   /**
    * A bitmask of supported features that the code generator supports.
@@ -206,7 +206,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional uint64 supported_features = 2;
    */
-  supportedFeatures?: bigint;
+  supportedFeatures?: bigint | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.compiler.CodeGeneratorResponse.File file = 15;
@@ -286,7 +286,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * If non-empty, indicates that the named file should already exist, and the
@@ -329,14 +329,14 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string insertion_point = 2;
    */
-  insertionPoint?: string;
+  insertionPoint?: string | undefined;
 
   /**
    * The file contents.
    *
    * @generated from field: optional string content = 15;
    */
-  content?: string;
+  content?: string | undefined;
 
   /**
    * Information describing the file content being inserted. If an insertion
@@ -345,7 +345,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional google.protobuf.GeneratedCodeInfo generated_code_info = 16;
    */
-  generatedCodeInfo?: GeneratedCodeInfo;
+  generatedCodeInfo?: GeneratedCodeInfo | undefined;
 
   constructor(data?: PartialMessage<CodeGeneratorResponse_File>) {
     super();

--- a/packages/protobuf/src/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/google/protobuf/descriptor_pb.ts
@@ -82,14 +82,14 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    *
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  package?: string | undefined;
 
   /**
    * Names of files imported by this file.
@@ -138,7 +138,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.FileOptions options = 8;
    */
-  options?: FileOptions;
+  options?: FileOptions | undefined;
 
   /**
    * This field contains optional information about the original source code.
@@ -148,7 +148,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional google.protobuf.SourceCodeInfo source_code_info = 9;
    */
-  sourceCodeInfo?: SourceCodeInfo;
+  sourceCodeInfo?: SourceCodeInfo | undefined;
 
   /**
    * The syntax of the proto file.
@@ -156,7 +156,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  syntax?: string | undefined;
 
   constructor(data?: PartialMessage<FileDescriptorProto>) {
     super();
@@ -206,7 +206,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto field = 2;
@@ -241,7 +241,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.MessageOptions options = 7;
    */
-  options?: MessageOptions;
+  options?: MessageOptions | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9;
@@ -302,19 +302,19 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start?: number | undefined;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
    */
-  options?: ExtensionRangeOptions;
+  options?: ExtensionRangeOptions | undefined;
 
   constructor(data?: PartialMessage<DescriptorProto_ExtensionRange>) {
     super();
@@ -359,14 +359,14 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start?: number | undefined;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end?: number | undefined;
 
   constructor(data?: PartialMessage<DescriptorProto_ReservedRange>) {
     super();
@@ -445,17 +445,17 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional int32 number = 3;
    */
-  number?: number;
+  number?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Label label = 4;
    */
-  label?: FieldDescriptorProto_Label;
+  label?: FieldDescriptorProto_Label | undefined;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
@@ -463,7 +463,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Type type = 5;
    */
-  type?: FieldDescriptorProto_Type;
+  type?: FieldDescriptorProto_Type | undefined;
 
   /**
    * For message and enum types, this is the name of the type.  If the name
@@ -474,7 +474,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string type_name = 6;
    */
-  typeName?: string;
+  typeName?: string | undefined;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
@@ -482,7 +482,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string extendee = 2;
    */
-  extendee?: string;
+  extendee?: string | undefined;
 
   /**
    * For numeric types, contains the original text representation of the value.
@@ -492,7 +492,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string default_value = 7;
    */
-  defaultValue?: string;
+  defaultValue?: string | undefined;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
@@ -500,7 +500,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional int32 oneof_index = 9;
    */
-  oneofIndex?: number;
+  oneofIndex?: number | undefined;
 
   /**
    * JSON name of this field. The value is set by protocol compiler. If the
@@ -510,12 +510,12 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string json_name = 10;
    */
-  jsonName?: string;
+  jsonName?: string | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
    */
-  options?: FieldOptions;
+  options?: FieldOptions | undefined;
 
   /**
    * If true, this is a proto3 "optional". When a proto3 field is optional, it
@@ -542,7 +542,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional bool proto3_optional = 17;
    */
-  proto3Optional?: boolean;
+  proto3Optional?: boolean | undefined;
 
   constructor(data?: PartialMessage<FieldDescriptorProto>) {
     super();
@@ -757,12 +757,12 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
    */
-  options?: OneofOptions;
+  options?: OneofOptions | undefined;
 
   constructor(data?: PartialMessage<OneofDescriptorProto>) {
     super();
@@ -802,7 +802,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.EnumValueDescriptorProto value = 2;
@@ -812,7 +812,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.EnumOptions options = 3;
    */
-  options?: EnumOptions;
+  options?: EnumOptions | undefined;
 
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
@@ -879,14 +879,14 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start?: number | undefined;
 
   /**
    * Inclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end?: number | undefined;
 
   constructor(data?: PartialMessage<EnumDescriptorProto_EnumReservedRange>) {
     super();
@@ -926,17 +926,17 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: optional int32 number = 2;
    */
-  number?: number;
+  number?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
    */
-  options?: EnumValueOptions;
+  options?: EnumValueOptions | undefined;
 
   constructor(data?: PartialMessage<EnumValueDescriptorProto>) {
     super();
@@ -977,7 +977,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.MethodDescriptorProto method = 2;
@@ -987,7 +987,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   /**
    * @generated from field: optional google.protobuf.ServiceOptions options = 3;
    */
-  options?: ServiceOptions;
+  options?: ServiceOptions | undefined;
 
   constructor(data?: PartialMessage<ServiceDescriptorProto>) {
     super();
@@ -1028,7 +1028,7 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name?: string | undefined;
 
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -1036,31 +1036,31 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
    *
    * @generated from field: optional string input_type = 2;
    */
-  inputType?: string;
+  inputType?: string | undefined;
 
   /**
    * @generated from field: optional string output_type = 3;
    */
-  outputType?: string;
+  outputType?: string | undefined;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
    */
-  options?: MethodOptions;
+  options?: MethodOptions | undefined;
 
   /**
    * Identifies if client streams multiple client messages
    *
    * @generated from field: optional bool client_streaming = 5 [default = false];
    */
-  clientStreaming?: boolean;
+  clientStreaming?: boolean | undefined;
 
   /**
    * Identifies if server streams multiple server messages
    *
    * @generated from field: optional bool server_streaming = 6 [default = false];
    */
-  serverStreaming?: boolean;
+  serverStreaming?: boolean | undefined;
 
   constructor(data?: PartialMessage<MethodDescriptorProto>) {
     super();
@@ -1107,7 +1107,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_package = 1;
    */
-  javaPackage?: string;
+  javaPackage?: string | undefined;
 
   /**
    * Controls the name of the wrapper Java class generated for the .proto file.
@@ -1118,7 +1118,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_outer_classname = 8;
    */
-  javaOuterClassname?: string;
+  javaOuterClassname?: string | undefined;
 
   /**
    * If enabled, then the Java code generator will generate a separate .java
@@ -1130,7 +1130,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_multiple_files = 10 [default = false];
    */
-  javaMultipleFiles?: boolean;
+  javaMultipleFiles?: boolean | undefined;
 
   /**
    * This option does nothing.
@@ -1138,7 +1138,7 @@ export class FileOptions extends Message<FileOptions> {
    * @generated from field: optional bool java_generate_equals_and_hash = 20 [deprecated = true];
    * @deprecated
    */
-  javaGenerateEqualsAndHash?: boolean;
+  javaGenerateEqualsAndHash?: boolean | undefined;
 
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -1150,12 +1150,12 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_string_check_utf8 = 27 [default = false];
    */
-  javaStringCheckUtf8?: boolean;
+  javaStringCheckUtf8?: boolean | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9 [default = SPEED];
    */
-  optimizeFor?: FileOptions_OptimizeMode;
+  optimizeFor?: FileOptions_OptimizeMode | undefined;
 
   /**
    * Sets the Go package where structs generated from this .proto will be
@@ -1166,7 +1166,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string go_package = 11;
    */
-  goPackage?: string;
+  goPackage?: string | undefined;
 
   /**
    * Should generic services be generated in each language?  "Generic" services
@@ -1182,22 +1182,22 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_generic_services = 16 [default = false];
    */
-  ccGenericServices?: boolean;
+  ccGenericServices?: boolean | undefined;
 
   /**
    * @generated from field: optional bool java_generic_services = 17 [default = false];
    */
-  javaGenericServices?: boolean;
+  javaGenericServices?: boolean | undefined;
 
   /**
    * @generated from field: optional bool py_generic_services = 18 [default = false];
    */
-  pyGenericServices?: boolean;
+  pyGenericServices?: boolean | undefined;
 
   /**
    * @generated from field: optional bool php_generic_services = 42 [default = false];
    */
-  phpGenericServices?: boolean;
+  phpGenericServices?: boolean | undefined;
 
   /**
    * Is this file deprecated?
@@ -1207,7 +1207,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool deprecated = 23 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
@@ -1215,7 +1215,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_enable_arenas = 31 [default = true];
    */
-  ccEnableArenas?: boolean;
+  ccEnableArenas?: boolean | undefined;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
@@ -1223,14 +1223,14 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string objc_class_prefix = 36;
    */
-  objcClassPrefix?: string;
+  objcClassPrefix?: string | undefined;
 
   /**
    * Namespace for generated classes; defaults to the package.
    *
    * @generated from field: optional string csharp_namespace = 37;
    */
-  csharpNamespace?: string;
+  csharpNamespace?: string | undefined;
 
   /**
    * By default Swift generators will take the proto package and CamelCase it
@@ -1240,7 +1240,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string swift_prefix = 39;
    */
-  swiftPrefix?: string;
+  swiftPrefix?: string | undefined;
 
   /**
    * Sets the php class prefix which is prepended to all php generated classes
@@ -1248,7 +1248,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_class_prefix = 40;
    */
-  phpClassPrefix?: string;
+  phpClassPrefix?: string | undefined;
 
   /**
    * Use this option to change the namespace of php generated classes. Default
@@ -1257,7 +1257,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_namespace = 41;
    */
-  phpNamespace?: string;
+  phpNamespace?: string | undefined;
 
   /**
    * Use this option to change the namespace of php generated metadata classes.
@@ -1266,7 +1266,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_metadata_namespace = 44;
    */
-  phpMetadataNamespace?: string;
+  phpMetadataNamespace?: string | undefined;
 
   /**
    * Use this option to change the package of ruby generated classes. Default
@@ -1275,7 +1275,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string ruby_package = 45;
    */
-  rubyPackage?: string;
+  rubyPackage?: string | undefined;
 
   /**
    * The parser stores options it doesn't recognize here.
@@ -1395,7 +1395,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool message_set_wire_format = 1 [default = false];
    */
-  messageSetWireFormat?: boolean;
+  messageSetWireFormat?: boolean | undefined;
 
   /**
    * Disables the generation of the standard "descriptor()" accessor, which can
@@ -1404,7 +1404,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool no_standard_descriptor_accessor = 2 [default = false];
    */
-  noStandardDescriptorAccessor?: boolean;
+  noStandardDescriptorAccessor?: boolean | undefined;
 
   /**
    * Is this message deprecated?
@@ -1414,7 +1414,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * Whether the message is an automatically generated map entry type for the
@@ -1441,7 +1441,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool map_entry = 7;
    */
-  mapEntry?: boolean;
+  mapEntry?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1494,7 +1494,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.CType ctype = 1 [default = STRING];
    */
-  ctype?: FieldOptions_CType;
+  ctype?: FieldOptions_CType | undefined;
 
   /**
    * The packed option can be enabled for repeated primitive fields to enable
@@ -1505,7 +1505,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool packed = 2;
    */
-  packed?: boolean;
+  packed?: boolean | undefined;
 
   /**
    * The jstype option determines the JavaScript type used for values of the
@@ -1522,7 +1522,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL];
    */
-  jstype?: FieldOptions_JSType;
+  jstype?: FieldOptions_JSType | undefined;
 
   /**
    * Should this field be parsed lazily?  Lazy applies only to message-type
@@ -1562,7 +1562,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool lazy = 5 [default = false];
    */
-  lazy?: boolean;
+  lazy?: boolean | undefined;
 
   /**
    * unverified_lazy does no correctness checks on the byte stream. This should
@@ -1571,7 +1571,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool unverified_lazy = 15 [default = false];
    */
-  unverifiedLazy?: boolean;
+  unverifiedLazy?: boolean | undefined;
 
   /**
    * Is this field deprecated?
@@ -1581,14 +1581,14 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * For Google-internal migration only. Do not use.
    *
    * @generated from field: optional bool weak = 10 [default = false];
    */
-  weak?: boolean;
+  weak?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1741,7 +1741,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool allow_alias = 2;
    */
-  allowAlias?: boolean;
+  allowAlias?: boolean | undefined;
 
   /**
    * Is this enum deprecated?
@@ -1751,7 +1751,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1802,7 +1802,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool deprecated = 1 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1852,7 +1852,7 @@ export class ServiceOptions extends Message<ServiceOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1902,12 +1902,12 @@ export class MethodOptions extends Message<MethodOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated?: boolean | undefined;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
    */
-  idempotencyLevel?: MethodOptions_IdempotencyLevel;
+  idempotencyLevel?: MethodOptions_IdempotencyLevel | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2002,32 +2002,32 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
    *
    * @generated from field: optional string identifier_value = 3;
    */
-  identifierValue?: string;
+  identifierValue?: string | undefined;
 
   /**
    * @generated from field: optional uint64 positive_int_value = 4;
    */
-  positiveIntValue?: bigint;
+  positiveIntValue?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 negative_int_value = 5;
    */
-  negativeIntValue?: bigint;
+  negativeIntValue?: bigint | undefined;
 
   /**
    * @generated from field: optional double double_value = 6;
    */
-  doubleValue?: number;
+  doubleValue?: number | undefined;
 
   /**
    * @generated from field: optional bytes string_value = 7;
    */
-  stringValue?: Uint8Array;
+  stringValue?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional string aggregate_value = 8;
    */
-  aggregateValue?: string;
+  aggregateValue?: string | undefined;
 
   constructor(data?: PartialMessage<UninterpretedOption>) {
     super();
@@ -2076,12 +2076,12 @@ export class UninterpretedOption_NamePart extends Message<UninterpretedOption_Na
   /**
    * @generated from field: required string name_part = 1;
    */
-  namePart?: string;
+  namePart?: string | undefined;
 
   /**
    * @generated from field: required bool is_extension = 2;
    */
-  isExtension?: boolean;
+  isExtension?: boolean | undefined;
 
   constructor(data?: PartialMessage<UninterpretedOption_NamePart>) {
     super();
@@ -2291,12 +2291,12 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
    *
    * @generated from field: optional string leading_comments = 3;
    */
-  leadingComments?: string;
+  leadingComments?: string | undefined;
 
   /**
    * @generated from field: optional string trailing_comments = 4;
    */
-  trailingComments?: string;
+  trailingComments?: string | undefined;
 
   /**
    * @generated from field: repeated string leading_detached_comments = 6;
@@ -2396,7 +2396,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional string source_file = 2;
    */
-  sourceFile?: string;
+  sourceFile?: string | undefined;
 
   /**
    * Identifies the starting offset in bytes in the generated code
@@ -2404,7 +2404,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 begin = 3;
    */
-  begin?: number;
+  begin?: number | undefined;
 
   /**
    * Identifies the ending offset in bytes in the generated code that
@@ -2413,7 +2413,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 end = 4;
    */
-  end?: number;
+  end?: number | undefined;
 
   constructor(data?: PartialMessage<GeneratedCodeInfo_Annotation>) {
     super();

--- a/packages/protobuf/src/google/protobuf/type_pb.ts
+++ b/packages/protobuf/src/google/protobuf/type_pb.ts
@@ -90,7 +90,7 @@ export class Type extends Message<Type> {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -483,7 +483,7 @@ export class Enum extends Message<Enum> {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -606,7 +606,7 @@ export class Option extends Message<Option> {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value?: Any | undefined;
 
   constructor(data?: PartialMessage<Option>) {
     super();

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -162,7 +162,7 @@ function generateField(schema: Schema, f: GeneratedFile, field: DescField) {
     getFieldIntrinsicDefaultValue(field);
   const { typing, optional } = getFieldTyping(field, f);
   if (optional || defaultValue === undefined) {
-    e.push("?: ", typing);
+    e.push("?: ", typing, " | undefined");
   } else if (!typingInferrable) {
     e.push(": ", typing);
   }

--- a/packages/protoplugin-test/src/gen/proto/person_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/person_pb.ts
@@ -49,7 +49,7 @@ export class Person extends Message<Person> {
   /**
    * @generated from field: google.protobuf.Timestamp last_updated = 5;
    */
-  lastUpdated?: Timestamp;
+  lastUpdated?: Timestamp | undefined;
 
   constructor(data?: PartialMessage<Person>) {
     super();


### PR DESCRIPTION
This PR allows fields to be set to `undefined` explicitly even when the TypeScript compiler option `exactOptionalPropertyTypes` is enabled.

Currently optional message fields are typed as

```typescript
field?: Type
```

but with `exactOptionalPropertyTypes` this means you can't set them to `undefined`; you have to omit them. This is a bit inconvenient if you're trying to pass through a value from a variable.

This PR changes the optional fields to be typed as

```typescript
field?: Type | undefined
```

which removes the restriction.