### PR TITLE
Failing for toJson functionality for value of null

### DIFF
--- a/packages/protobuf/src/private/json-format-proto2.ts
+++ b/packages/protobuf/src/private/json-format-proto2.ts
@@ -33,6 +33,7 @@ export function makeJsonFormatProto2(): JsonFormat {
       value: any,
       options: JsonWriteOptions
     ): JsonValue | undefined {
+      if (value === undefined || value === null) { return undefined; }
       if (field.kind == "map") {
         const jsonObj: JsonObject = {};
         switch (field.V.kind) {

--- a/packages/protobuf/src/private/json-format-proto3.ts
+++ b/packages/protobuf/src/private/json-format-proto3.ts
@@ -33,6 +33,7 @@ export function makeJsonFormatProto3(): JsonFormat {
       value: any,
       options: JsonWriteOptions
     ): JsonValue | undefined {
+      if (value === undefined || value === null) { return undefined; }
       if (field.kind == "map") {
         const jsonObj: JsonObject = {};
         switch (field.V.kind) {


### PR DESCRIPTION
I was extending the message created from protos to create an Entity in typeorm which returns the values as null for nullable fields.
As null was not handled. It's throwing error saying **Cannot read properties of null (reading 'toJson')**