### PR TITLE
build(protobuf, protoplugin): reorder exports field for native esm compatibility

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -25,9 +25,9 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
-      "module": "./dist/esm/index.js",
+      "import": "./dist/proxy/index.js",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/proxy/index.js"
+      "module": "./dist/esm/index.js"
     }
   },
   "devDependencies": {

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -21,14 +21,14 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
-      "module": "./dist/esm/index.js",
+      "import": "./dist/proxy/index.js",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/proxy/index.js"
+      "module": "./dist/esm/index.js"
     },
     "./ecmascript": {
-      "module": "./dist/esm/ecmascript/index.js",
+      "import": "./dist/proxy/ecmascript/index.js",
       "require": "./dist/cjs/ecmascript/index.js",
-      "import": "./dist/proxy/ecmascript/index.js"
+      "module": "./dist/esm/ecmascript/index.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
Resolves #610

By using `import` export condition first, we ask bundlers such as rollup to prefer an export that is compatible with native ESM (ie: directly importing in Node.js when externalized in build). 

See https://github.com/bufbuild/protobuf-es/issues/610#issuecomment-1799898255 for more context.