### PR TITLE
Add basic performance benchmarks for binary parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,13 @@ $(GEN)/protobuf-conformance: $(BIN)/protoc $(BUILD)/protoc-gen-es Makefile
 	@touch $(@)
 
 $(GEN)/protobuf-example: $(BUILD)/protoc-gen-es packages/protobuf-example/buf.gen.yaml $(shell find packages/protobuf-example -name '*.proto')
-	@rm -rf packages/protobuf-example/src/gen/*
+	npm run -w packages/protobuf-example clean
 	npm run -w packages/protobuf-example generate
 	@mkdir -p $(@D)
 	@touch $(@)
 
 $(GEN)/protobuf-bench: $(BIN)/protoc $(BUILD)/protoc-gen-es packages/protobuf-bench Makefile
-	@rm -rf packages/protobuf-bench/src/gen/*
+	npm run -w packages/protobuf-bench clean
 	npx buf generate buf.build/bufbuild/buf:4505cba5e5a94a42af02ebc7ac3a0a04 --template packages/protobuf-bench/buf.gen.yaml --output packages/protobuf-bench
 	@mkdir -p $(@D)
 	@touch $(@)
@@ -205,6 +205,10 @@ format: node_modules $(BIN)/git-ls-files-unstaged $(BIN)/license-header ## Forma
 .PHONY: bench
 bench: node_modules $(GEN)/protobuf-bench $(BUILD)/protobuf ## Benchmark code size
 	npm run -w packages/protobuf-bench report
+
+.PHONY: perf
+perf: $(BUILD)/protobuf-test
+	npm run -w packages/protobuf-test perf
 
 .PHONY: boostrapwkt
 bootstrapwkt: $(BIN)/protoc $(BUILD)/protoc-gen-es $(BIN)/license-header ## Generate the well-known types in @bufbuild/protobuf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,6 +1644,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/benchmark": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-2.1.2.tgz",
+      "integrity": "sha512-EDKtLYNMKrig22jEvhXq8TBFyFgVNSPmDF2b9UzJ7+eylPqdZVo17PCUMkn1jP6/1A/0u78VqYC6VrX6b8pDWA=="
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -2191,6 +2196,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4569,6 +4583,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
@@ -4995,6 +5014,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5976,6 +6000,8 @@
       "name": "@bufbuild/protobuf-test",
       "dependencies": {
         "@bufbuild/protobuf": "1.2.0",
+        "@types/benchmark": "^2.1.2",
+        "benchmark": "^2.1.4",
         "long": "~5.0.1",
         "ts4_1_2": "npm:typescript@4.1.2",
         "ts4_2_4": "npm:typescript@4.2.4",

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -5,7 +5,8 @@
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types && npm run build:copy-gen-js",
     "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
-    "build:copy-gen-js": "rsync -a --exclude '*.js' src/gen/js dist/types/gen && rsync -a --exclude '*.d.ts' src/gen/js dist/esm/gen"
+    "build:copy-gen-js": "rsync -a --exclude '*.js' src/gen/js dist/types/gen && rsync -a --exclude '*.d.ts' src/gen/js dist/esm/gen",
+    "perf": "tsx src/perf.ts"
   },
   "type": "module",
   "types": "./dist/types/index.d.ts",
@@ -15,6 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "1.2.0",
+    "@types/benchmark": "^2.1.2",
+    "benchmark": "^2.1.4",
     "long": "~5.0.1",
     "ts4_1_2": "npm:typescript@4.1.2",
     "ts4_2_4": "npm:typescript@4.2.4",

--- a/packages/protobuf-test/src/perf.ts
+++ b/packages/protobuf-test/src/perf.ts
@@ -1,0 +1,211 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark from "benchmark";
+import { readFileSync } from "node:fs";
+import { FileDescriptorSet } from "./gen/ts/google/protobuf/descriptor_pb.js";
+import { User } from "./gen/ts/extra/example_pb.js";
+import { protoInt64 } from "@bufbuild/protobuf";
+import {
+  RepeatedScalarValuesMessage,
+  ScalarValuesMessage,
+} from "./gen/ts/extra/msg-scalar_pb.js";
+import { MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
+import {
+  MessageFieldMessage,
+  MessageFieldMessage_TestMessage,
+} from "./gen/ts/extra/msg-message_pb.js";
+
+/* eslint-disable no-console, import/no-named-as-default-member */
+
+run("Parsing binary", [
+  function () {
+    const data = readFileSync("./descriptorset.bin");
+    return {
+      name: `large google.protobuf.FileDescriptorSet (${data.byteLength} bytes)`,
+      fn: () => {
+        FileDescriptorSet.fromBinary(data);
+      },
+    };
+  },
+  function () {
+    const tinyUser = new User({
+      active: false,
+      manager: { active: true },
+    });
+    const data = tinyUser.toBinary();
+    return {
+      name: `tiny docs.User (${data.byteLength} bytes)`,
+      fn: () => {
+        FileDescriptorSet.fromBinary(data);
+      },
+    };
+  },
+  function () {
+    const message = new ScalarValuesMessage({
+      doubleField: 0.75,
+      floatField: -0.75,
+      int64Field: protoInt64.parse(-1),
+      uint64Field: protoInt64.uParse(1),
+      int32Field: -123,
+      fixed64Field: protoInt64.uParse(1),
+      fixed32Field: 123,
+      boolField: true,
+      stringField: "hello world",
+      bytesField: new Uint8Array([
+        104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100,
+      ]),
+      uint32Field: 123,
+      sfixed32Field: -123,
+      sfixed64Field: protoInt64.parse(-1),
+      sint32Field: -1,
+      sint64Field: protoInt64.parse(-1),
+    });
+    const data = message.toBinary();
+    return {
+      name: `scalar values (${data.byteLength} bytes)`,
+      fn: () => {
+        ScalarValuesMessage.fromBinary(data);
+      },
+    };
+  },
+  function () {
+    const message = new RepeatedScalarValuesMessage({
+      doubleField: [0.75, 0, 1],
+      floatField: [0.75, -0.75],
+      int64Field: [protoInt64.parse(-1), protoInt64.parse(-2)],
+      uint64Field: [protoInt64.uParse(1), protoInt64.uParse(2)],
+      int32Field: [-123, 500],
+      fixed64Field: [protoInt64.uParse(1), protoInt64.uParse(99)],
+      fixed32Field: [123, 999],
+      boolField: [true, false, true],
+      stringField: ["hello", "world"],
+      bytesField: [
+        new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
+      ],
+      uint32Field: [123, 123],
+      sfixed32Field: [-123, -123, -123],
+      sfixed64Field: [
+        protoInt64.parse(-1),
+        protoInt64.parse(-2),
+        protoInt64.parse(100),
+      ],
+      sint32Field: [-1, -2, 999],
+      sint64Field: [
+        protoInt64.parse(-1),
+        protoInt64.parse(-99),
+        protoInt64.parse(99),
+      ],
+    });
+    const data = message.toBinary();
+    return {
+      name: `repeated scalar fields (${data.byteLength} bytes)`,
+      fn: () => {
+        RepeatedScalarValuesMessage.fromBinary(data);
+      },
+    };
+  },
+  function () {
+    const message = new MapsMessage({
+      strStrField: { a: "str", b: "xx" },
+      strInt32Field: { a: 123, b: 455 },
+      strInt64Field: { a: protoInt64.parse(123) },
+      strBoolField: { a: true, b: false },
+      strBytesField: {
+        a: new Uint8Array([
+          104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100,
+        ]),
+      },
+      int32StrField: { 123: "hello" },
+      int64StrField: { "9223372036854775807": "hello" },
+      boolStrField: { true: "yes", false: "no" },
+      strEnuField: { a: 0, b: 1, c: 2 },
+      int32EnuField: { 1: 0, 2: 1, 0: 2 },
+      int64EnuField: { "-1": 0, "2": 1, "0": 2 },
+    });
+    const data = message.toBinary();
+    return {
+      name: `map with scalar keys and values (${data.byteLength} bytes)`,
+      fn: () => {
+        MapsMessage.fromBinary(data);
+      },
+    };
+  },
+  function () {
+    const message = new MessageFieldMessage();
+    for (let i = 0; i < 1000; i++) {
+      message.repeatedMessageField.push(new MessageFieldMessage_TestMessage());
+    }
+    const data = message.toBinary();
+    return {
+      name: `repeated field with 1000 messages (${data.byteLength} bytes)`,
+      fn: () => {
+        MessageFieldMessage.fromBinary(data);
+      },
+    };
+  },
+  function () {
+    const message = new MapsMessage();
+    for (let i = 0; i < 1000; i++) {
+      message.strMsgField[i.toString()] = new MapsMessage();
+    }
+    const data = message.toBinary();
+    return {
+      name: `map field with 1000 messages (${data.byteLength} bytes)`,
+      fn: () => {
+        MapsMessage.fromBinary(data);
+      },
+    };
+  },
+]);
+
+interface Test {
+  name: string;
+  fn: () => void;
+}
+
+/**
+ * Benchmark a suite of tests with the npm package "benchmark". Results are
+ * printed to standard out.
+ */
+function run(name: string, tests: (Test | (() => Test))[]): void {
+  let error: unknown;
+  const suite = new Benchmark.Suite({
+    name,
+    onCycle(event: Event) {
+      console.log(String(event.target));
+    },
+    onError(event: Event) {
+      const target = event.target as unknown;
+      if (typeof target == "object" && target !== null && "error" in target) {
+        error = (target as { error: unknown }).error;
+      }
+    },
+    async: false,
+  });
+  for (const testOrProvider of tests) {
+    if (typeof testOrProvider == "function") {
+      const { name, fn } = testOrProvider();
+      suite.add(name, fn);
+    } else {
+      const { name, fn } = testOrProvider;
+      suite.add(name, fn);
+    }
+  }
+  console.log(`### ${String(suite.name)}`);
+  suite.run();
+  if (error !== undefined) {
+    throw error;
+  }
+}


### PR DESCRIPTION
This adds a simple suite of performance benchmarks for parsing from the binary format.

`make bench` outputs:

```
### Parsing binary
large google.protobuf.FileDescriptorSet (1027010 bytes) x 29.20 ops/sec ±6.57% (51 runs sampled)
tiny docs.User (4 bytes) x 2,482,014 ops/sec ±0.70% (93 runs sampled)
scalar values (102 bytes) x 528,864 ops/sec ±0.16% (99 runs sampled)
repeated scalar fields (195 bytes) x 268,070 ops/sec ±0.16% (97 runs sampled)
map with scalar keys and values (186 bytes) x 173,328 ops/sec ±0.08% (100 runs sampled)
repeated field with 1000 messages (2000 bytes) x 2,798 ops/sec ±0.12% (101 runs sampled)
map field with 1000 messages (8890 bytes) x 1,746 ops/sec ±0.13% (99 runs sampled)
```