### PR TITLE
Fix flaky stream close call in tests

### DIFF
--- a/packages/protobuf-test/src/proto-delimited.test.ts
+++ b/packages/protobuf-test/src/proto-delimited.test.ts
@@ -141,7 +141,9 @@ describe("protoDelimited", function () {
           writeStream.write(protoDelimited.enc(m));
         }
         writeStream.end();
-        writeStream.close();
+        await new Promise<void>((resolve, reject) =>
+          writeStream.close((err) => (err ? reject(err) : resolve()))
+        );
         const readStream = createReadStream(path);
         let i = 0;
         for await (const m of protoDelimited.decStream(


### PR DESCRIPTION
https://github.com/bufbuild/protobuf-es/pull/387 added a test that passed CI initially, but turns out to be flaky. 

We write to a file using a stream, then read from that file using a stream. But under a bit of pressure, the file never makes it to disk before we try reading it. This adds a callback to the stream.close call we make after writing the file, and now we wait for it before reading the file.