### PR TITLE
Fix type declaration emitting when using NodeNext module resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 /packages/*/dist
-/packages/protobuf-test/typescript/out
 /packages/protobuf-test/descriptorset.bin
 /packages/protoplugin-test/descriptorset.bin
 /.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 /packages/*/dist
+/packages/protobuf-test/typescript/out
 /packages/protobuf-test/descriptorset.bin
 /packages/protoplugin-test/descriptorset.bin
 /.tmp

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ test-ts-compat: $(GEN)/protobuf-test node_modules
 		formatted=$$(echo "$${number}" | sed -r 's/[\.]/_/g'); \
 		dirname=packages/protobuf-test/typescript ; \
 		echo "Testing TypeScript `node_modules/ts$$formatted/bin/tsc --version`" ; \
-		node_modules/ts$$formatted/bin/tsc -p $$dirname/tsconfig.$${formatted}.json --noEmit || exit ; \
+		node_modules/ts$$formatted/bin/tsc -p $$dirname/tsconfig.$${formatted}.json --outDir $$dirname/out/$$formatted || exit ; \
 	done
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,9 @@ test-conformance: $(BIN)/conformance_test_runner $(BUILD)/protobuf-conformance
 test-ts-compat: $(GEN)/protobuf-test node_modules 
 	@for number in $(TS_VERSIONS) ; do \
 		formatted=$$(echo "$${number}" | sed -r 's/[\.]/_/g'); \
-		dirname=packages/protobuf-test/typescript ; \
+		dirname=packages/protobuf-test ; \
 		echo "Testing TypeScript `node_modules/ts$$formatted/bin/tsc --version`" ; \
