### PR TITLE
Add additional tests to illustrate FieldMask serialization failures

### DIFF
--- a/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.js
@@ -282,7 +282,7 @@ FieldMask.prototype.toJson = function toJson(options) {
   }
   return this.paths.map(p => {
     if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
-      throw new Error("cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
+      throw new Error("cannot encode google.protobuf.FieldMask to JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
     }
     return protoCamelCase(p);
   }).join(",");

--- a/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/field_mask_pb.js
@@ -282,7 +282,7 @@ FieldMask.prototype.toJson = function toJson(options) {
   }
   return this.paths.map(p => {
     if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
-      throw new Error("cannot decode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
+      throw new Error("cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
     }
     return protoCamelCase(p);
   }).join(",");

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
@@ -289,7 +289,7 @@ export class FieldMask extends Message<FieldMask> {
     }
     return this.paths.map(p => {
       if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
-        throw new Error("cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
+        throw new Error("cannot encode google.protobuf.FieldMask to JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
       }
       return protoCamelCase(p);
     }).join(",");

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/field_mask_pb.ts
@@ -289,7 +289,7 @@ export class FieldMask extends Message<FieldMask> {
     }
     return this.paths.map(p => {
       if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
-        throw new Error("cannot decode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
+        throw new Error("cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
       }
       return protoCamelCase(p);
     }).join(",");

--- a/packages/protobuf-test/src/google/protobuf/field_mask.test.ts
+++ b/packages/protobuf-test/src/google/protobuf/field_mask.test.ts
@@ -34,5 +34,23 @@ describe("google.protobuf.FieldMask", () => {
       });
       expect(FieldMask.fromJson(json)).toStrictEqual(want);
     });
+    test("toJson fails on invalid fieldmask paths", () => {
+      const fieldMask = new FieldMask({
+        paths: ["user.displayName", "photo"],
+      });
+      expect(() => {
+        fieldMask.toJson();
+      }).toThrow(
+        'cannot decode google.protobuf.FieldMask from JSON: lowerCamelCase of path name "user.displayName" is irreversible'
+      );
+    });
+    test("fromJson fails on invalid json", () => {
+      const json = "user.display_name,photo";
+      expect(() => {
+        FieldMask.fromJson(json);
+      }).toThrow(
+        "cannot decode google.protobuf.FieldMask from JSON: path names must be lowerCamelCase"
+      );
+    });
   });
 });

--- a/packages/protobuf-test/src/google/protobuf/field_mask.test.ts
+++ b/packages/protobuf-test/src/google/protobuf/field_mask.test.ts
@@ -41,7 +41,7 @@ describe("google.protobuf.FieldMask", () => {
       expect(() => {
         fieldMask.toJson();
       }).toThrow(
-        'cannot decode google.protobuf.FieldMask from JSON: lowerCamelCase of path name "user.displayName" is irreversible'
+        'cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name "user.displayName" is irreversible'
       );
     });
     test("fromJson fails on invalid json", () => {

--- a/packages/protobuf-test/src/google/protobuf/field_mask.test.ts
+++ b/packages/protobuf-test/src/google/protobuf/field_mask.test.ts
@@ -41,7 +41,7 @@ describe("google.protobuf.FieldMask", () => {
       expect(() => {
         fieldMask.toJson();
       }).toThrow(
-        'cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name "user.displayName" is irreversible'
+        'cannot encode google.protobuf.FieldMask to JSON: lowerCamelCase of path name "user.displayName" is irreversible'
       );
     });
     test("fromJson fails on invalid json", () => {

--- a/packages/protobuf/src/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf/src/google/protobuf/field_mask_pb.ts
@@ -277,7 +277,7 @@ export class FieldMask extends Message<FieldMask> {
     }
     return this.paths.map(p => {
       if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
-        throw new Error("cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
+        throw new Error("cannot encode google.protobuf.FieldMask to JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
       }
       return protoCamelCase(p);
     }).join(",");

--- a/packages/protobuf/src/google/protobuf/field_mask_pb.ts
+++ b/packages/protobuf/src/google/protobuf/field_mask_pb.ts
@@ -277,7 +277,7 @@ export class FieldMask extends Message<FieldMask> {
     }
     return this.paths.map(p => {
       if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
-        throw new Error("cannot decode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
+        throw new Error("cannot encode google.protobuf.FieldMask from JSON: lowerCamelCase of path name \"" + p + "\" is irreversible");
       }
       return protoCamelCase(p);
     }).join(",");

--- a/packages/protoc-gen-es/src/javascript.ts
+++ b/packages/protoc-gen-es/src/javascript.ts
@@ -359,7 +359,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`    text += "." + nanosStr;`)
       f.print("    if (this.", localName(ref.nanos), " < 0 && this.", localName(ref.seconds), " === ", protoInt64, ".zero) {");
       f.print(`        text = "-" + text;`);
-      f.print(`    }`);      
+      f.print(`    }`);
       f.print("  }")
       f.print(`  return text + "s";`)
       f.print("};");
@@ -486,7 +486,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`  }`)
       f.print(`  return this.`, localName(ref.paths), `.map(p => {`)
       f.print(`    if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {`)
-      f.print(`      throw new Error("cannot decode `, message.typeName, ` from JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
+      f.print(`      throw new Error("cannot encode `, message.typeName, ` from JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
       f.print(`    }`)
       f.print(`    return protoCamelCase(p);`)
       f.print(`  }).join(",");`)

--- a/packages/protoc-gen-es/src/javascript.ts
+++ b/packages/protoc-gen-es/src/javascript.ts
@@ -486,7 +486,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`  }`)
       f.print(`  return this.`, localName(ref.paths), `.map(p => {`)
       f.print(`    if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {`)
-      f.print(`      throw new Error("cannot encode `, message.typeName, ` from JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
+      f.print(`      throw new Error("cannot encode `, message.typeName, ` to JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
       f.print(`    }`)
       f.print(`    return protoCamelCase(p);`)
       f.print(`  }).join(",");`)

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -384,7 +384,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`      text += "." + nanosStr;`)
       f.print("      if (this.", localName(ref.nanos), " < 0 && this.", localName(ref.seconds), " === ", protoInt64, ".zero) {");
       f.print(`          text = "-" + text;`);
-      f.print(`      }`);      
+      f.print(`      }`);
       f.print("    }")
       f.print(`    return text + "s";`)
       f.print("  }")
@@ -513,7 +513,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`    }`)
       f.print(`    return this.`, localName(ref.paths), `.map(p => {`)
       f.print(`      if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {`)
-      f.print(`        throw new Error("cannot decode `, message.typeName, ` from JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
+      f.print(`        throw new Error("cannot encode `, message.typeName, ` from JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
       f.print(`      }`)
       f.print(`      return protoCamelCase(p);`)
       f.print(`    }).join(",");`)

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -513,7 +513,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`    }`)
       f.print(`    return this.`, localName(ref.paths), `.map(p => {`)
       f.print(`      if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {`)
-      f.print(`        throw new Error("cannot encode `, message.typeName, ` from JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
+      f.print(`        throw new Error("cannot encode `, message.typeName, ` to JSON: lowerCamelCase of path name \\"" + p + "\\" is irreversible");`)
       f.print(`      }`)
       f.print(`      return protoCamelCase(p);`)
       f.print(`    }).join(",");`)


### PR DESCRIPTION
This adds additional unit tests to test the failure scenarios when serializing a `FieldMask` with invalid path names and when deserializing JSON with invalid field names in the string.