### PR TITLE
Update link for new examples-es repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You should now see a generated file at `src/gen/example_pb.ts` that contains a c
 
 * [connect-es](https://github.com/bufbuild/connect-es):
   Type-safe APIs with Protobuf and TypeScript.
-* [examples-es](https://github.com/connectrpc/examples-es):
+* [connect-es Examples](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
 * [protobuf-conformance](https://github.com/bufbuild/protobuf-conformance):
   A repository running the Protobuf conformance tests against various libraries.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You should now see a generated file at `src/gen/example_pb.ts` that contains a c
 
 * [connect-es](https://github.com/bufbuild/connect-es):
   Type-safe APIs with Protobuf and TypeScript.
-* [connect-es-integration](https://github.com/bufbuild/connect-es-integration):
+* [examples-es](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
 * [protobuf-conformance](https://github.com/bufbuild/protobuf-conformance):
   A repository running the Protobuf conformance tests against various libraries.


### PR DESCRIPTION
This updates the link to use the new `examples-es` repo (FKA `connect-es-integration`).