-		node_modules/ts$$formatted/bin/tsc -p $$dirname/tsconfig.$${formatted}.json --outDir $$dirname/out/$$formatted || exit ; \
+		node_modules/ts$$formatted/bin/tsc -p $$dirname/typescript/tsconfig.$${formatted}.json --outDir $$dirname/dist/typescript/$$formatted || exit ; \
 	done
 
 .PHONY: lint

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 86,785 b      | 36,950 b | 9,642 b |
+| protobuf-es         | 86,785 b      | 36,950 b | 9,654 b |
 | protobuf-javascript | 375,550 b  | 271,672 b | 43,769 b |

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/envelope_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/envelope_pb.ts
@@ -952,7 +952,7 @@ export class ActionBufAlphaRegistryV1Alpha1DownloadInfo extends Message<ActionBu
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DownloadInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -992,7 +992,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetImageInfo extends Message<ActionBu
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetImageInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1032,7 +1032,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateOrganizationInfo extends Messag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateOrganizationInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1072,7 +1072,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeleteOrganizationInfo extends Messag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeleteOrganizationInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1112,7 +1112,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeleteOrganizationByNameInfo extends 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeleteOrganizationByNameInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1163,7 +1163,7 @@ export class ActionBufAlphaRegistryV1Alpha1AddOrganizationMemberInfo extends Mes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1AddOrganizationMemberInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1216,7 +1216,7 @@ export class ActionBufAlphaRegistryV1Alpha1UpdateOrganizationMemberInfo extends 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1UpdateOrganizationMemberInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1263,7 +1263,7 @@ export class ActionBufAlphaRegistryV1Alpha1RemoveOrganizationMemberInfo extends 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1RemoveOrganizationMemberInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1319,7 +1319,7 @@ export class ActionBufAlphaRegistryV1Alpha1UpdateOrganizationSettingsInfo extend
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1UpdateOrganizationSettingsInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1372,7 +1372,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreatePluginInfo extends Message<Acti
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreatePluginInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1419,7 +1419,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeletePluginInfo extends Message<Acti
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeletePluginInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1460,7 +1460,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetTemplateVersionInfo extends Messag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetTemplateVersionInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1516,7 +1516,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateTemplateInfo extends Message<Ac
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateTemplateInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1564,7 +1564,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeleteTemplateInfo extends Message<Ac
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeleteTemplateInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1621,7 +1621,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateTemplateVersionInfo extends Mes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateTemplateVersionInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1694,7 +1694,7 @@ export class ActionBufAlphaRegistryV1Alpha1PushInfo extends Message<ActionBufAlp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1PushInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1769,7 +1769,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetReferenceByNameInfo extends Messag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetReferenceByNameInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1819,7 +1819,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateRepositoryBranchInfo extends Me
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateRepositoryBranchInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1860,7 +1860,7 @@ export class ActionBufAlphaRegistryV1Alpha1ListRepositoryCommitsByBranchInfo ext
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1ListRepositoryCommitsByBranchInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_branch_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1900,7 +1900,7 @@ export class ActionBufAlphaRegistryV1Alpha1ListRepositoryCommitsByReferenceInfo 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1ListRepositoryCommitsByReferenceInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1940,7 +1940,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetRepositoryCommitByReferenceInfo ex
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetRepositoryCommitByReferenceInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1985,7 +1985,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetRepositoryCommitBySequenceIDInfo e
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetRepositoryCommitBySequenceIDInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_branch_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2037,7 +2037,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateRepositoryTagInfo extends Messa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateRepositoryTagInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2085,7 +2085,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateRepositoryByFullNameInfo extend
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateRepositoryByFullNameInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "full_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2126,7 +2126,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeleteRepositoryInfo extends Message<
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeleteRepositoryInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2166,7 +2166,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeleteRepositoryByFullNameInfo extend
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeleteRepositoryByFullNameInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "full_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2216,7 +2216,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeprecateRepositoryByNameInfo extends
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeprecateRepositoryByNameInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2263,7 +2263,7 @@ export class ActionBufAlphaRegistryV1Alpha1UndeprecateRepositoryByNameInfo exten
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1UndeprecateRepositoryByNameInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2314,7 +2314,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetModulePinsInfo extends Message<Act
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetModulePinsInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "module_references", kind: "message", T: ModuleReference, repeated: true },
@@ -2366,7 +2366,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetLocalModulePinsInfo extends Messag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetLocalModulePinsInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "local_module_references", kind: "message", T: BufAlphaRegistryV1Alpha1LocalModuleReference, repeated: true },
@@ -2413,7 +2413,7 @@ export class ActionBufAlphaRegistryV1Alpha1SearchInfo extends Message<ActionBufA
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1SearchInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2459,7 +2459,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateTokenInfo extends Message<Actio
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateTokenInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "note", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2500,7 +2500,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeleteTokenInfo extends Message<Actio
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeleteTokenInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "token_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2540,7 +2540,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateUserInfo extends Message<Action
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateUserInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "username", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2580,7 +2580,7 @@ export class ActionBufAlphaRegistryV1Alpha1ListUsersInfo extends Message<ActionB
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1ListUsersInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_state_filter", kind: "enum", T: proto3.getEnumType(BufAlphaRegistryV1Alpha1UserState) },
@@ -2620,7 +2620,7 @@ export class ActionBufAlphaRegistryV1Alpha1DeactivateUserInfo extends Message<Ac
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1DeactivateUserInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2666,7 +2666,7 @@ export class ActionBufAlphaRegistryV1Alpha1UpdateUserServerRoleInfo extends Mess
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1UpdateUserServerRoleInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2717,7 +2717,7 @@ export class ActionBufAlphaRegistryinternalV1Alpha1CreatePluginVersionInfo exten
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryinternalV1Alpha1CreatePluginVersionInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2769,7 +2769,7 @@ export class ActionBufAlphaRegistryinternalV1Alpha1CreatePluginVersionMetadataIn
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryinternalV1Alpha1CreatePluginVersionMetadataInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2811,7 +2811,7 @@ export class ActionBufAlphaRegistryinternalV1Alpha1DeletePluginVersionInfo exten
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryinternalV1Alpha1DeletePluginVersionInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2851,7 +2851,7 @@ export class ActionBufAlphaRegistryV1Alpha1SetRepositoryContributorInfo extends 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1SetRepositoryContributorInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_role", kind: "enum", T: proto3.getEnumType(BufAlphaRegistryV1Alpha1RepositoryRole) },
@@ -2891,7 +2891,7 @@ export class ActionBufAlphaRegistryV1Alpha1SetPluginContributorInfo extends Mess
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1SetPluginContributorInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_role", kind: "enum", T: proto3.getEnumType(BufAlphaRegistryV1Alpha1PluginRole) },
@@ -2931,7 +2931,7 @@ export class ActionBufAlphaRegistryV1Alpha1SetTemplateContributorInfo extends Me
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1SetTemplateContributorInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_role", kind: "enum", T: proto3.getEnumType(BufAlphaRegistryV1Alpha1TemplateRole) },
@@ -2971,7 +2971,7 @@ export class ActionBufAlphaRegistryV1Alpha1CreateRepositoryTrackInfo extends Mes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1CreateRepositoryTrackInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "track", kind: "message", T: BufAlphaRegistryV1Alpha1RepositoryTrack },
@@ -3011,7 +3011,7 @@ export class ActionBufAlphaRegistryV1Alpha1SetOrganizationMemberInfo extends Mes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1SetOrganizationMemberInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_role", kind: "enum", T: proto3.getEnumType(BufAlphaRegistryV1Alpha1OrganizationRole) },
@@ -3051,7 +3051,7 @@ export class ActionBufAlphaRegistryV1Alpha1GetJSONSchema extends Message<ActionB
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.ActionBufAlphaRegistryV1Alpha1GetJSONSchema";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3454,7 +3454,7 @@ export class Event extends Message<Event> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.Event";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3567,7 +3567,7 @@ export class UserActor extends Message<UserActor> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.UserActor";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3618,7 +3618,7 @@ export class UserObject extends Message<UserObject> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.UserObject";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3662,7 +3662,7 @@ export class OrganizationObject extends Message<OrganizationObject> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.OrganizationObject";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3720,7 +3720,7 @@ export class RepositoryObject extends Message<RepositoryObject> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.RepositoryObject";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3781,7 +3781,7 @@ export class PluginObject extends Message<PluginObject> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.PluginObject";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3842,7 +3842,7 @@ export class TemplateObject extends Message<TemplateObject> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.TemplateObject";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3883,7 +3883,7 @@ export class TokenObject extends Message<TokenObject> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.TokenObject";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3956,7 +3956,7 @@ export class Object$ extends Message<Object$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.Object";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: UserObject, oneof: "type" },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/module_pb.ts
@@ -96,7 +96,7 @@ export class BufAlphaRegistryV1Alpha1LocalModulePin extends Message<BufAlphaRegi
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1LocalModulePin";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -148,7 +148,7 @@ export class BufAlphaRegistryV1Alpha1LocalModuleReference extends Message<BufAlp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1LocalModuleReference";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -197,7 +197,7 @@ export class BufAlphaRegistryV1Alpha1LocalModuleResolveResult extends Message<Bu
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1LocalModuleResolveResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "message", T: BufAlphaRegistryV1Alpha1LocalModuleReference },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/plugin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/plugin_pb.ts
@@ -74,7 +74,7 @@ export class BufAlphaRegistryV1Alpha1PluginVersionMapping extends Message<BufAlp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginVersionMapping";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -129,7 +129,7 @@ export class BufAlphaRegistryV1Alpha1PluginConfig extends Message<BufAlphaRegist
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginConfig";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -174,7 +174,7 @@ export class BufAlphaRegistryV1Alpha1PluginVersionRuntimeLibrary extends Message
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1PluginVersionRuntimeLibrary";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/repository_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/audit/v1alpha1/repository_pb.ts
@@ -76,7 +76,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryBranch extends Message<BufAlphaRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1RepositoryBranch";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -138,7 +138,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryTag extends Message<BufAlphaRegis
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1RepositoryTag";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -214,7 +214,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryCommit extends Message<BufAlphaRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1RepositoryCommit";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -270,7 +270,7 @@ export class BufAlphaRegistryV1Alpha1RepositoryTrack extends Message<BufAlphaReg
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.audit.v1alpha1.BufAlphaRegistryV1Alpha1RepositoryTrack";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/breaking/v1/config_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/breaking/v1/config_pb.ts
@@ -84,7 +84,7 @@ export class Config extends Message<Config> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.breaking.v1.Config";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -133,7 +133,7 @@ export class IDPaths extends Message<IDPaths> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.breaking.v1.IDPaths";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
@@ -37,7 +37,7 @@ export class Image extends Message<Image> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "buf.alpha.image.v1.Image";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "file", kind: "message", T: ImageFile, repeated: true },
@@ -150,7 +150,7 @@ export class ImageFile extends Message<ImageFile> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "buf.alpha.image.v1.ImageFile";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -257,7 +257,7 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "buf.alpha.image.v1.ImageFileExtension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "is_import", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
@@ -313,7 +313,7 @@ export class ModuleInfo extends Message<ModuleInfo> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "buf.alpha.image.v1.ModuleInfo";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "message", T: ModuleName, opt: true },
@@ -365,7 +365,7 @@ export class ModuleName extends Message<ModuleName> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "buf.alpha.image.v1.ModuleName";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "remote", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/lint/v1/config_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/lint/v1/config_pb.ts
@@ -118,7 +118,7 @@ export class Config extends Message<Config> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.lint.v1.Config";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -172,7 +172,7 @@ export class IDPaths extends Message<IDPaths> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.lint.v1.IDPaths";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/module/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/module/v1alpha1/module_pb.ts
@@ -75,7 +75,7 @@ export class Module extends Message<Module> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.module.v1alpha1.Module";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "files", kind: "message", T: ModuleFile, repeated: true },
@@ -128,7 +128,7 @@ export class ModuleFile extends Message<ModuleFile> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.module.v1alpha1.ModuleFile";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -185,7 +185,7 @@ export class ModuleReference extends Message<ModuleReference> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.module.v1alpha1.ModuleReference";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "remote", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -257,7 +257,7 @@ export class ModulePin extends Message<ModulePin> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.module.v1alpha1.ModulePin";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "remote", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/admin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/admin_pb.ts
@@ -37,7 +37,7 @@ export class ForceDeleteUserRequest extends Message<ForceDeleteUserRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ForceDeleteUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -104,7 +104,7 @@ export class ForceDeleteUserResponse extends Message<ForceDeleteUserResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ForceDeleteUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/audit_logs_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/audit_logs_pb.ts
@@ -68,7 +68,7 @@ export class ListAuditLogsRequest extends Message<ListAuditLogsRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListAuditLogsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -116,7 +116,7 @@ export class ListAuditLogsResponse extends Message<ListAuditLogsResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListAuditLogsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "audit_logs", kind: "message", T: Event, repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authn_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authn_pb.ts
@@ -29,7 +29,7 @@ export class GetCurrentUserRequest extends Message<GetCurrentUserRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetCurrentUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -65,7 +65,7 @@ export class GetCurrentUserResponse extends Message<GetCurrentUserResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetCurrentUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -97,7 +97,7 @@ export class GetCurrentUserSubjectRequest extends Message<GetCurrentUserSubjectR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetCurrentUserSubjectRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -138,7 +138,7 @@ export class GetCurrentUserSubjectResponse extends Message<GetCurrentUserSubject
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetCurrentUserSubjectResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "subject", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authz_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/authz_pb.ts
@@ -37,7 +37,7 @@ export class UserCanCreateOrganizationRepositoryRequest extends Message<UserCanC
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateOrganizationRepositoryRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -74,7 +74,7 @@ export class UserCanCreateOrganizationRepositoryResponse extends Message<UserCan
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateOrganizationRepositoryResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -114,7 +114,7 @@ export class UserCanSeeRepositorySettingsRequest extends Message<UserCanSeeRepos
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeRepositorySettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -151,7 +151,7 @@ export class UserCanSeeRepositorySettingsResponse extends Message<UserCanSeeRepo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeRepositorySettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -191,7 +191,7 @@ export class UserCanSeeOrganizationSettingsRequest extends Message<UserCanSeeOrg
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeOrganizationSettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -228,7 +228,7 @@ export class UserCanSeeOrganizationSettingsResponse extends Message<UserCanSeeOr
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeOrganizationSettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -274,7 +274,7 @@ export class UserCanReadPluginRequest extends Message<UserCanReadPluginRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanReadPluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -312,7 +312,7 @@ export class UserCanReadPluginResponse extends Message<UserCanReadPluginResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanReadPluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -358,7 +358,7 @@ export class UserCanCreatePluginVersionRequest extends Message<UserCanCreatePlug
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreatePluginVersionRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -396,7 +396,7 @@ export class UserCanCreatePluginVersionResponse extends Message<UserCanCreatePlu
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreatePluginVersionResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -442,7 +442,7 @@ export class UserCanCreateTemplateVersionRequest extends Message<UserCanCreateTe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateTemplateVersionRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -480,7 +480,7 @@ export class UserCanCreateTemplateVersionResponse extends Message<UserCanCreateT
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateTemplateVersionResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -520,7 +520,7 @@ export class UserCanCreateOrganizationPluginRequest extends Message<UserCanCreat
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateOrganizationPluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -557,7 +557,7 @@ export class UserCanCreateOrganizationPluginResponse extends Message<UserCanCrea
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateOrganizationPluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -597,7 +597,7 @@ export class UserCanCreateOrganizationTemplateRequest extends Message<UserCanCre
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateOrganizationTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -634,7 +634,7 @@ export class UserCanCreateOrganizationTemplateResponse extends Message<UserCanCr
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanCreateOrganizationTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -680,7 +680,7 @@ export class UserCanSeePluginSettingsRequest extends Message<UserCanSeePluginSet
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeePluginSettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -718,7 +718,7 @@ export class UserCanSeePluginSettingsResponse extends Message<UserCanSeePluginSe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeePluginSettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -764,7 +764,7 @@ export class UserCanSeeTemplateSettingsRequest extends Message<UserCanSeeTemplat
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeTemplateSettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -802,7 +802,7 @@ export class UserCanSeeTemplateSettingsResponse extends Message<UserCanSeeTempla
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeTemplateSettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -842,7 +842,7 @@ export class UserCanAddOrganizationMemberRequest extends Message<UserCanAddOrgan
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanAddOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -882,7 +882,7 @@ export class UserCanAddOrganizationMemberResponse extends Message<UserCanAddOrga
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanAddOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized_roles", kind: "enum", T: proto3.getEnumType(OrganizationRole), repeated: true },
@@ -922,7 +922,7 @@ export class UserCanUpdateOrganizationMemberRequest extends Message<UserCanUpdat
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanUpdateOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -962,7 +962,7 @@ export class UserCanUpdateOrganizationMemberResponse extends Message<UserCanUpda
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanUpdateOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized_roles", kind: "enum", T: proto3.getEnumType(OrganizationRole), repeated: true },
@@ -1002,7 +1002,7 @@ export class UserCanRemoveOrganizationMemberRequest extends Message<UserCanRemov
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanRemoveOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1042,7 +1042,7 @@ export class UserCanRemoveOrganizationMemberResponse extends Message<UserCanRemo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanRemoveOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized_roles", kind: "enum", T: proto3.getEnumType(OrganizationRole), repeated: true },
@@ -1082,7 +1082,7 @@ export class UserCanDeleteOrganizationRequest extends Message<UserCanDeleteOrgan
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteOrganizationRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1119,7 +1119,7 @@ export class UserCanDeleteOrganizationResponse extends Message<UserCanDeleteOrga
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteOrganizationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -1159,7 +1159,7 @@ export class UserCanDeleteRepositoryRequest extends Message<UserCanDeleteReposit
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteRepositoryRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1196,7 +1196,7 @@ export class UserCanDeleteRepositoryResponse extends Message<UserCanDeleteReposi
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteRepositoryResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -1236,7 +1236,7 @@ export class UserCanDeleteTemplateRequest extends Message<UserCanDeleteTemplateR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1273,7 +1273,7 @@ export class UserCanDeleteTemplateResponse extends Message<UserCanDeleteTemplate
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -1313,7 +1313,7 @@ export class UserCanDeletePluginRequest extends Message<UserCanDeletePluginReque
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeletePluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1350,7 +1350,7 @@ export class UserCanDeletePluginResponse extends Message<UserCanDeletePluginResp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeletePluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -1382,7 +1382,7 @@ export class UserCanDeleteUserRequest extends Message<UserCanDeleteUserRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1418,7 +1418,7 @@ export class UserCanDeleteUserResponse extends Message<UserCanDeleteUserResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanDeleteUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -1450,7 +1450,7 @@ export class UserCanSeeServerAdminPanelRequest extends Message<UserCanSeeServerA
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeServerAdminPanelRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1486,7 +1486,7 @@ export class UserCanSeeServerAdminPanelResponse extends Message<UserCanSeeServer
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanSeeServerAdminPanelResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -1526,7 +1526,7 @@ export class UserCanManageRepositoryContributorsRequest extends Message<UserCanM
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanManageRepositoryContributorsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1566,7 +1566,7 @@ export class UserCanManageRepositoryContributorsResponse extends Message<UserCan
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanManageRepositoryContributorsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized_roles", kind: "enum", T: proto3.getEnumType(RepositoryRole), repeated: true },
@@ -1606,7 +1606,7 @@ export class UserCanManagePluginContributorsRequest extends Message<UserCanManag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanManagePluginContributorsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1646,7 +1646,7 @@ export class UserCanManagePluginContributorsResponse extends Message<UserCanMana
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanManagePluginContributorsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized_roles", kind: "enum", T: proto3.getEnumType(PluginRole), repeated: true },
@@ -1686,7 +1686,7 @@ export class UserCanManageTemplateContributorsRequest extends Message<UserCanMan
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanManageTemplateContributorsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1726,7 +1726,7 @@ export class UserCanManageTemplateContributorsResponse extends Message<UserCanMa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserCanManageTemplateContributorsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "authorized_roles", kind: "enum", T: proto3.getEnumType(TemplateRole), repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/display_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/display_pb.ts
@@ -37,7 +37,7 @@ export class DisplayOrganizationElementsRequest extends Message<DisplayOrganizat
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayOrganizationElementsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -111,7 +111,7 @@ export class DisplayOrganizationElementsResponse extends Message<DisplayOrganiza
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayOrganizationElementsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "create_repository", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -156,7 +156,7 @@ export class DisplayRepositoryElementsRequest extends Message<DisplayRepositoryE
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayRepositoryElementsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -202,7 +202,7 @@ export class DisplayRepositoryElementsResponse extends Message<DisplayRepository
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayRepositoryElementsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "settings", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -243,7 +243,7 @@ export class DisplayPluginElementsRequest extends Message<DisplayPluginElementsR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayPluginElementsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -296,7 +296,7 @@ export class DisplayPluginElementsResponse extends Message<DisplayPluginElements
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayPluginElementsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "create_version", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -338,7 +338,7 @@ export class DisplayTemplateElementsRequest extends Message<DisplayTemplateEleme
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayTemplateElementsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -391,7 +391,7 @@ export class DisplayTemplateElementsResponse extends Message<DisplayTemplateElem
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayTemplateElementsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "create_version", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -425,7 +425,7 @@ export class DisplayUserElementsRequest extends Message<DisplayUserElementsReque
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayUserElementsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -463,7 +463,7 @@ export class DisplayUserElementsResponse extends Message<DisplayUserElementsResp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayUserElementsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "delete", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -495,7 +495,7 @@ export class DisplayServerElementsRequest extends Message<DisplayServerElementsR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayServerElementsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -533,7 +533,7 @@ export class DisplayServerElementsResponse extends Message<DisplayServerElements
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DisplayServerElementsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "admin_panel", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -573,7 +573,7 @@ export class ListManageableRepositoryRolesRequest extends Message<ListManageable
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableRepositoryRolesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -613,7 +613,7 @@ export class ListManageableRepositoryRolesResponse extends Message<ListManageabl
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableRepositoryRolesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "roles", kind: "enum", T: proto3.getEnumType(RepositoryRole), repeated: true },
@@ -661,7 +661,7 @@ export class ListManageableUserRepositoryRolesRequest extends Message<ListManage
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableUserRepositoryRolesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -702,7 +702,7 @@ export class ListManageableUserRepositoryRolesResponse extends Message<ListManag
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableUserRepositoryRolesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "roles", kind: "enum", T: proto3.getEnumType(RepositoryRole), repeated: true },
@@ -742,7 +742,7 @@ export class ListManageablePluginRolesRequest extends Message<ListManageablePlug
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageablePluginRolesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -782,7 +782,7 @@ export class ListManageablePluginRolesResponse extends Message<ListManageablePlu
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageablePluginRolesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "roles", kind: "enum", T: proto3.getEnumType(PluginRole), repeated: true },
@@ -830,7 +830,7 @@ export class ListManageableUserPluginRolesRequest extends Message<ListManageable
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableUserPluginRolesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -871,7 +871,7 @@ export class ListManageableUserPluginRolesResponse extends Message<ListManageabl
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableUserPluginRolesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "roles", kind: "enum", T: proto3.getEnumType(PluginRole), repeated: true },
@@ -911,7 +911,7 @@ export class ListManageableTemplateRolesRequest extends Message<ListManageableTe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableTemplateRolesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -951,7 +951,7 @@ export class ListManageableTemplateRolesResponse extends Message<ListManageableT
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableTemplateRolesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "roles", kind: "enum", T: proto3.getEnumType(TemplateRole), repeated: true },
@@ -999,7 +999,7 @@ export class ListManageableUserTemplateRolesRequest extends Message<ListManageab
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableUserTemplateRolesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1040,7 +1040,7 @@ export class ListManageableUserTemplateRolesResponse extends Message<ListManagea
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListManageableUserTemplateRolesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "roles", kind: "enum", T: proto3.getEnumType(TemplateRole), repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/doc_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/doc_pb.ts
@@ -45,7 +45,7 @@ export class GetSourceDirectoryInfoRequest extends Message$1<GetSourceDirectoryI
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetSourceDirectoryInfoRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -86,7 +86,7 @@ export class GetSourceDirectoryInfoResponse extends Message$1<GetSourceDirectory
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetSourceDirectoryInfoResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "root", kind: "message", T: FileInfo },
@@ -138,7 +138,7 @@ export class FileInfo extends Message$1<FileInfo> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.FileInfo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -196,7 +196,7 @@ export class GetSourceFileRequest extends Message$1<GetSourceFileRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetSourceFileRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -240,7 +240,7 @@ export class GetSourceFileResponse extends Message$1<GetSourceFileResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetSourceFileResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "content", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
@@ -289,7 +289,7 @@ export class GetModulePackagesRequest extends Message$1<GetModulePackagesRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetModulePackagesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -335,7 +335,7 @@ export class GetModulePackagesResponse extends Message$1<GetModulePackagesRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetModulePackagesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -380,7 +380,7 @@ export class ModulePackage extends Message$1<ModulePackage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ModulePackage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -430,7 +430,7 @@ export class GetModuleDocumentationRequest extends Message$1<GetModuleDocumentat
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetModuleDocumentationRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -471,7 +471,7 @@ export class GetModuleDocumentationResponse extends Message$1<GetModuleDocumenta
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetModuleDocumentationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "module_documentation", kind: "message", T: ModuleDocumentation },
@@ -520,7 +520,7 @@ export class ModuleDocumentation extends Message$1<ModuleDocumentation> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ModuleDocumentation";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -577,7 +577,7 @@ export class GetPackageDocumentationRequest extends Message$1<GetPackageDocument
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetPackageDocumentationRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -619,7 +619,7 @@ export class GetPackageDocumentationResponse extends Message$1<GetPackageDocumen
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetPackageDocumentationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "package_documentation", kind: "message", T: PackageDocumentation },
@@ -698,7 +698,7 @@ export class PackageDocumentation extends Message$1<PackageDocumentation> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PackageDocumentation";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -760,7 +760,7 @@ export class Location extends Message$1<Location> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Location";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "start_line", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -844,7 +844,7 @@ export class Service extends Message$1<Service> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Service";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -909,7 +909,7 @@ export class Method extends Message$1<Method> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Method";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -980,7 +980,7 @@ export class MethodRequestResponse extends Message$1<MethodRequestResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.MethodRequestResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "nested_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1064,7 +1064,7 @@ export class Enum extends Message$1<Enum> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Enum";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1124,7 +1124,7 @@ export class EnumValue extends Message$1<EnumValue> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.EnumValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1188,7 +1188,7 @@ export class ImportModuleRef extends Message$1<ImportModuleRef> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ImportModuleRef";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "remote", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1282,7 +1282,7 @@ export class Message extends Message$1<Message> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Message";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1341,7 +1341,7 @@ export class MessageField extends Message$1<MessageField> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.MessageField";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "field", kind: "message", T: Field, oneof: "message_field" },
@@ -1386,7 +1386,7 @@ export class Oneof extends Message$1<Oneof> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Oneof";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1484,7 +1484,7 @@ export class Field extends Message$1<Field> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Field";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1555,7 +1555,7 @@ export class MapEntry extends Message$1<MapEntry> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.MapEntry";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "key_full_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1628,7 +1628,7 @@ export class FileExtension extends Message$1<FileExtension> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.FileExtension";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "extension_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/download_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/download_pb.ts
@@ -44,7 +44,7 @@ export class DownloadRequest extends Message<DownloadRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DownloadRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -83,7 +83,7 @@ export class DownloadResponse extends Message<DownloadResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DownloadResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "module", kind: "message", T: Module },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/generate_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/generate_pb.ts
@@ -46,7 +46,7 @@ export class File extends Message<File> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.File";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -102,7 +102,7 @@ export class RuntimeLibrary extends Message<RuntimeLibrary> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RuntimeLibrary";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -166,7 +166,7 @@ export class PluginReference extends Message<PluginReference> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PluginReference";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -235,7 +235,7 @@ export class GeneratePluginsRequest extends Message<GeneratePluginsRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GeneratePluginsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "image", kind: "message", T: Image },
@@ -290,7 +290,7 @@ export class GeneratePluginsResponse extends Message<GeneratePluginsResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GeneratePluginsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "responses", kind: "message", T: CodeGeneratorResponse, repeated: true },
@@ -374,7 +374,7 @@ export class GenerateTemplateRequest extends Message<GenerateTemplateRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GenerateTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "image", kind: "message", T: Image },
@@ -429,7 +429,7 @@ export class GenerateTemplateResponse extends Message<GenerateTemplateResponse> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GenerateTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "files", kind: "message", T: File, repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/image_pb.ts
@@ -127,7 +127,7 @@ export class GetImageRequest extends Message<GetImageRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetImageRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -170,7 +170,7 @@ export class GetImageResponse extends Message<GetImageResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetImageResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "image", kind: "message", T: Image },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/jsonschema_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/jsonschema_pb.ts
@@ -52,7 +52,7 @@ export class GetJSONSchemaRequest extends Message<GetJSONSchemaRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetJSONSchemaRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -97,7 +97,7 @@ export class GetJSONSchemaResponse extends Message<GetJSONSchemaResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetJSONSchemaResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "json_schema", kind: "scalar", T: 12 /* ScalarType.BYTES */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/module_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/module_pb.ts
@@ -49,7 +49,7 @@ export class LocalModuleReference extends Message<LocalModuleReference> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.LocalModuleReference";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -117,7 +117,7 @@ export class LocalModulePin extends Message<LocalModulePin> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.LocalModulePin";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/organization_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/organization_pb.ts
@@ -57,7 +57,7 @@ export class Organization extends Message<Organization> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Organization";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -105,7 +105,7 @@ export class OrganizationMembership extends Message<OrganizationMembership> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.OrganizationMembership";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization", kind: "message", T: Organization },
@@ -143,7 +143,7 @@ export class GetOrganizationRequest extends Message<GetOrganizationRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOrganizationRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -180,7 +180,7 @@ export class GetOrganizationResponse extends Message<GetOrganizationResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOrganizationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization", kind: "message", T: Organization },
@@ -217,7 +217,7 @@ export class GetOrganizationByNameRequest extends Message<GetOrganizationByNameR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOrganizationByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -254,7 +254,7 @@ export class GetOrganizationByNameResponse extends Message<GetOrganizationByName
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOrganizationByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization", kind: "message", T: Organization },
@@ -303,7 +303,7 @@ export class ListOrganizationsRequest extends Message<ListOrganizationsRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -349,7 +349,7 @@ export class ListOrganizationsResponse extends Message<ListOrganizationsResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organizations", kind: "message", T: Organization, repeated: true },
@@ -406,7 +406,7 @@ export class ListUserOrganizationsRequest extends Message<ListUserOrganizationsR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserOrganizationsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -453,7 +453,7 @@ export class ListUserOrganizationsResponse extends Message<ListUserOrganizations
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserOrganizationsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organizations", kind: "message", T: OrganizationMembership, repeated: true },
@@ -493,7 +493,7 @@ export class CreateOrganizationRequest extends Message<CreateOrganizationRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateOrganizationRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -530,7 +530,7 @@ export class CreateOrganizationResponse extends Message<CreateOrganizationRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateOrganizationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization", kind: "message", T: Organization },
@@ -567,7 +567,7 @@ export class DeleteOrganizationRequest extends Message<DeleteOrganizationRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteOrganizationRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -599,7 +599,7 @@ export class DeleteOrganizationResponse extends Message<DeleteOrganizationRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteOrganizationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -635,7 +635,7 @@ export class DeleteOrganizationByNameRequest extends Message<DeleteOrganizationB
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteOrganizationByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -667,7 +667,7 @@ export class DeleteOrganizationByNameResponse extends Message<DeleteOrganization
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteOrganizationByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -719,7 +719,7 @@ export class AddOrganizationMemberRequest extends Message<AddOrganizationMemberR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -753,7 +753,7 @@ export class AddOrganizationMemberResponse extends Message<AddOrganizationMember
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.AddOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -805,7 +805,7 @@ export class UpdateOrganizationMemberRequest extends Message<UpdateOrganizationM
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -839,7 +839,7 @@ export class UpdateOrganizationMemberResponse extends Message<UpdateOrganization
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UpdateOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -884,7 +884,7 @@ export class RemoveOrganizationMemberRequest extends Message<RemoveOrganizationM
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RemoveOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -917,7 +917,7 @@ export class RemoveOrganizationMemberResponse extends Message<RemoveOrganization
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RemoveOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -970,7 +970,7 @@ export class SetOrganizationMemberRequest extends Message<SetOrganizationMemberR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1004,7 +1004,7 @@ export class SetOrganizationMemberResponse extends Message<SetOrganizationMember
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetOrganizationMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1042,7 +1042,7 @@ export class GetOrganizationSettingsRequest extends Message<GetOrganizationSetti
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOrganizationSettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1096,7 +1096,7 @@ export class GetOrganizationSettingsResponse extends Message<GetOrganizationSett
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_base_role", kind: "enum", T: proto3.getEnumType(RepositoryRole) },
@@ -1159,7 +1159,7 @@ export class UpdateOrganizationSettingsRequest extends Message<UpdateOrganizatio
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1194,7 +1194,7 @@ export class UpdateOrganizationSettingsResponse extends Message<UpdateOrganizati
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/owner_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/owner_pb.ts
@@ -51,7 +51,7 @@ export class Owner extends Message<Owner> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Owner";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User, oneof: "owner" },
@@ -91,7 +91,7 @@ export class GetOwnerByNameRequest extends Message<GetOwnerByNameRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOwnerByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -128,7 +128,7 @@ export class GetOwnerByNameResponse extends Message<GetOwnerByNameResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetOwnerByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "message", T: Owner },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/plugin_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/plugin_pb.ts
@@ -105,7 +105,7 @@ export class Plugin extends Message<Plugin> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Plugin";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -190,7 +190,7 @@ export class PluginVersion extends Message<PluginVersion> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PluginVersion";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -284,7 +284,7 @@ export class Template extends Message<Template> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Template";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -353,7 +353,7 @@ export class PluginConfig extends Message<PluginConfig> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PluginConfig";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -429,7 +429,7 @@ export class TemplateVersion extends Message<TemplateVersion> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.TemplateVersion";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -495,7 +495,7 @@ export class PluginVersionMapping extends Message<PluginVersionMapping> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PluginVersionMapping";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -557,7 +557,7 @@ export class PluginContributor extends Message<PluginContributor> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PluginContributor";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -619,7 +619,7 @@ export class TemplateContributor extends Message<TemplateContributor> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.TemplateContributor";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -671,7 +671,7 @@ export class ListPluginsRequest extends Message<ListPluginsRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListPluginsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -717,7 +717,7 @@ export class ListPluginsResponse extends Message<ListPluginsResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListPluginsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugins", kind: "message", T: Plugin, repeated: true },
@@ -774,7 +774,7 @@ export class ListUserPluginsRequest extends Message<ListUserPluginsRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserPluginsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -821,7 +821,7 @@ export class ListUserPluginsResponse extends Message<ListUserPluginsResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserPluginsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugins", kind: "message", T: Plugin, repeated: true },
@@ -878,7 +878,7 @@ export class ListOrganizationPluginsRequest extends Message<ListOrganizationPlug
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationPluginsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -925,7 +925,7 @@ export class ListOrganizationPluginsResponse extends Message<ListOrganizationPlu
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationPluginsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugins", kind: "message", T: Plugin, repeated: true },
@@ -979,7 +979,7 @@ export class GetPluginVersionRequest extends Message<GetPluginVersionRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetPluginVersionRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1018,7 +1018,7 @@ export class GetPluginVersionResponse extends Message<GetPluginVersionResponse> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetPluginVersionResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_version", kind: "message", T: PluginVersion },
@@ -1083,7 +1083,7 @@ export class ListPluginVersionsRequest extends Message<ListPluginVersionsRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListPluginVersionsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1131,7 +1131,7 @@ export class ListPluginVersionsResponse extends Message<ListPluginVersionsRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListPluginVersionsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_versions", kind: "message", T: PluginVersion, repeated: true },
@@ -1189,7 +1189,7 @@ export class CreatePluginRequest extends Message<CreatePluginRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreatePluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1230,7 +1230,7 @@ export class CreatePluginResponse extends Message<CreatePluginResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreatePluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin", kind: "message", T: Plugin },
@@ -1276,7 +1276,7 @@ export class GetPluginRequest extends Message<GetPluginRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetPluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1314,7 +1314,7 @@ export class GetPluginResponse extends Message<GetPluginResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetPluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin", kind: "message", T: Plugin },
@@ -1360,7 +1360,7 @@ export class DeletePluginRequest extends Message<DeletePluginRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeletePluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1393,7 +1393,7 @@ export class DeletePluginResponse extends Message<DeletePluginResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeletePluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1446,7 +1446,7 @@ export class SetPluginContributorRequest extends Message<SetPluginContributorReq
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetPluginContributorRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1480,7 +1480,7 @@ export class SetPluginContributorResponse extends Message<SetPluginContributorRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetPluginContributorResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1533,7 +1533,7 @@ export class ListPluginContributorsRequest extends Message<ListPluginContributor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListPluginContributorsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "plugin_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1580,7 +1580,7 @@ export class ListPluginContributorsResponse extends Message<ListPluginContributo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListPluginContributorsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "users", kind: "message", T: PluginContributor, repeated: true },
@@ -1634,7 +1634,7 @@ export class DeprecatePluginRequest extends Message<DeprecatePluginRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeprecatePluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1668,7 +1668,7 @@ export class DeprecatePluginResponse extends Message<DeprecatePluginResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeprecatePluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1713,7 +1713,7 @@ export class UndeprecatePluginRequest extends Message<UndeprecatePluginRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UndeprecatePluginRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1746,7 +1746,7 @@ export class UndeprecatePluginResponse extends Message<UndeprecatePluginResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UndeprecatePluginResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1791,7 +1791,7 @@ export class GetTemplateRequest extends Message<GetTemplateRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1829,7 +1829,7 @@ export class GetTemplateResponse extends Message<GetTemplateResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template", kind: "message", T: Template },
@@ -1878,7 +1878,7 @@ export class ListTemplatesRequest extends Message<ListTemplatesRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTemplatesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -1924,7 +1924,7 @@ export class ListTemplatesResponse extends Message<ListTemplatesResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTemplatesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "templates", kind: "message", T: Template, repeated: true },
@@ -1981,7 +1981,7 @@ export class ListUserTemplatesRequest extends Message<ListUserTemplatesRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserTemplatesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2028,7 +2028,7 @@ export class ListUserTemplatesResponse extends Message<ListUserTemplatesResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserTemplatesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "templates", kind: "message", T: Template, repeated: true },
@@ -2082,7 +2082,7 @@ export class GetTemplateVersionRequest extends Message<GetTemplateVersionRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetTemplateVersionRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2121,7 +2121,7 @@ export class GetTemplateVersionResponse extends Message<GetTemplateVersionRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetTemplateVersionResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_version", kind: "message", T: TemplateVersion },
@@ -2177,7 +2177,7 @@ export class ListOrganizationTemplatesRequest extends Message<ListOrganizationTe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationTemplatesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2224,7 +2224,7 @@ export class ListOrganizationTemplatesResponse extends Message<ListOrganizationT
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationTemplatesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "templates", kind: "message", T: Template, repeated: true },
@@ -2290,7 +2290,7 @@ export class ListTemplateVersionsRequest extends Message<ListTemplateVersionsReq
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTemplateVersionsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2338,7 +2338,7 @@ export class ListTemplateVersionsResponse extends Message<ListTemplateVersionsRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTemplateVersionsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_versions", kind: "message", T: TemplateVersion, repeated: true },
@@ -2403,7 +2403,7 @@ export class CreateTemplateRequest extends Message<CreateTemplateRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2445,7 +2445,7 @@ export class CreateTemplateResponse extends Message<CreateTemplateResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template", kind: "message", T: Template },
@@ -2491,7 +2491,7 @@ export class DeleteTemplateRequest extends Message<DeleteTemplateRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2524,7 +2524,7 @@ export class DeleteTemplateResponse extends Message<DeleteTemplateResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -2585,7 +2585,7 @@ export class CreateTemplateVersionRequest extends Message<CreateTemplateVersionR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateTemplateVersionRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2627,7 +2627,7 @@ export class CreateTemplateVersionResponse extends Message<CreateTemplateVersion
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateTemplateVersionResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_version", kind: "message", T: TemplateVersion },
@@ -2681,7 +2681,7 @@ export class SetTemplateContributorRequest extends Message<SetTemplateContributo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetTemplateContributorRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2715,7 +2715,7 @@ export class SetTemplateContributorResponse extends Message<SetTemplateContribut
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetTemplateContributorResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -2768,7 +2768,7 @@ export class ListTemplateContributorsRequest extends Message<ListTemplateContrib
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTemplateContributorsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2815,7 +2815,7 @@ export class ListTemplateContributorsResponse extends Message<ListTemplateContri
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTemplateContributorsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "users", kind: "message", T: TemplateContributor, repeated: true },
@@ -2869,7 +2869,7 @@ export class DeprecateTemplateRequest extends Message<DeprecateTemplateRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeprecateTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2903,7 +2903,7 @@ export class DeprecateTemplateResponse extends Message<DeprecateTemplateResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeprecateTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -2948,7 +2948,7 @@ export class UndeprecateTemplateRequest extends Message<UndeprecateTemplateReque
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UndeprecateTemplateRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2981,7 +2981,7 @@ export class UndeprecateTemplateResponse extends Message<UndeprecateTemplateResp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UndeprecateTemplateResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/push_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/push_pb.ts
@@ -67,7 +67,7 @@ export class PushRequest extends Message<PushRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PushRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -109,7 +109,7 @@ export class PushResponse extends Message<PushResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PushResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 5, name: "local_module_pin", kind: "message", T: LocalModulePin },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/recommendation_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/recommendation_pb.ts
@@ -56,7 +56,7 @@ export class RecommendedRepository extends Message<RecommendedRepository> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RecommendedRepository";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -115,7 +115,7 @@ export class RecommendedTemplate extends Message<RecommendedTemplate> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RecommendedTemplate";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -162,7 +162,7 @@ export class SetRecommendedRepository extends Message<SetRecommendedRepository> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRecommendedRepository";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -207,7 +207,7 @@ export class SetRecommendedTemplate extends Message<SetRecommendedTemplate> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRecommendedTemplate";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "template_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -240,7 +240,7 @@ export class RecommendedRepositoriesRequest extends Message<RecommendedRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RecommendedRepositoriesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -276,7 +276,7 @@ export class RecommendedRepositoriesResponse extends Message<RecommendedReposito
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RecommendedRepositoriesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: RecommendedRepository, repeated: true },
@@ -308,7 +308,7 @@ export class RecommendedTemplatesRequest extends Message<RecommendedTemplatesReq
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RecommendedTemplatesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -344,7 +344,7 @@ export class RecommendedTemplatesResponse extends Message<RecommendedTemplatesRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RecommendedTemplatesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "templates", kind: "message", T: RecommendedTemplate, repeated: true },
@@ -376,7 +376,7 @@ export class ListRecommendedRepositoriesRequest extends Message<ListRecommendedR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRecommendedRepositoriesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -412,7 +412,7 @@ export class ListRecommendedRepositoriesResponse extends Message<ListRecommended
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRecommendedRepositoriesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: RecommendedRepository, repeated: true },
@@ -444,7 +444,7 @@ export class ListRecommendedTemplatesRequest extends Message<ListRecommendedTemp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRecommendedTemplatesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -480,7 +480,7 @@ export class ListRecommendedTemplatesResponse extends Message<ListRecommendedTem
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRecommendedTemplatesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "templates", kind: "message", T: RecommendedTemplate, repeated: true },
@@ -517,7 +517,7 @@ export class SetRecommendedRepositoriesRequest extends Message<SetRecommendedRep
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRecommendedRepositoriesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: SetRecommendedRepository, repeated: true },
@@ -549,7 +549,7 @@ export class SetRecommendedRepositoriesResponse extends Message<SetRecommendedRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRecommendedRepositoriesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -585,7 +585,7 @@ export class SetRecommendedTemplatesRequest extends Message<SetRecommendedTempla
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRecommendedTemplatesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "templates", kind: "message", T: SetRecommendedTemplate, repeated: true },
@@ -617,7 +617,7 @@ export class SetRecommendedTemplatesResponse extends Message<SetRecommendedTempl
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRecommendedTemplatesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/reference_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/reference_pb.ts
@@ -69,7 +69,7 @@ export class Reference extends Message<Reference> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Reference";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "branch", kind: "message", T: RepositoryBranch, oneof: "reference" },
@@ -125,7 +125,7 @@ export class GetReferenceByNameRequest extends Message<GetReferenceByNameRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetReferenceByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -164,7 +164,7 @@ export class GetReferenceByNameResponse extends Message<GetReferenceByNameRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetReferenceByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "message", T: Reference },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_branch_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_branch_pb.ts
@@ -58,7 +58,7 @@ export class RepositoryBranch extends Message<RepositoryBranch> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositoryBranch";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -115,7 +115,7 @@ export class CreateRepositoryBranchRequest extends Message<CreateRepositoryBranc
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryBranchRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -154,7 +154,7 @@ export class CreateRepositoryBranchResponse extends Message<CreateRepositoryBran
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryBranchResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_branch", kind: "message", T: RepositoryBranch },
@@ -210,7 +210,7 @@ export class ListRepositoryBranchesRequest extends Message<ListRepositoryBranche
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryBranchesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -257,7 +257,7 @@ export class ListRepositoryBranchesResponse extends Message<ListRepositoryBranch
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryBranchesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_branches", kind: "message", T: RepositoryBranch, repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_commit_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_commit_pb.ts
@@ -89,7 +89,7 @@ export class RepositoryCommit extends Message<RepositoryCommit> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositoryCommit";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -164,7 +164,7 @@ export class ListRepositoryCommitsByBranchRequest extends Message<ListRepository
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryCommitsByBranchRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -211,7 +211,7 @@ export class ListRepositoryCommitsByBranchResponse extends Message<ListRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryCommitsByBranchResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_commits", kind: "message", T: RepositoryCommit, repeated: true },
@@ -280,7 +280,7 @@ export class ListRepositoryCommitsByReferenceRequest extends Message<ListReposit
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryCommitsByReferenceRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -327,7 +327,7 @@ export class ListRepositoryCommitsByReferenceResponse extends Message<ListReposi
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryCommitsByReferenceResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_commits", kind: "message", T: RepositoryCommit, repeated: true },
@@ -381,7 +381,7 @@ export class GetRepositoryCommitByReferenceRequest extends Message<GetRepository
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryCommitByReferenceRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -420,7 +420,7 @@ export class GetRepositoryCommitByReferenceResponse extends Message<GetRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryCommitByReferenceResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_commit", kind: "message", T: RepositoryCommit },
@@ -480,7 +480,7 @@ export class GetRepositoryCommitBySequenceIdRequest extends Message<GetRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryCommitBySequenceIdRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -520,7 +520,7 @@ export class GetRepositoryCommitBySequenceIdResponse extends Message<GetReposito
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryCommitBySequenceIdResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_commit", kind: "message", T: RepositoryCommit },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_pb.ts
@@ -124,7 +124,7 @@ export class Repository extends Message<Repository> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Repository";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -191,7 +191,7 @@ export class RepositoryContributor extends Message<RepositoryContributor> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositoryContributor";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -234,7 +234,7 @@ export class GetRepositoriesByFullNameRequest extends Message<GetRepositoriesByF
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "full_names", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
@@ -271,7 +271,7 @@ export class GetRepositoriesByFullNameResponse extends Message<GetRepositoriesBy
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: Repository, repeated: true },
@@ -308,7 +308,7 @@ export class GetRepositoryRequest extends Message<GetRepositoryRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -345,7 +345,7 @@ export class GetRepositoryResponse extends Message<GetRepositoryResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository", kind: "message", T: Repository },
@@ -382,7 +382,7 @@ export class GetRepositoryByFullNameRequest extends Message<GetRepositoryByFullN
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryByFullNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "full_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -419,7 +419,7 @@ export class GetRepositoryByFullNameResponse extends Message<GetRepositoryByFull
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryByFullNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository", kind: "message", T: Repository },
@@ -468,7 +468,7 @@ export class ListRepositoriesRequest extends Message<ListRepositoriesRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoriesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -514,7 +514,7 @@ export class ListRepositoriesResponse extends Message<ListRepositoriesResponse> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoriesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: Repository, repeated: true },
@@ -571,7 +571,7 @@ export class ListUserRepositoriesRequest extends Message<ListUserRepositoriesReq
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserRepositoriesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -618,7 +618,7 @@ export class ListUserRepositoriesResponse extends Message<ListUserRepositoriesRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUserRepositoriesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: Repository, repeated: true },
@@ -668,7 +668,7 @@ export class ListRepositoriesUserCanAccessRequest extends Message<ListRepositori
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoriesUserCanAccessRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -714,7 +714,7 @@ export class ListRepositoriesUserCanAccessResponse extends Message<ListRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoriesUserCanAccessResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: Repository, repeated: true },
@@ -771,7 +771,7 @@ export class ListOrganizationRepositoriesRequest extends Message<ListOrganizatio
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationRepositoriesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -818,7 +818,7 @@ export class ListOrganizationRepositoriesResponse extends Message<ListOrganizati
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationRepositoriesResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repositories", kind: "message", T: Repository, repeated: true },
@@ -863,7 +863,7 @@ export class CreateRepositoryByFullNameRequest extends Message<CreateRepositoryB
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "full_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -901,7 +901,7 @@ export class CreateRepositoryByFullNameResponse extends Message<CreateRepository
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository", kind: "message", T: Repository },
@@ -938,7 +938,7 @@ export class DeleteRepositoryRequest extends Message<DeleteRepositoryRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteRepositoryRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -970,7 +970,7 @@ export class DeleteRepositoryResponse extends Message<DeleteRepositoryResponse> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteRepositoryResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1006,7 +1006,7 @@ export class DeleteRepositoryByFullNameRequest extends Message<DeleteRepositoryB
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteRepositoryByFullNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "full_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1038,7 +1038,7 @@ export class DeleteRepositoryByFullNameResponse extends Message<DeleteRepository
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteRepositoryByFullNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1087,7 +1087,7 @@ export class DeprecateRepositoryByNameRequest extends Message<DeprecateRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1126,7 +1126,7 @@ export class DeprecateRepositoryByNameResponse extends Message<DeprecateReposito
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository", kind: "message", T: Repository },
@@ -1168,7 +1168,7 @@ export class UndeprecateRepositoryByNameRequest extends Message<UndeprecateRepos
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1206,7 +1206,7 @@ export class UndeprecateRepositoryByNameResponse extends Message<UndeprecateRepo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository", kind: "message", T: Repository },
@@ -1260,7 +1260,7 @@ export class SetRepositoryContributorRequest extends Message<SetRepositoryContri
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRepositoryContributorRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1294,7 +1294,7 @@ export class SetRepositoryContributorResponse extends Message<SetRepositoryContr
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SetRepositoryContributorResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1347,7 +1347,7 @@ export class ListRepositoryContributorsRequest extends Message<ListRepositoryCon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryContributorsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1394,7 +1394,7 @@ export class ListRepositoryContributorsResponse extends Message<ListRepositoryCo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryContributorsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "users", kind: "message", T: RepositoryContributor, repeated: true },
@@ -1434,7 +1434,7 @@ export class GetRepositorySettingsRequest extends Message<GetRepositorySettingsR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositorySettingsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1474,7 +1474,7 @@ export class GetRepositorySettingsResponse extends Message<GetRepositorySettings
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositorySettingsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "contributors_count", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_tag_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_tag_pb.ts
@@ -65,7 +65,7 @@ export class RepositoryTag extends Message<RepositoryTag> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositoryTag";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -122,7 +122,7 @@ export class CreateRepositoryTagRequest extends Message<CreateRepositoryTagReque
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryTagRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -161,7 +161,7 @@ export class CreateRepositoryTagResponse extends Message<CreateRepositoryTagResp
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryTagResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_tag", kind: "message", T: RepositoryTag },
@@ -217,7 +217,7 @@ export class ListRepositoryTagsRequest extends Message<ListRepositoryTagsRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryTagsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -264,7 +264,7 @@ export class ListRepositoryTagsResponse extends Message<ListRepositoryTagsRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryTagsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_tags", kind: "message", T: RepositoryTag, repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_commit_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_commit_pb.ts
@@ -62,7 +62,7 @@ export class RepositoryTrackCommit extends Message<RepositoryTrackCommit> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositoryTrackCommit";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 2, name: "create_time", kind: "message", T: Timestamp },
@@ -107,7 +107,7 @@ export class GetRepositoryTrackCommitByRepositoryCommitRequest extends Message<G
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryTrackCommitByRepositoryCommitRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -145,7 +145,7 @@ export class GetRepositoryTrackCommitByRepositoryCommitResponse extends Message<
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryTrackCommitByRepositoryCommitResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track_commit", kind: "message", T: RepositoryTrackCommit },
@@ -197,7 +197,7 @@ export class ListRepositoryTrackCommitsByRepositoryTrackRequest extends Message<
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryTrackCommitsByRepositoryTrackRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -242,7 +242,7 @@ export class ListRepositoryTrackCommitsByRepositoryTrackResponse extends Message
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryTrackCommitsByRepositoryTrackResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track_commits", kind: "message", T: RepositoryTrackCommit, repeated: true },
@@ -295,7 +295,7 @@ export class GetRepositoryTrackCommitByReferenceRequest extends Message<GetRepos
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryTrackCommitByReferenceRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_owner", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -335,7 +335,7 @@ export class GetRepositoryTrackCommitByReferenceResponse extends Message<GetRepo
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryTrackCommitByReferenceResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track_commit", kind: "message", T: RepositoryTrackCommit },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/repository_track_pb.ts
@@ -51,7 +51,7 @@ export class RepositoryTrack extends Message<RepositoryTrack> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositoryTrack";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -99,7 +99,7 @@ export class CreateRepositoryTrackRequest extends Message<CreateRepositoryTrackR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryTrackRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -137,7 +137,7 @@ export class CreateRepositoryTrackResponse extends Message<CreateRepositoryTrack
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateRepositoryTrackResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track", kind: "message", T: RepositoryTrack },
@@ -193,7 +193,7 @@ export class ListRepositoryTracksRequest extends Message<ListRepositoryTracksReq
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryTracksRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -240,7 +240,7 @@ export class ListRepositoryTracksResponse extends Message<ListRepositoryTracksRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListRepositoryTracksResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_tracks", kind: "message", T: RepositoryTrack, repeated: true },
@@ -290,7 +290,7 @@ export class DeleteRepositoryTrackByNameRequest extends Message<DeleteRepository
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteRepositoryTrackByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -324,7 +324,7 @@ export class DeleteRepositoryTrackByNameResponse extends Message<DeleteRepositor
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteRepositoryTrackByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -372,7 +372,7 @@ export class GetRepositoryTrackByNameRequest extends Message<GetRepositoryTrackB
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryTrackByNameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "owner_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -411,7 +411,7 @@ export class GetRepositoryTrackByNameResponse extends Message<GetRepositoryTrack
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetRepositoryTrackByNameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository_track", kind: "message", T: RepositoryTrack },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/resolve_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/resolve_pb.ts
@@ -89,7 +89,7 @@ export class GetModulePinsRequest extends Message<GetModulePinsRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetModulePinsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "module_references", kind: "message", T: ModuleReference, repeated: true },
@@ -127,7 +127,7 @@ export class GetModulePinsResponse extends Message<GetModulePinsResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetModulePinsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "module_pins", kind: "message", T: ModulePin, repeated: true },
@@ -164,7 +164,7 @@ export class GetLocalModulePinsRequest extends Message<GetLocalModulePinsRequest
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "local_module_references", kind: "message", T: LocalModuleReference, repeated: true },
@@ -217,7 +217,7 @@ export class LocalModuleResolveResult extends Message<LocalModuleResolveResult> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.LocalModuleResolveResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "reference", kind: "message", T: LocalModuleReference },
@@ -265,7 +265,7 @@ export class GetLocalModulePinsResponse extends Message<GetLocalModulePinsRespon
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "local_module_resolve_results", kind: "message", T: LocalModuleResolveResult, repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/search_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/search_pb.ts
@@ -110,7 +110,7 @@ export class RepositorySearchResult extends Message<RepositorySearchResult> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.RepositorySearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -156,7 +156,7 @@ export class OrganizationSearchResult extends Message<OrganizationSearchResult> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.OrganizationSearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -204,7 +204,7 @@ export class UserSearchResult extends Message<UserSearchResult> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UserSearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -253,7 +253,7 @@ export class TeamSearchResult extends Message<TeamSearchResult> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.TeamSearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -317,7 +317,7 @@ export class PluginSearchResult extends Message<PluginSearchResult> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.PluginSearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -383,7 +383,7 @@ export class TemplateSearchResult extends Message<TemplateSearchResult> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.TemplateSearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -460,7 +460,7 @@ export class SearchResult extends Message<SearchResult> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SearchResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repository", kind: "message", T: RepositorySearchResult, oneof: "item" },
@@ -525,7 +525,7 @@ export class SearchRequest extends Message<SearchRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SearchRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -572,7 +572,7 @@ export class SearchResponse extends Message<SearchResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.SearchResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "search_results", kind: "message", T: SearchResult, repeated: true },

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/token_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/token_pb.ts
@@ -48,7 +48,7 @@ export class Token extends Message<Token> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.Token";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -96,7 +96,7 @@ export class CreateTokenRequest extends Message<CreateTokenRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateTokenRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "note", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -136,7 +136,7 @@ export class CreateTokenResponse extends Message<CreateTokenResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateTokenResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "token", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -173,7 +173,7 @@ export class GetTokenRequest extends Message<GetTokenRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetTokenRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "token_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -210,7 +210,7 @@ export class GetTokenResponse extends Message<GetTokenResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetTokenResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "token", kind: "message", T: Token },
@@ -259,7 +259,7 @@ export class ListTokensRequest extends Message<ListTokensRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTokensRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -305,7 +305,7 @@ export class ListTokensResponse extends Message<ListTokensResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListTokensResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "tokens", kind: "message", T: Token, repeated: true },
@@ -343,7 +343,7 @@ export class DeleteTokenRequest extends Message<DeleteTokenRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteTokenRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "token_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -375,7 +375,7 @@ export class DeleteTokenResponse extends Message<DeleteTokenResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteTokenResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/user_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/registry/v1alpha1/user_pb.ts
@@ -90,7 +90,7 @@ export class User extends Message<User> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.User";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -147,7 +147,7 @@ export class OrganizationUser extends Message<OrganizationUser> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.OrganizationUser";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -186,7 +186,7 @@ export class CreateUserRequest extends Message<CreateUserRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "username", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -223,7 +223,7 @@ export class CreateUserResponse extends Message<CreateUserResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CreateUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -260,7 +260,7 @@ export class GetUserRequest extends Message<GetUserRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -297,7 +297,7 @@ export class GetUserResponse extends Message<GetUserResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -334,7 +334,7 @@ export class GetUserByUsernameRequest extends Message<GetUserByUsernameRequest> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetUserByUsernameRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "username", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -371,7 +371,7 @@ export class GetUserByUsernameResponse extends Message<GetUserByUsernameResponse
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.GetUserByUsernameResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user", kind: "message", T: User },
@@ -427,7 +427,7 @@ export class ListUsersRequest extends Message<ListUsersRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUsersRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -474,7 +474,7 @@ export class ListUsersResponse extends Message<ListUsersResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListUsersResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "users", kind: "message", T: User, repeated: true },
@@ -529,7 +529,7 @@ export class ListOrganizationUsersRequest extends Message<ListOrganizationUsersR
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationUsersRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -576,7 +576,7 @@ export class ListOrganizationUsersResponse extends Message<ListOrganizationUsers
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.ListOrganizationUsersResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "users", kind: "message", T: OrganizationUser, repeated: true },
@@ -609,7 +609,7 @@ export class DeleteUserRequest extends Message<DeleteUserRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -640,7 +640,7 @@ export class DeleteUserResponse extends Message<DeleteUserResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeleteUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -676,7 +676,7 @@ export class DeactivateUserRequest extends Message<DeactivateUserRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeactivateUserRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -708,7 +708,7 @@ export class DeactivateUserResponse extends Message<DeactivateUserResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.DeactivateUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -753,7 +753,7 @@ export class UpdateUserServerRoleRequest extends Message<UpdateUserServerRoleReq
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UpdateUserServerRoleRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -786,7 +786,7 @@ export class UpdateUserServerRoleResponse extends Message<UpdateUserServerRoleRe
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.UpdateUserServerRoleResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -824,7 +824,7 @@ export class CountUsersRequest extends Message<CountUsersRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CountUsersRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_state_filter", kind: "enum", T: proto3.getEnumType(UserState) },
@@ -861,7 +861,7 @@ export class CountUsersResponse extends Message<CountUsersResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.alpha.registry.v1alpha1.CountUsersResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "total_count", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },

