### PR TITLE
Add additional docs on descriptors and enums

### DIFF
--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -617,13 +617,13 @@ country.values.forEach((val) => console.log(val));
 //  { no: 2, name: 'CANADA', localName: 'CANADA' },
 ```
 
-Similar to messages, enums can also be created at run time, via [`proto3.makeEnum()`][src-proto3-makeEnum].
+Similar to messages, enums can also be created at runtime, via [`proto3.makeEnum()`][src-proto3-makeEnum].
 
 ```typescript
 import { proto3 } from "@bufbuild/protobuf";
 
 const Country = proto3.makeEnum(
-  "spec.Country",
+  "proto.Country",
   [
     {no: 0, name: "UNSPECIFIED", localName: "UNSPECIFIED"},
     {no: 1, name: "USA", localName: "USA"},
@@ -632,16 +632,20 @@ const Country = proto3.makeEnum(
 );
 ```
 
-
 ## Descriptors
 
-### Intro:
+The concept of descriptors is foundational in Protobuf. A descriptor is used to describe the properties of individual types in the Protobuf grammar. 
+Descriptors are also Protobuf messages themselves and are defined in Protobuf's [descriptor.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto) file.
 
-explain that proto compilers compile to descriptors (protobuf messages themselves!) - they are foundational in protobuf, and used for protobuf plugins too
+When Protobuf compilers such as `protoc` or `buf` are run against Protobuf files, they generate these descriptors. They can then be used in a variety of ways, such as generating code using Protobuf plugins.
 
-explain their idiosyncrasies, and that protobuf-es provides a convenient abstraction with Descriptor Interfaces
+Descriptors are very powerful and can be extremely convenient. However, they are not without their idiosyncrasies:
 
-### Descriptor interfaces
+* list of idiosyncrasies
+
+To help alleviate the difficulty of working with these peculiarities, Protobuf-ES provides a convenient abstraction with Descriptor Interfaces.
+
+### Descriptor Interfaces
 
 what we have documented is good, but
    we are missing a reference to DescriptorSet, and 
@@ -697,9 +701,6 @@ const registry = createRegistryFromDescriptors(
 );
 const User = registry.findMessage("doc.User");
 ```
-
-==============================================
-
 
 ## Advanced TypeScript types
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -13,15 +13,25 @@ provided by the library.
   - [Cloning messages](#cloning-messages)
   - [Comparing messages](#comparing-messages)
   - [Serializing messages](#serializing-messages)
-- [Using enumerations](#using-enumerations)
 - [Well-known types](#well-known-types)
-- [Message types](#message-types)
+  - [Additional convenience methods](#additional-convenience-methods)
+    - [`Timestamp`](#timestamp)
+    - [`Any`](#any)
+    - [`Struct`](#struct)
 - [64-bit-integral-types](#64-bit-integral-types)
+  - [`bigint` in unsupported environments](#bigint-in-unsupported-environments)
 - [Size-delimited messages](#size-delimited-messages)
+- [Message types](#message-types)
 - [Reflection](#reflection)
   - [Iterating over message fields](#iterating-over-message-fields)
+  - [Accessing enumerations](#accessing-enumerations)
+- [Descriptors](#descriptors)
+  - [Descriptor Interfaces](#descriptor-interfaces)
   - [Registries](#registries)
 - [Advanced TypeScript types](#advanced-typescript-types)
+  - [`PartialMessage`](#partialmessage)
+  - [`PlainMessage`](#plainmessage)
+  - [`AnyMessage`](#anymessage)
 
 
 ## Message class
@@ -312,10 +322,11 @@ Protocol buffers have a small standard library of well-known types.
 | [`Value`](../packages/protobuf/src/google/protobuf/struct_pb.ts)                 | message | [google/protobuf/struct.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/struct.proto)                 |
 </details>
 
+### Additional convenience methods
+
 Some of the well-known types provide additional methods for convenience:
 
-
-### Timestamp
+#### Timestamp
 
 ````typescript
 import { Timestamp } from "@bufbuild/protobuf";
@@ -330,7 +341,7 @@ ts = Timestamp.now()
 ts.toDate();
 ````
 
-### Any
+#### Any
 
 ```typescript
 import { Any } from "@bufbuild/protobuf";
@@ -357,8 +368,7 @@ any.unpackTo(ts); // false, you provided an instance of the wrong type
 
 ```
 
-
-### Struct
+#### Struct
 
 `google.protobuf.Struct` can represent anything JSON can represent. But it is a bit
 cumbersome to construct a `Struct`:

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -565,12 +565,68 @@ The resulting `User` is completely equivalent to the generated TypeScript class.
 this exact piece of code is generated with the plugin option `target=js`, because if saves us
 quite a bit of code size.
 
-
-
 ## Reflection
 
+### Iterating over message fields
+
+The following example shows how to iterate over the fields of an arbitrary message.
+
+```typescript
+function walkFields(message: AnyMessage) {
+  for (const fieldInfo of message.getType().fields.byNumber()) {
+    const value = message[fieldInfo.localName];
+    console.log(`field ${fieldInfo.localName}: ${value}`);
+  }
+}
+
+walkFields(user);
+// field firstName: Homer
+// field lastName: Simpson
+// field active: true
+// field manager: undefined
+// field locations: SPRINGFIELD
+// field projects: {"SPP":"Springfield Power Plant"}
+```
+
+Note that the example does not handle oneof groups. Please consult the sources code 
+for examples how to include them. The JSON and binary serialization mechanisms use this 
+technique. 
+
+### Accessing enumerations
+- show how to use getEnumType() to list enum values, and to get the JSON string value from a runtime enum value)
+
+## Descriptors
+
+### Intro:
+
+explain that proto compilers compile to descriptors (protobuf messages themselves!) - they are foundational in protobuf, and used for protobuf plugins too
+
+explain their idiosyncrasies, and that protobuf-es provides a convenient abstraction with Descriptor Interfaces
+
+### Descriptor interfaces
+
+what we have documented is good, but
+   we are missing a reference to DescriptorSet, and 
+   we need to explain createDescriptorSet() with an example, and 
+   we have to explain that those exact types are used for plugins with @bufbuild/protoplugin
+
+**Protobuf-ES** uses its own interfaces that mostly correspond to the FileDescriptor objects representing the various elements of Protobuf grammar (messages, enums, services, methods, etc.). Each of the framework interfaces is prefixed with `Desc`, i.e. `DescMessage`, `DescEnum`, `DescService`, `DescMethod`.
+
+The hierarchy starts with `DescFile`, which represents the contents of a Protobuf file.  This object then contains all the nested `Desc` types corresponding to the above.  For example:
+
+```
+-- DescFile
+   |--- DescEnum
+   |--- DescMessage
+      |--- DescField
+      |--- DescOneof
+   |--- DescService
+      |--- DescMethod
+```
 
 ### Registries
+
+> what we have documented is good, but with the sections above, we can tie it together, and explain that createRegistryFromDescriptors() also takes a DescriptorSet 
 
 **Protobuf-ES** does not provide a global registry of types because it can lead to runtime errors and also hampers tree-shaking.  However, it is possible to create your own registry using [`createRegistry()`](https://github.com/bufbuild/protobuf-es/blob/31ab04b1109520096a57f3c9b696c5d78b7b6caf/packages/protobuf/src/create-registry.ts).  For example:
 
@@ -604,46 +660,7 @@ const registry = createRegistryFromDescriptors(
 const User = registry.findMessage("doc.User");
 ```
 
-### Descriptor Interfaces
-
-**Protobuf-ES** uses its own interfaces that mostly correspond to the FileDescriptor objects representing the various elements of Protobuf grammar (messages, enums, services, methods, etc.). Each of the framework interfaces is prefixed with `Desc`, i.e. `DescMessage`, `DescEnum`, `DescService`, `DescMethod`.
-
-The hierarchy starts with `DescFile`, which represents the contents of a Protobuf file.  This object then contains all the nested `Desc` types corresponding to the above.  For example:
-
-```
--- DescFile
-   |--- DescEnum
-   |--- DescMessage
-      |--- DescField
-      |--- DescOneof
-   |--- DescService
-      |--- DescMethod
-```
-
-### Iterating over message fields
-
-The following example shows how to iterate over the fields of an arbitrary message.
-
-```typescript
-function walkFields(message: AnyMessage) {
-  for (const fieldInfo of message.getType().fields.byNumber()) {
-    const value = message[fieldInfo.localName];
-    console.log(`field ${fieldInfo.localName}: ${value}`);
-  }
-}
-
-walkFields(user);
-// field firstName: Homer
-// field lastName: Simpson
-// field active: true
-// field manager: undefined
-// field locations: SPRINGFIELD
-// field projects: {"SPP":"Springfield Power Plant"}
-```
-
-Note that the example does not handle oneof groups. Please consult the sources code 
-for examples how to include them. The JSON and binary serialization mechanisms use this 
-technique. 
+==============================================
 
 
 ## Advanced TypeScript types

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -571,28 +571,67 @@ for examples how to include them. The JSON and binary serialization mechanisms u
 technique. 
 
 ### Accessing enumerations
-- show how to use getEnumType() to list enum values, and to get the JSON string value from a runtime enum value)
 
-For enumerations, we lean on TypeScript enums. A quick refresher about them:
+For enumerations, we lean on TypeScript enums. For a quick refresher about them, see
+the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/enums.html).
 
-- It is possible to look up the name for an enum value:
-  ```typescript
-  let val: MyEnum = MyEnum.FOO;
-  let name = MyEnum[val]; // => "FOO"
-  ``` 
-- and to look up an enum value by name:
-  ```typescript
-  let val: MyEnum = MyEnum["FOO"];
-  ``` 
-- TypeScript enums are just plain objects in JavaScript.
-- TypeScript enums support aliases - as does protobuf with the `allow_alias` option.
+In addition to the basic characteristics of TypeScript enums, it is worth nothing that
+TypeScript enums support aliases - as does Protobuf with the `allow_alias` option.
 
-However, similar to MessageType, there is also [`EnumType`][src-enum-type].
-It provides the fully qualified protobuf type name, as well as the original values and 
+It is possible to look up the an enum name by value and vice versa. For example, 
+given the following enum definition:
+
+```protobuf
+enum Country {
+    UNSPECIFIED = 0;
+    USA = 1;
+    CANADA = 2;
+}
+```
+
+It is possible to look up the name by value:
+
+```typescript
+let val: Country = Country.USA;
+let name = Country[val]; // => "USA"
+``` 
+  
+And to look up the enum value by name:
+```typescript
+let val: Country = Country["USA"]; // => 1
+``` 
+
+Similar to `MessageType`, there is also [`EnumType`][src-enum-type].
+It provides the fully qualified Protobuf type name, as well as the original values and 
 their names. Use  [`proto3.getEnumType()`][src-proto3-getEnumType] to retrieve the 
-EnumType for a given enum.
+`EnumType` for a given enum. You can then use the `EnumType` to list the enum values:
+
+```typescript
+import { proto3, EnumType } from "@bufbuild/protobuf";
+
+const country: EnumType = proto3.getEnumType(Country);
+country.values.forEach((val) => console.log(val));
+
+//  { no: 0, name: 'UNSPECIFIED', localName: 'UNSPECIFIED' },
+//  { no: 1, name: 'USA', localName: 'USA' },
+//  { no: 2, name: 'CANADA', localName: 'CANADA' },
+```
 
 Similar to messages, enums can also be created at run time, via [`proto3.makeEnum()`][src-proto3-makeEnum].
+
+```typescript
+import { proto3 } from "@bufbuild/protobuf";
+
+const Country = proto3.makeEnum(
+  "spec.Country",
+  [
+    {no: 0, name: "UNSPECIFIED", localName: "UNSPECIFIED"},
+    {no: 1, name: "USA", localName: "USA"},
+    {no: 2, name: "CANADA", localName: "CANADA"},
+  ],
+);
+```
+
 
 ## Descriptors
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -269,28 +269,6 @@ For serializing multiple messages of the same type, also see [size-delimited mes
 
 
 
-## Using enumerations
-
-For enumerations, we lean on TypeScript enums. A quick refresher about them:
-
-- It is possible to look up the name for an enum value:
-  ```typescript
-  let val: MyEnum = MyEnum.FOO;
-  let name = MyEnum[val]; // => "FOO"
-  ``` 
-- and to look up an enum value by name:
-  ```typescript
-  let val: MyEnum = MyEnum["FOO"];
-  ``` 
-- TypeScript enums are just plain objects in JavaScript.
-- TypeScript enums support aliases - as does protobuf with the `allow_alias` option.
-
-However, similar to MessageType, there is also [`EnumType`][src-enum-type].
-It provides the fully qualified protobuf type name, as well as the original values and 
-their names. Use  [`proto3.getEnumType()`][src-proto3-getEnumType] to retrieve the 
-EnumType for a given enum.
-
-Similar to messages, enums can also be created at run time, via [`proto3.makeEnum()`][src-proto3-makeEnum].
 
 
 ## Well-known types
@@ -594,6 +572,27 @@ technique.
 
 ### Accessing enumerations
 - show how to use getEnumType() to list enum values, and to get the JSON string value from a runtime enum value)
+
+For enumerations, we lean on TypeScript enums. A quick refresher about them:
+
+- It is possible to look up the name for an enum value:
+  ```typescript
+  let val: MyEnum = MyEnum.FOO;
+  let name = MyEnum[val]; // => "FOO"
+  ``` 
+- and to look up an enum value by name:
+  ```typescript
+  let val: MyEnum = MyEnum["FOO"];
+  ``` 
+- TypeScript enums are just plain objects in JavaScript.
+- TypeScript enums support aliases - as does protobuf with the `allow_alias` option.
+
+However, similar to MessageType, there is also [`EnumType`][src-enum-type].
+It provides the fully qualified protobuf type name, as well as the original values and 
+their names. Use  [`proto3.getEnumType()`][src-proto3-getEnumType] to retrieve the 
+EnumType for a given enum.
+
+Similar to messages, enums can also be created at run time, via [`proto3.makeEnum()`][src-proto3-makeEnum].
 
 ## Descriptors
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -599,14 +599,14 @@ enum Country {
 }
 ```
 
-It is possible to look up the name by value:
+You can look up the name by value:
 
 ```typescript
 let val: Country = Country.USA;
 let name = Country[val]; // => "USA"
 ``` 
   
-And to look up the enum value by name:
+And look up the enum value by name:
 ```typescript
 let val: Country = Country["USA"]; // => 1
 ``` 


### PR DESCRIPTION
This expands on the documentation for descriptors and enums and also ensures the table of contents contains all the correct headings in the doc body.