### PR TITLE
Fix equals for oneof

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 86,785 b      | 36,950 b | 11,079 b |
+| protobuf-es         | 86,799 b      | 36,976 b | 11,083 b |
 | protobuf-javascript | 394,384 b  | 288,775 b | 54,825 b |

--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -26,24 +26,24 @@ import { describeMT } from "./helpers.js";
 describe("equals", function () {
   describeMT({ ts: TS_OneofMessage, js: JS_OneofMessage }, (messageType) => {
     test("oneof scalars are equal", () => {
-      let a = new messageType({ scalar: { case: "value", value: 1 } });
-      let b = new messageType({ scalar: { case: "value", value: 1 } });
+      const a = new messageType({ scalar: { case: "value", value: 1 } });
+      const b = new messageType({ scalar: { case: "value", value: 1 } });
       expect(a).toStrictEqual(b);
       expect(a.equals(b)).toBeTruthy();
     });
 
     test("oneof scalars are not equal", () => {
-      let a = new messageType({ scalar: { case: "value", value: 1 } });
-      let b = new messageType({ scalar: { case: "value", value: 2 } });
+      const a = new messageType({ scalar: { case: "value", value: 1 } });
+      const b = new messageType({ scalar: { case: "value", value: 2 } });
       expect(a).not.toStrictEqual(b);
       expect(a.equals(b)).toBeFalsy();
     });
 
     test("oneof messages are equal", () => {
-      let a = new messageType({
+      const a = new messageType({
         message: { case: "foo", value: { name: "a" } },
       });
-      let b = new messageType({
+      const b = new messageType({
         message: { case: "foo", value: { name: "a" } },
       });
       expect(a).toStrictEqual(b);
@@ -51,10 +51,10 @@ describe("equals", function () {
     });
 
     test("oneof messages are not equal", () => {
-      let a = new messageType({
+      const a = new messageType({
         message: { case: "foo", value: { name: "a" } },
       });
-      let b = new messageType({
+      const b = new messageType({
         message: { case: "foo", value: { name: "b" } },
       });
       expect(a).not.toStrictEqual(b);
@@ -62,10 +62,10 @@ describe("equals", function () {
     });
 
     test("oneof messages are different", () => {
-      let a = new messageType({
+      const a = new messageType({
         message: { case: "foo", value: { name: "a" } },
       });
-      let b = new messageType({
+      const b = new messageType({
         message: { case: "bar", value: { a: 1 } },
       });
       expect(a).not.toStrictEqual(b);
@@ -73,15 +73,15 @@ describe("equals", function () {
     });
 
     test("oneof enums are equal", () => {
-      let a = new messageType({ enum: { case: "e", value: 1 } });
-      let b = new messageType({ enum: { case: "e", value: 1 } });
+      const a = new messageType({ enum: { case: "e", value: 1 } });
+      const b = new messageType({ enum: { case: "e", value: 1 } });
       expect(a).toStrictEqual(b);
       expect(a.equals(b)).toBeTruthy();
     });
 
     test("oneof enums are not equal", () => {
-      let a = new messageType({ enum: { case: "e", value: 1 } });
-      let b = new messageType({ enum: { case: "e", value: 2 } });
+      const a = new messageType({ enum: { case: "e", value: 1 } });
+      const b = new messageType({ enum: { case: "e", value: 2 } });
       expect(a).not.toStrictEqual(b);
       expect(a.equals(b)).toBeFalsy();
     });

--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -19,9 +19,73 @@ import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/ms
 import { MessageFieldMessage as JS_MessageFieldMessage } from "./gen/js/extra/msg-message_pb.js";
 import { ScalarValuesMessage as TS_ScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb.js";
 import { ScalarValuesMessage as JS_ScalarValuesMessage } from "./gen/js/extra/msg-scalar_pb.js";
+import { OneofMessage as TS_OneofMessage } from "./gen/ts/extra/msg-oneof_pb.js";
+import { OneofMessage as JS_OneofMessage } from "./gen/js/extra/msg-oneof_pb.js";
 import { describeMT } from "./helpers.js";
 
 describe("equals", function () {
+  describeMT({ ts: TS_OneofMessage, js: JS_OneofMessage }, (messageType) => {
+    test("oneof scalars are equal", () => {
+      let a = new messageType({ scalar: { case: "value", value: 1 } });
+      let b = new messageType({ scalar: { case: "value", value: 1 } });
+      expect(a).toStrictEqual(b);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    test("oneof scalars are not equal", () => {
+      let a = new messageType({ scalar: { case: "value", value: 1 } });
+      let b = new messageType({ scalar: { case: "value", value: 2 } });
+      expect(a).not.toStrictEqual(b);
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    test("oneof messages are equal", () => {
+      let a = new messageType({
+        message: { case: "foo", value: { name: "a" } },
+      });
+      let b = new messageType({
+        message: { case: "foo", value: { name: "a" } },
+      });
+      expect(a).toStrictEqual(b);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    test("oneof messages are not equal", () => {
+      let a = new messageType({
+        message: { case: "foo", value: { name: "a" } },
+      });
+      let b = new messageType({
+        message: { case: "foo", value: { name: "b" } },
+      });
+      expect(a).not.toStrictEqual(b);
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    test("oneof messages are different", () => {
+      let a = new messageType({
+        message: { case: "foo", value: { name: "a" } },
+      });
+      let b = new messageType({
+        message: { case: "bar", value: { a: 1 } },
+      });
+      expect(a).not.toStrictEqual(b);
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    test("oneof enums are equal", () => {
+      let a = new messageType({ enum: { case: "e", value: 1 } });
+      let b = new messageType({ enum: { case: "e", value: 1 } });
+      expect(a).toStrictEqual(b);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    test("oneof enums are not equal", () => {
+      let a = new messageType({ enum: { case: "e", value: 1 } });
+      let b = new messageType({ enum: { case: "e", value: 2 } });
+      expect(a).not.toStrictEqual(b);
+      expect(a.equals(b)).toBeFalsy();
+    });
+  });
   describeMT(
     { ts: TS_MessageFieldMessage, js: JS_MessageFieldMessage },
     (messageType) => {

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -147,19 +147,18 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             if (va.case !== vb.case) {
               return false;
             }
-            const k = va.case,
-              s = m.findField(k);
+            let s = m.findField(va.case);
             if (s === undefined) {
               return true;
             }
             // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- oneof fields are never "map"
             switch (s.kind) {
               case "message":
-                return s.T.equals(va[k], vb[k]);
+                return s.T.equals(va.value, vb.value);
               case "enum":
-                return scalarEquals(ScalarType.INT32, va, vb);
+                return scalarEquals(ScalarType.INT32, va.value, vb.value);
               case "scalar":
-                return scalarEquals(s.T, va, vb);
+                return scalarEquals(s.T, va.value, vb.value);
             }
             throw new Error(`oneof cannot contain ${s.kind}`);
           case "map":

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -147,7 +147,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             if (va.case !== vb.case) {
               return false;
             }
-            let s = m.findField(va.case);
+            const s = m.findField(va.case);
             if (s === undefined) {
               return true;
             }


### PR DESCRIPTION
Fixes `equals` for `oneof` fields in messages.

- Use `value` to read the actual field value
- Add test cases for each type of field that can be in a `oneof`