### PR TITLE
Add tooling script to cache key

### DIFF
--- a/packages/upstream-protobuf/bin/upstream-files.mjs
+++ b/packages/upstream-protobuf/bin/upstream-files.mjs
@@ -43,7 +43,6 @@ async function main(args) {
             exitUsage();
     }
     stdout.write(protoInclude.files.join(" "));
-    exit(0);
 }
 
 /**

--- a/packages/upstream-protobuf/bin/upstream-include.mjs
+++ b/packages/upstream-protobuf/bin/upstream-include.mjs
@@ -43,7 +43,6 @@ async function main(args) {
             exitUsage();
     }
     stdout.write(protoInclude.dir);
-    exit(0);
 }
 
 /**


### PR DESCRIPTION
In packages/upstream-protobuf, we're fetching `protoc` and other dependencies, and cache them based on the version. Since the logic of the script can affect the outcome, this is brittle. This PR adds the script itself to the cache key.