### PR TITLE
Switch code size benchmark to use a JS brotli implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,6 +1875,25 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -1891,6 +1910,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -2844,10 +2871,6 @@
       "dependencies": {
         "bser": "2.1.1"
       }
-    },
-    "node_modules/fflate": {
-      "version": "0.7.4",
-      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -5457,8 +5480,8 @@
       "dependencies": {
         "@bufbuild/buf": "^1.15.0-1",
         "@bufbuild/protobuf": "1.2.0",
+        "brotli": "^1.3.3",
         "esbuild": "^0.17.10",
-        "fflate": "^0.7.4",
         "google-protobuf": "3.21.2"
       }
     },

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 87,033 b      | 37,025 b | 11,104 b |
-| protobuf-javascript | 394,384 b  | 288,775 b | 54,825 b |
+| protobuf-es         | 87,033 b      | 37,025 b | 9,688 b |
+| protobuf-javascript | 394,384 b  | 288,775 b | 45,187 b |

--- a/packages/protobuf-bench/package.json
+++ b/packages/protobuf-bench/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@bufbuild/buf": "^1.15.0-1",
     "@bufbuild/protobuf": "1.2.0",
+    "brotli": "^1.3.3",
     "esbuild": "^0.17.10",
-    "fflate": "^0.7.4",
     "google-protobuf": "3.21.2"
   }
 }

--- a/packages/protobuf-bench/report.mjs
+++ b/packages/protobuf-bench/report.mjs
@@ -1,5 +1,5 @@
 import { buildSync } from "esbuild";
-import {compress} from "brotli";
+import { compress } from "brotli";
 
 const protobufEs = gather("src/entry-protobuf-es.ts");
 const googleProtobuf = gather("src/entry-google-protobuf.js");

--- a/packages/protobuf-bench/report.mjs
+++ b/packages/protobuf-bench/report.mjs
@@ -1,5 +1,5 @@
 import { buildSync } from "esbuild";
-import { gzipSync } from "fflate";
+import {compress} from "brotli";
 
 const protobufEs = gather("src/entry-protobuf-es.ts");
 const googleProtobuf = gather("src/entry-google-protobuf.js");
@@ -23,11 +23,7 @@ server would usually do.
 function gather(entryPoint) {
   const bundle = build(entryPoint, false, "esm");
   const bundleMinified = build(entryPoint, true, "esm");
-  const compressed = gzipSync(bundleMinified, {
-    mtime: 0,
-    level: 6,
-    mem: 6,
-  });
+  const compressed = compress(bundleMinified);
   return {
     entryPoint,
     size: formatSize(bundle.byteLength),


### PR DESCRIPTION
We have moved from brotli via zlib to gzip via `fflate`, a pure JS implementation in https://github.com/bufbuild/protobuf-es/pull/411.

It allowed us to run diffchecks in CI on the results, but it forced us to use gzip instead of brotli. This PR switches back to brotli, but with a JS implementation instead.