### PR TITLE
Update to use Buf from NPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(BUILD)/protoplugin-test: $(BUILD)/protoplugin $(GEN)/protoplugin-test node_mod
 
 $(BUILD)/protoplugin-example: $(BUILD)/protoc-gen-es packages/protoplugin-example/buf.gen.yaml node_modules tsconfig.base.json packages/protoplugin-example/tsconfig.json $(shell find packages/protoplugin-example/src -name '*.ts')
 	npm run -w packages/protoplugin-example clean
-	npm run -w packages/protoplugin-example generate
+	npx -w packages/protoplugin-example buf generate buf.build/bufbuild/eliza
 	npm run -w packages/protoplugin-example build
 	@mkdir -p $(@D)
 	@touch $(@)

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(BUILD)/protoplugin-test: $(BUILD)/protoplugin $(GEN)/protoplugin-test node_mod
 
 $(BUILD)/protoplugin-example: $(BUILD)/protoc-gen-es packages/protoplugin-example/buf.gen.yaml node_modules tsconfig.base.json packages/protoplugin-example/tsconfig.json $(shell find packages/protoplugin-example/src -name '*.ts')
 	npm run -w packages/protoplugin-example clean
-	npm run -w packages/protoplugin-example buf:generate
+	npm run -w packages/protoplugin-example generate
 	npm run -w packages/protoplugin-example build
 	@mkdir -p $(@D)
 	@touch $(@)
