### PR TITLE
Fix unused MethodInfo properties in createRegistryFromDescriptors

### DIFF
--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -189,16 +189,15 @@ export function createRegistryFromDescriptors(
             method.output.typeName
           }" for ${method.toString()} not found`
         );
-        const m = {
+        methods[localName(method)] = {
           name: method.name,
-          localName: localName(method),
           I,
           O,
           kind: method.methodKind,
           idempotency: method.idempotency,
-          options: {},
+          // We do not surface options at this time
+          // options: {},
         };
-        methods[m.localName] = m;
       }
       return (services[typeName] = {
         typeName: desc.typeName,

--- a/packages/protobuf/src/proto-base64.ts
+++ b/packages/protobuf/src/proto-base64.ts
@@ -42,8 +42,6 @@ export const protoBase64 = {
   dec(base64Str: string): Uint8Array {
     // estimate byte size, not accounting for inner padding and whitespace
     let es = (base64Str.length * 3) / 4;
-    // if (es % 3 !== 0)
-    // throw new Error("invalid base64 string");
     if (base64Str[base64Str.length - 2] == "=") es -= 2;
     else if (base64Str[base64Str.length - 1] == "=") es -= 1;
 

--- a/packages/protobuf/src/service-type.ts
+++ b/packages/protobuf/src/service-type.ts
@@ -41,8 +41,6 @@ export interface ServiceType {
  * call. All methods provide the following properties:
  *
  * - "name": The original name of the protobuf rpc.
- * - "localName": A variation of the name that follows the lowerCamelCase
- *    naming convention in ECMAScript.
  * - "I": The input message type.
  * - "O": The output message type.
  * - "kind": The method type.


### PR DESCRIPTION
We still document the `localName` property of `MethodInfo` of an older version, and we still populate the property through `createRegistryFromDescriptors()`, but it isn't part of the types.

This PR removes the unused property completely.

Thanks to @dimitropoulos for calling it out.