### PR TITLE
Add TypeScript 5.0 beta to compatibility tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LICENSE_HEADER_IGNORES := .tmp\/ node_module\/ packages\/protobuf-conformance\/b
 GOOGLE_PROTOBUF_WKT = google/protobuf/api.proto google/protobuf/any.proto google/protobuf/compiler/plugin.proto google/protobuf/descriptor.proto google/protobuf/duration.proto google/protobuf/descriptor.proto google/protobuf/empty.proto google/protobuf/field_mask.proto google/protobuf/source_context.proto google/protobuf/struct.proto google/protobuf/timestamp.proto google/protobuf/type.proto google/protobuf/wrappers.proto
 GOOGLE_PROTOBUF_VERSION = 21.12
 BAZEL_VERSION = 5.4.0
-TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.4
+TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.4 5.0.0-beta
 
 node_modules: package-lock.json
 	npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -5834,6 +5834,19 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ts5_0_0-beta": {
+      "name": "typescript",
+      "version": "5.0.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.0-beta.tgz",
+      "integrity": "sha512-+SSabbSXG5mtF+QGdV9uXXt9Saq1cSyI6hSG7znhaLoquleJpnmfkwSxFngK9c2fWWi1W/263TuzXQOsIcdjjA==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "dev": true,
@@ -6212,7 +6225,8 @@
         "ts4_5_2": "npm:typescript@4.5.2",
         "ts4_6_4": "npm:typescript@4.6.4",
         "ts4_7_4": "npm:typescript@4.7.4",
-        "ts4_8_4": "npm:typescript@4.8.4"
+        "ts4_8_4": "npm:typescript@4.8.4",
+        "ts5_0_0-beta": "npm:typescript@5.0.0-beta"
       }
     },
     "packages/protobuf-test/node_modules/long": {
@@ -6791,7 +6805,8 @@
         "ts4_5_2": "npm:typescript@4.5.2",
         "ts4_6_4": "npm:typescript@4.6.4",
         "ts4_7_4": "npm:typescript@4.7.4",
-        "ts4_8_4": "npm:typescript@4.8.4"
+        "ts4_8_4": "npm:typescript@4.8.4",
+        "ts5_0_0-beta": "npm:typescript@5.0.0-beta"
       },
       "dependencies": {
         "long": {
@@ -10118,6 +10133,11 @@
     },
     "ts4_8_4": {
       "version": "npm:typescript@4.8.4"
+    },
+    "ts5_0_0-beta": {
+      "version": "npm:typescript@5.0.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.0-beta.tgz",
+      "integrity": "sha512-+SSabbSXG5mtF+QGdV9uXXt9Saq1cSyI6hSG7znhaLoquleJpnmfkwSxFngK9c2fWWi1W/263TuzXQOsIcdjjA=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 74,150 b      | 36,950 b | 9,642 b |
-| protobuf-javascript | 370,614 b  | 271,672 b | 43,769 b |
+| protobuf-es         | 86,785 b      | 36,950 b | 9,642 b |
+| protobuf-javascript | 375,550 b  | 271,672 b | 43,769 b |

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -23,6 +23,7 @@
     "ts4_5_2": "npm:typescript@4.5.2",
     "ts4_6_4": "npm:typescript@4.6.4",
     "ts4_7_4": "npm:typescript@4.7.4",
-    "ts4_8_4": "npm:typescript@4.8.4"
+    "ts4_8_4": "npm:typescript@4.8.4",
+    "ts5_0_0-beta": "npm:typescript@5.0.0-beta"
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.5_0_0-beta.json
+++ b/packages/protobuf-test/typescript/tsconfig.5_0_0-beta.json
@@ -1,0 +1,17 @@
+{
+  "include": ["../src/**/*"],
+  // These are the default compiler options for TypeScript v5.0.0-beta, created
+  // with `tsc --init` (except where noted in comments below)
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    // To guard against regression and ensure we are remaining backwards
+    // compatible, set the skipLibCheck flag to false explicitly.
+    "skipLibCheck": false,
+    // To test forward-compatibility, set to NodeNext
+    "moduleResolution": "NodeNext"
+  }
+}


### PR DESCRIPTION
This adds the TypeScript `5.0.0-beta` release to our list of TypeScript compatibility tests.