--- a/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
+++ b/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
@@ -152,7 +152,7 @@ export class FailureSet extends Message<FailureSet> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "conformance.FailureSet";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "failure", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
@@ -269,7 +269,7 @@ export class ConformanceRequest extends Message<ConformanceRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "conformance.ConformanceRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "protobuf_payload", kind: "scalar", T: 12 /* ScalarType.BYTES */, oneof: "payload" },
@@ -394,7 +394,7 @@ export class ConformanceResponse extends Message<ConformanceResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "conformance.ConformanceResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "parse_error", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "result" },
@@ -442,7 +442,7 @@ export class JspbEncodingConfig extends Message<JspbEncodingConfig> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "conformance.JspbEncodingConfig";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "use_jspb_array_any_format", kind: "scalar", T: 8 /* ScalarType.BOOL */ },

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -779,7 +779,7 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -987,7 +987,7 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1032,7 +1032,7 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.Data";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 202, name: "group_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1067,7 +1067,7 @@ export class TestAllTypesProto2_MessageSetCorrect extends Message<TestAllTypesPr
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1103,7 +1103,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 25, name: "str", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1140,7 +1140,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 9, name: "i", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1177,7 +1177,7 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.ForeignMessageProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1239,7 +1239,7 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.UnknownToTestAllTypes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1001, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1281,7 +1281,7 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1313,7 +1313,7 @@ export class NullHypothesisProto2 extends Message<NullHypothesisProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.NullHypothesisProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1344,7 +1344,7 @@ export class EnumOnlyProto2 extends Message<EnumOnlyProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.EnumOnlyProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1400,7 +1400,7 @@ export class OneStringProto2 extends Message<OneStringProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.OneStringProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -870,7 +870,7 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.TestAllTypesProto3";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1140,7 +1140,7 @@ export class TestAllTypesProto3_NestedMessage extends Message<TestAllTypesProto3
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1178,7 +1178,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1210,7 +1210,7 @@ export class NullHypothesisProto3 extends Message<NullHypothesisProto3> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.NullHypothesisProto3";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1241,7 +1241,7 @@ export class EnumOnlyProto3 extends Message<EnumOnlyProto3> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.EnumOnlyProto3";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-example/src/gen/addressbook_pb.ts
+++ b/packages/protobuf-example/src/gen/addressbook_pb.ts
@@ -56,7 +56,7 @@ export class Person extends Message<Person> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.Person";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -128,7 +128,7 @@ export class Person_PhoneNumber extends Message<Person_PhoneNumber> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.Person.PhoneNumber";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "number", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -168,7 +168,7 @@ export class AddressBook extends Message<AddressBook> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.AddressBook";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "people", kind: "message", T: Person, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
@@ -153,7 +153,7 @@ export class MessageWithComments extends Message<MessageWithComments> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.MessageWithComments";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "foo", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -191,7 +191,7 @@ export class EmptyMessageWithComment extends Message<EmptyMessageWithComment> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.EmptyMessageWithComment";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -272,7 +272,7 @@ export class GoogleCommentExample extends Message<GoogleCommentExample> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.GoogleCommentExample";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "foo", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -82,7 +82,7 @@ export class DeprecatedMessage extends Message<DeprecatedMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.DeprecatedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -131,7 +131,7 @@ export class DeprecatedFieldMessage extends Message<DeprecatedFieldMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.DeprecatedFieldMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "deprecated_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
@@ -29,7 +29,7 @@ export class ImplicitlyDeprecatedMessage extends Message<ImplicitlyDeprecatedMes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ImplicitlyDeprecatedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/extra/enum_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/enum_pb.ts
@@ -118,7 +118,7 @@ export class EnumMessage extends Message<EnumMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.EnumMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
@@ -58,7 +58,7 @@ export class User extends Message<User> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "docs.User";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "first_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-json-names_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-json-names_pb.ts
@@ -68,7 +68,7 @@ export class JsonNamesMessage extends Message<JsonNamesMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.JsonNamesMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "scalar_field", jsonName: "scalarFieldJsonName", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-maps_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-maps_pb.ts
@@ -124,7 +124,7 @@ export class MapsMessage extends Message<MapsMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.MapsMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "str_str_field", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
@@ -38,7 +38,7 @@ export class MessageFieldMessage extends Message<MessageFieldMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.MessageFieldMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "message_field", kind: "message", T: MessageFieldMessage_TestMessage },
@@ -76,7 +76,7 @@ export class MessageFieldMessage_TestMessage extends Message<MessageFieldMessage
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.MessageFieldMessage.TestMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
@@ -105,7 +105,7 @@ export class OneofMessage extends Message<OneofMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.OneofMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "scalar" },
@@ -152,7 +152,7 @@ export class OneofMessageFoo extends Message<OneofMessageFoo> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.OneofMessageFoo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -195,7 +195,7 @@ export class OneofMessageBar extends Message<OneofMessageBar> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.OneofMessageBar";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-scalar_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-scalar_pb.ts
@@ -103,7 +103,7 @@ export class ScalarValuesMessage extends Message<ScalarValuesMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ScalarValuesMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */ },
@@ -224,7 +224,7 @@ export class RepeatedScalarValuesMessage extends Message<RepeatedScalarValuesMes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.RepeatedScalarValuesMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-self-reference_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-self-reference_pb.ts
@@ -43,7 +43,7 @@ export class SelfReferencingMessage extends Message<SelfReferencingMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.SelfReferencingMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "self", kind: "message", T: SelfReferencingMessage },

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -28,7 +28,7 @@ export class ReservedPropertyNames extends Message$1<ReservedPropertyNames> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ReservedPropertyNames";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -181,7 +181,7 @@ export class ReservedPropertyNames_BuiltIn extends Message$1<ReservedPropertyNam
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ReservedPropertyNames.BuiltIn";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 2, name: "constructor", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -279,7 +279,7 @@ export class ReservedPropertyNames_Runtime extends Message$1<ReservedPropertyNam
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ReservedPropertyNames.Runtime";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 4, name: "to_json", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -348,7 +348,7 @@ export class ReservedPropertyNames_OneofBultIn extends Message$1<ReservedPropert
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ReservedPropertyNames.OneofBultIn";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "constructor", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "built_in" },
@@ -442,7 +442,7 @@ export class ReservedPropertyNames_OneofRuntime extends Message$1<ReservedProper
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ReservedPropertyNames.OneofRuntime";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 5, name: "to_json", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "runtime" },
@@ -484,7 +484,7 @@ export class interface$ extends Message$1<interface$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.interface";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -517,7 +517,7 @@ export class function$ extends Message$1<function$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.function";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -550,7 +550,7 @@ export class instanceof$ extends Message$1<instanceof$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.instanceof";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -583,7 +583,7 @@ export class switch$ extends Message$1<switch$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.switch";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -616,7 +616,7 @@ export class case$ extends Message$1<case$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.case";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -649,7 +649,7 @@ export class return$ extends Message$1<return$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.return";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -682,7 +682,7 @@ export class Message extends Message$1<Message> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Message";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -715,7 +715,7 @@ export class PartialMessage extends Message$1<PartialMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.PartialMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -748,7 +748,7 @@ export class PlainMessage extends Message$1<PlainMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.PlainMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -793,7 +793,7 @@ export class Error extends Message$1<Error> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Error";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "field_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -828,7 +828,7 @@ export class Object$ extends Message$1<Object$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Object";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -859,7 +859,7 @@ export class object$ extends Message$1<object$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.object";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -892,7 +892,7 @@ export class array extends Message$1<array> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.array";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -925,7 +925,7 @@ export class string$ extends Message$1<string$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.string";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -958,7 +958,7 @@ export class number$ extends Message$1<number$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.number";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -991,7 +991,7 @@ export class boolean$ extends Message$1<boolean$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.boolean";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1024,7 +1024,7 @@ export class bigint$ extends Message$1<bigint$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.bigint";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1057,7 +1057,7 @@ export class Uint8Array$ extends Message$1<Uint8Array$> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Uint8Array";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1090,7 +1090,7 @@ export class Array extends Message$1<Array> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Array";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1123,7 +1123,7 @@ export class String extends Message$1<String> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.String";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1156,7 +1156,7 @@ export class Number extends Message$1<Number> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Number";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1189,7 +1189,7 @@ export class Boolean extends Message$1<Boolean> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Boolean";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1222,7 +1222,7 @@ export class BigInt extends Message$1<BigInt> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.BigInt";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1253,7 +1253,7 @@ export class ClashParent extends Message$1<ClashParent> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ClashParent";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1286,7 +1286,7 @@ export class ClashParent_ClashChild extends Message$1<ClashParent_ClashChild> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ClashParent.ClashChild";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1359,7 +1359,7 @@ export class NoClashFields extends Message$1<NoClashFields> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.NoClashFields";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "const", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1449,7 +1449,7 @@ export class NoClashOneof extends Message$1<NoClashOneof> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.NoClashOneof";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "const", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "kind" },
@@ -1491,7 +1491,7 @@ export class NoClashOneofADT extends Message$1<NoClashOneofADT> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.NoClashOneofADT";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "m", kind: "message", T: NoClashOneofADT_M },
@@ -1533,7 +1533,7 @@ export class NoClashOneofADT_M extends Message$1<NoClashOneofADT_M> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.NoClashOneofADT.M";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "case", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -1568,7 +1568,7 @@ export class NoClashEnumWrap extends Message$1<NoClashEnumWrap> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.NoClashEnumWrap";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -63,7 +63,7 @@ export class Proto2PackedMessage extends Message<Proto2PackedMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2PackedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 101, name: "packed_double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true, packed: true },
@@ -112,7 +112,7 @@ export class Proto2UnpackedMessage extends Message<Proto2UnpackedMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2UnpackedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 201, name: "unpacked_double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
@@ -161,7 +161,7 @@ export class Proto2UnspecifiedPackedMessage extends Message<Proto2UnspecifiedPac
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2UnspecifiedPackedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
@@ -215,7 +215,7 @@ export class Proto2OptionalMessage extends Message<Proto2OptionalMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2OptionalMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -270,7 +270,7 @@ export class Proto2RequiredMessage extends Message<Proto2RequiredMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2RequiredMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -325,7 +325,7 @@ export class Proto2RequiredDefaultsMessage extends Message<Proto2RequiredDefault
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2RequiredDefaultsMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, default: "hello \" */ " },
@@ -400,7 +400,7 @@ export class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2DefaultsMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "hello \" */ " },
@@ -444,7 +444,7 @@ export class Proto2ChildMessage extends Message<Proto2ChildMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "spec.Proto2ChildMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -69,7 +69,7 @@ export class Proto3PackedMessage extends Message<Proto3PackedMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Proto3PackedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 101, name: "packed_double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
@@ -118,7 +118,7 @@ export class Proto3UnpackedMessage extends Message<Proto3UnpackedMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Proto3UnpackedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 201, name: "unpacked_double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true, packed: false },
@@ -167,7 +167,7 @@ export class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Proto3UnlabelledMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
@@ -221,7 +221,7 @@ export class Proto3OptionalMessage extends Message<Proto3OptionalMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Proto3OptionalMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
@@ -88,7 +88,7 @@ export class ExampleRequest extends Message<ExampleRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ExampleRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "question", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -151,7 +151,7 @@ export class ExampleResponse extends Message<ExampleResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.ExampleResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "answer", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
@@ -222,7 +222,7 @@ export class WrappersMessage extends Message<WrappersMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.WrappersMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "double_value_field", kind: "message", T: DoubleValue },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/any_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/any_pb.ts
@@ -268,7 +268,7 @@ export class Any extends Message<Any> {
     return name;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Any";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "type_url", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/api_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/api_pb.ts
@@ -127,7 +127,7 @@ export class Api extends Message<Api> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Api";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -216,7 +216,7 @@ export class Method extends Message<Method> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Method";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -348,7 +348,7 @@ export class Mixin extends Message<Mixin> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Mixin";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
@@ -86,7 +86,7 @@ export class Version extends Message<Version> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.Version";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "major", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -166,7 +166,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.CodeGeneratorRequest";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "file_to_generate", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
@@ -230,7 +230,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.CodeGeneratorResponse";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -364,7 +364,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.CodeGeneratorResponse.File";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
@@ -60,7 +60,7 @@ export class FileDescriptorSet extends Message<FileDescriptorSet> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FileDescriptorSet";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "file", kind: "message", T: FileDescriptorProto, repeated: true },
@@ -175,7 +175,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FileDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -273,7 +273,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.DescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -333,7 +333,7 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.DescriptorProto.ExtensionRange";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "start", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -385,7 +385,7 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.DescriptorProto.ReservedRange";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "start", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -425,7 +425,7 @@ export class ExtensionRangeOptions extends Message<ExtensionRangeOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.ExtensionRangeOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 999, name: "uninterpreted_option", kind: "message", T: UninterpretedOption, repeated: true },
@@ -561,7 +561,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FieldDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -781,7 +781,7 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.OneofDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -848,7 +848,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -905,7 +905,7 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumDescriptorProto.EnumReservedRange";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "start", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -955,7 +955,7 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumValueDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1006,7 +1006,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.ServiceDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1079,7 +1079,7 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.MethodDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1302,7 +1302,7 @@ export class FileOptions extends Message<FileOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FileOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "java_package", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1467,7 +1467,7 @@ export class MessageOptions extends Message<MessageOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.MessageOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "message_set_wire_format", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -1614,7 +1614,7 @@ export class FieldOptions extends Message<FieldOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FieldOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "ctype", kind: "enum", T: proto2.getEnumType(FieldOptions_CType), opt: true, default: FieldOptions_CType.STRING },
@@ -1720,7 +1720,7 @@ export class OneofOptions extends Message<OneofOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.OneofOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 999, name: "uninterpreted_option", kind: "message", T: UninterpretedOption, repeated: true },
@@ -1777,7 +1777,7 @@ export class EnumOptions extends Message<EnumOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "allow_alias", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
@@ -1828,7 +1828,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumValueOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "deprecated", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -1878,7 +1878,7 @@ export class ServiceOptions extends Message<ServiceOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.ServiceOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 33, name: "deprecated", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -1933,7 +1933,7 @@ export class MethodOptions extends Message<MethodOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.MethodOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 33, name: "deprecated", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -2046,7 +2046,7 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.UninterpretedOption";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "name", kind: "message", T: UninterpretedOption_NamePart, repeated: true },
@@ -2100,7 +2100,7 @@ export class UninterpretedOption_NamePart extends Message<UninterpretedOption_Na
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.UninterpretedOption.NamePart";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name_part", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2185,7 +2185,7 @@ export class SourceCodeInfo extends Message<SourceCodeInfo> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.SourceCodeInfo";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "location", kind: "message", T: SourceCodeInfo_Location, repeated: true },
@@ -2320,7 +2320,7 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.SourceCodeInfo.Location";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },
@@ -2368,7 +2368,7 @@ export class GeneratedCodeInfo extends Message<GeneratedCodeInfo> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.GeneratedCodeInfo";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "annotation", kind: "message", T: GeneratedCodeInfo_Annotation, repeated: true },
@@ -2432,7 +2432,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.GeneratedCodeInfo.Annotation";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/duration_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/duration_pb.ts
@@ -167,7 +167,7 @@ export class Duration extends Message<Duration> {
     return text + "s";
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Duration";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "seconds", kind: "scalar", T: 3 /* ScalarType.INT64 */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/empty_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/empty_pb.ts
@@ -53,7 +53,7 @@ export class Empty extends Message<Empty> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Empty";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
@@ -313,7 +313,7 @@ export class FieldMask extends Message<FieldMask> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.FieldMask";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "paths", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/source_context_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/source_context_pb.ts
@@ -55,7 +55,7 @@ export class SourceContext extends Message<SourceContext> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.SourceContext";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "file_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/struct_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/struct_pb.ts
@@ -99,7 +99,7 @@ export class Struct extends Message<Struct> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Struct";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "fields", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Value} },
@@ -234,7 +234,7 @@ export class Value extends Message<Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "null_value", kind: "enum", T: proto3.getEnumType(NullValue), oneof: "kind" },
@@ -296,7 +296,7 @@ export class ListValue extends Message<ListValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.ListValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "values", kind: "message", T: Value, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
@@ -779,7 +779,7 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -987,7 +987,7 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1032,7 +1032,7 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.Data";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 202, name: "group_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1067,7 +1067,7 @@ export class TestAllTypesProto2_MessageSetCorrect extends Message<TestAllTypesPr
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1103,7 +1103,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 25, name: "str", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1140,7 +1140,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 9, name: "i", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1177,7 +1177,7 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.ForeignMessageProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1239,7 +1239,7 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.UnknownToTestAllTypes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1001, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1281,7 +1281,7 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1313,7 +1313,7 @@ export class NullHypothesisProto2 extends Message<NullHypothesisProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.NullHypothesisProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1344,7 +1344,7 @@ export class EnumOnlyProto2 extends Message<EnumOnlyProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.EnumOnlyProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1400,7 +1400,7 @@ export class OneStringProto2 extends Message<OneStringProto2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_test_messages.proto2.OneStringProto2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
@@ -870,7 +870,7 @@ export class TestAllTypesProto3 extends Message<TestAllTypesProto3> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.TestAllTypesProto3";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1140,7 +1140,7 @@ export class TestAllTypesProto3_NestedMessage extends Message<TestAllTypesProto3
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1178,7 +1178,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1210,7 +1210,7 @@ export class NullHypothesisProto3 extends Message<NullHypothesisProto3> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.NullHypothesisProto3";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1241,7 +1241,7 @@ export class EnumOnlyProto3 extends Message<EnumOnlyProto3> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_test_messages.proto3.EnumOnlyProto3";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/timestamp_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/timestamp_pb.ts
@@ -206,7 +206,7 @@ export class Timestamp extends Message<Timestamp> {
     return new Date(Number(this.seconds) * 1000 + Math.ceil(this.nanos / 1000000));
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Timestamp";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "seconds", kind: "scalar", T: 3 /* ScalarType.INT64 */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
@@ -116,7 +116,7 @@ export class Type extends Message<Type> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Type";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -227,7 +227,7 @@ export class Field extends Message<Field> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Field";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "kind", kind: "enum", T: proto3.getEnumType(Field_Kind) },
@@ -509,7 +509,7 @@ export class Enum extends Message<Enum> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Enum";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -568,7 +568,7 @@ export class EnumValue extends Message<EnumValue> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.EnumValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -625,7 +625,7 @@ export class Option extends Message<Option> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Option";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_arena_pb.ts
@@ -49,7 +49,7 @@ export class NestedMessage extends Message<NestedMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "proto2_arena_unittest.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "d", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -86,7 +86,7 @@ export class ArenaMessage extends Message<ArenaMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "proto2_arena_unittest.ArenaMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "repeated_nested_message", kind: "message", T: NestedMessage, repeated: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -111,7 +111,7 @@ export class TestMessageWithCustomOptions extends Message<TestMessageWithCustomO
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageWithCustomOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "field1", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -168,7 +168,7 @@ export class CustomOptionFooRequest extends Message<CustomOptionFooRequest> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionFooRequest";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -199,7 +199,7 @@ export class CustomOptionFooResponse extends Message<CustomOptionFooResponse> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionFooResponse";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -230,7 +230,7 @@ export class CustomOptionFooClientMessage extends Message<CustomOptionFooClientM
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionFooClientMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -261,7 +261,7 @@ export class CustomOptionFooServerMessage extends Message<CustomOptionFooServerM
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionFooServerMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -292,7 +292,7 @@ export class DummyMessageContainingEnum extends Message<DummyMessageContainingEn
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.DummyMessageContainingEnum";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -343,7 +343,7 @@ export class DummyMessageInvalidAsOptionType extends Message<DummyMessageInvalid
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.DummyMessageInvalidAsOptionType";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -374,7 +374,7 @@ export class CustomOptionMinIntegerValues extends Message<CustomOptionMinInteger
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionMinIntegerValues";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -405,7 +405,7 @@ export class CustomOptionMaxIntegerValues extends Message<CustomOptionMaxInteger
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionMaxIntegerValues";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -436,7 +436,7 @@ export class CustomOptionOtherValues extends Message<CustomOptionOtherValues> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.CustomOptionOtherValues";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -467,7 +467,7 @@ export class SettingRealsFromPositiveInts extends Message<SettingRealsFromPositi
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.SettingRealsFromPositiveInts";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -498,7 +498,7 @@ export class SettingRealsFromNegativeInts extends Message<SettingRealsFromNegati
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.SettingRealsFromNegativeInts";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -549,7 +549,7 @@ export class ComplexOptionType1 extends Message<ComplexOptionType1> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOptionType1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foo", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -604,7 +604,7 @@ export class ComplexOptionType2 extends Message<ComplexOptionType2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOptionType2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "bar", kind: "message", T: ComplexOptionType1, opt: true },
@@ -644,7 +644,7 @@ export class ComplexOptionType2_ComplexOptionType4 extends Message<ComplexOption
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOptionType2.ComplexOptionType4";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "waldo", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -686,7 +686,7 @@ export class ComplexOptionType3 extends Message<ComplexOptionType3> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOptionType3";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "moo", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -724,7 +724,7 @@ export class ComplexOptionType3_ComplexOptionType5 extends Message<ComplexOption
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOptionType3.ComplexOptionType5";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 3, name: "plugh", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -761,7 +761,7 @@ export class ComplexOpt6 extends Message<ComplexOpt6> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ComplexOpt6";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 7593951, name: "xyzzy", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -795,7 +795,7 @@ export class VariousComplexOptions extends Message<VariousComplexOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.VariousComplexOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -826,7 +826,7 @@ export class AggregateMessageSet extends Message<AggregateMessageSet> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.AggregateMessageSet";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -862,7 +862,7 @@ export class AggregateMessageSetElement extends Message<AggregateMessageSetEleme
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.AggregateMessageSetElement";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "s", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -934,7 +934,7 @@ export class Aggregate extends Message<Aggregate> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.Aggregate";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "i", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -976,7 +976,7 @@ export class AggregateMessage extends Message<AggregateMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.AggregateMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "fieldname", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1010,7 +1010,7 @@ export class NestedOptionType extends Message<NestedOptionType> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NestedOptionType";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1060,7 +1060,7 @@ export class NestedOptionType_NestedMessage extends Message<NestedOptionType_Nes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NestedOptionType.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "nested_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1100,7 +1100,7 @@ export class OldOptionType extends Message<OldOptionType> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.OldOptionType";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "value", kind: "enum", T: proto2.getEnumType(OldOptionType_TestEnum) },
@@ -1153,7 +1153,7 @@ export class NewOptionType extends Message<NewOptionType> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NewOptionType";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "value", kind: "enum", T: proto2.getEnumType(NewOptionType_TestEnum) },
@@ -1207,7 +1207,7 @@ export class TestMessageWithRequiredEnumOption extends Message<TestMessageWithRe
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageWithRequiredEnumOption";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_drop_unknown_fields_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_drop_unknown_fields_pb.ts
@@ -54,7 +54,7 @@ export class Foo extends Message<Foo> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "unittest_drop_unknown_fields.Foo";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "int32_value", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -128,7 +128,7 @@ export class FooWithExtraFields extends Message<FooWithExtraFields> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "unittest_drop_unknown_fields.FooWithExtraFields";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "int32_value", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
@@ -64,7 +64,7 @@ export class TestEmbedOptimizedForSize extends Message<TestEmbedOptimizedForSize
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEmbedOptimizedForSize";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_message", kind: "message", T: TestOptimizedForSize, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
@@ -5052,7 +5052,7 @@ export class TestEnormousDescriptor extends Message<TestEnormousDescriptor> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEnormousDescriptor";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong" },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
@@ -79,7 +79,7 @@ export class ImportMessageLite extends Message<ImportMessageLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest_import.ImportMessageLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "d", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
@@ -114,7 +114,7 @@ export class ImportMessage extends Message<ImportMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest_import.ImportMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "d", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
@@ -51,7 +51,7 @@ export class PublicImportMessageLite extends Message<PublicImportMessageLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest_import.PublicImportMessageLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "e", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
@@ -51,7 +51,7 @@ export class PublicImportMessage extends Message<PublicImportMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest_import.PublicImportMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "e", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_custom_option_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_custom_option_pb.ts
@@ -59,7 +59,7 @@ export class LazyMessage extends Message<LazyMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.lazy_imports.LazyMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lazy_dependencies_pb.ts
@@ -60,7 +60,7 @@ export class ImportedMessage extends Message<ImportedMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.lazy_imports.ImportedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "lazy_message", kind: "message", T: LazyMessage, opt: true },
@@ -92,7 +92,7 @@ export class MessageCustomOption extends Message<MessageCustomOption> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.lazy_imports.MessageCustomOption";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -123,7 +123,7 @@ export class MessageCustomOption2 extends Message<MessageCustomOption2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.lazy_imports.MessageCustomOption2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
@@ -61,7 +61,7 @@ export class TestLiteImportsNonlite extends Message<TestLiteImportsNonlite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestLiteImportsNonlite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "message", kind: "message", T: TestAllTypes, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
@@ -530,7 +530,7 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypesLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -676,7 +676,7 @@ export class TestAllTypesLite_NestedMessage extends Message<TestAllTypesLite_Nes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypesLite.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -714,7 +714,7 @@ export class TestAllTypesLite_NestedMessage2 extends Message<TestAllTypesLite_Ne
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypesLite.NestedMessage2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "dd", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -751,7 +751,7 @@ export class TestAllTypesLite_OptionalGroup extends Message<TestAllTypesLite_Opt
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypesLite.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 17, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -788,7 +788,7 @@ export class TestAllTypesLite_RepeatedGroup extends Message<TestAllTypesLite_Rep
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypesLite.RepeatedGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 47, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -825,7 +825,7 @@ export class ForeignMessageLite extends Message<ForeignMessageLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ForeignMessageLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -927,7 +927,7 @@ export class TestPackedTypesLite extends Message<TestPackedTypesLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPackedTypesLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 90, name: "packed_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },
@@ -972,7 +972,7 @@ export class TestAllExtensionsLite extends Message<TestAllExtensionsLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllExtensionsLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1008,7 +1008,7 @@ export class OptionalGroup_extension_lite extends Message<OptionalGroup_extensio
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.OptionalGroup_extension_lite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 17, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1045,7 +1045,7 @@ export class RepeatedGroup_extension_lite extends Message<RepeatedGroup_extensio
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.RepeatedGroup_extension_lite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 47, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1077,7 +1077,7 @@ export class TestPackedExtensionsLite extends Message<TestPackedExtensionsLite> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPackedExtensionsLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1108,7 +1108,7 @@ export class TestNestedExtensionLite extends Message<TestNestedExtensionLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedExtensionLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1166,7 +1166,7 @@ export class TestDeprecatedLite extends Message<TestDeprecatedLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDeprecatedLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "deprecated_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1228,7 +1228,7 @@ export class TestParsingMergeLite extends Message<TestParsingMergeLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMergeLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "required_all_types", kind: "message", T: TestAllTypesLite },
@@ -1299,7 +1299,7 @@ export class TestParsingMergeLite_RepeatedFieldsGenerator extends Message<TestPa
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMergeLite.RepeatedFieldsGenerator";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "field1", kind: "message", T: TestAllTypesLite, repeated: true },
@@ -1342,7 +1342,7 @@ export class TestParsingMergeLite_RepeatedFieldsGenerator_Group1 extends Message
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMergeLite.RepeatedFieldsGenerator.Group1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 11, name: "field1", kind: "message", T: TestAllTypesLite, opt: true },
@@ -1379,7 +1379,7 @@ export class TestParsingMergeLite_RepeatedFieldsGenerator_Group2 extends Message
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMergeLite.RepeatedFieldsGenerator.Group2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 21, name: "field1", kind: "message", T: TestAllTypesLite, opt: true },
@@ -1416,7 +1416,7 @@ export class TestParsingMergeLite_OptionalGroup extends Message<TestParsingMerge
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMergeLite.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 11, name: "optional_group_all_types", kind: "message", T: TestAllTypesLite, opt: true },
@@ -1453,7 +1453,7 @@ export class TestParsingMergeLite_RepeatedGroup extends Message<TestParsingMerge
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMergeLite.RepeatedGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 21, name: "repeated_group_all_types", kind: "message", T: TestAllTypesLite, opt: true },
@@ -1493,7 +1493,7 @@ export class TestMergeExceptionLite extends Message<TestMergeExceptionLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMergeExceptionLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "all_extensions", kind: "message", T: TestAllExtensionsLite, opt: true },
@@ -1527,7 +1527,7 @@ export class TestEmptyMessageLite extends Message<TestEmptyMessageLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEmptyMessageLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1561,7 +1561,7 @@ export class TestEmptyMessageWithExtensionsLite extends Message<TestEmptyMessage
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEmptyMessageWithExtensionsLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1602,7 +1602,7 @@ export class V1MessageLite extends Message<V1MessageLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.V1MessageLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "int_field", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1645,7 +1645,7 @@ export class V2MessageLite extends Message<V2MessageLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.V2MessageLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "int_field", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1757,7 +1757,7 @@ export class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbersLite> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestHugeFieldNumbersLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 536870000, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1807,7 +1807,7 @@ export class TestHugeFieldNumbersLite_OptionalGroup extends Message<TestHugeFiel
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestHugeFieldNumbersLite.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 536870009, name: "group_a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1898,7 +1898,7 @@ export class TestOneofParsingLite extends Message<TestOneofParsingLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneofParsingLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "oneof_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "oneof_field" },
@@ -1938,7 +1938,7 @@ export class TestMessageSetLite extends Message<TestMessageSetLite> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageSetLite";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1978,7 +1978,7 @@ export class PackedInt32 extends Message<PackedInt32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.PackedInt32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2048, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },
@@ -2015,7 +2015,7 @@ export class NonPackedInt32 extends Message<NonPackedInt32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NonPackedInt32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2048, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -2052,7 +2052,7 @@ export class PackedFixed32 extends Message<PackedFixed32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.PackedFixed32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2048, name: "repeated_fixed32", kind: "scalar", T: 7 /* ScalarType.FIXED32 */, repeated: true, packed: true },
@@ -2089,7 +2089,7 @@ export class NonPackedFixed32 extends Message<NonPackedFixed32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NonPackedFixed32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2048, name: "repeated_fixed32", kind: "scalar", T: 7 /* ScalarType.FIXED32 */, repeated: true },
@@ -2123,7 +2123,7 @@ export class DupEnum extends Message<DupEnum> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.DupEnum";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -2202,7 +2202,7 @@ export class RecursiveMessage extends Message<RecursiveMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.RecursiveMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "recurse", kind: "message", T: RecursiveMessage, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
@@ -57,7 +57,7 @@ export class TestMessageSetContainer extends Message<TestMessageSetContainer> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageSetContainer";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "message_set", kind: "message", T: TestMessageSet, opt: true },
@@ -99,7 +99,7 @@ export class NestedTestMessageSetContainer extends Message<NestedTestMessageSetC
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NestedTestMessageSetContainer";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "container", kind: "message", T: TestMessageSetContainer, opt: true },
@@ -147,7 +147,7 @@ export class TestMessageSetExtension1 extends Message<TestMessageSetExtension1> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageSetExtension1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 15, name: "i", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -186,7 +186,7 @@ export class TestMessageSetExtension2 extends Message<TestMessageSetExtension2> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageSetExtension2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 25, name: "str", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -228,7 +228,7 @@ export class NestedTestInt extends Message<NestedTestInt> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NestedTestInt";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 7 /* ScalarType.FIXED32 */, opt: true },
@@ -266,7 +266,7 @@ export class TestMessageSetExtension3 extends Message<TestMessageSetExtension3> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageSetExtension3";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 35, name: "msg", kind: "message", T: NestedTestInt, opt: true },
@@ -305,7 +305,7 @@ export class RawMessageSet extends Message<RawMessageSet> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.RawMessageSet";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "item", kind: "message", T: RawMessageSet_Item, repeated: true },
@@ -347,7 +347,7 @@ export class RawMessageSet_Item extends Message<RawMessageSet_Item> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.RawMessageSet.Item";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "type_id", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
@@ -52,7 +52,7 @@ export class TestMessageSet extends Message<TestMessageSet> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "proto2_wireformat_unittest.TestMessageSet";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -88,7 +88,7 @@ export class TestMessageSetWireFormatContainer extends Message<TestMessageSetWir
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "proto2_wireformat_unittest.TestMessageSetWireFormatContainer";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "message_set", kind: "message", T: TestMessageSet, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_field_presence_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_field_presence_pb.ts
@@ -345,7 +345,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto2_nofieldpresence_unittest.TestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -457,7 +457,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto2_nofieldpresence_unittest.TestAllTypes.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -494,7 +494,7 @@ export class TestProto2Required extends Message<TestProto2Required> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto2_nofieldpresence_unittest.TestProto2Required";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "proto2", kind: "message", T: TestRequired },
@@ -534,7 +534,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto2_nofieldpresence_unittest.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
@@ -65,7 +65,7 @@ export class TestMessage extends Message<TestMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.no_generic_services_test.TestMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
@@ -78,7 +78,7 @@ export class TestOptimizedForSize extends Message<TestOptimizedForSize> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOptimizedForSize";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "i", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -118,7 +118,7 @@ export class TestRequiredOptimizedForSize extends Message<TestRequiredOptimizedF
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRequiredOptimizedForSize";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "x", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -155,7 +155,7 @@ export class TestOptionalOptimizedForSize extends Message<TestOptionalOptimizedF
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOptionalOptimizedForSize";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "o", kind: "message", T: TestRequiredOptimizedForSize, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -1192,7 +1192,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1342,7 +1342,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypes.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1379,7 +1379,7 @@ export class TestAllTypes_OptionalGroup extends Message<TestAllTypes_OptionalGro
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypes.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 17, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1416,7 +1416,7 @@ export class TestAllTypes_RepeatedGroup extends Message<TestAllTypes_RepeatedGro
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllTypes.RepeatedGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 47, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1475,7 +1475,7 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.NestedTestAllTypes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "child", kind: "message", T: NestedTestAllTypes, opt: true },
@@ -1529,7 +1529,7 @@ export class TestDeprecatedFields extends Message<TestDeprecatedFields> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDeprecatedFields";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "deprecated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1563,7 +1563,7 @@ export class TestDeprecatedMessage extends Message<TestDeprecatedMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDeprecatedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1607,7 +1607,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ForeignMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1640,7 +1640,7 @@ export class TestReservedFields extends Message<TestReservedFields> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestReservedFields";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1671,7 +1671,7 @@ export class TestAllExtensions extends Message<TestAllExtensions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestAllExtensions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1707,7 +1707,7 @@ export class OptionalGroup_extension extends Message<OptionalGroup_extension> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.OptionalGroup_extension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 17, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1744,7 +1744,7 @@ export class RepeatedGroup_extension extends Message<RepeatedGroup_extension> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.RepeatedGroup_extension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 47, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1786,7 +1786,7 @@ export class TestGroup extends Message<TestGroup> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 16, name: "optionalgroup", kind: "message", T: TestGroup_OptionalGroup, opt: true },
@@ -1824,7 +1824,7 @@ export class TestGroup_OptionalGroup extends Message<TestGroup_OptionalGroup> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestGroup.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 17, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1856,7 +1856,7 @@ export class TestGroupExtension extends Message<TestGroupExtension> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestGroupExtension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1887,7 +1887,7 @@ export class TestNestedExtension extends Message<TestNestedExtension> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedExtension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -1923,7 +1923,7 @@ export class TestNestedExtension_OptionalGroup_extension extends Message<TestNes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedExtension.OptionalGroup_extension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 17, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -1970,7 +1970,7 @@ export class TestChildExtension extends Message<TestChildExtension> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestChildExtension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -2022,7 +2022,7 @@ export class TestChildExtensionData extends Message<TestChildExtensionData> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestChildExtensionData";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -2061,7 +2061,7 @@ export class TestChildExtensionData_NestedTestAllExtensionsData extends Message<
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 409707008, name: "dynamic", kind: "message", T: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions, opt: true },
@@ -2103,7 +2103,7 @@ export class TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExt
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData.NestedDynamicExtensions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -2146,7 +2146,7 @@ export class TestNestedChildExtension extends Message<TestNestedChildExtension> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedChildExtension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -2192,7 +2192,7 @@ export class TestNestedChildExtensionData extends Message<TestNestedChildExtensi
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedChildExtensionData";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -2406,7 +2406,7 @@ export class TestRequired extends Message<TestRequired> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRequired";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -2486,7 +2486,7 @@ export class TestRequiredForeign extends Message<TestRequiredForeign> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRequiredForeign";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_message", kind: "message", T: TestRequired, opt: true },
@@ -2535,7 +2535,7 @@ export class TestRequiredMessage extends Message<TestRequiredMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRequiredMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_message", kind: "message", T: TestRequired, opt: true },
@@ -2584,7 +2584,7 @@ export class TestNestedRequiredForeign extends Message<TestNestedRequiredForeign
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedRequiredForeign";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "child", kind: "message", T: TestNestedRequiredForeign, opt: true },
@@ -2625,7 +2625,7 @@ export class TestForeignNested extends Message<TestForeignNested> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestForeignNested";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foreign_nested", kind: "message", T: TestAllTypes_NestedMessage, opt: true },
@@ -2659,7 +2659,7 @@ export class TestEmptyMessage extends Message<TestEmptyMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEmptyMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -2693,7 +2693,7 @@ export class TestEmptyMessageWithExtensions extends Message<TestEmptyMessageWith
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEmptyMessageWithExtensions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -2726,7 +2726,7 @@ export class TestPickleNestedMessage extends Message<TestPickleNestedMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPickleNestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -2762,7 +2762,7 @@ export class TestPickleNestedMessage_NestedMessage extends Message<TestPickleNes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPickleNestedMessage.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -2799,7 +2799,7 @@ export class TestPickleNestedMessage_NestedMessage_NestedNestedMessage extends M
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPickleNestedMessage.NestedMessage.NestedNestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "cc", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -2831,7 +2831,7 @@ export class TestMultipleExtensionRanges extends Message<TestMultipleExtensionRa
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMultipleExtensionRanges";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -2877,7 +2877,7 @@ export class TestReallyLargeTagNumber extends Message<TestReallyLargeTagNumber> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestReallyLargeTagNumber";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -2920,7 +2920,7 @@ export class TestRecursiveMessage extends Message<TestRecursiveMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRecursiveMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "message", T: TestRecursiveMessage, opt: true },
@@ -2965,7 +2965,7 @@ export class TestMutualRecursionA extends Message<TestMutualRecursionA> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMutualRecursionA";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "message", T: TestMutualRecursionB, opt: true },
@@ -3003,7 +3003,7 @@ export class TestMutualRecursionA_SubMessage extends Message<TestMutualRecursion
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMutualRecursionA.SubMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "b", kind: "message", T: TestMutualRecursionB, opt: true },
@@ -3047,7 +3047,7 @@ export class TestMutualRecursionA_SubGroup extends Message<TestMutualRecursionA_
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMutualRecursionA.SubGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 3, name: "sub_message", kind: "message", T: TestMutualRecursionA_SubMessage, opt: true },
@@ -3090,7 +3090,7 @@ export class TestMutualRecursionB extends Message<TestMutualRecursionB> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMutualRecursionB";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "message", T: TestMutualRecursionA, opt: true },
@@ -3128,7 +3128,7 @@ export class TestIsInitialized extends Message<TestIsInitialized> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestIsInitialized";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "sub_message", kind: "message", T: TestIsInitialized_SubMessage, opt: true },
@@ -3165,7 +3165,7 @@ export class TestIsInitialized_SubMessage extends Message<TestIsInitialized_SubM
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestIsInitialized.SubMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "subgroup", kind: "message", T: TestIsInitialized_SubMessage_SubGroup, opt: true },
@@ -3202,7 +3202,7 @@ export class TestIsInitialized_SubMessage_SubGroup extends Message<TestIsInitial
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestIsInitialized.SubMessage.SubGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "i", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -3258,7 +3258,7 @@ export class TestDupFieldNumber extends Message<TestDupFieldNumber> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDupFieldNumber";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -3297,7 +3297,7 @@ export class TestDupFieldNumber_Foo extends Message<TestDupFieldNumber_Foo> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDupFieldNumber.Foo";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -3334,7 +3334,7 @@ export class TestDupFieldNumber_Bar extends Message<TestDupFieldNumber_Bar> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDupFieldNumber.Bar";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -3373,7 +3373,7 @@ export class TestEagerMessage extends Message<TestEagerMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEagerMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "sub_message", kind: "message", T: TestAllTypes, opt: true },
@@ -3410,7 +3410,7 @@ export class TestLazyMessage extends Message<TestLazyMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestLazyMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "sub_message", kind: "message", T: TestAllTypes, opt: true },
@@ -3457,7 +3457,7 @@ export class TestEagerMaybeLazy extends Message<TestEagerMaybeLazy> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEagerMaybeLazy";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "message_foo", kind: "message", T: TestAllTypes, opt: true },
@@ -3496,7 +3496,7 @@ export class TestEagerMaybeLazy_NestedMessage extends Message<TestEagerMaybeLazy
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestEagerMaybeLazy.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "packed", kind: "message", T: TestPackedTypes, opt: true },
@@ -3535,7 +3535,7 @@ export class TestNestedMessageHasBits extends Message<TestNestedMessageHasBits> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedMessageHasBits";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_nested_message", kind: "message", T: TestNestedMessageHasBits_NestedMessage, opt: true },
@@ -3577,7 +3577,7 @@ export class TestNestedMessageHasBits_NestedMessage extends Message<TestNestedMe
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedMessageHasBits.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "nestedmessage_repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -3673,7 +3673,7 @@ export class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldNames> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestCamelCaseFieldNames";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "PrimitiveField", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -3739,7 +3739,7 @@ export class TestFieldOrderings extends Message<TestFieldOrderings> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestFieldOrderings";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 11, name: "my_string", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -3788,7 +3788,7 @@ export class TestFieldOrderings_NestedMessage extends Message<TestFieldOrderings
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestFieldOrderings.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "oo", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
@@ -3826,7 +3826,7 @@ export class TestExtensionOrderings1 extends Message<TestExtensionOrderings1> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestExtensionOrderings1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "my_string", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -3863,7 +3863,7 @@ export class TestExtensionOrderings2 extends Message<TestExtensionOrderings2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestExtensionOrderings2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "my_string", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -3900,7 +3900,7 @@ export class TestExtensionOrderings2_TestExtensionOrderings3 extends Message<Tes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestExtensionOrderings2.TestExtensionOrderings3";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "my_string", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -4085,7 +4085,7 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestExtremeDefaultValues";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "escaped_bytes", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true, default: new Uint8Array([0x00, 0x01, 0x07, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B, 0x5C, 0xFE]) },
@@ -4148,7 +4148,7 @@ export class SparseEnumMessage extends Message<SparseEnumMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.SparseEnumMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "sparse_enum", kind: "enum", T: proto2.getEnumType(TestSparseEnum), opt: true },
@@ -4187,7 +4187,7 @@ export class OneString extends Message<OneString> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.OneString";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -4224,7 +4224,7 @@ export class MoreString extends Message<MoreString> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.MoreString";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
@@ -4261,7 +4261,7 @@ export class OneBytes extends Message<OneBytes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.OneBytes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
@@ -4298,7 +4298,7 @@ export class MoreBytes extends Message<MoreBytes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.MoreBytes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 12 /* ScalarType.BYTES */, repeated: true },
@@ -4490,7 +4490,7 @@ export class ManyOptionalString extends Message<ManyOptionalString> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.ManyOptionalString";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "str1", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -4560,7 +4560,7 @@ export class Int32Message extends Message<Int32Message> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.Int32Message";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -4597,7 +4597,7 @@ export class Uint32Message extends Message<Uint32Message> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.Uint32Message";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
@@ -4634,7 +4634,7 @@ export class Int64Message extends Message<Int64Message> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.Int64Message";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
@@ -4671,7 +4671,7 @@ export class Uint64Message extends Message<Uint64Message> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.Uint64Message";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
@@ -4708,7 +4708,7 @@ export class BoolMessage extends Message<BoolMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.BoolMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "data", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
@@ -4771,7 +4771,7 @@ export class TestOneof extends Message<TestOneof> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneof";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foo_int", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "foo" },
@@ -4816,7 +4816,7 @@ export class TestOneof_FooGroup extends Message<TestOneof_FooGroup> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneof.FooGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 5, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -4869,7 +4869,7 @@ export class TestOneofBackwardsCompatible extends Message<TestOneofBackwardsComp
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneofBackwardsCompatible";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foo_int", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -4914,7 +4914,7 @@ export class TestOneofBackwardsCompatible_FooGroup extends Message<TestOneofBack
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneofBackwardsCompatible.FooGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 5, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -5081,7 +5081,7 @@ export class TestOneof2 extends Message<TestOneof2> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneof2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foo_int", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "foo" },
@@ -5169,7 +5169,7 @@ export class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneof2.FooGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 9, name: "a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -5212,7 +5212,7 @@ export class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestOneof2.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "moo_int", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
@@ -5268,7 +5268,7 @@ export class TestRequiredOneof extends Message<TestRequiredOneof> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRequiredOneof";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foo_int", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "foo" },
@@ -5307,7 +5307,7 @@ export class TestRequiredOneof_NestedMessage extends Message<TestRequiredOneof_N
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRequiredOneof.NestedMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "required_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */ },
@@ -5409,7 +5409,7 @@ export class TestPackedTypes extends Message<TestPackedTypes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPackedTypes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 90, name: "packed_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },
@@ -5527,7 +5527,7 @@ export class TestUnpackedTypes extends Message<TestUnpackedTypes> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestUnpackedTypes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 90, name: "unpacked_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -5572,7 +5572,7 @@ export class TestPackedExtensions extends Message<TestPackedExtensions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestPackedExtensions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -5603,7 +5603,7 @@ export class TestUnpackedExtensions extends Message<TestUnpackedExtensions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestUnpackedExtensions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -5673,7 +5673,7 @@ export class TestDynamicExtensions extends Message<TestDynamicExtensions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDynamicExtensions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2000, name: "scalar_extension", kind: "scalar", T: 7 /* ScalarType.FIXED32 */, opt: true },
@@ -5742,7 +5742,7 @@ export class TestDynamicExtensions_DynamicMessageType extends Message<TestDynami
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestDynamicExtensions.DynamicMessageType";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2100, name: "dynamic_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -5814,7 +5814,7 @@ export class TestRepeatedScalarDifferentTagSizes extends Message<TestRepeatedSca
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestRepeatedScalarDifferentTagSizes";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 12, name: "repeated_fixed32", kind: "scalar", T: 7 /* ScalarType.FIXED32 */, repeated: true },
@@ -5879,7 +5879,7 @@ export class TestParsingMerge extends Message<TestParsingMerge> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMerge";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "required_all_types", kind: "message", T: TestAllTypes },
@@ -5956,7 +5956,7 @@ export class TestParsingMerge_RepeatedFieldsGenerator extends Message<TestParsin
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMerge.RepeatedFieldsGenerator";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "field1", kind: "message", T: TestAllTypes, repeated: true },
@@ -5999,7 +5999,7 @@ export class TestParsingMerge_RepeatedFieldsGenerator_Group1 extends Message<Tes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMerge.RepeatedFieldsGenerator.Group1";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 11, name: "field1", kind: "message", T: TestAllTypes, opt: true },
@@ -6036,7 +6036,7 @@ export class TestParsingMerge_RepeatedFieldsGenerator_Group2 extends Message<Tes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMerge.RepeatedFieldsGenerator.Group2";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 21, name: "field1", kind: "message", T: TestAllTypes, opt: true },
@@ -6073,7 +6073,7 @@ export class TestParsingMerge_OptionalGroup extends Message<TestParsingMerge_Opt
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMerge.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 11, name: "optional_group_all_types", kind: "message", T: TestAllTypes, opt: true },
@@ -6110,7 +6110,7 @@ export class TestParsingMerge_RepeatedGroup extends Message<TestParsingMerge_Rep
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestParsingMerge.RepeatedGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 21, name: "repeated_group_all_types", kind: "message", T: TestAllTypes, opt: true },
@@ -6150,7 +6150,7 @@ export class TestMergeException extends Message<TestMergeException> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMergeException";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "all_extensions", kind: "message", T: TestAllExtensions, opt: true },
@@ -6189,7 +6189,7 @@ export class TestCommentInjectionMessage extends Message<TestCommentInjectionMes
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestCommentInjectionMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "a", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "*/ <- Neither should this." },
@@ -6254,7 +6254,7 @@ export class TestMessageSize extends Message<TestMessageSize> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestMessageSize";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "m1", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
@@ -6293,7 +6293,7 @@ export class FooRequest extends Message<FooRequest> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.FooRequest";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -6324,7 +6324,7 @@ export class FooResponse extends Message<FooResponse> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.FooResponse";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -6355,7 +6355,7 @@ export class FooClientMessage extends Message<FooClientMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.FooClientMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -6386,7 +6386,7 @@ export class FooServerMessage extends Message<FooServerMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.FooServerMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -6417,7 +6417,7 @@ export class BarRequest extends Message<BarRequest> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.BarRequest";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -6448,7 +6448,7 @@ export class BarResponse extends Message<BarResponse> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.BarResponse";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
   ]);
