### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,8 +15,27 @@ updates:
       timezone: UTC
       time: "07:00"
     ignore:
-      # These dependencies are explicitly pinned for usage in the plugin 
+      # These dependencies are explicitly pinned for usage in the plugin
       # transpilation process and should only be updated manually / intentionally.
       - dependency-name: "typescript"
       - dependency-name: "@typescript/vfs"
     open-pull-requests-limit: 50
+    groups:
+      test:
+        patterns:
+          - "jest"
+          - "@arethetypeswrong/*"
+          - "benchmark"
+          - "@types/benchmark"
+          - "long"
+      bench:
+        patterns:
+          - "google-protobuf"
+          - "brotli"
+          - "esbuild"
+      eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "eslint-*"
+          - "eslint"
+


### PR DESCRIPTION
Dependabot supports grouping PRs now. ([Blog post](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/), [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups))

This adds grouping to make updates a bit easier. The grouping probably is not ideal yet, but we have to start somewhere 🙂 