@@ -120,7 +120,7 @@ $(GEN)/protobuf-test: $(BIN)/protoc $(BUILD)/protoc-gen-es $(shell find packages
 $(GEN)/protoplugin-test: $(BUILD)/protoc-gen-es $(shell find packages/protoplugin-test/proto -name '*.proto')
 	@rm -rf packages/protoplugin-test/src/gen/* packages/protoplugin-test/descriptorset.bin
 	@npm run -w packages/protoplugin-test buf:build
-	@npm run -w packages/protoplugin-test buf:generate
+	@npm run -w packages/protoplugin-test generate
 
 $(GEN)/protobuf-conformance: $(BIN)/protoc $(BUILD)/protoc-gen-es Makefile
 	@rm -rf packages/protobuf-conformance/src/gen/*
@@ -134,13 +134,13 @@ $(GEN)/protobuf-conformance: $(BIN)/protoc $(BUILD)/protoc-gen-es Makefile
 
 $(GEN)/protobuf-example: $(BUILD)/protoc-gen-es packages/protobuf-example/buf.gen.yaml $(shell find packages/protobuf-example -name '*.proto')
 	@rm -rf packages/protobuf-example/src/gen/*
-	npm run -w packages/protobuf-example buf:generate
+	npm run -w packages/protobuf-example generate
 	@mkdir -p $(@D)
 	@touch $(@)
 
 $(GEN)/protobuf-bench: $(BIN)/protoc $(BUILD)/protoc-gen-es packages/protobuf-bench Makefile
 	@rm -rf packages/protobuf-bench/src/gen/*
-	buf generate buf.build/bufbuild/buf:4505cba5e5a94a42af02ebc7ac3a0a04 --template packages/protobuf-bench/buf.gen.yaml --output packages/protobuf-bench
+	npx buf generate buf.build/bufbuild/buf:4505cba5e5a94a42af02ebc7ac3a0a04 --template packages/protobuf-bench/buf.gen.yaml --output packages/protobuf-bench
 	@mkdir -p $(@D)
 	@touch $(@)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Protocol Buffers also allow you to serialize this structured data.  So, your app
    version: v1
    plugins:
       - name: es
-        path: ./node_modules/.bin/protoc-gen-es
         opt: target=ts
         out: src/gen
    ```

--- a/README.md
+++ b/README.md
@@ -53,12 +53,10 @@ Protocol Buffers also allow you to serialize this structured data.  So, your app
 
 ## Quickstart
 
-To get started generating code right away, first make sure you have [Buf](https://docs.buf.build/installation) installed.  If desired, you can also use `protoc`.  
-
-1. Install the code generator and the runtime library:
+1. Install the code generator, the runtime library, and the [Buf CLI](https://docs.buf.build/build/usage):
 
    ```bash
-   npm install @bufbuild/protobuf @bufbuild/protoc-gen-es
+   npm install @bufbuild/protobuf @bufbuild/protoc-gen-es @bufbuild/buf
    ```
 
 2. Create a `buf.gen.yaml` file that looks like this:
@@ -83,8 +81,10 @@ To get started generating code right away, first make sure you have [Buf](https:
 4. Generate your code:
 
    ```bash
-   buf generate proto
+   npx buf generate proto
    ```
+
+   ** Note you can also use `protoc` if desired.
 
 You should now see a generated file at `src/gen/example_pb.ts` that contains a class named `User`.  From here, you can begin to work with your schema.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -609,6 +609,118 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@bufbuild/buf": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.14.0.tgz",
+      "integrity": "sha512-hW6wua/V+goxF99TSoQ/ps/gLdLkyuMjUs6zm15rpNvYOqB5UNg3t4N29SOWqfGhwVU5eeAC2XubT24eVOCcRQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "buf": "bin/buf",
+        "protoc-gen-buf-breaking": "bin/protoc-gen-buf-breaking",
+        "protoc-gen-buf-lint": "bin/protoc-gen-buf-lint"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@bufbuild/buf-darwin-arm64": "1.14.0",
+        "@bufbuild/buf-darwin-x64": "1.14.0",
+        "@bufbuild/buf-linux-aarch64": "1.14.0",
+        "@bufbuild/buf-linux-x64": "1.14.0",
+        "@bufbuild/buf-win32-arm64": "1.14.0",
+        "@bufbuild/buf-win32-x64": "1.14.0"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-arm64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.14.0.tgz",
+      "integrity": "sha512-V6WonyHSLtrCd+xl5XAqzpDXUMLhJF3seVD6ap4yJW6nigHw49+Oz38oE0DgwOlkIOoNgS8TWsRZFUyBXfV9vQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-x64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.14.0.tgz",
+      "integrity": "sha512-ZhPc0mN7K8E8IJGWzdCxb5CHqwmv3HSB25IgEjqTkwCDIUV7cPIUfb/56G6ir0shWCcVRoGPv2KbSG5rL0AYIw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-aarch64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.14.0.tgz",
+      "integrity": "sha512-M7La4zzSXGgIwhKclZFgh5OXvKkx5/1fsGKTJWfDL25xPMYrvZI7y1i44iOK5H8ciKe24fatITZHE0ZQVRohoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-x64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.14.0.tgz",
+      "integrity": "sha512-/fqaKAUpFNbP6A2ROU/r35R2Fxig55MtseYtHNSLcQI6k9ubhdVsI3cM0MlOZ1VawclDYFiTpCd1urUL7spvsw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-arm64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.14.0.tgz",
+      "integrity": "sha512-t7cd8MfqJ2ew6uXUYVbgq97OzN/ybnJ5Q5yKbEGexkyOBHQZsEhv0FkJWkAn1DN93j5iqHO6xlDkHpGMjAW1sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-x64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.14.0.tgz",
+      "integrity": "sha512-KD0T1rkX7yfykKZodnAj2WxhIZfkA/sox6VAY20F6X6ckLP96/3TSVWvDPfDN2DNkTcmokygNtA2/ir0KejDfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "resolved": "packages/protobuf",
       "link": true
@@ -6157,6 +6269,7 @@
     "packages/protobuf-bench": {
       "name": "@bufbuild/protobuf-bench",
       "dependencies": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protobuf": "1.0.0",
         "esbuild": "^0.17.5",
         "google-protobuf": "3.21.0"
@@ -6208,6 +6321,7 @@
       "name": "@bufbuild/protobuf-example",
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "dependencies": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protobuf": "1.0.0",
         "@bufbuild/protoc-gen-es": "1.0.0",
         "typescript": "^4.9.4"
@@ -6273,6 +6387,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protobuf": "^1.0.0",
         "@bufbuild/protoc-gen-es": "^1.0.0",
         "@bufbuild/protoplugin": "^1.0.0",
@@ -6286,6 +6401,7 @@
     "packages/protoplugin-test": {
       "name": "@bufbuild/protoplugin-test",
       "dependencies": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protoplugin": "1.0.0"
       }
     },
@@ -6737,12 +6853,62 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@bufbuild/buf": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.14.0.tgz",
+      "integrity": "sha512-hW6wua/V+goxF99TSoQ/ps/gLdLkyuMjUs6zm15rpNvYOqB5UNg3t4N29SOWqfGhwVU5eeAC2XubT24eVOCcRQ==",
+      "requires": {
+        "@bufbuild/buf-darwin-arm64": "1.14.0",
+        "@bufbuild/buf-darwin-x64": "1.14.0",
+        "@bufbuild/buf-linux-aarch64": "1.14.0",
+        "@bufbuild/buf-linux-x64": "1.14.0",
+        "@bufbuild/buf-win32-arm64": "1.14.0",
+        "@bufbuild/buf-win32-x64": "1.14.0"
+      }
+    },
+    "@bufbuild/buf-darwin-arm64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.14.0.tgz",
+      "integrity": "sha512-V6WonyHSLtrCd+xl5XAqzpDXUMLhJF3seVD6ap4yJW6nigHw49+Oz38oE0DgwOlkIOoNgS8TWsRZFUyBXfV9vQ==",
+      "optional": true
+    },
+    "@bufbuild/buf-darwin-x64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.14.0.tgz",
+      "integrity": "sha512-ZhPc0mN7K8E8IJGWzdCxb5CHqwmv3HSB25IgEjqTkwCDIUV7cPIUfb/56G6ir0shWCcVRoGPv2KbSG5rL0AYIw==",
+      "optional": true
+    },
+    "@bufbuild/buf-linux-aarch64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.14.0.tgz",
+      "integrity": "sha512-M7La4zzSXGgIwhKclZFgh5OXvKkx5/1fsGKTJWfDL25xPMYrvZI7y1i44iOK5H8ciKe24fatITZHE0ZQVRohoQ==",
+      "optional": true
+    },
+    "@bufbuild/buf-linux-x64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.14.0.tgz",
+      "integrity": "sha512-/fqaKAUpFNbP6A2ROU/r35R2Fxig55MtseYtHNSLcQI6k9ubhdVsI3cM0MlOZ1VawclDYFiTpCd1urUL7spvsw==",
+      "optional": true
+    },
+    "@bufbuild/buf-win32-arm64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.14.0.tgz",
+      "integrity": "sha512-t7cd8MfqJ2ew6uXUYVbgq97OzN/ybnJ5Q5yKbEGexkyOBHQZsEhv0FkJWkAn1DN93j5iqHO6xlDkHpGMjAW1sg==",
+      "optional": true
+    },
+    "@bufbuild/buf-win32-x64": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.14.0.tgz",
+      "integrity": "sha512-KD0T1rkX7yfykKZodnAj2WxhIZfkA/sox6VAY20F6X6ckLP96/3TSVWvDPfDN2DNkTcmokygNtA2/ir0KejDfQ==",
+      "optional": true
+    },
     "@bufbuild/protobuf": {
       "version": "file:packages/protobuf"
     },
     "@bufbuild/protobuf-bench": {
       "version": "file:packages/protobuf-bench",
       "requires": {
+        "@bufbuild/buf": "*",
         "@bufbuild/protobuf": "1.0.0",
         "esbuild": "^0.17.5",
         "google-protobuf": "3.21.0"
@@ -6788,6 +6954,7 @@
     "@bufbuild/protobuf-example": {
       "version": "file:packages/protobuf-example",
       "requires": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protobuf": "1.0.0",
         "@bufbuild/protoc-gen-es": "1.0.0",
         "typescript": "^4.9.4"
@@ -6843,6 +7010,7 @@
     "@bufbuild/protoplugin-example": {
       "version": "file:packages/protoplugin-example",
       "requires": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protobuf": "^1.0.0",
         "@bufbuild/protoc-gen-es": "^1.0.0",
         "@bufbuild/protoplugin": "^1.0.0",
@@ -6853,6 +7021,7 @@
     "@bufbuild/protoplugin-test": {
       "version": "file:packages/protoplugin-test",
       "requires": {
+        "@bufbuild/buf": "^1.14.0",
         "@bufbuild/protoplugin": "1.0.0"
       }
     },

--- a/packages/protobuf-bench/package.json
+++ b/packages/protobuf-bench/package.json
@@ -6,6 +6,7 @@
     "clean": "rm -rf README.md src/gen"
   },
   "dependencies": {
+    "@bufbuild/buf": "^1.14.0",
     "@bufbuild/protobuf": "1.0.0",
     "esbuild": "^0.17.5",
     "google-protobuf": "3.21.0"

--- a/packages/protobuf-example/README.md
+++ b/packages/protobuf-example/README.md
@@ -49,7 +49,7 @@ node dist/esm/list-people.js addressbook.bin
 ### Generate code yourself
 
 If you want to use [`buf`](https://github.com/bufbuild/buf) to generate the code, 
-simply run `npm run buf:generate` in this directory. [`buf.gen.yaml`](./buf.gen.yaml) 
+simply run `npm run generate` in this directory. [`buf.gen.yaml`](./buf.gen.yaml) 
 contains the plugin configuration.
 
 If you want to use `protoc`, the following command is equivalent:

--- a/packages/protobuf-example/package.json
+++ b/packages/protobuf-example/package.json
@@ -7,10 +7,11 @@
     "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "add-person": "node dist/esm/add-person.js addressbook.bin",
     "list-people": "node dist/esm/list-people.js addressbook.bin",
-    "buf:generate": "buf generate"
+    "generate": "npx buf generate"
   },
   "type": "module",
   "dependencies": {
+    "@bufbuild/buf": "^1.14.0",
     "@bufbuild/protobuf": "1.0.0",
     "@bufbuild/protoc-gen-es": "1.0.0",
     "typescript": "^4.9.4"

--- a/packages/protobuf-example/package.json
+++ b/packages/protobuf-example/package.json
@@ -7,7 +7,7 @@
     "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "add-person": "node dist/esm/add-person.js addressbook.bin",
     "list-people": "node dist/esm/list-people.js addressbook.bin",
-    "generate": "npx buf generate"
+    "generate": "buf generate"
   },
   "type": "module",
   "dependencies": {

--- a/packages/protoplugin-example/README.md
+++ b/packages/protoplugin-example/README.md
@@ -25,9 +25,11 @@ cd packages/protoplugin-example
 npm run build
 ```
 
-To run the plugin (i.e. generate files):
+To run the plugin (i.e. generate files), use the following command. This will generate files based on the 
+[Eliza module](https://buf.build/bufbuild/eliza) in the Buf Schema Registry (BSR).  You can change this path to generate
+additional files locally or from the BSR.
 
-`npm run generate`
+`npx buf generate buf.build/bufbuild/eliza`
 
 To run the example webpage and see the generated code in action:
 

--- a/packages/protoplugin-example/README.md
+++ b/packages/protoplugin-example/README.md
@@ -5,7 +5,9 @@ plugin framework.  It also contains a separate webpage which shows the generated
 
 The code generation logic for the actual plugin is located in [`protoc-gen-twirp-es.ts`](src/protoc-gen-twirp-es.ts).
 
-The sample plugin generates a [Twirp](https://twitchtv.github.io/twirp/docs/spec_v7.html) client from service definitions in Protobuf files.  The Twirp client uses base types generated from [`@bufbuild/protobuf-es`](https://www.npmjs.com/package/@bufbuild/protoc-gen-es).
+The sample plugin generates a [Twirp](https://twitchtv.github.io/twirp/docs/spec_v7.html) client from service 
+definitions in Protobuf files.  The Twirp client uses base types generated from 
+[`@bufbuild/protobuf-es`](https://www.npmjs.com/package/@bufbuild/protoc-gen-es).
 
 From the project root, first install and build all required packages:
 
@@ -25,7 +27,7 @@ npm run build
 
 To run the plugin (i.e. generate files):
 
-`npm run buf:generate`
+`npm run generate`
 
 To run the example webpage and see the generated code in action:
 

--- a/packages/protoplugin-example/package.json
+++ b/packages/protoplugin-example/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "clean": "rm -rf src/gen",
     "build": "../../node_modules/typescript/bin/tsc --noEmit",
-    "generate": "buf generate buf.build/bufbuild/eliza",
     "start": "npx esbuild src/index.ts --serve=localhost:3000 --servedir=www --outdir=www --bundle --global-name=eliza"
   },
   "author": "Buf",

--- a/packages/protoplugin-example/package.json
+++ b/packages/protoplugin-example/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rm -rf src/gen",
     "build": "../../node_modules/typescript/bin/tsc --noEmit",
-    "generate": "npx buf generate buf.build/bufbuild/eliza",
+    "generate": "buf generate buf.build/bufbuild/eliza",
     "start": "npx esbuild src/index.ts --serve=localhost:3000 --servedir=www --outdir=www --bundle --global-name=eliza"
   },
   "author": "Buf",

--- a/packages/protoplugin-example/package.json
+++ b/packages/protoplugin-example/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rm -rf src/gen",
     "build": "../../node_modules/typescript/bin/tsc --noEmit",
-    "buf:generate": "buf generate buf.build/bufbuild/eliza",
+    "generate": "npx buf generate buf.build/bufbuild/eliza",
     "start": "npx esbuild src/index.ts --serve=localhost:3000 --servedir=www --outdir=www --bundle --global-name=eliza"
   },
   "author": "Buf",
@@ -15,6 +15,7 @@
     "node": ">=14"
   },
   "dependencies": {
+    "@bufbuild/buf": "^1.14.0",
     "@bufbuild/protobuf": "^1.0.0",
     "@bufbuild/protoc-gen-es": "^1.0.0",
     "@bufbuild/protoplugin": "^1.0.0",

--- a/packages/protoplugin-test/package.json
+++ b/packages/protoplugin-test/package.json
@@ -5,8 +5,8 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types",
     "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
-    "buf:build": "npx buf build -o descriptorset.bin",
-    "generate": "npx buf generate",
+    "buf:build": "buf build -o descriptorset.bin",
+    "generate": "buf generate",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest"
   },
   "type": "module",

--- a/packages/protoplugin-test/package.json
+++ b/packages/protoplugin-test/package.json
@@ -5,8 +5,8 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types",
     "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
-    "buf:build": "buf build -o descriptorset.bin",
-    "buf:generate": "buf generate",
+    "buf:build": "npx buf build -o descriptorset.bin",
+    "generate": "npx buf generate",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest"
   },
   "type": "module",
@@ -16,6 +16,7 @@
     "default": "./dist/esm/index.js"
   },
   "dependencies": {
+    "@bufbuild/buf": "^1.14.0",
     "@bufbuild/protoplugin": "1.0.0"
   }
 }


### PR DESCRIPTION
This updates Protobuf-ES to use the Buf NPM package in examples, docs, and the Makefile.