@@ -6514,7 +6514,7 @@ export class TestJsonName extends Message<TestJsonName> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestJsonName";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "field_name1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -6631,7 +6631,7 @@ export class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestHugeFieldNumbers";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 536870000, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -6681,7 +6681,7 @@ export class TestHugeFieldNumbers_OptionalGroup extends Message<TestHugeFieldNum
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestHugeFieldNumbers.OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 536870009, name: "group_a", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -6758,7 +6758,7 @@ export class TestExtensionInsideTable extends Message<TestExtensionInsideTable> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestExtensionInsideTable";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "field1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -6805,7 +6805,7 @@ export class TestNestedGroupExtensionOuter extends Message<TestNestedGroupExtens
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedGroupExtensionOuter";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "layer1optionalgroup", kind: "message", T: TestNestedGroupExtensionOuter_Layer1OptionalGroup, opt: true },
@@ -6847,7 +6847,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup extends Message<T
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "layer2repeatedgroup", kind: "message", T: TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGroup, repeated: true },
@@ -6885,7 +6885,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGro
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup.Layer2RepeatedGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 6, name: "another_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -6922,7 +6922,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOpti
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup.Layer2AnotherOptionalRepeatedGroup";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 5, name: "but_why_tho", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -6959,7 +6959,7 @@ export class TestNestedGroupExtensionInnerExtension extends Message<TestNestedGr
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestNestedGroupExtensionInnerExtension";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "inner_name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -7011,7 +7011,7 @@ export class TestExtensionRangeSerialize extends Message<TestExtensionRangeSeria
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestExtensionRangeSerialize";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "foo_one", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -7066,7 +7066,7 @@ export class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyInt32Simple";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -7131,7 +7131,7 @@ export class TestVerifyInt32 extends Message<TestVerifyInt32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyInt32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_int32_1", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -7213,7 +7213,7 @@ export class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyMostlyInt32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 30, name: "optional_int64_30", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
@@ -7303,7 +7303,7 @@ export class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVerifyMostl
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 30, name: "optional_int64_30", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
@@ -7364,7 +7364,7 @@ export class TestVerifyUint32Simple extends Message<TestVerifyUint32Simple> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyUint32Simple";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
@@ -7429,7 +7429,7 @@ export class TestVerifyUint32 extends Message<TestVerifyUint32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyUint32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
@@ -7496,7 +7496,7 @@ export class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyOneUint32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_uint32_1", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
@@ -7568,7 +7568,7 @@ export class TestVerifyOneInt32BigFieldNumber extends Message<TestVerifyOneInt32
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyOneInt32BigFieldNumber";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 65, name: "optional_int32_65", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -7646,7 +7646,7 @@ export class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt32BigFie
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyInt32BigFieldNumber";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1000, name: "optional_int32_1000", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -7725,7 +7725,7 @@ export class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUint32BigF
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyUint32BigFieldNumber";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1000, name: "optional_uint32_1000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
@@ -7769,7 +7769,7 @@ export class TestVerifyBigFieldNumberUint32 extends Message<TestVerifyBigFieldNu
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyBigFieldNumberUint32";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "optional_nested", kind: "message", T: TestVerifyBigFieldNumberUint32_Nested, opt: true },
@@ -7851,7 +7851,7 @@ export class TestVerifyBigFieldNumberUint32_Nested extends Message<TestVerifyBig
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 5000, name: "optional_uint32_5000", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum2_pb.ts
@@ -109,7 +109,7 @@ export class MyMessage extends Message<MyMessage> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "proto2_preserve_unknown_enum_unittest.MyMessage";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "e", kind: "enum", T: proto2.getEnumType(MyEnum), opt: true },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_preserve_unknown_enum_pb.ts
@@ -141,7 +141,7 @@ export class MyMessage extends Message<MyMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_preserve_unknown_enum_unittest.MyMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "e", kind: "enum", T: proto3.getEnumType(MyEnum) },
@@ -215,7 +215,7 @@ export class MyMessagePlusExtra extends Message<MyMessagePlusExtra> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_preserve_unknown_enum_unittest.MyMessagePlusExtra";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "e", kind: "enum", T: proto3.getEnumType(MyEnumPlusExtra) },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_lite_pb.ts
@@ -351,7 +351,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.TestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -482,7 +482,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.TestAllTypes.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -584,7 +584,7 @@ export class TestPackedTypes extends Message<TestPackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.TestPackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 90, name: "packed_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -701,7 +701,7 @@ export class TestUnpackedTypes extends Message<TestUnpackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.TestUnpackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: false },
@@ -758,7 +758,7 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.NestedTestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "child", kind: "message", T: NestedTestAllTypes },
@@ -799,7 +799,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -833,7 +833,7 @@ export class TestEmptyMessage extends Message<TestEmptyMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_lite_unittest.TestEmptyMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_arena_pb.ts
@@ -438,7 +438,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -586,7 +586,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestAllTypes.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -688,7 +688,7 @@ export class TestPackedTypes extends Message<TestPackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestPackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 90, name: "packed_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -805,7 +805,7 @@ export class TestUnpackedTypes extends Message<TestUnpackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestUnpackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: false },
@@ -867,7 +867,7 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.NestedTestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "child", kind: "message", T: NestedTestAllTypes },
@@ -909,7 +909,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -943,7 +943,7 @@ export class TestEmptyMessage extends Message<TestEmptyMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestEmptyMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -976,7 +976,7 @@ export class TestPickleNestedMessage extends Message<TestPickleNestedMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestPickleNestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -1012,7 +1012,7 @@ export class TestPickleNestedMessage_NestedMessage extends Message<TestPickleNes
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestPickleNestedMessage.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -1049,7 +1049,7 @@ export class TestPickleNestedMessage_NestedMessage_NestedNestedMessage extends M
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_arena_unittest.TestPickleNestedMessage.NestedMessage.NestedNestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "cc", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_lite_pb.ts
@@ -351,7 +351,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.TestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -482,7 +482,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.TestAllTypes.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -584,7 +584,7 @@ export class TestPackedTypes extends Message<TestPackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.TestPackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 90, name: "packed_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -701,7 +701,7 @@ export class TestUnpackedTypes extends Message<TestUnpackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.TestUnpackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: false },
@@ -758,7 +758,7 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.NestedTestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "child", kind: "message", T: NestedTestAllTypes },
@@ -799,7 +799,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -833,7 +833,7 @@ export class TestEmptyMessage extends Message<TestEmptyMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_lite_unittest.TestEmptyMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
@@ -153,7 +153,7 @@ export class TestProto3Optional extends Message<TestProto3Optional> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.TestProto3Optional";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -254,7 +254,7 @@ export class TestProto3Optional_NestedMessage extends Message<TestProto3Optional
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.TestProto3Optional.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -296,7 +296,7 @@ export class TestProto3OptionalMessage extends Message<TestProto3OptionalMessage
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.TestProto3OptionalMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "nested_message", kind: "message", T: TestProto3OptionalMessage_NestedMessage },
@@ -334,7 +334,7 @@ export class TestProto3OptionalMessage_NestedMessage extends Message<TestProto3O
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.TestProto3OptionalMessage.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "s", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -366,7 +366,7 @@ export class Proto3OptionalExtensions extends Message<Proto3OptionalExtensions> 
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.Proto3OptionalExtensions";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
@@ -361,7 +361,7 @@ export class TestAllTypes extends Message<TestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "optional_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -494,7 +494,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestAllTypes.NestedMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "bb", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -596,7 +596,7 @@ export class TestPackedTypes extends Message<TestPackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestPackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 90, name: "packed_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true },
@@ -713,7 +713,7 @@ export class TestUnpackedTypes extends Message<TestUnpackedTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestUnpackedTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "repeated_int32", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: false },
@@ -770,7 +770,7 @@ export class NestedTestAllTypes extends Message<NestedTestAllTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.NestedTestAllTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "child", kind: "message", T: NestedTestAllTypes },
@@ -811,7 +811,7 @@ export class ForeignMessage extends Message<ForeignMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.ForeignMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "c", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -845,7 +845,7 @@ export class TestEmptyMessage extends Message<TestEmptyMessage> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestEmptyMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -886,7 +886,7 @@ export class TestMessageWithDummy extends Message<TestMessageWithDummy> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestMessageWithDummy";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 536870911, name: "dummy", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -932,7 +932,7 @@ export class TestOneof2 extends Message<TestOneof2> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "proto3_unittest.TestOneof2";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 6, name: "foo_enum", kind: "enum", T: proto3.getEnumType(TestOneof2_NestedEnum), oneof: "foo" },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
@@ -116,7 +116,7 @@ export class TestWellKnownTypes extends Message<TestWellKnownTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.TestWellKnownTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "any_field", kind: "message", T: Any },
@@ -260,7 +260,7 @@ export class RepeatedWellKnownTypes extends Message<RepeatedWellKnownTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.RepeatedWellKnownTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "any_field", kind: "message", T: Any, repeated: true },
@@ -422,7 +422,7 @@ export class OneofWellKnownTypes extends Message<OneofWellKnownTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.OneofWellKnownTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "any_field", kind: "message", T: Any, oneof: "oneof_field" },
@@ -565,7 +565,7 @@ export class MapWellKnownTypes extends Message<MapWellKnownTypes> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "protobuf_unittest.MapWellKnownTypes";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "any_field", kind: "map", K: 5 /* ScalarType.INT32 */, V: {kind: "message", T: Any} },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/wrappers_pb.ts
@@ -82,7 +82,7 @@ export class DoubleValue extends Message<DoubleValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.DoubleValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 1 /* ScalarType.DOUBLE */ },
@@ -151,7 +151,7 @@ export class FloatValue extends Message<FloatValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.FloatValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
@@ -220,7 +220,7 @@ export class Int64Value extends Message<Int64Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Int64Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
@@ -289,7 +289,7 @@ export class UInt64Value extends Message<UInt64Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.UInt64Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
@@ -358,7 +358,7 @@ export class Int32Value extends Message<Int32Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Int32Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -427,7 +427,7 @@ export class UInt32Value extends Message<UInt32Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.UInt32Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -496,7 +496,7 @@ export class BoolValue extends Message<BoolValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.BoolValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -565,7 +565,7 @@ export class StringValue extends Message<StringValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.StringValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -634,7 +634,7 @@ export class BytesValue extends Message<BytesValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.BytesValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 12 /* ScalarType.BYTES */ },

