### PR TITLE
Upgrade to TypeScript 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LICENSE_HEADER_IGNORES := .tmp\/ node_module\/ packages\/protobuf-conformance\/b
 GOOGLE_PROTOBUF_WKT = google/protobuf/api.proto google/protobuf/any.proto google/protobuf/compiler/plugin.proto google/protobuf/descriptor.proto google/protobuf/duration.proto google/protobuf/descriptor.proto google/protobuf/empty.proto google/protobuf/field_mask.proto google/protobuf/source_context.proto google/protobuf/struct.proto google/protobuf/timestamp.proto google/protobuf/type.proto google/protobuf/wrappers.proto
 GOOGLE_PROTOBUF_VERSION = 22.2
 BAZEL_VERSION = 5.4.0
-TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.4 5.0.0-beta
+TS_VERSIONS = 4.1.2 4.2.4 4.3.5 4.4.4 4.5.2 4.6.4 4.7.4 4.8.4 4.9.5
 
 node_modules: package-lock.json
 	npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
         "jest": "^29.4.3"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.54.0",
-        "@typescript-eslint/parser": "^5.54.0",
+        "@typescript-eslint/eslint-plugin": "^5.57.1",
+        "@typescript-eslint/parser": "^5.57.1",
         "eslint": "^8.35.0",
         "eslint-import-resolver-typescript": "^3.5.4",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-node": "^11.1.0",
         "prettier": "^2.8.7",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.3"
       },
       "engines": {
         "node": ">=16",
@@ -675,6 +675,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "2.0.0",
       "dev": true,
@@ -1242,8 +1266,9 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1265,8 +1290,9 @@
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -1284,18 +1310,19 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.54.0",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz",
+      "integrity": "sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/type-utils": "5.54.0",
-        "@typescript-eslint/utils": "5.54.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/type-utils": "5.57.1",
+        "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
-        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
@@ -1316,58 +1343,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.54.0",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.1.tgz",
+      "integrity": "sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/typescript-estree": "5.57.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1386,67 +1370,14 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.0",
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1457,12 +1388,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.54.0",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz",
+      "integrity": "sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.54.0",
-        "@typescript-eslint/utils": "5.54.0",
+        "@typescript-eslint/typescript-estree": "5.57.1",
+        "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1482,10 +1414,11 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1494,13 +1427,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.0",
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+      "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1520,34 +1454,19 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.54.0",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.1.tgz",
+      "integrity": "sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/typescript-estree": "5.57.1",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -1561,66 +1480,13 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.0",
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
+        "@typescript-eslint/types": "5.57.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1751,8 +1617,9 @@
     },
     "node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2635,8 +2502,9 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -2765,8 +2633,9 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -3090,8 +2959,9 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -5182,10 +5052,11 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ts5_0_0-beta": {
+    "node_modules/ts4_9_5": {
       "name": "typescript",
-      "version": "5.0.0-beta",
-      "license": "Apache-2.0",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5294,14 +5165,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "license": "Apache-2.0",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -5511,7 +5383,7 @@
         "@bufbuild/buf": "^1.15.0-1",
         "@bufbuild/protobuf": "1.2.0",
         "@bufbuild/protoc-gen-es": "1.2.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.3"
       }
     },
     "packages/protobuf-test": {
@@ -5527,7 +5399,7 @@
         "ts4_6_4": "npm:typescript@4.6.4",
         "ts4_7_4": "npm:typescript@4.7.4",
         "ts4_8_4": "npm:typescript@4.8.4",
-        "ts5_0_0-beta": "npm:typescript@5.0.0-beta"
+        "ts4_9_5": "npm:typescript@4.9.5"
       }
     },
     "packages/protobuf-test/node_modules/long": {
@@ -5579,7 +5451,7 @@
         "@bufbuild/protoc-gen-es": "^1.2.0",
         "@bufbuild/protoplugin": "^1.2.0",
         "tsx": "^3.12.3",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.3"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "npm": ">=8"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.54.0",
-    "@typescript-eslint/parser": "^5.54.0",
+    "@typescript-eslint/eslint-plugin": "^5.57.1",
+    "@typescript-eslint/parser": "^5.57.1",
     "eslint": "^8.35.0",
     "eslint-import-resolver-typescript": "^3.5.4",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-node": "^11.1.0",
     "prettier": "^2.8.7",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@typescript/vfs": "1.0.0",

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 87,033 b      | 37,025 b | 9,688 b |
+| protobuf-es         | 87,033 b      | 37,025 b | 9,675 b |
 | protobuf-javascript | 394,384 b  | 288,775 b | 45,187 b |

--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/types/*",
     "build": "npm run build:esm+types",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "type": "module",
   "types": "./dist/types/index.d.ts",

--- a/packages/protobuf-example/package.json
+++ b/packages/protobuf-example/package.json
@@ -4,7 +4,7 @@
   "license": "(Apache-2.0 AND BSD-3-Clause)",
   "scripts": {
     "clean": "rm -rf ./dist/esm/* ./dist/types/*",
-    "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "add-person": "node dist/esm/add-person.js addressbook.bin",
     "list-people": "node dist/esm/list-people.js addressbook.bin",
     "generate": "buf generate"
@@ -14,6 +14,6 @@
     "@bufbuild/buf": "^1.15.0-1",
     "@bufbuild/protobuf": "1.2.0",
     "@bufbuild/protoc-gen-es": "1.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   }
 }

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types && npm run build:copy-gen-js",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "build:copy-gen-js": "rsync -a --exclude '*.js' src/gen/js dist/types/gen && rsync -a --exclude '*.d.ts' src/gen/js dist/esm/gen"
   },
   "type": "module",
@@ -24,6 +24,6 @@
     "ts4_6_4": "npm:typescript@4.6.4",
     "ts4_7_4": "npm:typescript@4.7.4",
     "ts4_8_4": "npm:typescript@4.8.4",
-    "ts5_0_0-beta": "npm:typescript@5.0.0-beta"
+    "ts4_9_5": "npm:typescript@4.9.5"
   }
 }

--- a/packages/protobuf-test/src/proto-delimited.test.ts
+++ b/packages/protobuf-test/src/proto-delimited.test.ts
@@ -16,11 +16,11 @@ import { describe, expect, it } from "@jest/globals";
 import {
   BinaryReader,
   BinaryWriter,
-  MessageType,
   protoDelimited,
   WireType,
   Message,
 } from "@bufbuild/protobuf";
+import type { MessageType } from "@bufbuild/protobuf";
 import { TestAllTypesProto3 } from "./gen/ts/google/protobuf/test_messages_proto3_pb.js";
 import { createReadStream, createWriteStream } from "fs";
 import { tmpdir } from "os";

--- a/packages/protobuf-test/typescript/tsconfig.4_9_5.json
+++ b/packages/protobuf-test/typescript/tsconfig.4_9_5.json
@@ -1,6 +1,6 @@
 {
   "include": ["../src/**/*"],
-  // These are the default compiler options for TypeScript v5.0.0-beta, created
+  // These are the default compiler options for TypeScript v4.9.5, created
   // with `tsc --init` (except where noted in comments below)
   "compilerOptions": {
     "target": "es2016",

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:cjs && npm run build:esm+types",
     "build:cjs": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
   "main": "./dist/cjs/index.js",
   "type": "module",

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -19,12 +19,8 @@ export { protoBase64 } from "./proto-base64.js";
 export { protoDelimited } from "./proto-delimited.js";
 export { codegenInfo } from "./codegen-info.js";
 
-export {
-  Message,
-  AnyMessage,
-  PartialMessage,
-  PlainMessage,
-} from "./message.js";
+export { Message } from "./message.js";
+export type { AnyMessage, PartialMessage, PlainMessage } from "./message.js";
 
 export type { FieldInfo } from "./field.js";
 export type { FieldList } from "./field-list.js";
@@ -50,7 +46,7 @@ export type {
   BinaryReadOptions,
 } from "./binary-format.js";
 
-export {
+export type {
   JsonFormat,
   JsonObject,
   JsonValue,
@@ -59,7 +55,7 @@ export {
   JsonWriteStringOptions,
 } from "./json-format.js";
 
-export {
+export type {
   DescriptorSet,
   AnyDesc,
   DescFile,
@@ -74,7 +70,7 @@ export {
   DescComments,
 } from "./descriptor-set.js";
 export { createDescriptorSet } from "./create-descriptor-set.js";
-export { IMessageTypeRegistry } from "./type-registry.js";
+export type { IMessageTypeRegistry } from "./type-registry.js";
 export { createRegistry } from "./create-registry.js";
 export { createRegistryFromDescriptors } from "./create-registry-from-desc.js";
 

--- a/packages/protobuf/src/private/binary-format-common.ts
+++ b/packages/protobuf/src/private/binary-format-common.ts
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  BinaryReader,
-  BinaryWriter,
-  IBinaryReader,
-  IBinaryWriter,
-  WireType,
-} from "../binary-encoding.js";
+import { BinaryReader, BinaryWriter, WireType } from "../binary-encoding.js";
+import type { IBinaryReader, IBinaryWriter } from "../binary-encoding.js";
 import type {
   BinaryReadOptions,
   BinaryWriteOptions,
 } from "../binary-format.js";
 import type { BinaryFormat } from "../binary-format.js";
 import { Message } from "../message.js";
-import { FieldInfo, ScalarType } from "../field.js";
+import { ScalarType } from "../field.js";
+import type { FieldInfo } from "../field.js";
 import { wrapField } from "./field-wrapper.js";
 import { scalarDefaultValue, scalarTypeInfo } from "./scalars.js";
 import { assert } from "./assert.js";

--- a/packages/protobuf/src/private/binary-format-proto2.ts
+++ b/packages/protobuf/src/private/binary-format-proto2.ts
@@ -15,7 +15,8 @@
 import type { AnyMessage, Message } from "../message.js";
 import type { BinaryFormat, BinaryWriteOptions } from "../binary-format.js";
 import type { IBinaryWriter } from "../binary-encoding.js";
-import { FieldInfo, ScalarType } from "../field.js";
+import type { FieldInfo } from "../field.js";
+import { ScalarType } from "../field.js";
 import {
   makeBinaryFormatCommon,
   writeMapEntry,

--- a/packages/protobuf/src/private/json-format-common.ts
+++ b/packages/protobuf/src/private/json-format-common.ts
@@ -20,9 +20,11 @@ import type {
   JsonWriteOptions,
   JsonWriteStringOptions,
 } from "../json-format.js";
-import { AnyMessage, Message } from "../message.js";
+import { Message } from "../message.js";
+import type { AnyMessage } from "../message.js";
 import type { MessageType } from "../message-type.js";
-import { FieldInfo, ScalarType } from "../field.js";
+import { ScalarType } from "../field.js";
+import type { FieldInfo } from "../field.js";
 import { assert, assertFloat32, assertInt32, assertUInt32 } from "./assert.js";
 import { protoInt64 } from "../proto-int64.js";
 import { protoBase64 } from "../proto-base64.js";

--- a/packages/protobuf/src/private/message-type.ts
+++ b/packages/protobuf/src/private/message-type.ts
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  AnyMessage,
-  Message,
-  PartialMessage,
-  PlainMessage,
-} from "../message.js";
+import { Message } from "../message.js";
+import type { AnyMessage, PartialMessage, PlainMessage } from "../message.js";
 import type { FieldListSource } from "./field-list.js";
 import type { JsonReadOptions, JsonValue } from "../json-format.js";
 import type { MessageType } from "../message-type.js";

--- a/packages/protobuf/src/private/scalars.ts
+++ b/packages/protobuf/src/private/scalars.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { ScalarType } from "../field.js";
-import { IBinaryWriter, WireType } from "../binary-encoding.js";
+import type { IBinaryWriter } from "../binary-encoding.js";
+import { WireType } from "../binary-encoding.js";
 import { protoInt64 } from "../proto-int64.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -13,14 +13,11 @@
 // limitations under the License.
 
 import { setEnumType } from "./enum.js";
-import {
-  AnyMessage,
-  Message,
-  PartialMessage,
-  PlainMessage,
-} from "../message.js";
+import { Message } from "../message.js";
+import type { AnyMessage, PartialMessage, PlainMessage } from "../message.js";
 import type { MessageType } from "../message-type.js";
-import { FieldInfo, ScalarType } from "../field.js";
+import { ScalarType } from "../field.js";
+import type { FieldInfo } from "../field.js";
 import type { Util } from "./util.js";
 import { scalarEquals } from "./scalars.js";
 

--- a/packages/protobuf/src/proto2.ts
+++ b/packages/protobuf/src/proto2.ts
@@ -15,7 +15,8 @@
 import { makeProtoRuntime } from "./private/proto-runtime.js";
 import { makeBinaryFormatProto2 } from "./private/binary-format-proto2.js";
 import { makeUtilCommon } from "./private/util-common.js";
-import { FieldListSource, InternalFieldList } from "./private/field-list.js";
+import { InternalFieldList } from "./private/field-list.js";
+import type { FieldListSource } from "./private/field-list.js";
 import type { FieldList } from "./field-list.js";
 import type { AnyMessage, Message } from "./message.js";
 import type { FieldInfo } from "./field.js";

--- a/packages/protobuf/src/proto3.ts
+++ b/packages/protobuf/src/proto3.ts
@@ -16,11 +16,13 @@ import { makeProtoRuntime } from "./private/proto-runtime.js";
 import { makeBinaryFormatProto3 } from "./private/binary-format-proto3.js";
 import { makeJsonFormatProto3 } from "./private/json-format-proto3.js";
 import { makeUtilCommon } from "./private/util-common.js";
-import { FieldListSource, InternalFieldList } from "./private/field-list.js";
+import { InternalFieldList } from "./private/field-list.js";
+import type { FieldListSource } from "./private/field-list.js";
 import type { FieldList } from "./field-list.js";
 import type { AnyMessage, Message } from "./message.js";
 import { scalarDefaultValue } from "./private/scalars.js";
-import { FieldInfo, ScalarType } from "./field.js";
+import { ScalarType } from "./field.js";
+import type { FieldInfo } from "./field.js";
 import { InternalOneofInfo } from "./private/field.js";
 import { localFieldName, fieldJsonName } from "./private/names.js";
 

--- a/packages/protoplugin-example/package.json
+++ b/packages/protoplugin-example/package.json
@@ -19,6 +19,6 @@
     "@bufbuild/protoc-gen-es": "^1.2.0",
     "@bufbuild/protoplugin": "^1.2.0",
     "tsx": "^3.12.3",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   }
 }

--- a/packages/protoplugin-example/tsconfig.json
+++ b/packages/protoplugin-example/tsconfig.json
@@ -2,6 +2,7 @@
   "files": ["src/protoc-gen-twirp-es.ts", "src/index.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/protoplugin-test/package.json
+++ b/packages/protoplugin-test/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "buf:build": "buf build -o descriptorset.bin",
     "generate": "buf generate",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest"

--- a/packages/protoplugin-test/src/create-es-plugin.test.ts
+++ b/packages/protoplugin-test/src/create-es-plugin.test.ts
@@ -15,7 +15,8 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import { getCodeGeneratorRequest } from "./helpers.js";
 import type { CodeGeneratorRequest } from "@bufbuild/protobuf";
-import { createEcmaScriptPlugin, Plugin } from "@bufbuild/protoplugin";
+import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
+import type { Plugin } from "@bufbuild/protoplugin";
 import type { Schema, Target } from "@bufbuild/protoplugin/ecmascript";
 import { makeJsDoc } from "@bufbuild/protoplugin/ecmascript";
 

--- a/packages/protoplugin-test/src/generated-file.test.ts
+++ b/packages/protoplugin-test/src/generated-file.test.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { describe, expect, it, test } from "@jest/globals";
-import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
+import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
+import type { Schema } from "@bufbuild/protoplugin";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
 import { assert, getDescriptorSet } from "./helpers";
 import { CodeGeneratorRequest } from "@bufbuild/protobuf";

--- a/packages/protoplugin-test/src/import_extension.test.ts
+++ b/packages/protoplugin-test/src/import_extension.test.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
+import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
+import type { Schema } from "@bufbuild/protoplugin";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
 import { CodeGeneratorRequest } from "@bufbuild/protobuf";
 

--- a/packages/protoplugin-test/src/rewrite_imports.test.ts
+++ b/packages/protoplugin-test/src/rewrite_imports.test.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createEcmaScriptPlugin, Schema } from "@bufbuild/protoplugin";
+import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
+import type { Schema } from "@bufbuild/protoplugin";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
 import { assert, getDescriptorSet } from "./helpers";
 import { CodeGeneratorRequest } from "@bufbuild/protobuf";

--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import {
-  CodeGeneratorRequest,
-  DescFile,
-  FileDescriptorProto,
-} from "@bufbuild/protobuf";
+import { CodeGeneratorRequest, FileDescriptorProto } from "@bufbuild/protobuf";
+import type { DescFile } from "@bufbuild/protobuf";
 import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
 import type { Schema } from "@bufbuild/protoplugin/ecmascript";
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es2017",
     "esModuleInterop": false,
-    "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This upgrades Protobuf-ES to use TypeScript 5.0.3. 

The only major change needed for the upgrade was to accommodate the new [`verbatimModuleSyntax`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax) flag. This required removing the usage of `importsNotUsedAsValues` from our main tsconfig and applying the new flag to any build commands generating ESM output. Note that we can't use this in our main `tsconfig.base.json` because it isn't permitted when the module output is CJS.

For consistency, this flag was used in all the CLI commands for generating ESM. The only place where it was put into the actual `tsconfig.json` was for the `protoplugin-example`.

Finally, this also removes 5.0.0 from our TS compatibility tests in favor of the last major / minor version of 4.9.5.