### PR TITLE
fix: resolve field type name in file descriptor

### DIFF
--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -534,7 +534,21 @@ function newField(
           ...getMapFieldTypes(mapEntry),
         };
       }
-      const message = cart.messages.get(trimLeadingDot(proto.typeName));
+
+      const trimmedName = trimLeadingDot(proto.typeName);
+      let message = cart.messages.get(trimmedName);
+      if (message === undefined && !trimmedName.includes('.')) {
+        const parts = parent.typeName.split('.');
+        while (parts.length > 0) {
+          const parentName = parts.join('.');
+          message = cart.messages.get(`${parentName}.${trimmedName}`);
+          if (message !== undefined) {
+              break;
+          }
+          parts.pop();
+        }
+      }
+
       assert(
         message !== undefined,
         `invalid FieldDescriptorProto: type_name ${proto.typeName} not found`


### PR DESCRIPTION
Ref: https://github.com/bufbuild/protobuf-es/issues/494

This is merely meant to demonstrate the problem I'm facing. I'm absolutely not sure if this needs fixing here or in `protobufjs`. Are fields referencing local types supposed to be fully resolved to their fully qualified names in a file descriptor? It seems that `protobufjs` thinks they shouldn't be because it apparently strips them even if you provide them in the source `.proto` manually.