### PR TITLE
Add link to the bufbuild/protobuf-conformance repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ You should now see a generated file at `src/gen/example_pb.ts` that contains a c
   Type-safe APIs with Protobuf and TypeScript.
 * [connect-es-integration](https://github.com/bufbuild/connect-es-integration):
   Examples for using Connect with various TypeScript web frameworks and tooling
+* [protobuf-conformance](https://github.com/bufbuild/protobuf-conformance):
+  A repository running the Protobuf conformance tests against various libraries.
 * [Buf Studio](https://studio.buf.build/): Web UI for ad-hoc RPCs
 
 

--- a/packages/protobuf-conformance/README.md
+++ b/packages/protobuf-conformance/README.md
@@ -1,10 +1,13 @@
 # Conformance tests
 
 This package implements a testee for the protocol buffers [conformance test 
-suite](https://github.com/protocolbuffers/protobuf/tree/main/conformance).
+suite](https://github.com/protocolbuffers/protobuf/tree/main/conformance) to 
+ensure completeness and correctness of the implementation. 
 
-The conformance tests run on code transpiled to ECMAScript modules.
+If you would like to know how it stacks up compared to other implementations, 
+please take a look at the [protobuf-conformance repository](https://github.com/bufbuild/protobuf-conformance).
 
-To cover the code path for our string-based fallback for 64-bit integers, the
-conformance tests should be run with the environment variable 
+
+Note: To cover the code path for our string-based fallback for 64-bit integers, 
+the conformance tests should be run with the environment variable 
 `BUF_BIGINT_DISABLE=1`, which disables our BigInt feature detection. 


### PR DESCRIPTION
Add link to the bufbuild/protobuf-conformance repository from the top-level README in the _Ecosystem_ section, and also from the package README for protobuf-conformance.