### PR TITLE
Make `toPlainMessage` idempotent

### DIFF
--- a/packages/protobuf-test/src/to-plain-message.test.ts
+++ b/packages/protobuf-test/src/to-plain-message.test.ts
@@ -261,6 +261,14 @@ describe("toPlainMessage", () => {
     const act = toPlainMessage(new WrappersMessage(exp));
     expect(act).toEqual(exp);
   });
+  describe("on plain messages", () => {
+    const exp: PlainMessage<MessageFieldMessage> = {
+      messageField: undefined,
+      repeatedMessageField: [],
+    };
+    const act = toPlainMessage(exp);
+    expect(act).toBe(exp);
+  });
 });
 
 function expectPlainObject(value: unknown) {

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -18,14 +18,21 @@ import { Message } from "./message.js";
 import type { AnyMessage, PlainMessage } from "./message.js";
 
 /**
- * toPlainMessage returns a new object by striping
+ * toPlainMessage returns a new object by stripping
  * all methods from a message, leaving only fields and
  * oneof groups. It is recursive, meaning it applies this
  * same logic to all nested message fields as well.
+ *
+ * If the argument is already a plain message, it is
+ * returned as-is.
  */
 export function toPlainMessage<T extends Message<T>>(
-  message: T,
+  message: T | PlainMessage<T>,
 ): PlainMessage<T> {
+  if (!(message instanceof Message)) {
+    return message;
+  }
+
   const type = message.getType();
   const target = {} as AnyMessage;
   for (const member of type.fields.byMember()) {


### PR DESCRIPTION
This PR makes it possible to call `toPlainMessage` on a `PlainMessage<T>` object as well as a `Message<T>` instance.

The motivation for this change is the lack of exact types in TypeScript. Specifically, if I define a function that accepts a `PlainMessage<T>` as an argument, it's valid to pass a `Message<T>` instance as well, because it has all the properties necessary to satisfy the `PlainMessage<T>` interface.

If I need to ensure that I actually have a `PlainMessage<T>` inside the function (e.g. for the reasons described in https://github.com/connectrpc/connect-es/issues/505), at the moment I have to type the parameter as `T | PlainMessage<T>`, and check with `instanceof Message` before calling `toPlainMessage`.