### PR TITLE
Allow `number[]` for `bytes` fields in constructor

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 88,734 b      | 37,796 b | 9,861 b |
+| protobuf-es         | 88,732 b      | 37,780 b | 9,820 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 89,089 b      | 37,980 b | 9,879 b |
+| protobuf-es         | 88,734 b      | 37,796 b | 9,861 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 87,781 b      | 37,517 b | 9,777 b |
+| protobuf-es         | 89,089 b      | 37,980 b | 9,879 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 88,732 b      | 37,780 b | 9,820 b |
+| protobuf-es         | 88,726 b      | 37,779 b | 9,864 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 88,726 b      | 37,779 b | 9,864 b |
+| protobuf-es         | 88,672 b      | 37,773 b | 9,865 b |
 | protobuf-javascript | 394,384 b  | 288,761 b | 45,123 b |

--- a/packages/protobuf-test/extra/msg-oneof.proto
+++ b/packages/protobuf-test/extra/msg-oneof.proto
@@ -19,6 +19,7 @@ message OneofMessage {
     oneof scalar {
         int32 value = 1;
         string error = 2;
+        bytes bytes = 3;
     }
     oneof message {
         OneofMessageFoo foo = 11;

--- a/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.d.ts
@@ -58,6 +58,12 @@ export declare class OneofMessage extends Message<OneofMessage> {
      */
     value: string;
     case: "error";
+  } | {
+    /**
+     * @generated from field: bytes bytes = 3;
+     */
+    value: Uint8Array;
+    case: "bytes";
   } | { case: undefined; value?: undefined };
 
   /**

--- a/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.js
@@ -38,6 +38,7 @@ export const OneofMessage = proto3.makeMessageType(
   () => [
     { no: 1, name: "value", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "scalar" },
     { no: 2, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "scalar" },
+    { no: 3, name: "bytes", kind: "scalar", T: 12 /* ScalarType.BYTES */, oneof: "scalar" },
     { no: 11, name: "foo", kind: "message", T: OneofMessageFoo, oneof: "message" },
     { no: 12, name: "bar", kind: "message", T: OneofMessageBar, oneof: "message" },
     { no: 13, name: "baz", kind: "message", T: OneofMessageBar, oneof: "message" },

--- a/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
@@ -64,6 +64,12 @@ export class OneofMessage extends Message<OneofMessage> {
      */
     value: string;
     case: "error";
+  } | {
+    /**
+     * @generated from field: bytes bytes = 3;
+     */
+    value: Uint8Array;
+    case: "bytes";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   /**
@@ -110,6 +116,7 @@ export class OneofMessage extends Message<OneofMessage> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "value", kind: "scalar", T: 5 /* ScalarType.INT32 */, oneof: "scalar" },
     { no: 2, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "scalar" },
+    { no: 3, name: "bytes", kind: "scalar", T: 12 /* ScalarType.BYTES */, oneof: "scalar" },
     { no: 11, name: "foo", kind: "message", T: OneofMessageFoo, oneof: "message" },
     { no: 12, name: "bar", kind: "message", T: OneofMessageBar, oneof: "message" },
     { no: 13, name: "baz", kind: "message", T: OneofMessageBar, oneof: "message" },

--- a/packages/protobuf-test/src/msg-maps.test.ts
+++ b/packages/protobuf-test/src/msg-maps.test.ts
@@ -105,4 +105,21 @@ describeMT({ ts: TS_MapsMessage, js: JS_MapsMessage }, (messageType) => {
     const got = { ...messageType.fromJson(exampleJson) };
     expect(got).toStrictEqual(exampleFields);
   });
+  test("allow number[] for bytes field", () => {
+    const bytes = [0xff];
+    const got = {
+      ...new messageType({
+        ...defaultFields,
+        strBytesField: {
+          a: bytes as any, //eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-explicit-any
+        },
+      }),
+    };
+    expect(got).toStrictEqual({
+      ...defaultFields,
+      strBytesField: {
+        a: new Uint8Array(bytes),
+      },
+    });
+  });
 });

--- a/packages/protobuf-test/src/msg-oneof.test.ts
+++ b/packages/protobuf-test/src/msg-oneof.test.ts
@@ -65,4 +65,17 @@ describeMT({ ts: TS_OneofMessage, js: JS_OneofMessage }, (messageType) => {
     const got = { ...messageType.fromJson(exampleJson) };
     expect(got).toStrictEqual(exampleFields);
   });
+  test("allows number[] for bytes field", () => {
+    const bytes = [0xff];
+    const got = {
+      ...new messageType({
+        ...defaultFields,
+        scalar: { case: "bytes", value: bytes as any }, //eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-explicit-any
+      }),
+    };
+    expect(got).toStrictEqual({
+      ...defaultFields,
+      scalar: { case: "bytes", value: new Uint8Array(bytes) },
+    });
+  });
 });