--- a/packages/protobuf-test/typescript/tsconfig.4_1_2.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_1_2.json
@@ -17,6 +17,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_1_2.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_1_2.json
@@ -16,6 +16,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_2_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_2_4.json
@@ -17,6 +17,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_2_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_2_4.json
@@ -16,6 +16,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_3_5.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_3_5.json
@@ -9,6 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_3_5.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_3_5.json
@@ -8,6 +8,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_4_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_4_4.json
@@ -7,6 +7,8 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_4_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_4_4.json
@@ -6,6 +6,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_5_2.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_5_2.json
@@ -10,6 +10,8 @@
     "strict": true,
     // To guard against regression and ensure we are remaining backwards
     // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_5_2.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_5_2.json
@@ -11,6 +11,8 @@
     // To guard against regression and ensure we are remaining backwards
     // compatible, set the skipLibCheck flag to false explicitly.
     "skipLibCheck": false,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_6_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_6_4.json
@@ -10,6 +10,8 @@
     "strict": true,
     // To guard against regression and ensure we are remaining backwards
     // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_6_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_6_4.json
@@ -11,6 +11,8 @@
     // To guard against regression and ensure we are remaining backwards
     // compatible, set the skipLibCheck flag to false explicitly.
     "skipLibCheck": false,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_7_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_7_4.json
