### PR TITLE
Add `toPlainMessage`

### DIFF
--- a/packages/protobuf-test/extra/enum.proto
+++ b/packages/protobuf-test/extra/enum.proto
@@ -37,6 +37,7 @@ message EnumMessage {
         NESTED_ZERO = 0;
         NESTED_ONE = 1;
     }
+    NestedEnum enum_field = 1;
 }
 
 enum SimpleEnum {

--- a/packages/protobuf-test/jest.config.js
+++ b/packages/protobuf-test/jest.config.js
@@ -23,6 +23,8 @@ const config = {
 
   // The root directory that Jest should scan for tests and modules within
   rootDir: "dist/esm",
+  // Enabled so jest would stop complaining about serializing BigInt.  See https://github.com/jestjs/jest/issues/11617#issuecomment-1458155552 for details
+  workerThreads: true,
 
   transform: {},
 };

--- a/packages/protobuf-test/jest.config.js
+++ b/packages/protobuf-test/jest.config.js
@@ -23,8 +23,6 @@ const config = {
 
   // The root directory that Jest should scan for tests and modules within
   rootDir: "dist/esm",
-  // Enabled so jest would stop complaining about serializing BigInt.  See https://github.com/jestjs/jest/issues/11617#issuecomment-1458155552 for details
-  workerThreads: true,
 
   transform: {},
 };

--- a/packages/protobuf-test/src/gen/js/extra/enum_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/enum_pb.d.ts
@@ -92,6 +92,11 @@ export declare enum PrefixEnum {
  * @generated from message spec.EnumMessage
  */
 export declare class EnumMessage extends Message<EnumMessage> {
+  /**
+   * @generated from field: spec.EnumMessage.NestedEnum enum_field = 1;
+   */
+  enumField: EnumMessage_NestedEnum;
+
   constructor(data?: PartialMessage<EnumMessage>);
 
   static readonly runtime: typeof proto3;

--- a/packages/protobuf-test/src/gen/js/extra/enum_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/enum_pb.js
@@ -72,7 +72,9 @@ export const PrefixEnum = proto3.makeEnum(
  */
 export const EnumMessage = proto3.makeMessageType(
   "spec.EnumMessage",
-  [],
+  () => [
+    { no: 1, name: "enum_field", kind: "enum", T: proto3.getEnumType(EnumMessage_NestedEnum) },
+  ],
 );
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/enum_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/enum_pb.ts
@@ -113,6 +113,11 @@ proto3.util.setEnumType(PrefixEnum, "spec.PrefixEnum", [
  * @generated from message spec.EnumMessage
  */
 export class EnumMessage extends Message<EnumMessage> {
+  /**
+   * @generated from field: spec.EnumMessage.NestedEnum enum_field = 1;
+   */
+  enumField = EnumMessage_NestedEnum.NESTED_ZERO;
+
   constructor(data?: PartialMessage<EnumMessage>) {
     super();
     proto3.util.initPartial(data, this);
@@ -121,6 +126,7 @@ export class EnumMessage extends Message<EnumMessage> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.EnumMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "enum_field", kind: "enum", T: proto3.getEnumType(EnumMessage_NestedEnum) },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): EnumMessage {

--- a/packages/protobuf-test/src/to-plain-message.test.ts
+++ b/packages/protobuf-test/src/to-plain-message.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { ScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb.js";
 import { toPlainMessage, protoInt64 } from "@bufbuild/protobuf";
 import type { PlainMessage } from "@bufbuild/protobuf";
@@ -26,7 +26,7 @@ import { MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { EnumMessage, EnumMessage_NestedEnum } from "./gen/ts/extra/enum_pb.js";
 import { WrappersMessage } from "./gen/ts/extra/wkt-wrappers_pb.js";
 
-describeToPlainMessage(() => {
+describe("toPlainMessage", () => {
   describe("on scalar", () => {
     test("returns unset defaults", () => {
       const defaultValue: PlainMessage<ScalarValuesMessage> = {
@@ -262,27 +262,6 @@ describeToPlainMessage(() => {
     expect(act).toEqual(exp);
   });
 });
-
-function describeToPlainMessage(testBlock: () => void) {
-  describe("toPlainMessage", () => {
-    describe("with structuredClone", () => {
-      if (typeof structuredClone !== "function")
-        throw new Error("structuredClone is not available");
-      testBlock();
-    });
-    describe("without structuredClone", () => {
-      const structuredCloneCopy = global.structuredClone;
-      beforeEach(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
-        delete (global as any).structuredClone;
-      });
-      afterEach(() => {
-        global.structuredClone = structuredCloneCopy;
-      });
-      testBlock();
-    });
-  });
-}
 
 function expectPlainObject(value: unknown) {
   expect(Object.getPrototypeOf(value)).toEqual(Object.prototype);

--- a/packages/protobuf-test/src/to-plain-message.test.ts
+++ b/packages/protobuf-test/src/to-plain-message.test.ts
@@ -1,0 +1,252 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+import { ScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb.js";
+import { toPlainMessage, protoInt64 } from "@bufbuild/protobuf";
+import type { PlainMessage } from "@bufbuild/protobuf";
+import {
+  OneofEnum,
+  OneofMessage,
+  OneofMessageFoo,
+} from "./gen/ts/extra/msg-oneof_pb.js";
+import { MapsEnum, MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
+import { MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
+import { EnumMessage, EnumMessage_NestedEnum } from "./gen/ts/extra/enum_pb.js";
+
+describeToPlainMessage(() => {
+  describe("on scalar", () => {
+    test("returns unset defaults", () => {
+      const defaultValue: PlainMessage<ScalarValuesMessage> = {
+        boolField: false,
+        bytesField: new Uint8Array(),
+        doubleField: 0,
+        fixed32Field: 0,
+        fixed64Field: protoInt64.zero,
+        floatField: 0,
+        int32Field: 0,
+        int64Field: protoInt64.zero,
+        sfixed32Field: 0,
+        sfixed64Field: protoInt64.zero,
+        sint32Field: 0,
+        sint64Field: protoInt64.zero,
+        stringField: "",
+        uint32Field: 0,
+        uint64Field: protoInt64.zero,
+      };
+      const act = toPlainMessage(new ScalarValuesMessage({}));
+      expect(act).toEqual(defaultValue);
+      expectPlainObject(act);
+    });
+    test("returns set fields", () => {
+      const exp = {
+        boolField: true,
+        bytesField: new Uint8Array([1]),
+        doubleField: 1.2,
+        fixed32Field: 1,
+        fixed64Field: protoInt64.parse(1),
+        floatField: 1,
+        int32Field: 1,
+        int64Field: protoInt64.parse(1),
+        sfixed32Field: 1,
+        sfixed64Field: protoInt64.parse(1),
+        sint32Field: 1,
+        sint64Field: protoInt64.parse(1),
+        stringField: "some",
+        uint32Field: 1,
+        uint64Field: protoInt64.parse(1),
+      };
+      const act = toPlainMessage(new ScalarValuesMessage(exp));
+      expect(act).toEqual(exp);
+      expectPlainObject(act);
+    });
+  });
+  describe("on enums", () => {
+    test("returns unset defaults", () => {
+      const act = toPlainMessage(new EnumMessage({}));
+      expect(act).toEqual({
+        enumField: EnumMessage_NestedEnum.NESTED_ZERO,
+      });
+      expectPlainObject(act);
+    });
+  });
+  describe("on oneof", () => {
+    test("when not set", () => {
+      const act = toPlainMessage(new OneofMessage({}));
+      expect(act).toEqual({
+        enum: { case: undefined },
+        message: { case: undefined },
+        scalar: { case: undefined },
+      });
+      expectPlainObject(act);
+    });
+    test("with enums", () => {
+      const act = toPlainMessage(
+        new OneofMessage({
+          enum: {
+            case: "e",
+            value: OneofEnum.A,
+          },
+        })
+      );
+      expect(act).toEqual({
+        enum: { case: "e", value: OneofEnum.A },
+        message: { case: undefined },
+        scalar: { case: undefined },
+      });
+      expectPlainObject(act);
+    });
+    test("with messages", () => {
+      const act = toPlainMessage(
+        new OneofMessage({
+          message: {
+            case: "foo",
+            value: new OneofMessageFoo(),
+          },
+        })
+      );
+      expect(act).toEqual({
+        message: {
+          case: "foo",
+          value: {
+            name: "",
+            toggle: false,
+          },
+        },
+        enum: { case: undefined },
+        scalar: { case: undefined },
+      });
+      expectPlainObject(act);
+    });
+    test("with scalars", () => {
+      const act = toPlainMessage(
+        new OneofMessage({
+          scalar: {
+            case: "value",
+            value: 1,
+          },
+        })
+      );
+      expect(act).toEqual({
+        scalar: { case: "value", value: 1 },
+        message: { case: undefined },
+        enum: { case: undefined },
+      });
+      expectPlainObject(act);
+    });
+  });
+  describe("on maps", () => {
+    const defaultValue: PlainMessage<MapsMessage> = {
+      strStrField: {},
+      strInt32Field: {},
+      strInt64Field: {},
+      strBoolField: {},
+      strBytesField: {},
+      int32StrField: {},
+      int64StrField: {},
+      boolStrField: {},
+      strMsgField: {},
+      int32MsgField: {},
+      int64MsgField: {},
+      strEnuField: {},
+      int32EnuField: {},
+      int64EnuField: {},
+    };
+    test("returns unset defaults", () => {
+      const act = toPlainMessage(new MapsMessage({}));
+      expect(act).toEqual(defaultValue);
+      expectPlainObject(act);
+    });
+    test("returns set fields", () => {
+      const exp = {
+        strStrField: { a: "str", b: "xx" },
+        strInt32Field: { a: 123, b: 455 },
+        strInt64Field: { a: protoInt64.parse(123) },
+        strBoolField: { a: true, b: false },
+        strBytesField: {
+          a: new Uint8Array([
+            104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100,
+          ]),
+        },
+        int32StrField: { 123: "hello" },
+        int64StrField: { "9223372036854775807": "hello" },
+        boolStrField: { true: "yes", false: "no" },
+        strMsgField: {
+          a: defaultValue,
+        },
+        int32MsgField: {
+          1: defaultValue,
+        },
+        int64MsgField: {
+          "1": defaultValue,
+        },
+        strEnuField: { a: MapsEnum.ANY, b: MapsEnum.NO, c: MapsEnum.YES },
+        int32EnuField: { 1: MapsEnum.ANY, 2: MapsEnum.NO, 0: MapsEnum.YES },
+        int64EnuField: {
+          "-1": MapsEnum.ANY,
+          "2": MapsEnum.NO,
+          "0": MapsEnum.YES,
+        },
+      };
+      const act = toPlainMessage(new MapsMessage(exp));
+      expect(act).toEqual(exp);
+      expectPlainObject(act);
+    });
+  });
+  describe("on messages", () => {
+    test("returns unset defaults", () => {
+      const exp: PlainMessage<MessageFieldMessage> = {
+        messageField: undefined,
+        repeatedMessageField: [],
+      };
+      const act = toPlainMessage(new MessageFieldMessage(exp));
+      expect(act).toEqual(exp);
+      expectPlainObject(act);
+    });
+    test("returns set fields", () => {
+      const exp: PlainMessage<MessageFieldMessage> = {
+        messageField: { name: "" },
+        repeatedMessageField: [{ name: "" }],
+      };
+      const act = toPlainMessage(new MessageFieldMessage(exp));
+      expect(act).toEqual(exp);
+      expectPlainObject(act);
+    });
+  });
+});
+
+function describeToPlainMessage(testBlock: () => void) {
+  describe("toPlainMessage", () => {
+    describe("with structuredClone", () => {
+      if (typeof structuredClone !== "function")
+        throw new Error("structuredClone is not available");
+      testBlock();
+    });
+    describe("without structuredClone", () => {
+      const structuredCloneCopy = global.structuredClone;
+      beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
+        delete (global as any).structuredClone;
+      });
+      afterEach(() => {
+        global.structuredClone = structuredCloneCopy;
+      });
+      testBlock();
+    });
+  });
+}
+
+function expectPlainObject(value: unknown) {
+  expect(Object.getPrototypeOf(value)).toEqual(Object.prototype);
+}

--- a/packages/protobuf-test/src/to-plain-message.test.ts
+++ b/packages/protobuf-test/src/to-plain-message.test.ts
@@ -24,6 +24,7 @@ import {
 import { MapsEnum, MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
 import { MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { EnumMessage, EnumMessage_NestedEnum } from "./gen/ts/extra/enum_pb.js";
+import { WrappersMessage } from "./gen/ts/extra/wkt-wrappers_pb.js";
 
 describeToPlainMessage(() => {
   describe("on scalar", () => {
@@ -223,6 +224,42 @@ describeToPlainMessage(() => {
       expect(act).toEqual(exp);
       expectPlainObject(act);
     });
+  });
+  describe("on wrapper messages", () => {
+    const exp: PlainMessage<WrappersMessage> = {
+      mapStringValueField: {},
+      mapBoolValueField: {},
+      mapBytesValueField: {},
+      oneofFields: {
+        case: undefined,
+      },
+      repeatedDoubleValueField: [],
+      repeatedBoolValueField: [],
+      repeatedFloatValueField: [],
+      repeatedInt64ValueField: [],
+      repeatedUint64ValueField: [],
+      repeatedInt32ValueField: [],
+      repeatedUint32ValueField: [],
+      repeatedStringValueField: [],
+      repeatedBytesValueField: [],
+      mapDoubleValueField: {},
+      mapFloatValueField: {},
+      mapInt64ValueField: {},
+      mapUint64ValueField: {},
+      mapInt32ValueField: {},
+      mapUint32ValueField: {},
+      boolValueField: true,
+      bytesValueField: new Uint8Array(),
+      doubleValueField: 1.2,
+      floatValueField: 1.2,
+      int32ValueField: 1,
+      int64ValueField: protoInt64.parse(1),
+      stringValueField: "some",
+      uint32ValueField: 1,
+      uint64ValueField: protoInt64.uParse(1),
+    };
+    const act = toPlainMessage(new WrappersMessage(exp));
+    expect(act).toEqual(exp);
   });
 });
 

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -74,6 +74,7 @@ export { createDescriptorSet } from "./create-descriptor-set.js";
 export type { IMessageTypeRegistry } from "./type-registry.js";
 export { createRegistry } from "./create-registry.js";
 export { createRegistryFromDescriptors } from "./create-registry-from-desc.js";
+export { toPlainMessage } from "./to-plain-message.js";
 
 // ideally, we would export these types with sub-path exports:
 export * from "./google/protobuf/compiler/plugin_pb.js";

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -1,0 +1,85 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-argument,no-case-declarations */
+
+import { Message } from "./message.js";
+import type { AnyMessage, PlainMessage } from "./message.js";
+
+/**
+ * toPlainMessage returns a new object by striping
+ * all methods from a message, leaving only fields and
+ * oneof groups. It is recursive, meaning it applies this
+ * same logic to all nested message fields as well.
+ */
+export function toPlainMessage<T extends Message<T>>(
+  message: T
+): PlainMessage<T> {
+  if (typeof structuredClone === "function") {
+    return structuredClone(message) as PlainMessage<T>;
+  }
+  const type = message.getType();
+  const source = message as AnyMessage;
+  const target = {} as PlainMessage<AnyMessage>;
+  for (const member of type.fields.byMember()) {
+    const localName = member.localName;
+    switch (member.kind) {
+      case "scalar":
+      case "enum":
+        target[localName] = source[localName];
+        break;
+      case "message":
+        if (member.repeated) {
+          target[localName] = (source[localName] as any[]).map((val) =>
+            toPlainMessage(val)
+          );
+        } else if (source[localName] !== undefined) {
+          target[localName] = toPlainMessage(source[localName]);
+        } else {
+          target[localName] = undefined;
+        }
+        break;
+      case "oneof":
+        const _case = source[localName].case;
+        if (_case === undefined) {
+          target[localName] = { case: undefined };
+          break;
+        }
+        let value = source[localName].value;
+        const sourceField = member.findField(_case);
+        if (sourceField !== undefined && sourceField.kind === "message") {
+          value = toPlainMessage(value);
+        }
+        target[localName] = { case: _case, value: value };
+        break;
+      case "map":
+        const plainMap: Record<string, any> = {};
+        switch (member.V.kind) {
+          case "enum":
+          case "scalar":
+            Object.assign(plainMap, source[localName]);
+            break;
+          case "message":
+            const msgMap = source[localName];
+            for (const k of Object.keys(msgMap)) {
+              plainMap[k] = toPlainMessage(msgMap[k]);
+            }
+            break;
+        }
+        target[localName] = plainMap;
+        break;
+    }
+  }
+  return target as PlainMessage<T>;
+}

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -26,9 +26,6 @@ import type { AnyMessage, PlainMessage } from "./message.js";
 export function toPlainMessage<T extends Message<T>>(
   message: T
 ): PlainMessage<T> {
-  if (typeof structuredClone === "function") {
-    return structuredClone(message) as PlainMessage<T>;
-  }
   const type = message.getType();
   const target = {} as AnyMessage;
   for (const member of type.fields.byMember()) {


### PR DESCRIPTION
Add `toPlainMessage` to convert `Message` objects to their `PlainMessage` variants. 

Helps in cases like https://github.com/bufbuild/connect-es/issues/505.