--- a/packages/protobuf-test/src/msg-scalar.test.ts
+++ b/packages/protobuf-test/src/msg-scalar.test.ts
@@ -106,6 +106,19 @@ describeMT(
       const got = { ...messageType.fromJson(exampleJson) };
       expect(got).toStrictEqual(exampleFields);
     });
+    test("allow number[] for bytes field", () => {
+      const bytes = [0xff];
+      const got = {
+        ...new messageType({
+          ...defaultFields,
+          bytesField: bytes as any, //eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-explicit-any
+        }),
+      };
+      expect(got).toStrictEqual({
+        ...defaultFields,
+        bytesField: new Uint8Array(bytes),
+      });
+    });
   }
 );
 
@@ -197,6 +210,19 @@ describeMT(
     test("example decodes from JSON", () => {
       const got = { ...messageType.fromJson(exampleJson) };
       expect(got).toStrictEqual(exampleFields);
+    });
+    test("allow number[] for bytes field", () => {
+      const bytes = [0xff];
+      const got = {
+        ...new messageType({
+          ...defaultFields,
+          bytesField: [bytes] as any, //eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-explicit-any
+        }),
+      };
+      expect(got).toStrictEqual({
+        ...defaultFields,
+        bytesField: [new Uint8Array(bytes)],
+      });
     });
   }
 );

--- a/packages/protobuf-test/src/wkt-wrappers.test.ts
+++ b/packages/protobuf-test/src/wkt-wrappers.test.ts
@@ -70,6 +70,15 @@ describeMT(
         const want = `{"boolValueField":true}`;
         expect(got).toBe(want);
       });
+      test("allow number[] for bytes field", () => {
+        const bytes = [0xff];
+        const got = {
+          ...new messageType({
+            bytesValueField: bytes as any, //eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-explicit-any
+          }),
+        };
+        expect(got.bytesValueField).toStrictEqual(new Uint8Array(bytes));
+      });
     });
     describe("oneof fields", () => {
       const w = new messageType({

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -80,8 +80,8 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
                 let target = s[localName];
                 if (member.V.T === ScalarType.BYTES) {
                   target = {};
-                  for (const k of Object.keys(s[localName])) {
-                    target[k] = toU8Arr(s[localName][k] as ArrayLike<number>);
+                  for (const [k, v] of Object.entries(s[localName])) {
+                    target[k] = toU8Arr(v as ArrayLike<number>);
                   }
                 }
                 Object.assign(t[localName], target);

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -213,7 +213,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
         const source = (message as AnyMessage)[member.localName];
         let copy: any;
         if (member.repeated) {
-          copy = (source as any[]).map((e) => cloneSingularField(e));
+          copy = (source as any[]).map(cloneSingularField);
         } else if (member.kind == "map") {
           copy = any[member.localName];
           for (const [key, v] of Object.entries(source)) {

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -79,12 +79,10 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
               case "enum":
                 let target = s[localName];
                 if (member.V.T === ScalarType.BYTES) {
-                  target = Object.fromEntries(
-                    Object.entries(target).map(([k, v]) => [
-                      k,
-                      toU8Arr(v as ArrayLike<number>),
-                    ])
-                  );
+                  target = {};
+                  for (const k of Object.keys(s[localName])) {
+                    target[k] = toU8Arr(s[localName][k] as ArrayLike<number>);
+                  }
                 }
                 Object.assign(t[localName], target);
                 break;

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -65,26 +65,25 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             break;
           case "scalar":
           case "enum":
-            let target = s[localName];
+            let copy = s[localName];
             if (member.T === ScalarType.BYTES) {
-              target = member.repeated
-                ? (target as ArrayLike<number>[]).map(toU8Arr)
-                : toU8Arr(target);
+              copy = member.repeated
+                ? (copy as ArrayLike<number>[]).map(toU8Arr)
+                : toU8Arr(copy);
             }
-            t[localName] = target;
+            t[localName] = copy;
             break;
           case "map":
             switch (member.V.kind) {
               case "scalar":
               case "enum":
-                let target = s[localName];
                 if (member.V.T === ScalarType.BYTES) {
-                  target = {};
                   for (const [k, v] of Object.entries(s[localName])) {
-                    target[k] = toU8Arr(v as ArrayLike<number>);
+                    t[localName][k] = toU8Arr(v as ArrayLike<number>);
                   }
+                } else {
+                  Object.assign(t[localName], s[localName]);
                 }
-                Object.assign(t[localName], target);
                 break;
               case "message":
                 const messageType = member.V.T;


### PR DESCRIPTION
Follow up work to #511. This doesn't change the types but loosens the runtime to also accept `number[]` alongside `Uint8Array` values for `bytes` fields.