@@ -12,6 +12,8 @@
     // compatible, set the skipLibCheck flag to false explicitly.
     "skipLibCheck": false,
     // To test forward-compatibility, set to NodeNext
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_7_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_7_4.json
@@ -13,6 +13,8 @@
     "skipLibCheck": false,
     // To test forward-compatibility, set to NodeNext
     "moduleResolution": "NodeNext",
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.4_8_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_8_4.json
@@ -12,6 +12,8 @@
     // compatible, set the skipLibCheck flag to false explicitly.
     "skipLibCheck": false,
     // To test forward-compatibility, set to NodeNext
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.4_8_4.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_8_4.json
@@ -13,6 +13,8 @@
     "skipLibCheck": false,
     // To test forward-compatibility, set to NodeNext
     "moduleResolution": "NodeNext",
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf-test/typescript/tsconfig.5_0_0-beta.json
+++ b/packages/protobuf-test/typescript/tsconfig.5_0_0-beta.json
@@ -12,6 +12,8 @@
     // compatible, set the skipLibCheck flag to false explicitly.
     "skipLibCheck": false,
     // To test forward-compatibility, set to NodeNext
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/protobuf-test/typescript/tsconfig.5_0_0-beta.json
+++ b/packages/protobuf-test/typescript/tsconfig.5_0_0-beta.json
@@ -13,6 +13,8 @@
     "skipLibCheck": false,
     // To test forward-compatibility, set to NodeNext
     "moduleResolution": "NodeNext",
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,
     "declarationMap": true
   }

