### PR TITLE
Improve binary read performance

### DIFF
--- a/packages/protobuf/src/binary-encoding.ts
+++ b/packages/protobuf/src/binary-encoding.ts
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { BinaryReadOptions } from "./binary-format.js";
 import {
   varint32read,
   varint32write,
   varint64read,
   varint64write,
 } from "./google/varint.js";
+import { Message } from "./message.js";
 import { assertFloat32, assertInt32, assertUInt32 } from "./private/assert.js";
 import { protoInt64 } from "./proto-int64.js";
 
@@ -164,6 +166,23 @@ export interface IBinaryReader {
    * Read a `bytes` field, length-delimited arbitrary data.
    */
   bytes(): Uint8Array;
+
+  /**
+   * Reads a message of length `length` into `message` and returns the message.
+   */
+  message<T extends Message>(
+    message: T,
+    length: number,
+    options: Partial<BinaryReadOptions>
+  ): T;
+
+  /**
+   * Reads a length-delimited message into `message` and returns it.
+   */
+  messageField<T extends Message>(
+    message: T,
+    options: Partial<BinaryReadOptions>
+  ): T;
 
   /**
    * Read a `string` field, length-delimited data converted to UTF-8 text.
@@ -744,5 +763,21 @@ export class BinaryReader implements IBinaryReader {
    */
   string(): string {
     return this.textDecoder.decode(this.bytes());
+  }
+
+  message<T extends Message>(
+    message: T,
+    length: number,
+    options: BinaryReadOptions
+  ): T {
+    const type = message.getType(),
+      format = type.runtime.bin;
+
+    format.readMessage(message, this, length, options);
+    return message;
+  }
+
+  messageField<T extends Message>(message: T, options: BinaryReadOptions): T {
+    return this.message(message, this.uint32(), options);
   }
 }

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -66,10 +66,8 @@ export class Message<T extends Message<T> = AnyMessage> {
    * new data.
    */
   fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): this {
-    const type = this.getType(),
-      format = type.runtime.bin,
-      opt = format.makeReadOptions(options);
-    format.readMessage(this, opt.readerFactory(bytes), bytes.byteLength, opt);
+    const opt = this.getType().runtime.bin.makeReadOptions(options);
+    opt.readerFactory(bytes).message(this, bytes.byteLength, opt);
     return this;
   }
 

--- a/packages/protobuf/src/private/binary-format-common.ts
+++ b/packages/protobuf/src/private/binary-format-common.ts
@@ -145,14 +145,14 @@ export function makeBinaryFormatCommon(): Omit<BinaryFormat, "writeMessage"> {
             if (repeated) {
               // safe to assume presence of array, oneof cannot contain repeated values
               (target[localName] as any[]).push(
-                messageType.fromBinary(reader.bytes(), options)
+                reader.messageField(new messageType(), options)
               );
             } else {
               if (target[localName] instanceof Message) {
-                target[localName].fromBinary(reader.bytes(), options);
+                reader.messageField(target[localName], options);
               } else {
-                target[localName] = messageType.fromBinary(
-                  reader.bytes(),
+                target[localName] = reader.messageField(
+                  new messageType(),
                   options
                 );
                 if (
@@ -235,8 +235,34 @@ function readMapEntry(
 }
 
 function readScalar(reader: IBinaryReader, type: ScalarType): any {
-  let [, method] = scalarTypeInfo(type);
-  return reader[method]();
+  switch (type) {
+    case ScalarType.STRING:
+      return reader.string();
+    case ScalarType.BOOL:
+      return reader.bool();
+    case ScalarType.DOUBLE:
+      return reader.double();
+    case ScalarType.FLOAT:
+      return reader.float();
+    case ScalarType.INT32:
+      return reader.int32();
+    case ScalarType.INT64:
+      return reader.int64();
+    case ScalarType.UINT64:
+      return reader.uint64();
+    case ScalarType.FIXED64:
+      return reader.fixed64();
+    case ScalarType.BYTES:
+      return reader.bytes();
+    case ScalarType.FIXED32:
+      return reader.fixed32();
+    case ScalarType.SFIXED32:
+      return reader.sfixed32();
+    case ScalarType.SFIXED64:
+      return reader.sfixed64();
+    case ScalarType.SINT64:
+      return reader.sint64();
+  }
 }
 
 export function writeMapEntry(


### PR DESCRIPTION
This PR makes a couple of improvements to binary read performance:

1. One of the slowest things during a read with many messages is initializing a BinaryReader for each message with its DataView and TextDecoder. This PR adds a `messageField()` method to BinaryReader that reads a size-delimited message field without constructing a new BinaryReader. (`Message.fromBinary` is refactored to share code). A knock-on effect of this change is that we pass `options` along without repeated calls to `makeReadOptions`, which otherwise needlessly spreads `options` into `readDefaults` when `options` is already equivalent to `readDefaults`.
1. readScalar was calling `reader[method]()` which seems to incur an implicit call to .bind() on the reader method (i.e. it is equivalent to `reader[method].bind(reader)()`. By using an inline switch statement we can avoid that indirection and use a faster path.

I put together a simple benchmark (https://github.com/kbongort/protobuf-es/pull/1) using the following message definitions:
```
message User {
  string first_name = 1;
  string last_name = 2;
  bool active = 3;
  User manager = 4;
  repeated string locations = 5;
  map<string, string> projects = 6;
  int32 number = 7;
}

message UserList {
  repeated User users = 1;
}
```

The benchmark uses both a more complete version of the User message and one with only a few fields set:
```
const userMessage = new User({
  firstName: "Jane",
  lastName: "Doe",
  active: true,
  manager: { firstName: "Jane", lastName: "Doe", active: false },
  locations: ["Seattle", "New York", "Tokyo"],
  projects: { foo: "project foo", bar: "project bar" },
});

const smallUserMessage = new User({
  manager: { active: true },
  number: 2,
});
```

After warming up the cache by reading a serialized userMessage 1000 times, it measures the time to read `userMessage`, to read a UserList of 1000 `userMessage`s, and to read a UserList of 1000 `smallUserMessage`s. The amount of time it takes to call `JSON.parse()` on the JSON version of the message is provided as a point of comparison. Without the changes in this PR, the results are:
```
Benchmark: Single user
	Time to parse JSON: 1135 µs
	Time to parse from binary: 3548 µs
	Ratio: 312%
Benchmark: List of 1000 users
	Time to parse JSON: 920 ms
	Time to parse from binary: 2957 ms
	Ratio: 321%
Benchmark: List of 1000 small users
	Time to parse JSON: 260 ms
	Time to parse from binary: 923 ms
	Ratio: 355%
```

After the changes in this PR, the results are:
```
Benchmark: Single user
	Time to parse JSON: 1088 µs
	Time to parse from binary: 2755 µs
	Ratio: 253%
Benchmark: List of 1000 users
	Time to parse JSON: 921 ms
	Time to parse from binary: 1729 ms
	Ratio: 188%
Benchmark: List of 1000 small users
	Time to parse JSON: 255 ms
	Time to parse from binary: 237 ms
	Ratio: 93%
```

The three test cases show speedups of 29%, 71%, and 290% respectively. The effect of (1) and is especially pronounced when there are many small messages, as in the last benchmark test.