### PR TITLE
Switch to eslint-plugin-n

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const {readdirSync, existsSync} = require("fs");
-const {join} = require("path");
+const { readdirSync, existsSync } = require("fs");
+const { join } = require("path");
 
 module.exports = {
   env: {
@@ -27,79 +27,76 @@ module.exports = {
     "packages/*/.tmp/**",
     "node_modules/**",
   ],
-  plugins: ["@typescript-eslint", "node", "import"],
+  plugins: ["@typescript-eslint", "n", "import"],
   // Rules and settings that do not require a non-default parser
-  extends: [
-    "eslint:recommended",
-  ],
+  extends: ["eslint:recommended"],
   rules: {
     "no-console": "error",
     "import/no-duplicates": "off",
   },
   settings: {},
   overrides: [
-      ...readdirSync("packages", {withFileTypes: true})
-        .filter(entry => entry.isDirectory())
-        .map(entry => join("packages", entry.name))
-        .filter(dir => existsSync(join(dir, "tsconfig.json")))
-        .map(dir => {
-          return {
-            files: [join(dir, "src/**/*.ts")],
-            parser: "@typescript-eslint/parser",
-            parserOptions: {
-              project: "./tsconfig.json",
-              tsconfigRootDir: dir,
+    ...readdirSync("packages", { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join("packages", entry.name))
+      .filter((dir) => existsSync(join(dir, "tsconfig.json")))
+      .map((dir) => {
+        return {
+          files: [join(dir, "src/**/*.ts")],
+          parser: "@typescript-eslint/parser",
+          parserOptions: {
+            project: "./tsconfig.json",
+            tsconfigRootDir: dir,
+          },
+          settings: {
+            "import/resolver": {
+              typescript: {
+                project: "packages/*/tsconfig.json",
+              },
             },
-            settings: {
-              "import/resolver": {
-                "typescript": {
-                  "project": "packages/*/tsconfig.json",
-                }
-              }
-            },
-            extends: [
-              "plugin:@typescript-eslint/recommended",
-              "plugin:@typescript-eslint/recommended-requiring-type-checking",
-              "plugin:import/recommended",
-              "plugin:import/typescript",
-            ],
-            rules: {
-              "@typescript-eslint/strict-boolean-expressions": "error",
-              "@typescript-eslint/no-unnecessary-condition": "error",
-              "@typescript-eslint/array-type": "off", // we use complex typings, where Array is actually more readable than T[]
-              "@typescript-eslint/switch-exhaustiveness-check": "error",
-              "@typescript-eslint/prefer-nullish-coalescing": "error",
-              "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
-              "@typescript-eslint/no-invalid-void-type": "error",
-              "@typescript-eslint/no-base-to-string": "error",
-              "import/no-cycle": "error",
-              "import/no-duplicates": "off",
-            },
-          };
-        }),
+          },
+          extends: [
+            "plugin:@typescript-eslint/recommended",
+            "plugin:@typescript-eslint/recommended-requiring-type-checking",
+            "plugin:import/recommended",
+            "plugin:import/typescript",
+          ],
+          rules: {
+            "@typescript-eslint/strict-boolean-expressions": "error",
+            "@typescript-eslint/no-unnecessary-condition": "error",
+            "@typescript-eslint/array-type": "off", // we use complex typings, where Array is actually more readable than T[]
+            "@typescript-eslint/switch-exhaustiveness-check": "error",
+            "@typescript-eslint/prefer-nullish-coalescing": "error",
+            "@typescript-eslint/no-unnecessary-boolean-literal-compare":
+              "error",
+            "@typescript-eslint/no-invalid-void-type": "error",
+            "@typescript-eslint/no-base-to-string": "error",
+            "import/no-cycle": "error",
+            "import/no-duplicates": "off",
+          },
+        };
+      }),
     // For scripts and configurations, use Node.js rules
     {
       files: ["**/*.{js,mjs,cjs}"],
       parserOptions: {
         ecmaVersion: 13, // ES2022 - https://eslint.org/docs/latest/use/configure/language-options#specifying-environments
       },
-      extends: ["eslint:recommended", "plugin:node/recommended"],
+      extends: ["eslint:recommended", "plugin:n/recommended"],
       rules: {
-        "node/shebang": "off", // this plugin only determines shebang necessary for files that are in a package.json "bin" field
-        "node/exports-style": ["error", "module.exports"],
-        "node/file-extension-in-import": ["error", "always"],
-        "node/prefer-global/buffer": ["error", "always"],
-        "node/prefer-global/console": ["error", "always"],
-        "node/prefer-global/process": ["error", "always"],
-        "node/prefer-global/url-search-params": ["error", "always"],
-        "node/prefer-global/url": ["error", "always"],
-        "node/prefer-promises/dns": "error",
-        "node/prefer-promises/fs": "error",
-        "no-process-exit": "off",
-        "node/no-unsupported-features/node-builtins": ["error", {
-          "version": ">=16.0.0",
-          "ignores": []
-        }]
+        "n/shebang": "off", // this rule reports _any_ shebang outside of an npm binary as an error
+        "n/prefer-global/process": "off",
+        "n/no-process-exit": "off",
+        "n/exports-style": ["error", "module.exports"],
+        "n/file-extension-in-import": ["error", "always"],
+        "n/prefer-global/buffer": ["error", "always"],
+        "n/prefer-global/console": ["error", "always"],
+        "n/prefer-global/url-search-params": ["error", "always"],
+        "n/prefer-global/url": ["error", "always"],
+        "n/prefer-promises/dns": "error",
+        "n/prefer-promises/fs": "error",
+        "n/no-unsupported-features/node-builtins": "error",
+        "n/no-unsupported-features/es-syntax": "error",
       },
     },
   ],

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ lint: node_modules $(BUILD)/protobuf $(BUILD)/protobuf-test $(BUILD)/protobuf-co
 
 .PHONY: format
 format: node_modules ## Format all files, adding license headers
-	npx prettier --write '**/*.{json,js,jsx,ts,tsx,css,mjs}' --log-level error
+	npx prettier --write '**/*.{json,js,jsx,ts,tsx,css,mjs,cjs}' --log-level error
 	npx license-header --ignore packages/protobuf/src/google/varint.ts
 
 .PHONY: bench

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "protobuf-es-4",
+  "name": "protobuf-es-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -29,7 +29,7 @@
         "eslint": "^8.50.0",
         "eslint-import-resolver-typescript": "^3.6.0",
         "eslint-plugin-import": "^2.28.0",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^16.3.1",
         "jest": "^29.7.0",
         "prettier": "^3.0.0",
         "typescript": "^5.2.2"
@@ -2095,6 +2095,18 @@
       "version": "1.1.2",
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "dev": true,
@@ -2730,22 +2742,23 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.3.0.tgz",
+      "integrity": "sha512-W9zIs+k00I/I13+Bdkl/zG1MEO07G97XjUSQuH117w620SJ6bHtLUmoMvkGA2oYnI/gNdr+G7BONLyYnFaLLEQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
-        "eslint": ">=4.19.1"
+        "eslint": ">=8"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -2805,31 +2818,31 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
+    "node_modules/eslint-plugin-n": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+      "integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.1.0",
+        "get-tsconfig": "^4.7.0",
+        "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -2845,28 +2858,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -3544,6 +3535,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {
@@ -5103,17 +5109,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.13.0",
+    "@bufbuild/license-header": "^0.0.4",
+    "@types/node": "^20.8.8",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "eslint": "^8.50.0",
     "eslint-import-resolver-typescript": "^3.6.0",
     "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^16.3.1",
+    "jest": "^29.7.0",
     "prettier": "^3.0.0",
-    "typescript": "^5.2.2",
-    "@types/node": "^20.8.8",
-    "@bufbuild/license-header": "^0.0.4",
-    "jest": "^29.7.0"
+    "typescript": "^5.2.2"
   },
   "//": "avoid hoisting, see packages/protoplugin/src/ecmascript/transpile.ts",
   "dependencies": {


### PR DESCRIPTION
I noticed some odd behavior in the Node.js linter. The original `eslint-plugin-node` does not seem to be maintained anymore. Let's switch to the fork [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n).