--- a/packages/protobuf/src/google/protobuf/any_pb.ts
+++ b/packages/protobuf/src/google/protobuf/any_pb.ts
@@ -258,7 +258,7 @@ export class Any extends Message<Any> {
     return name;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Any";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "type_url", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf/src/google/protobuf/api_pb.ts
+++ b/packages/protobuf/src/google/protobuf/api_pb.ts
@@ -115,7 +115,7 @@ export class Api extends Message<Api> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Api";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -204,7 +204,7 @@ export class Method extends Message<Method> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Method";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -336,7 +336,7 @@ export class Mixin extends Message<Mixin> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Mixin";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
@@ -74,7 +74,7 @@ export class Version extends Message<Version> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.Version";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "major", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -154,7 +154,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.CodeGeneratorRequest";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "file_to_generate", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
@@ -218,7 +218,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.CodeGeneratorResponse";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -352,7 +352,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.compiler.CodeGeneratorResponse.File";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/packages/protobuf/src/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/google/protobuf/descriptor_pb.ts
@@ -48,7 +48,7 @@ export class FileDescriptorSet extends Message<FileDescriptorSet> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FileDescriptorSet";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "file", kind: "message", T: FileDescriptorProto, repeated: true },
@@ -163,7 +163,7 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FileDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -261,7 +261,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.DescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -321,7 +321,7 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.DescriptorProto.ExtensionRange";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "start", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -373,7 +373,7 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.DescriptorProto.ReservedRange";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "start", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -413,7 +413,7 @@ export class ExtensionRangeOptions extends Message<ExtensionRangeOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.ExtensionRangeOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 999, name: "uninterpreted_option", kind: "message", T: UninterpretedOption, repeated: true },
@@ -549,7 +549,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FieldDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -769,7 +769,7 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.OneofDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -836,7 +836,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -893,7 +893,7 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumDescriptorProto.EnumReservedRange";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "start", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
@@ -943,7 +943,7 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumValueDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -994,7 +994,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.ServiceDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1067,7 +1067,7 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.MethodDescriptorProto";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1290,7 +1290,7 @@ export class FileOptions extends Message<FileOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FileOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "java_package", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
@@ -1455,7 +1455,7 @@ export class MessageOptions extends Message<MessageOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.MessageOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "message_set_wire_format", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -1602,7 +1602,7 @@ export class FieldOptions extends Message<FieldOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.FieldOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "ctype", kind: "enum", T: proto2.getEnumType(FieldOptions_CType), opt: true, default: FieldOptions_CType.STRING },
@@ -1708,7 +1708,7 @@ export class OneofOptions extends Message<OneofOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.OneofOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 999, name: "uninterpreted_option", kind: "message", T: UninterpretedOption, repeated: true },
@@ -1765,7 +1765,7 @@ export class EnumOptions extends Message<EnumOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "allow_alias", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
@@ -1816,7 +1816,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.EnumValueOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "deprecated", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -1866,7 +1866,7 @@ export class ServiceOptions extends Message<ServiceOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.ServiceOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 33, name: "deprecated", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -1921,7 +1921,7 @@ export class MethodOptions extends Message<MethodOptions> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.MethodOptions";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 33, name: "deprecated", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: false },
@@ -2034,7 +2034,7 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.UninterpretedOption";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 2, name: "name", kind: "message", T: UninterpretedOption_NamePart, repeated: true },
@@ -2088,7 +2088,7 @@ export class UninterpretedOption_NamePart extends Message<UninterpretedOption_Na
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.UninterpretedOption.NamePart";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "name_part", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2173,7 +2173,7 @@ export class SourceCodeInfo extends Message<SourceCodeInfo> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.SourceCodeInfo";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "location", kind: "message", T: SourceCodeInfo_Location, repeated: true },
@@ -2308,7 +2308,7 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.SourceCodeInfo.Location";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },
@@ -2356,7 +2356,7 @@ export class GeneratedCodeInfo extends Message<GeneratedCodeInfo> {
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.GeneratedCodeInfo";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "annotation", kind: "message", T: GeneratedCodeInfo_Annotation, repeated: true },
@@ -2420,7 +2420,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
     proto2.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto2;
+  static readonly runtime: typeof proto2 = proto2;
   static readonly typeName = "google.protobuf.GeneratedCodeInfo.Annotation";
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "path", kind: "scalar", T: 5 /* ScalarType.INT32 */, repeated: true, packed: true },

