### PR TITLE
Fix JSDoc for protoBase64.enc

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 87,033 b      | 37,025 b | 9,675 b |
+| protobuf-es         | 86,756 b      | 37,025 b | 9,675 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf/src/proto-base64.ts
+++ b/packages/protobuf/src/proto-base64.ts
@@ -92,15 +92,7 @@ export const protoBase64 = {
     return bytes.subarray(0, bytePos);
   },
   /**
-   * Decodes a base64 string to a byte array.
-   *
-   * - ignores white-space, including line breaks and tabs
-   * - allows inner padding (can decode concatenated base64 strings)
-   * - does not require padding
-   * - understands base64url encoding:
-   *   "-" instead of "+",
-   *   "_" instead of "/",
-   *   no padding
+   * Encode a byte array to a base64 string.
    */
   enc(bytes: Uint8Array): string {
     let base64 = "",
@@ -129,7 +121,7 @@ export const protoBase64 = {
       }
     }
 
-    // padding required?
+    // add output padding
     if (groupPos) {
       base64 += encTable[p];
       base64 += "=";


### PR DESCRIPTION
The JSDoc for the function to encode was a copy of the JSDoc for decode. 

Closes #468.