### PR TITLE
Remove usage of globalThis in generated code

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 87,781 b      | 37,518 b | 9,777 b |
+| protobuf-es         | 87,781 b      | 37,518 b | 9,782 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.js
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.js
@@ -44,7 +44,7 @@
 // that the generated code doesn't depend on being in the proto2 namespace.
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
-import { proto2, protoInt64 } from "@bufbuild/protobuf";
+import { proto2, protoDouble, protoInt64 } from "@bufbuild/protobuf";
 import { ImportEnum, ImportMessage } from "./unittest_import_pb.js";
 import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
@@ -1061,12 +1061,12 @@ export const TestExtremeDefaultValues = proto2.makeMessageType(
     { no: 11, name: "negative_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: -1.5 },
     { no: 12, name: "large_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: 200000000 },
     { no: 13, name: "small_negative_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: -8e-28 },
-    { no: 14, name: "inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: globalThis.Number.POSITIVE_INFINITY },
-    { no: 15, name: "neg_inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: globalThis.Number.NEGATIVE_INFINITY },
-    { no: 16, name: "nan_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: globalThis.Number.NaN },
-    { no: 17, name: "inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: globalThis.Number.POSITIVE_INFINITY },
-    { no: 18, name: "neg_inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: globalThis.Number.NEGATIVE_INFINITY },
-    { no: 19, name: "nan_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: globalThis.Number.NaN },
+    { no: 14, name: "inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: protoDouble.POSITIVE_INFINITY },
+    { no: 15, name: "neg_inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: protoDouble.NEGATIVE_INFINITY },
+    { no: 16, name: "nan_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: protoDouble.NaN },
+    { no: 17, name: "inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: protoDouble.POSITIVE_INFINITY },
+    { no: 18, name: "neg_inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: protoDouble.NEGATIVE_INFINITY },
+    { no: 19, name: "nan_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: protoDouble.NaN },
     { no: 20, name: "cpp_trigraph", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "? ? ?? ?? ??? ??/ ??-" },
     { no: 23, name: "string_with_zero", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "hel lo" },
     { no: 24, name: "bytes_with_zero", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true, default: new Uint8Array([0x77, 0x6F, 0x72, 0x00, 0x6C, 0x64]) },

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -45,7 +45,7 @@
 // In test_util.h we do "using namespace unittest = protobuf_unittest".
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
+import { Message, proto2, protoDouble, protoInt64 } from "@bufbuild/protobuf";
 import { ImportEnum, ImportMessage } from "./unittest_import_pb.js";
 import { PublicImportMessage } from "./unittest_import_public_pb.js";
 
@@ -4239,12 +4239,12 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
     { no: 11, name: "negative_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: -1.5 },
     { no: 12, name: "large_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: 200000000 },
     { no: 13, name: "small_negative_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: -8e-28 },
-    { no: 14, name: "inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: globalThis.Number.POSITIVE_INFINITY },
-    { no: 15, name: "neg_inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: globalThis.Number.NEGATIVE_INFINITY },
-    { no: 16, name: "nan_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: globalThis.Number.NaN },
-    { no: 17, name: "inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: globalThis.Number.POSITIVE_INFINITY },
-    { no: 18, name: "neg_inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: globalThis.Number.NEGATIVE_INFINITY },
-    { no: 19, name: "nan_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: globalThis.Number.NaN },
+    { no: 14, name: "inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: protoDouble.POSITIVE_INFINITY },
+    { no: 15, name: "neg_inf_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: protoDouble.NEGATIVE_INFINITY },
+    { no: 16, name: "nan_double", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, opt: true, default: protoDouble.NaN },
+    { no: 17, name: "inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: protoDouble.POSITIVE_INFINITY },
+    { no: 18, name: "neg_inf_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: protoDouble.NEGATIVE_INFINITY },
+    { no: 19, name: "nan_float", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: protoDouble.NaN },
     { no: 20, name: "cpp_trigraph", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "? ? ?? ?? ??? ??/ ??-" },
     { no: 23, name: "string_with_zero", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "hel lo" },
     { no: 24, name: "bytes_with_zero", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true, default: new Uint8Array([0x77, 0x6F, 0x72, 0x00, 0x6C, 0x64]) },

--- a/packages/protobuf/src/codegen-info.ts
+++ b/packages/protobuf/src/codegen-info.ts
@@ -47,6 +47,7 @@ type RuntimeSymbolName =
   | "JsonWriteOptions"
   | "JsonValue"
   | "JsonObject"
+  | "protoDouble"
   | "protoInt64"
   | "ScalarType"
   | "MethodKind"
@@ -84,6 +85,7 @@ export const codegenInfo: CodegenInfo = {
     JsonWriteOptions:     {typeOnly: true,  privateImportPath: "./json-format.js",   publicImportPath: packageName},
     JsonValue:            {typeOnly: true,  privateImportPath: "./json-format.js",   publicImportPath: packageName},
     JsonObject:           {typeOnly: true,  privateImportPath: "./json-format.js",   publicImportPath: packageName},
+    protoDouble:          {typeOnly: false, privateImportPath: "./proto-double.js",  publicImportPath: packageName},
     protoInt64:           {typeOnly: false, privateImportPath: "./proto-int64.js",   publicImportPath: packageName},
     ScalarType:           {typeOnly: false, privateImportPath: "./field.js",         publicImportPath: packageName},
     MethodKind:           {typeOnly: false, privateImportPath: "./service-type.js",  publicImportPath: packageName},

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -14,6 +14,7 @@
 
 export { proto3 } from "./proto3.js";
 export { proto2 } from "./proto2.js";
+export { protoDouble } from "./proto-double.js";
 export { protoInt64 } from "./proto-int64.js";
 export { protoBase64 } from "./proto-base64.js";
 export { protoDelimited } from "./proto-delimited.js";

--- a/packages/protobuf/src/proto-double.ts
+++ b/packages/protobuf/src/proto-double.ts
@@ -1,0 +1,27 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Export global Number constants. This is done so that we can safely use
+// these global constants when generating code and be assured we're using
+// the correct values. We cannot rely on globalThis since we support ES2017
+// and globalThis was introduced in ES2020. We also don't want to explicitly
+// generate code using, for example, Number.NaN, since this could clash with
+// a message name of Number. Instead we can export them here since this will
+// be in a different scope as the generated code and we are guaranteed to use
+// the intended global values.
+export const protoDouble = {
+  NaN: Number.NaN,
+  POSITIVE_INFINITY: Number.POSITIVE_INFINITY,
+  NEGATIVE_INFINITY: Number.NEGATIVE_INFINITY,
+} as const;

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -241,7 +241,7 @@ function printableToEl(
           el.push(p);
           break;
         case "number":
-          el.push(literalNumber(p));
+          el.push(...literalNumber(p, runtimeImports));
           break;
         case "boolean":
           el.push(p.toString());
@@ -408,15 +408,18 @@ function processImports(
   return symbolToIdentifier;
 }
 
-function literalNumber(value: number): string {
+function literalNumber(
+  value: number,
+  runtimeImports: RuntimeImports
+): El[] | string {
   if (Number.isNaN(value)) {
-    return "globalThis.Number.NaN";
+    return [runtimeImports.protoDouble, ".NaN"];
   }
   if (value === Number.POSITIVE_INFINITY) {
-    return "globalThis.Number.POSITIVE_INFINITY";
+    return [runtimeImports.protoDouble, ".POSITIVE_INFINITY"];
   }
   if (value === Number.NEGATIVE_INFINITY) {
-    return "globalThis.Number.NEGATIVE_INFINITY";
+    return [runtimeImports.protoDouble, ".NEGATIVE_INFINITY"];
   }
   return value.toString(10);
 }

--- a/packages/protoplugin/src/ecmascript/runtime-imports.ts
+++ b/packages/protoplugin/src/ecmascript/runtime-imports.ts
@@ -30,6 +30,7 @@ export interface RuntimeImports {
   JsonWriteOptions: ImportSymbol;
   JsonValue: ImportSymbol;
   JsonObject: ImportSymbol;
+  protoDouble: ImportSymbol;
   protoInt64: ImportSymbol;
   ScalarType: ImportSymbol;
   MethodKind: ImportSymbol;
@@ -53,6 +54,7 @@ export function createRuntimeImports(bootstrapWkt: boolean): RuntimeImports {
     JsonWriteOptions:      infoToSymbol("JsonWriteOptions",     bootstrapWkt),
     JsonValue:             infoToSymbol("JsonValue",            bootstrapWkt),
     JsonObject:            infoToSymbol("JsonObject",           bootstrapWkt),
+    protoDouble:           infoToSymbol("protoDouble",          bootstrapWkt),
     protoInt64:            infoToSymbol("protoInt64",           bootstrapWkt),
     ScalarType:            infoToSymbol("ScalarType",           bootstrapWkt),
     MethodKind:            infoToSymbol("MethodKind",           bootstrapWkt),


### PR DESCRIPTION
This removes the usage of `globalThis` in generated code by instead using an export of global `Number` constants. 

This is done so that we can safely use these global constants when generating code and be assured we're using the correct values. We cannot use `globalThis` since we support ES2017 and `globalThis` was introduced in ES2020. We also don't want to explicitly generate code using, for example, `Number.NaN`, since this could clash with a message name of `Number`. 

Instead we can export them in a local `proto-double.js` file since this will be in a different scope as the generated code and we are guaranteed to use the intended global values.

Note that this complements https://github.com/bufbuild/protobuf-es/pull/488 to remove usage of `globalThis` in the repo.