### PR TITLE
Add additional information to docs for serialization

### DIFF
--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -237,7 +237,8 @@ The `toBinary` function also accepts an options object which can be used to cust
 
 ```typescript
 {
-   // Indicates whether to include unknown fields in the serialized output. Defaults to `true`.
+   // Indicates whether to include unknown fields in the serialized output. 
+   // Defaults to `true`.
    // For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
    writeUnknownFields?: boolean;
    
@@ -258,7 +259,8 @@ The `fromBinary` function also accepts an options object which can be used to cu
 
 ```typescript
 {
-   // Indicates whether to retain unknown fields during parsing and include them in the serialized output. Defaults to `true`.
+   // Indicates whether to retain unknown fields during parsing and include them 
+   // in the serialized output. Defaults to `true`.
    // For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
    readUnknownFields?: boolean;
    
@@ -279,18 +281,23 @@ The `toJson` function also accepts an options object which can be used to custom
 
 ```typescript
 {
-   // Indicates whether to emit fields with default values. Fields with default values are omitted by default in proto3 JSON output. 
-   // This option overrides this behavior and outputs fields with their default values.
+   // Indicates whether to emit fields with default values. 
+   // Fields with default values are omitted by default in proto3 JSON output. 
+   // This option overrides this behavior and outputs fields with 
+   // their default values.
    emitDefaultValues?: boolean;
    
    // Indicates whether to emit enum values as integers instead of strings.
-   // The name of an enum value is used by default in JSON output. An option may be provided to use the numeric value of the enum value instead.
+   // The name of an enum value is used by default in JSON output. An option 
+   // may be provided to use the numeric value of the enum value instead.
    enumAsInteger?: boolean;
    
-   // Whether to use the proto field name instead of converting to lowerCamelCase.
-   // By default the proto3 JSON printer should convert the field name to lowerCamelCase and use that as the JSON name. 
-   // An implementation may provide an option to use the proto field name as the JSON name instead. 
-   // Proto3 JSON parsers are required to accept both the converted lowerCamelCase name and the proto field name.
+   // Whether to use the proto field name instead of converting 
+   // to lowerCamelCase. By default the proto3 JSON printer should 
+   // convert the field name to lowerCamelCase and use that as the JSON name. 
+   // An implementation may provide an option to use the proto field name as 
+   // the JSON name instead. Proto3 JSON parsers are required to accept both 
+   // the converted lowerCamelCase name and the proto field name.
    useProtoFieldName?: boolean;
 }
 ```

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -12,7 +12,7 @@ provided by the library.
   - [Accessing oneof groups](#accessing-oneof-groups)
   - [Cloning messages](#cloning-messages)
   - [Comparing messages](#comparing-messages)
-- [Serialization and parsing](#serialization-and-parsing)
+- [Serialization](#serialization)
 - [Using enumerations](#using-enumerations)
 - [Well-known types](#well-known-types)
 - [Message types](#message-types)
@@ -221,20 +221,18 @@ User.equals(user, null); // false
 User.typeName; // docs.User
 ```
 
-## Serialization and parsing
+## Serialization
 
 All messages provide functions for serializing and parsing data between the binary and JSON formats. 
-The JSON format is great for debugging, but the binary format is more resilient
-to changes. For example, you can rename a field, and still parse binary data serialized
-with the previous version. In general, the binary format is also more performant than
-JSON.
 
-Conformance with the binary and the JSON format is ensured by the
-[conformance tests](../packages/protobuf-conformance). We do not implement the text format.
+Conformance with both formats is ensured by the
+[conformance tests](../packages/protobuf-conformance). Protobuf-ES does not implement the text format.
 
-For serializing multiple messages of the same type, also see [size-delimited messages](#size-delimited-messages).
+For serializing multiple messages of the same type, see [size-delimited messages](#size-delimited-messages).
 
 ### Binary
+
+**`toBinary`**
 
 Serializing to the binary format is very straight-forward and is done via the `toBinary` function on all message instances.
 
@@ -267,6 +265,8 @@ const base64: string = protoBase64.enc(bytes)
 User.fromBinary(protoBase64.dec(base64));
 ```
 
+**`fromBinary`**
+
 Parsing binary data is done with the `fromBinary` method, which is a static method on all messages. 
 
 ```typescript
@@ -289,6 +289,13 @@ The `fromBinary` function also accepts an options object which can be used to cu
 
 ### JSON
 
+The JSON format is great for debugging, but the binary format is more resilient
+to changes. For example, you can rename a field, and still parse binary data serialized
+with the previous version. In general, the binary format is also more performant than
+JSON.
+
+**`toJson`**
+
 Serializing to JSON can be done via the `toJson` method on all message instances. 
 
 ```typescript
@@ -310,7 +317,7 @@ The `toJson` function also accepts an options object which can be used to custom
    // may be provided to use the numeric value of the enum value instead.
    enumAsInteger?: boolean;
    
-   // Whether to use the proto field name instead of converting 
+   // Indicates whether to use the proto field name instead of converting 
    // to lowerCamelCase. By default the proto3 JSON printer should 
    // convert the field name to lowerCamelCase and use that as the JSON name. 
    // An implementation may provide an option to use the proto field name as 
@@ -318,37 +325,15 @@ The `toJson` function also accepts an options object which can be used to custom
    // the converted lowerCamelCase name and the proto field name.
    useProtoFieldName?: boolean;
    
-
-  // Required to write `google.protobuf.Any` to JSON format.
+  // A type registry to use when parsing. This is required to write 
+  // google.protobuf.Any to JSON format.
   typeRegistry?: IMessageTypeRegistry;
 }
 ```
-
-Parsing JSON data is done with the `fromJson` method, which is a static method on all messages. 
-
-```typescript
-User.fromJson(json);
-```
-
-The `fromJson` function also accepts an options object for customizing the parsing behavior:
-
-```typescript
-{
-  // Ignore unknown fields: Proto3 JSON parser should reject unknown fields
-  // by default. This option ignores unknown fields in parsing, as well as
-  // unrecognized enum string representations.
-  ignoreUnknownFields?: boolean;
-
-  // Required to read `google.protobuf.Any` from JSON format.
-  typeRegistry?: IMessageTypeRegistry;
-}
-```
-
-
 
 Note that the result of `toJson` will be a [JSON value][src-json-value] – a primitive JavaScript object that can 
 be converted to a JSON string with the built-in function `JSON.stringify()`. For 
-convenience, we also provide methods that include the stringify step:
+convenience, we also provide a method that includes the stringify step:
 
 ```typescript
 // Equivalent to:
@@ -369,10 +354,47 @@ options for the stringify step:
    // It indicates the number of space characters to be used as indentation, clamped to 10 
    // (that is, any number greater than 10 is treated as if it were 10). 
    // Values less than 1 indicate that no space should be used.
-   // For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify.
+   // For more information, see 
+   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify.
    prettySpaces?: number;
 }
 ```
+
+**`fromJson`**
+
+Parsing JSON data is done with the `fromJson` method, which is a static method on all messages. 
+
+```typescript
+User.fromJson(json);
+```
+
+The `fromJson` function also accepts an options object for customizing the parsing behavior:
+
+```typescript
+{
+  // Whether to ignore unknown fields: Proto3 JSON parser should reject unknown fields
+  // by default. This option ignores unknown fields in parsing, as well as
+  // unrecognized enum string representations.
+  ignoreUnknownFields?: boolean;
+
+  // A type registry to use when parsing. This is required to read google.protobuf.Any
+  // from JSON format.
+  typeRegistry?: IMessageTypeRegistry;
+}
+```
+
+Note that `fromJson` expects a [JSON value][src-json-value] – a primitive JavaScript object - as its 
+argument. For convenience, we also provide a function that accepts a JSON string which will first be
+converted to a JSON value and then passed to `fromJson`:
+
+```typescript
+const json = user.toJson();
+const jsonStr = JSON.stringify(json);
+
+user = User.fromJsonString(jsonStr);
+```
+
+The `fromJsonString` function accepts the same options object as `fromJson`.
 
 
 ## Using enumerations

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -247,6 +247,18 @@ The `toBinary` function also accepts an options object which can be used to cust
 }
 ```
 
+It is also possible to serialize to the base64 format from the binary format 
+using the exposed methods from `protoBase64`:
+
+```typescript
+import { protoBase64 } from '@bufbuild/protobuf';
+
+const bytes: Uint8Array = user.toBinary();
+const base64: string = protoBase64.enc(bytes)
+User.fromBinary(protoBase64.dec(base64));
+```
+
+
 ### `fromBinary`
 
 Parsing binary data is done with the `fromBinary` method, which is a static method on all messages. 
@@ -299,98 +311,40 @@ The `toJson` function also accepts an options object which can be used to custom
    // the JSON name instead. Proto3 JSON parsers are required to accept both 
    // the converted lowerCamelCase name and the proto field name.
    useProtoFieldName?: boolean;
-}
-```
-
-
-/**
- * Options for parsing JSON data.
- */
-fromJson / fromJsonString
-JsonReadOptions {
-  /**
-   * Ignore unknown fields: Proto3 JSON parser should reject unknown fields
-   * by default. This option ignores unknown fields in parsing, as well as
-   * unrecognized enum string representations.
-   */
-  ignoreUnknownFields: boolean;
-
-  /**
-   * This option is required to read `google.protobuf.Any`
-   * from JSON format.
-   */
-  typeRegistry?: IMessageTypeRegistry;
-}
-
-/**
- * Options for serializing to JSON.
- */
- toJson
-JsonWriteOptions {
-  /**
-   * Emit fields with default values: Fields with default values are omitted
-   * by default in proto3 JSON output. This option overrides this behavior
-   * and outputs fields with their default values.
-   */
-  emitDefaultValues: boolean;
-
-  /**
-   * Emit enum values as integers instead of strings: The name of an enum
-   * value is used by default in JSON output. An option may be provided to
-   * use the numeric value of the enum value instead.
-   */
-  enumAsInteger: boolean;
-
-  /**
-   * Use proto field name instead of lowerCamelCase name: By default proto3
-   * JSON printer should convert the field name to lowerCamelCase and use
-   * that as the JSON name. An implementation may provide an option to use
-   * proto field name as the JSON name instead. Proto3 JSON parsers are
-   * required to accept both the converted lowerCamelCase name and the proto
-   * field name.
-   */
-  useProtoFieldName: boolean;
-
-  /**
+   
+     /**
    * This option is required to write `google.protobuf.Any`
    * to JSON format.
    */
   typeRegistry?: IMessageTypeRegistry;
 }
-
-## toJsonString
-JsonWriteStringOptions extends JsonWriteOptions {
-  prettySpaces: number;
-}
-
-=================================================
-
-
-Serializing to the base64 format is one step further, using the exposed methods from `protoBase64`:
-
-```typescript
-import { protoBase64 } from '@bufbuild/protobuf';
-
-const bytes: Uint8Array = user.toBinary();
-const base64: string = protoBase64.enc(bytes)
-User.fromBinary(protoBase64.dec(base64));
 ```
 
-Serializing to the JSON format is equally simple:
-
-```typescript
-const json = user.toJson();
-User.fromJson(json);
-```
-
-But the result will be a [JSON value][src-json-value] – a primitive JavaScript that can 
+Note that the result of `toJson` will be a [JSON value][src-json-value] – a primitive JavaScript object that can 
 be converted to a JSON string with the built-in function `JSON.stringify()`. For 
 convenience, we also provide methods that include the stringify step:
 
+```typescript
+// Equivalent to:
+// const json = user.toJson();
+// const jsonStr = JSON.stringify(json);
+
+const jsonStr = user.toJsonString();
+```
+
+The `toJsonString` function also accepts an options object which is the same as the `toJson` options plus one additional option:
 
 ```typescript
-const json = user.toJsonString();
-User.fromJsonString(json);
+{
+   // A convenience property for the `space` option to `JSON.stringify`.
+   // It is used to insert white space (including indentation, line break 
+   // characters, etc.) into the output JSON string for readability purposes.
+   // It indicates the number of space characters to be used as indentation, clamped to 10 
+   // (that is, any number greater than 10 is treated as if it were 10). 
+   // Values less than 1 indicate that no space should be used.
+   // For more information, see [`JSON.stringify`.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
+   prettySpaces?: number;
+}
 ```
 
 Note that the JSON format is great for debugging, but the binary format is more resilient
@@ -403,7 +357,27 @@ Conformance with the binary and the JSON format is ensured by the
 
 For serializing multiple messages of the same type, also see [size-delimited messages](#size-delimited-messages).
 
+### `fromJson`
 
+Parsing JSON data is done with the `fromJson` method, which is a static method on all messages. 
+
+```typescript
+User.fromJson(json);
+```
+
+The `fromJson` function also accepts an options object for customizing the parsing behavior:
+
+```typescript
+{
+  // Ignore unknown fields: Proto3 JSON parser should reject unknown fields
+  // by default. This option ignores unknown fields in parsing, as well as
+  // unrecognized enum string representations.
+  ignoreUnknownFields?: boolean;
+
+  // Required to read `google.protobuf.Any` from JSON format.
+  typeRegistry?: IMessageTypeRegistry;
+}
+```
 
 ## Using enumerations
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -221,14 +221,114 @@ User.equals(user, null); // false
 User.typeName; // docs.User
 ```
 
-### Serializing messages
+### Serializing and parsing messages
 
-Serializing to the binary format is very straight-forward:
+Protobuf-ES supports the binary and JSON format and provides methods for serializing and parsing across these formats.
+
+#### Binary
+
+Serializing to the binary format can be done via the `toBinary` method on all message instances. The method accepts an
+options object which can be used to customize the serialization behavior. Supported options are:
+
+| Option                 | Description                                                                     | Type      | Default |
+|------------------------|---------------------------------------------------------------------------------|-----------|---------|
+| `readUnknownFields`    | Retain unknown fields during parsing and include them in the serialized output. | `boolean` | `true`
+| `readerFactory`        | Allows specifying a custom implementation to decode binary data.                | `(bytes: Uint8Array) => IBinaryReader`
+
+For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
 
 ```typescript
 const bytes: Uint8Array = user.toBinary();
 User.fromBinary(bytes);
 ```
+
+
+Options
+fromBinary BinaryReadOptions {
+  readUnknownFields: boolean;
+
+  /**
+   * Allows to use a custom implementation to decode binary data.
+   */
+  readerFactory: (bytes: Uint8Array) => IBinaryReader;
+}
+
+toBinary BinaryWriteOptions
+  /**
+   * Include unknown fields in the serialized output? The default behavior
+   * is to retain unknown fields and include them in the serialized output.
+   *
+   * For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
+   */
+  writeUnknownFields: boolean;
+
+  /**
+   * Allows to use a custom implementation to encode binary data.
+   */
+  writerFactory: () => IBinaryWriter;
+}
+/**
+ * Options for parsing JSON data.
+ */
+fromJson / fromJsonString
+JsonReadOptions {
+  /**
+   * Ignore unknown fields: Proto3 JSON parser should reject unknown fields
+   * by default. This option ignores unknown fields in parsing, as well as
+   * unrecognized enum string representations.
+   */
+  ignoreUnknownFields: boolean;
+
+  /**
+   * This option is required to read `google.protobuf.Any`
+   * from JSON format.
+   */
+  typeRegistry?: IMessageTypeRegistry;
+}
+
+/**
+ * Options for serializing to JSON.
+ */
+ toJson
+JsonWriteOptions {
+  /**
+   * Emit fields with default values: Fields with default values are omitted
+   * by default in proto3 JSON output. This option overrides this behavior
+   * and outputs fields with their default values.
+   */
+  emitDefaultValues: boolean;
+
+  /**
+   * Emit enum values as integers instead of strings: The name of an enum
+   * value is used by default in JSON output. An option may be provided to
+   * use the numeric value of the enum value instead.
+   */
+  enumAsInteger: boolean;
+
+  /**
+   * Use proto field name instead of lowerCamelCase name: By default proto3
+   * JSON printer should convert the field name to lowerCamelCase and use
+   * that as the JSON name. An implementation may provide an option to use
+   * proto field name as the JSON name instead. Proto3 JSON parsers are
+   * required to accept both the converted lowerCamelCase name and the proto
+   * field name.
+   */
+  useProtoFieldName: boolean;
+
+  /**
+   * This option is required to write `google.protobuf.Any`
+   * to JSON format.
+   */
+  typeRegistry?: IMessageTypeRegistry;
+}
+
+## toJsonString
+JsonWriteStringOptions extends JsonWriteOptions {
+  prettySpaces: number;
+}
+
+=================================================
+
 
 Serializing to the base64 format is one step further, using the exposed methods from `protoBase64`:
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -223,9 +223,18 @@ User.typeName; // docs.User
 
 ## Serialization and parsing
 
-All messages provide functions for serializing and parsing data between the binary and JSON formats.
+All messages provide functions for serializing and parsing data between the binary and JSON formats. 
+The JSON format is great for debugging, but the binary format is more resilient
+to changes. For example, you can rename a field, and still parse binary data serialized
+with the previous version. In general, the binary format is also more performant than
+JSON.
 
-### `toBinary`
+Conformance with the binary and the JSON format is ensured by the
+[conformance tests](../packages/protobuf-conformance). We do not implement the text format.
+
+For serializing multiple messages of the same type, also see [size-delimited messages](#size-delimited-messages).
+
+### Binary
 
 Serializing to the binary format is very straight-forward and is done via the `toBinary` function on all message instances.
 
@@ -258,9 +267,6 @@ const base64: string = protoBase64.enc(bytes)
 User.fromBinary(protoBase64.dec(base64));
 ```
 
-
-### `fromBinary`
-
 Parsing binary data is done with the `fromBinary` method, which is a static method on all messages. 
 
 ```typescript
@@ -281,7 +287,7 @@ The `fromBinary` function also accepts an options object which can be used to cu
 }
 ```
 
-### `toJson`
+### JSON
 
 Serializing to JSON can be done via the `toJson` method on all message instances. 
 
@@ -312,52 +318,11 @@ The `toJson` function also accepts an options object which can be used to custom
    // the converted lowerCamelCase name and the proto field name.
    useProtoFieldName?: boolean;
    
-     /**
-   * This option is required to write `google.protobuf.Any`
-   * to JSON format.
-   */
+
+  // Required to write `google.protobuf.Any` to JSON format.
   typeRegistry?: IMessageTypeRegistry;
 }
 ```
-
-Note that the result of `toJson` will be a [JSON value][src-json-value] – a primitive JavaScript object that can 
-be converted to a JSON string with the built-in function `JSON.stringify()`. For 
-convenience, we also provide methods that include the stringify step:
-
-```typescript
-// Equivalent to:
-// const json = user.toJson();
-// const jsonStr = JSON.stringify(json);
-
-const jsonStr = user.toJsonString();
-```
-
-The `toJsonString` function also accepts an options object which is the same as the `toJson` options plus one additional option:
-
-```typescript
-{
-   // A convenience property for the `space` option to `JSON.stringify`.
-   // It is used to insert white space (including indentation, line break 
-   // characters, etc.) into the output JSON string for readability purposes.
-   // It indicates the number of space characters to be used as indentation, clamped to 10 
-   // (that is, any number greater than 10 is treated as if it were 10). 
-   // Values less than 1 indicate that no space should be used.
-   // For more information, see [`JSON.stringify`.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
-   prettySpaces?: number;
-}
-```
-
-Note that the JSON format is great for debugging, but the binary format is more resilient
-to changes. For example, you can rename a field, and still parse binary data serialized
-with the previous version. In general, the binary format is also more performant than
-JSON.
-
-Conformance with the binary and the JSON format is ensured by the
-[conformance tests](../packages/protobuf-conformance). We do not implement the text format.
-
-For serializing multiple messages of the same type, also see [size-delimited messages](#size-delimited-messages).
-
-### `fromJson`
 
 Parsing JSON data is done with the `fromJson` method, which is a static method on all messages. 
 
@@ -378,6 +343,37 @@ The `fromJson` function also accepts an options object for customizing the parsi
   typeRegistry?: IMessageTypeRegistry;
 }
 ```
+
+
+
+Note that the result of `toJson` will be a [JSON value][src-json-value] – a primitive JavaScript object that can 
+be converted to a JSON string with the built-in function `JSON.stringify()`. For 
+convenience, we also provide methods that include the stringify step:
+
+```typescript
+// Equivalent to:
+// const json = user.toJson();
+// const jsonStr = JSON.stringify(json);
+
+const jsonStr = user.toJsonString();
+```
+
+Since `toJsonString` calls `toJson` under the hood, it accepts the same options object as `toJson` as well as additional
+options for the stringify step:
+
+```typescript
+{
+   // ... all toJson options
+   
+   // A convenience property for the space option to `JSON.stringify`.
+   // It indicates the number of space characters to be used as indentation, clamped to 10 
+   // (that is, any number greater than 10 is treated as if it were 10). 
+   // Values less than 1 indicate that no space should be used.
+   // For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify.
+   prettySpaces?: number;
+}
+```
+
 
 ## Using enumerations
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -12,7 +12,7 @@ provided by the library.
   - [Accessing oneof groups](#accessing-oneof-groups)
   - [Cloning messages](#cloning-messages)
   - [Comparing messages](#comparing-messages)
-  - [Serializing messages](#serializing-messages)
+- [Serialization and parsing](#serialization-and-parsing)
 - [Using enumerations](#using-enumerations)
 - [Well-known types](#well-known-types)
 - [Message types](#message-types)
@@ -221,50 +221,79 @@ User.equals(user, null); // false
 User.typeName; // docs.User
 ```
 
-### Serializing and parsing messages
+## Serialization and parsing
 
-Protobuf-ES supports the binary and JSON format and provides methods for serializing and parsing across these formats.
+All messages provide functions for serializing and parsing data between the binary and JSON formats.
 
-#### Binary
+### `toBinary`
 
-Serializing to the binary format can be done via the `toBinary` method on all message instances. The method returns a `Uint8Array` and accepts an
-options object which can be used to customize the serialization behavior. Supported options are:
-
-| Option                 | Description                                                                     | Type      |
-|------------------------|---------------------------------------------------------------------------------|-----------|
-| `writeUnknownFields`   | Include unknown fields in the serialized output.<br>Defaults to `true`<br>For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns| `boolean` |
-| `writerFactory`        | Allows specifying a custom implementation to encode binary data.                | `() => IBinaryWriter` |
-
-Parsing binary data is done with the `fromBinary` method, which is a static method on all messages. It returns a message instance and accepts a `Uint8Array` with an options object that can be used to customize the parsing behavior. Supported options are:
-
-| Option                 | Description                                                                     | Type      |
-|------------------------|---------------------------------------------------------------------------------|-----------|
-| `readUnknownFields`    | Retain unknown fields during parsing and include them in the serialized output.<br>Defaults to `true`.<br>For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns| `boolean` |
-| `readerFactory`        | Allows specifying a custom implementation to decode binary data.                | `(bytes: Uint8Array) => IBinaryReader` |
-
+Serializing to the binary format is very straight-forward and is done via the `toBinary` function on all message instances.
 
 ```typescript
 const bytes: Uint8Array = user.toBinary();
+```
+
+The `toBinary` function also accepts an options object which can be used to customize the serialization behavior. Supported options are:
+
+```typescript
+{
+   // Indicates whether to include unknown fields in the serialized output. Defaults to `true`.
+   // For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
+   writeUnknownFields?: boolean;
+   
+   // A function for specifying a custom implementation to encode binary data.
+   writerFactory?: () => IBinaryWriter;
+}
+```
+
+### `fromBinary`
+
+Parsing binary data is done with the `fromBinary` method, which is a static method on all messages. 
+
+```typescript
 User.fromBinary(bytes);
 ```
 
-TBD - Divide by binary/json or by serializing/deserializing (the latter is what's done now)
+The `fromBinary` function also accepts an options object which can be used to customize the serialization behavior. Supported options are:
 
-#### JSON
+```typescript
+{
+   // Indicates whether to retain unknown fields during parsing and include them in the serialized output. Defaults to `true`.
+   // For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
+   readUnknownFields?: boolean;
+   
+   // A function for specifying a custom implementation to encode binary data.
+   readerFactory?: (bytes: Uint8Array) => IBinaryReader;
+}
+```
 
-Serializing to JSON can be done via the `toJson` method on all message instances. The method returns a `JsonValue` type and accepts an options object which can be used to customize the serialization behavior. Supported options are:
+### `toJson`
 
-| Option                 | Description                                                                     | Type      |
-|------------------------|---------------------------------------------------------------------------------|-----------|
-| `emitDefaultValues`   | Emit fields with default values. Fields with default values are omitted by default in proto3 JSON output. This option overrides this behavior and outputs fields with their default values. | `boolean` |
-| `enumAsInteger`        | Emit enum values as integers instead of strings: The name of an enum value is used by default in JSON output. An option may be provided to use the numeric value of the enum value instead.              | `boolean` |
-| `useProtoFieldName`        |    Use proto field name instead of lowerCamelCase name: By default proto3
-   * JSON printer should convert the field name to lowerCamelCase and use
-   * that as the JSON name. An implementation may provide an option to use
-   * proto field name as the JSON name instead. Proto3 JSON parsers are
-   * required to accept both the converted lowerCamelCase name and the proto
-   * field name.             | `boolean` |
+Serializing to JSON can be done via the `toJson` method on all message instances. 
 
+```typescript
+const json = user.toJson();
+```
+
+The `toJson` function also accepts an options object which can be used to customize the serialization behavior. Supported options are:
+
+```typescript
+{
+   // Indicates whether to emit fields with default values. Fields with default values are omitted by default in proto3 JSON output. 
+   // This option overrides this behavior and outputs fields with their default values.
+   emitDefaultValues?: boolean;
+   
+   // Indicates whether to emit enum values as integers instead of strings.
+   // The name of an enum value is used by default in JSON output. An option may be provided to use the numeric value of the enum value instead.
+   enumAsInteger?: boolean;
+   
+   // Whether to use the proto field name instead of converting to lowerCamelCase.
+   // By default the proto3 JSON printer should convert the field name to lowerCamelCase and use that as the JSON name. 
+   // An implementation may provide an option to use the proto field name as the JSON name instead. 
+   // Proto3 JSON parsers are required to accept both the converted lowerCamelCase name and the proto field name.
+   useProtoFieldName?: boolean;
+}
+```
 
 
 /**

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -227,46 +227,46 @@ Protobuf-ES supports the binary and JSON format and provides methods for seriali
 
 #### Binary
 
-Serializing to the binary format can be done via the `toBinary` method on all message instances. The method accepts an
+Serializing to the binary format can be done via the `toBinary` method on all message instances. The method returns a `Uint8Array` and accepts an
 options object which can be used to customize the serialization behavior. Supported options are:
 
-| Option                 | Description                                                                     | Type      | Default |
-|------------------------|---------------------------------------------------------------------------------|-----------|---------|
-| `readUnknownFields`    | Retain unknown fields during parsing and include them in the serialized output. | `boolean` | `true`
-| `readerFactory`        | Allows specifying a custom implementation to decode binary data.                | `(bytes: Uint8Array) => IBinaryReader`
+| Option                 | Description                                                                     | Type      |
+|------------------------|---------------------------------------------------------------------------------|-----------|
+| `writeUnknownFields`   | Include unknown fields in the serialized output.<br>Defaults to `true`<br>For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns| `boolean` |
+| `writerFactory`        | Allows specifying a custom implementation to encode binary data.                | `() => IBinaryWriter` |
 
-For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
+Parsing binary data is done with the `fromBinary` method, which is a static method on all messages. It returns a message instance and accepts a `Uint8Array` with an options object that can be used to customize the parsing behavior. Supported options are:
+
+| Option                 | Description                                                                     | Type      |
+|------------------------|---------------------------------------------------------------------------------|-----------|
+| `readUnknownFields`    | Retain unknown fields during parsing and include them in the serialized output.<br>Defaults to `true`.<br>For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns| `boolean` |
+| `readerFactory`        | Allows specifying a custom implementation to decode binary data.                | `(bytes: Uint8Array) => IBinaryReader` |
+
 
 ```typescript
 const bytes: Uint8Array = user.toBinary();
 User.fromBinary(bytes);
 ```
 
+TBD - Divide by binary/json or by serializing/deserializing (the latter is what's done now)
 
-Options
-fromBinary BinaryReadOptions {
-  readUnknownFields: boolean;
+#### JSON
 
-  /**
-   * Allows to use a custom implementation to decode binary data.
-   */
-  readerFactory: (bytes: Uint8Array) => IBinaryReader;
-}
+Serializing to JSON can be done via the `toJson` method on all message instances. The method returns a `JsonValue` type and accepts an options object which can be used to customize the serialization behavior. Supported options are:
 
-toBinary BinaryWriteOptions
-  /**
-   * Include unknown fields in the serialized output? The default behavior
-   * is to retain unknown fields and include them in the serialized output.
-   *
-   * For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
-   */
-  writeUnknownFields: boolean;
+| Option                 | Description                                                                     | Type      |
+|------------------------|---------------------------------------------------------------------------------|-----------|
+| `emitDefaultValues`   | Emit fields with default values. Fields with default values are omitted by default in proto3 JSON output. This option overrides this behavior and outputs fields with their default values. | `boolean` |
+| `enumAsInteger`        | Emit enum values as integers instead of strings: The name of an enum value is used by default in JSON output. An option may be provided to use the numeric value of the enum value instead.              | `boolean` |
+| `useProtoFieldName`        |    Use proto field name instead of lowerCamelCase name: By default proto3
+   * JSON printer should convert the field name to lowerCamelCase and use
+   * that as the JSON name. An implementation may provide an option to use
+   * proto field name as the JSON name instead. Proto3 JSON parsers are
+   * required to accept both the converted lowerCamelCase name and the proto
+   * field name.             | `boolean` |
 
-  /**
-   * Allows to use a custom implementation to encode binary data.
-   */
-  writerFactory: () => IBinaryWriter;
-}
+
+
 /**
  * Options for parsing JSON data.
  */


### PR DESCRIPTION
This expands a bit on the documentation for serialization. It explains the individual methods in a bit more detail and lists their respective options for customizing the serialization behavior.