### PR TITLE
Enables exactOptionalPropertyTypes

### DIFF
--- a/packages/protobuf-example/tsconfig.json
+++ b/packages/protobuf-example/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2016",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "moduleResolution": "Node"
   }
 }

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -213,6 +213,10 @@ function addEnum(
   cart: Cart
 ): void {
   assert(proto.name, `invalid EnumDescriptorProto: missing name`);
+  const sharedPrefix = findEnumSharedPrefix(
+    proto.name,
+    proto.value.map((v) => v.name ?? "")
+  );
   const desc: DescEnum = {
     kind: "enum",
     proto,
@@ -222,10 +226,7 @@ function addEnum(
     name: proto.name,
     typeName: makeTypeName(proto, parent, file),
     values: [],
-    sharedPrefix: findEnumSharedPrefix(
-      proto.name,
-      proto.value.map((v) => v.name ?? "")
-    ),
+    ...(sharedPrefix !== undefined ? { sharedPrefix } : {}),
     toString(): string {
       return `enum ${this.typeName}`;
     },
@@ -429,7 +430,7 @@ function newMethod(
     methodKind,
     input,
     output,
-    idempotency,
+    ...(idempotency !== undefined ? { idempotency } : {}),
     toString() {
       return `rpc ${parent.typeName}.${name}`;
     },
@@ -867,10 +868,12 @@ function findComments(
     if (location.path.some((value, index) => sourcePath[index] !== value)) {
       continue;
     }
+    const leading = location.leadingComments;
+    const trailing = location.trailingComments;
     return {
       leadingDetached: location.leadingDetachedComments,
-      leading: location.leadingComments,
-      trailing: location.trailingComments,
+      ...(leading !== undefined ? { leading } : {}),
+      ...(trailing !== undefined ? { trailing } : {}),
       sourcePath,
     };
   }

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -430,7 +430,7 @@ function newMethod(
     methodKind,
     input,
     output,
-    ...(idempotency !== undefined ? { idempotency } : {}),
+    idempotency,
     toString() {
       return `rpc ${parent.typeName}.${name}`;
     },

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -197,7 +197,7 @@ export function createRegistryFromDescriptors(
           idempotency: method.idempotency,
           // We do not surface options at this time
           // options: {},
-        };
+        } as MethodInfo;
       }
       return (services[typeName] = {
         typeName: desc.typeName,
@@ -232,11 +232,12 @@ function makeMapFieldInfo(
   field: DescField & { fieldKind: "map" },
   resolver: Resolver
 ): PartialFieldInfo {
+  const jsonName = field.jsonName;
   const base = {
     kind: "map",
     no: field.number,
     name: field.name,
-    jsonName: field.jsonName,
+    ...(jsonName !== undefined ? { jsonName } : {}),
     K: field.mapKey,
   } as const;
   if (field.mapValue.message) {
@@ -281,11 +282,12 @@ function makeMapFieldInfo(
 function makeScalarFieldInfo(
   field: DescField & { fieldKind: "scalar" }
 ): PartialFieldInfo {
+  const jsonName = field.jsonName;
   const base = {
     kind: "scalar",
     no: field.number,
     name: field.name,
-    jsonName: field.jsonName,
+    ...(jsonName !== undefined ? { jsonName } : {}),
     T: field.scalar,
   } as const;
   if (field.repeated) {
@@ -321,11 +323,12 @@ function makeMessageFieldInfo(
     messageType,
     `message "${field.message.typeName}" for ${field.toString()} not found`
   );
+  const jsonName = field.jsonName;
   const base = {
     kind: "message",
     no: field.number,
     name: field.name,
-    jsonName: field.jsonName,
+    ...(jsonName !== undefined ? { jsonName } : {}),
     T: messageType,
   } as const;
   if (field.repeated) {
@@ -360,11 +363,12 @@ function makeEnumFieldInfo(
     enumType,
     `enum "${field.enum.typeName}" for ${field.toString()} not found`
   );
+  const jsonName = field.jsonName;
   const base = {
     kind: "enum",
     no: field.number,
     name: field.name,
-    jsonName: field.jsonName,
+    ...(jsonName !== undefined ? { jsonName } : {}),
     T: enumType,
   } as const;
   if (field.repeated) {

--- a/packages/protobuf/src/descriptor-set.ts
+++ b/packages/protobuf/src/descriptor-set.ts
@@ -671,7 +671,7 @@ export interface DescMethod {
   /**
    * The idempotency level declared in the protobuf source, if any.
    */
-  readonly idempotency?: MethodIdempotency;
+  readonly idempotency?: MethodIdempotency | undefined;
   /**
    * Marked as deprecated in the protobuf source.
    */

--- a/packages/protobuf/src/service-type.ts
+++ b/packages/protobuf/src/service-type.ts
@@ -101,7 +101,7 @@ interface miShared<
   readonly name: string;
   readonly I: MessageType<I>;
   readonly O: MessageType<O>;
-  readonly idempotency?: MethodIdempotency;
+  readonly idempotency?: MethodIdempotency | undefined;
   // We do not surface options at this time
   // options: OptionsMap;
 }

--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -37,7 +37,7 @@ function transpile(
     name: "test-plugin",
     version: "v99.0.0",
     generateTs: genTs,
-    parseOption,
+    ...(parseOption !== undefined ? { parseOption } : {}),
   });
   const res = plugin.run(req);
   return function linesOf(filename: string): string[] {
@@ -124,16 +124,12 @@ describe("transpile", function () {
         return {
           leadingDetached: [],
           sourcePath: [],
-          leading: undefined,
-          trailing: undefined,
         };
       },
       getSyntaxComments() {
         return {
           leadingDetached: [],
           sourcePath: [],
-          leading: undefined,
-          trailing: undefined,
         };
       },
     };

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -285,7 +285,7 @@ function buildPrintablesFromFragments(
 type MakeImportStatementFn = (
   typeOnly: boolean,
   from: string,
-  names: { name: string; alias?: string }[]
+  names: { name: string; alias?: string | undefined }[]
 ) => void;
 
 function processImports(
@@ -374,7 +374,7 @@ function processImports(
   // Make import statements.
   const handledSource = new Set<string>();
   const buildNames = (map: Map<string, string | undefined>) => {
-    const names: { name: string; alias?: string }[] = [];
+    const names: { name: string; alias: string | undefined }[] = [];
     map.forEach((value, key) => names.push({ name: key, alias: value }));
     names.sort((a, b) => a.name.localeCompare(b.name));
     return names;

--- a/packages/protoplugin/src/ecmascript/transpile.ts
+++ b/packages/protoplugin/src/ecmascript/transpile.ts
@@ -76,8 +76,9 @@ const defaultOptions: ts.CompilerOptions = {
  * npm does not support that yet.
  */
 function createTranspiler(options: ts.CompilerOptions, files: FileInfo[]) {
+  const { target } = options;
   const fsMap = createDefaultMapFromNodeModules({
-    target: options.target,
+    ...(target !== undefined ? { target } : {}),
   });
 
   files.forEach((file) => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
     "noImplicitThis": true,
     "useUnknownInCatchVariables": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
To quote from the TypeScript team lead:

> If we were to start TypeScript over again, we believe the behavior of strictOptionalProperties would be on by default
> https://github.com/microsoft/TypeScript/issues/44421

This [configuration](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) brings a pretty critical element to the type-soundness (critical because it drastically changes the behavior of operations that check for keys).  [SameValueZero](https://262.ecma-international.org/7.0/#sec-samevaluezero) checks remain unchanged, anyway, so there's basically no downside to having this rule enabled.  The [implementation](https://github.com/microsoft/TypeScript/pull/43947) from Anders provides some more context, as well.

Thankfully, this codebase was already pretty close to the mark, with only a few little minor things to update to increase strictness.  Once this PR merges, I'd like to do to same with the connect-es repo.