### PR TITLE
NPM v9 Packlist fix

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -24,6 +24,6 @@
     "types": "./dist/types/index.d.ts"
   },
   "files": [
-    "dist/**/"
+    "dist/**"
   ]
 }

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -40,7 +40,7 @@
     "typescript": "4.5.2"
   },
   "files": [
-    "dist/**/"
+    "dist/**"
   ],
   "devDependencies": {
     "@types/lz-string": "^1.3.34"


### PR DESCRIPTION
npm v9 changed how it parses its include/ignore lists, see https://github.com/npm/cli/issues/5853#issuecomment-1317760279. 

Where it would previously include all files within the `dist` directory with the following setting:

```json
  "files": [
    "dist/**/"
  ]
```

In v9.5.0, this pattern matches nothing.

This could lead to some packages being published empty (which occurred in connect-es)

This PR updates the pattern to work with npm v9, verified by running `npm pack` with and without the change.