### PR TITLE
Switch code size benchmark to use fflate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,5 @@ release: all ## Release @bufbuild/protobuf
 
 .PHONY: checkdiff
 checkdiff:
-	@# Used in CI to verify that `make` doesn't produce a diff, but ignore changes in benchmarks
-	git checkout packages/protobuf-bench/README.md
+	@# Used in CI to verify that `make` doesn't produce a diff
 	test -z "$$(git status --porcelain | tee /dev/stderr)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3226,6 +3226,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -5954,6 +5959,7 @@
         "@bufbuild/buf": "^1.14.0-1",
         "@bufbuild/protobuf": "1.0.0",
         "esbuild": "^0.17.10",
+        "fflate": "^0.7.4",
         "google-protobuf": "3.21.2"
       }
     },
@@ -6558,6 +6564,7 @@
         "@bufbuild/buf": "^1.14.0-1",
         "@bufbuild/protobuf": "1.0.0",
         "esbuild": "^0.17.10",
+        "fflate": "*",
         "google-protobuf": "3.21.2"
       }
     },
@@ -8287,6 +8294,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 86,785 b      | 36,950 b | 9,654 b |
-| protobuf-javascript | 394,384 b  | 288,775 b | 45,201 b |
+| protobuf-es         | 86,785 b      | 36,950 b | 11,079 b |
+| protobuf-javascript | 394,384 b  | 288,775 b | 54,825 b |

--- a/packages/protobuf-bench/package.json
+++ b/packages/protobuf-bench/package.json
@@ -9,6 +9,7 @@
     "@bufbuild/buf": "^1.14.0-1",
     "@bufbuild/protobuf": "1.0.0",
     "esbuild": "^0.17.10",
+    "fflate": "^0.7.4",
     "google-protobuf": "3.21.2"
   }
 }

--- a/packages/protobuf-bench/report.mjs
+++ b/packages/protobuf-bench/report.mjs
@@ -1,5 +1,5 @@
 import { buildSync } from "esbuild";
-import { brotliCompressSync } from "zlib";
+import { gzipSync } from "fflate";
 
 const protobufEs = gather("src/entry-protobuf-es.ts");
 const googleProtobuf = gather("src/entry-google-protobuf.js");
@@ -23,7 +23,11 @@ server would usually do.
 function gather(entryPoint) {
   const bundle = build(entryPoint, false, "esm");
   const bundleMinified = build(entryPoint, true, "esm");
-  const compressed = compress(bundleMinified);
+  const compressed = gzipSync(bundleMinified, {
+    mtime: 0,
+    level: 6,
+    mem: 6,
+  });
   return {
     entryPoint,
     size: formatSize(bundle.byteLength),
@@ -45,10 +49,6 @@ function build(entryPoint, minify, format) {
     throw new Error();
   }
   return result.outputFiles[0].contents;
-}
-
-function compress(buf) {
-  return brotliCompressSync(buf);
 }
 
 function formatSize(bytes) {


### PR DESCRIPTION
This switches the code size benchmark to use [fflate](https://github.com/101arrowz/fflate) instead of the Node.js `zlib` module.

We have seen slight variance of a couple of bytes between runs with the `zlib` module, and `fflate` will hopefully produce stable numbers. This allows us to enable diffchecks on the results, so that CI can ensure the report is always current.

This switches the benchmark to use gzip compression instead of brotli, increasing the values for both libraries tested, but keeping the relative difference within a percentage point. Gzip is still widely used, so using it in the benchmark is not unrealistic.
