### PR TITLE
Add `@bufbuild/protobuf` to the direct dependencies of protoc-gen-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "protobuf-es-5",
+  "name": "protobuf-es",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -6165,6 +6165,7 @@
       "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bufbuild/protobuf": "^1.4.1",
         "@bufbuild/protoplugin": "1.4.1"
       },
       "bin": {

--- a/packages/protoc-gen-es/package.json
+++ b/packages/protoc-gen-es/package.json
@@ -20,6 +20,7 @@
   },
   "preferUnplugged": true,
   "dependencies": {
+    "@bufbuild/protobuf": "^1.4.1",
     "@bufbuild/protoplugin": "1.4.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
The package is currently an optional peer dependency. It's also a transitive dependency through `@bufbuild/protoplugin`, but accessed directly, and users have reported issues with `pnpm` and global installation. 

We already have a direct dependency (in addition to the optional peer) in `protoc-gen-connect-es` and `protoc-gen-connect-query`. For consistency and to help with behavior with `pnpm` and global installation, let's do the same here.