--- a/packages/protobuf/src/google/protobuf/duration_pb.ts
+++ b/packages/protobuf/src/google/protobuf/duration_pb.ts
@@ -156,7 +156,7 @@ export class Duration extends Message<Duration> {
     return text + "s";
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Duration";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "seconds", kind: "scalar", T: 3 /* ScalarType.INT64 */ },

--- a/packages/protobuf/src/google/protobuf/empty_pb.ts
+++ b/packages/protobuf/src/google/protobuf/empty_pb.ts
@@ -41,7 +41,7 @@ export class Empty extends Message<Empty> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Empty";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);

--- a/packages/protobuf/src/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf/src/google/protobuf/field_mask_pb.ts
@@ -301,7 +301,7 @@ export class FieldMask extends Message<FieldMask> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.FieldMask";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "paths", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },

--- a/packages/protobuf/src/google/protobuf/source_context_pb.ts
+++ b/packages/protobuf/src/google/protobuf/source_context_pb.ts
@@ -43,7 +43,7 @@ export class SourceContext extends Message<SourceContext> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.SourceContext";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "file_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf/src/google/protobuf/struct_pb.ts
+++ b/packages/protobuf/src/google/protobuf/struct_pb.ts
@@ -87,7 +87,7 @@ export class Struct extends Message<Struct> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Struct";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "fields", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Value} },
@@ -222,7 +222,7 @@ export class Value extends Message<Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "null_value", kind: "enum", T: proto3.getEnumType(NullValue), oneof: "kind" },
@@ -284,7 +284,7 @@ export class ListValue extends Message<ListValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.ListValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "values", kind: "message", T: Value, repeated: true },

--- a/packages/protobuf/src/google/protobuf/timestamp_pb.ts
+++ b/packages/protobuf/src/google/protobuf/timestamp_pb.ts
@@ -195,7 +195,7 @@ export class Timestamp extends Message<Timestamp> {
     return new Date(Number(this.seconds) * 1000 + Math.ceil(this.nanos / 1000000));
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Timestamp";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "seconds", kind: "scalar", T: 3 /* ScalarType.INT64 */ },

--- a/packages/protobuf/src/google/protobuf/type_pb.ts
+++ b/packages/protobuf/src/google/protobuf/type_pb.ts
@@ -104,7 +104,7 @@ export class Type extends Message<Type> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Type";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -215,7 +215,7 @@ export class Field extends Message<Field> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Field";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "kind", kind: "enum", T: proto3.getEnumType(Field_Kind) },
@@ -497,7 +497,7 @@ export class Enum extends Message<Enum> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Enum";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -556,7 +556,7 @@ export class EnumValue extends Message<EnumValue> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.EnumValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -613,7 +613,7 @@ export class Option extends Message<Option> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Option";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protobuf/src/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf/src/google/protobuf/wrappers_pb.ts
@@ -72,7 +72,7 @@ export class DoubleValue extends Message<DoubleValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.DoubleValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 1 /* ScalarType.DOUBLE */ },
@@ -141,7 +141,7 @@ export class FloatValue extends Message<FloatValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.FloatValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
@@ -210,7 +210,7 @@ export class Int64Value extends Message<Int64Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Int64Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
@@ -279,7 +279,7 @@ export class UInt64Value extends Message<UInt64Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.UInt64Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
@@ -348,7 +348,7 @@ export class Int32Value extends Message<Int32Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.Int32Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -417,7 +417,7 @@ export class UInt32Value extends Message<UInt32Value> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.UInt32Value";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
@@ -486,7 +486,7 @@ export class BoolValue extends Message<BoolValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.BoolValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
@@ -555,7 +555,7 @@ export class StringValue extends Message<StringValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.StringValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -624,7 +624,7 @@ export class BytesValue extends Message<BytesValue> {
     return this;
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "google.protobuf.BytesValue";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 12 /* ScalarType.BYTES */ },

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -101,7 +101,7 @@ function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage)
   f.print("  }");
   f.print();
   generateWktMethods(schema, f, message);
-  f.print("  static readonly runtime = ", protoN, ";");
+  f.print("  static readonly runtime: typeof ", protoN, " = ", protoN, ";");
   f.print('  static readonly typeName = ', literalString(message.typeName), ';');
   f.print("  static readonly fields: ", FieldList, " = ", protoN, ".util.newFieldList(() => [");
   for (const field of message.fields) {

--- a/packages/protoplugin-example/src/gen/buf/connect/demo/eliza/v1/eliza_pb.ts
+++ b/packages/protoplugin-example/src/gen/buf/connect/demo/eliza/v1/eliza_pb.ts
@@ -36,7 +36,7 @@ export class SayRequest extends Message<SayRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.connect.demo.eliza.v1.SayRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "sentence", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -75,7 +75,7 @@ export class SayResponse extends Message<SayResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.connect.demo.eliza.v1.SayResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "sentence", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -114,7 +114,7 @@ export class ConverseRequest extends Message<ConverseRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.connect.demo.eliza.v1.ConverseRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "sentence", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -153,7 +153,7 @@ export class ConverseResponse extends Message<ConverseResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.connect.demo.eliza.v1.ConverseResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "sentence", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -192,7 +192,7 @@ export class IntroduceRequest extends Message<IntroduceRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.connect.demo.eliza.v1.IntroduceRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -231,7 +231,7 @@ export class IntroduceResponse extends Message<IntroduceResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "buf.connect.demo.eliza.v1.IntroduceResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "sentence", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protoplugin-test/src/gen/proto/address_book_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/address_book_pb.ts
@@ -37,7 +37,7 @@ export class AddressBook extends Message<AddressBook> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.AddressBook";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "people", kind: "message", T: Person, repeated: true },

--- a/packages/protoplugin-test/src/gen/proto/custom_options_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/custom_options_pb.ts
@@ -91,7 +91,7 @@ export class Configuration extends Message<Configuration> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.Configuration";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "foo", kind: "scalar", T: 5 /* ScalarType.INT32 */ },

--- a/packages/protoplugin-test/src/gen/proto/person_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/person_pb.ts
@@ -56,7 +56,7 @@ export class Person extends Message<Person> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.Person";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -128,7 +128,7 @@ export class Person_PhoneNumber extends Message<Person_PhoneNumber> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.Person.PhoneNumber";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "number", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/packages/protoplugin-test/src/gen/proto/service_pb.ts
+++ b/packages/protoplugin-test/src/gen/proto/service_pb.ts
@@ -91,7 +91,7 @@ export class MessageWithOptions extends Message<MessageWithOptions> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.MessageWithOptions";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "foo", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
@@ -128,7 +128,7 @@ export class GetRequest extends Message<GetRequest> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.GetRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
@@ -159,7 +159,7 @@ export class GetResponse extends Message<GetResponse> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "example.GetResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);


### PR DESCRIPTION
Removes `--noEmit` when testing compilation with the various tsc versions and configures `declarations` and `declarationMap` to be emitted.

Adds a ProtoRuntime typehint to the `runtime` property on generated messages.

Fixes #396