### PR TITLE
Fix the prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 /node_modules
-/packages/*/bin
+/packages/*/.tmp
 /packages/*/dist
 /packages/*/src/gen
 /packages/protobuf/src/google

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "protobuf-es-6",
+  "name": "protobuf-es",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -6443,6 +6443,7 @@
         "protoc": "bin/protoc.mjs",
         "upstream-files": "bin/upstream-files.mjs",
         "upstream-include": "bin/upstream-include.mjs",
+        "upstream-inject-feature-defaults": "bin/upstream-inject-feature-defaults.mjs",
         "upstream-warmup": "bin/upstream-warmup.mjs"
       }
     },

--- a/packages/protobuf-test/src/json-names.test.ts
+++ b/packages/protobuf-test/src/json-names.test.ts
@@ -13,115 +13,58 @@
 // limitations under the License.
 
 import { expect, test } from "@jest/globals";
-import { mkdtempSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
-import { spawnSync } from "child_process";
 import { FileDescriptorSet, proto3, ScalarType } from "@bufbuild/protobuf";
+import { UpstreamProtobuf } from "upstream-protobuf";
 
-test("JSON names equal protoc", () => {
-  expect(getProtocJsonName("foo_bar")).toBe("fooBar");
-  expectRuntimeJsonNameEqualsProtocJsonName("foo_bar");
-  expectRuntimeJsonNameEqualsProtocJsonName("__proto__");
-  expectRuntimeJsonNameEqualsProtocJsonName("fieldname1");
-  expectRuntimeJsonNameEqualsProtocJsonName("field_name2");
-  expectRuntimeJsonNameEqualsProtocJsonName("_field_name3");
-  expectRuntimeJsonNameEqualsProtocJsonName("field__name4_");
-  expectRuntimeJsonNameEqualsProtocJsonName("field0name5");
-  expectRuntimeJsonNameEqualsProtocJsonName("field_0_name6");
-  expectRuntimeJsonNameEqualsProtocJsonName("fieldName7");
-  expectRuntimeJsonNameEqualsProtocJsonName("FieldName8");
-  expectRuntimeJsonNameEqualsProtocJsonName("field_Name9");
-  expectRuntimeJsonNameEqualsProtocJsonName("Field_Name10");
-  expectRuntimeJsonNameEqualsProtocJsonName("FIELD_NAME11");
-  expectRuntimeJsonNameEqualsProtocJsonName("FIELD_name12");
-  expectRuntimeJsonNameEqualsProtocJsonName("__field_name13");
-  expectRuntimeJsonNameEqualsProtocJsonName("__Field_name14");
-  expectRuntimeJsonNameEqualsProtocJsonName("field__name15");
-  expectRuntimeJsonNameEqualsProtocJsonName("field__Name16");
-  expectRuntimeJsonNameEqualsProtocJsonName("field_name17__");
-  expectRuntimeJsonNameEqualsProtocJsonName("Field_name18__");
+test("JSON names equal protoc", async () => {
+  const names = [
+    "foo_bar",
+    "__proto__",
+    "fieldname1",
+    "field_name2",
+    "_field_name3",
+    "field__name4_",
+    "field0name5",
+    "field_0_name6",
+    "fieldName7",
+    "FieldName8",
+    "field_Name9",
+    "Field_Name10",
+    "FIELD_NAME11",
+    "FIELD_name12",
+    "__field_name13",
+    "__Field_name14",
+    "field__name15",
+    "field__Name16",
+    "field_name17__",
+    "Field_name18__",
+  ];
+  const protocNames = await getProtocJsonNames(names);
+  const runtimeNames = getRuntimeJsonNames(names);
+  expect(runtimeNames).toStrictEqual(protocNames);
 });
 
-// expectRuntimeJsonNameEqualsProtocJsonName takes the given proto field name
-// and runs it through protoc to get the JSON name.
-// The result is compared to our own implementation of the algorithm.
-// It is important that the implementations in JS and Go match the protoc
-// implementation.
-export function expectRuntimeJsonNameEqualsProtocJsonName(protoName: string) {
-  const want = getProtocJsonName(protoName);
-  const got = getRuntimeJsonName(protoName);
-  if (want === false) {
-    return;
-  }
-  expect(want).toBe(got);
-}
-
-function getRuntimeJsonName(name: string): string {
-  const mt = proto3.makeMessageType("Fuzz", [
-    { no: 1, kind: "scalar", T: ScalarType.BOOL, name: name },
-  ]);
-  const fi = mt.fields.find(1);
-  if (!fi) {
-    throw new Error();
-  }
-  return fi.jsonName;
-}
-
-// getProtocJsonName runs protoc to get the "json name" for a field
-function getProtocJsonName(protoName: string): string | false {
-  if (protoName.trim() !== protoName) {
-    return false;
-  }
-  const tempDir = mkdtempSync(join(tmpdir(), "node-protoc-workdir-"));
-  const inFilename = join(tempDir, "i.proto");
-  const outFilename = join(tempDir, "o");
-  const inData = [
-    `syntax = "proto3";`,
-    `message I {`,
-    `    int32 ${protoName} = 1;`,
-    `}`,
-  ].join("\n");
-  writeFileSync(inFilename, inData, { encoding: "utf-8" });
-  const result = spawnSync(
-    "protoc",
-    ["-I", tempDir, inFilename, "--descriptor_set_out", outFilename],
-    {
-      encoding: "utf-8",
-    },
+function getRuntimeJsonNames(protoFieldNames: string[]) {
+  const mt = proto3.makeMessageType(
+    "M",
+    protoFieldNames.map(
+      (n, i) =>
+        ({ no: i + 1, kind: "scalar", T: ScalarType.INT32, name: n }) as const,
+    ),
   );
-  if (result.stderr.length > 0) {
-    if (result.stderr.indexOf("Expected field name.") >= 0) {
-      return false;
-    }
-    if (result.stderr.indexOf("Expected field number.") >= 0) {
-      return false;
-    }
-    if (result.stderr.indexOf('Expected ";".') >= 0) {
-      return false;
-    }
-    if (result.stderr.indexOf("Missing field number.") >= 0) {
-      return false;
-    }
-    if (
-      result.stderr.indexOf(
-        "Invalid control characters encountered in text.",
-      ) >= 0
-    ) {
-      return false;
-    }
-    throw new Error(result.stderr);
-  }
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    throw new Error("exit code " + String(result.status));
-  }
-  const fds = FileDescriptorSet.fromBinary(readFileSync(outFilename));
-  const jsonName = fds.file[0].messageType[0].field[0].jsonName;
-  if (jsonName === undefined) {
-    throw new Error("missing json name");
-  }
-  return jsonName;
+  return mt.fields.list().map((f) => f.jsonName);
+}
+
+async function getProtocJsonNames(protoFieldNames: string[]) {
+  const upstream = new UpstreamProtobuf();
+  const bytes = await upstream.compileToDescriptorSet({
+    "i.proto": [
+      `syntax="proto3";`,
+      `message M {`,
+      ...protoFieldNames.map((n, i) => `int32 ${n} = ${i + 1};`),
+      `}`,
+    ].join("\n"),
+  });
+  const fds = FileDescriptorSet.fromBinary(bytes);
+  return fds.file[0].messageType[0].field.map((f) => f.jsonName);
 }

--- a/packages/upstream-protobuf/README.md
+++ b/packages/upstream-protobuf/README.md
@@ -1,7 +1,8 @@
 # Upstream protobuf
 
-This package provides `protoc`, `conformance_test_runner`, and related proto
-files via npm "binaries".
+This package provides `protoc`, `conformance_test_runner`, related proto files, 
+and feature-set defaults for editions via npm "binaries", and via an exported 
+class.
 
 To update this project to use a new version, update the version number in 
 version.txt and run `make`.

--- a/packages/upstream-protobuf/bin/conformance_test_runner.mjs
+++ b/packages/upstream-protobuf/bin/conformance_test_runner.mjs
@@ -16,7 +16,7 @@
 
 import { execFileSync } from "node:child_process";
 import { argv, exit, stderr } from "node:process";
-import { UpstreamProtobuf } from "../lib.mjs";
+import { UpstreamProtobuf } from "../index.mjs";
 
 const upstream = new UpstreamProtobuf();
 

--- a/packages/upstream-protobuf/bin/conformance_test_runner.mjs
+++ b/packages/upstream-protobuf/bin/conformance_test_runner.mjs
@@ -20,14 +20,16 @@ import { UpstreamProtobuf } from "../index.mjs";
 
 const upstream = new UpstreamProtobuf();
 
-upstream.getConformanceTestRunnerPath()
-    .then(path => {
-        execFileSync(path, argv.slice(2), {
-            shell: false,
-            stdio: "inherit",
-            maxBuffer: 1024 * 1024 * 100,
-        });
-    }).catch(reason => {
+upstream
+  .getConformanceTestRunnerPath()
+  .then((path) => {
+    execFileSync(path, argv.slice(2), {
+      shell: false,
+      stdio: "inherit",
+      maxBuffer: 1024 * 1024 * 100,
+    });
+  })
+  .catch((reason) => {
     stderr.write(String(reason) + "\n");
     exit(1);
-});
+  });

--- a/packages/upstream-protobuf/bin/protoc.mjs
+++ b/packages/upstream-protobuf/bin/protoc.mjs
@@ -20,14 +20,16 @@ import { UpstreamProtobuf } from "../index.mjs";
 
 const upstream = new UpstreamProtobuf();
 
-upstream.getProtocPath()
-    .then(path => {
-        execFileSync(path, argv.slice(2), {
-            shell: false,
-            stdio: "inherit",
-            maxBuffer: 1024 * 1024 * 100,
-        });
-    }).catch(reason => {
+upstream
+  .getProtocPath()
+  .then((path) => {
+    execFileSync(path, argv.slice(2), {
+      shell: false,
+      stdio: "inherit",
+      maxBuffer: 1024 * 1024 * 100,
+    });
+  })
+  .catch((reason) => {
     stderr.write(String(reason) + "\n");
     exit(1);
-});
+  });

--- a/packages/upstream-protobuf/bin/upstream-files.mjs
+++ b/packages/upstream-protobuf/bin/upstream-files.mjs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import {argv, exit, stderr, stdout} from "node:process";
-import {UpstreamProtobuf} from "../lib.mjs";
+import {UpstreamProtobuf} from "../index.mjs";
 
 void main(argv.slice(2));
 

--- a/packages/upstream-protobuf/bin/upstream-files.mjs
+++ b/packages/upstream-protobuf/bin/upstream-files.mjs
@@ -14,41 +14,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {argv, exit, stderr, stdout} from "node:process";
-import {UpstreamProtobuf} from "../index.mjs";
+import { argv, exit, stderr, stdout } from "node:process";
+import { UpstreamProtobuf } from "../index.mjs";
 
 void main(argv.slice(2));
 
 async function main(args) {
-    /**
-     * @typedef ProtoInclude
-     * @property {string} dir
-     * @property {string[]} files
-     */
+  /**
+   * @typedef ProtoInclude
+   * @property {string} dir
+   * @property {string[]} files
+   */
 
-    const upstream = new UpstreamProtobuf();
-    /** @type ProtoInclude */
-    let protoInclude;
-    switch (args[0]) {
-        case "wkt":
-            protoInclude = await upstream.getWktProtoInclude();
-            break;
-        case "conformance":
-            protoInclude = await upstream.getConformanceProtoInclude();
-            break;
-        case "test":
-            protoInclude = await upstream.getTestProtoInclude();
-            break;
-        default:
-            exitUsage();
-    }
-    stdout.write(protoInclude.files.join(" "));
+  const upstream = new UpstreamProtobuf();
+  /** @type ProtoInclude */
+  let protoInclude;
+  switch (args[0]) {
+    case "wkt":
+      protoInclude = await upstream.getWktProtoInclude();
+      break;
+    case "conformance":
+      protoInclude = await upstream.getConformanceProtoInclude();
+      break;
+    case "test":
+      protoInclude = await upstream.getTestProtoInclude();
+      break;
+    default:
+      exitUsage();
+  }
+  stdout.write(protoInclude.files.join(" "));
 }
 
 /**
  * @return never
  */
 function exitUsage() {
-    stderr.write(`USAGE: upstream-files wkt|conformance|test\n`);
-    exit(1);
+  stderr.write(`USAGE: upstream-files wkt|conformance|test\n`);
+  exit(1);
 }

--- a/packages/upstream-protobuf/bin/upstream-include.mjs
+++ b/packages/upstream-protobuf/bin/upstream-include.mjs
@@ -14,41 +14,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {argv, exit, stderr, stdout} from "node:process";
-import {UpstreamProtobuf} from "../index.mjs";
+import { argv, exit, stderr, stdout } from "node:process";
+import { UpstreamProtobuf } from "../index.mjs";
 
 void main(argv.slice(2));
 
 async function main(args) {
-    /**
-     * @typedef ProtoInclude
-     * @property {string} dir
-     * @property {string[]} files
-     */
+  /**
+   * @typedef ProtoInclude
+   * @property {string} dir
+   * @property {string[]} files
+   */
 
-    const upstream = new UpstreamProtobuf();
-    /** @type ProtoInclude */
-    let protoInclude;
-    switch (args[0]) {
-        case "wkt":
-            protoInclude = await upstream.getWktProtoInclude();
-            break;
-        case "conformance":
-            protoInclude = await upstream.getConformanceProtoInclude();
-            break;
-        case "test":
-            protoInclude = await upstream.getTestProtoInclude();
-            break;
-        default:
-            exitUsage();
-    }
-    stdout.write(protoInclude.dir);
+  const upstream = new UpstreamProtobuf();
+  /** @type ProtoInclude */
+  let protoInclude;
+  switch (args[0]) {
+    case "wkt":
+      protoInclude = await upstream.getWktProtoInclude();
+      break;
+    case "conformance":
+      protoInclude = await upstream.getConformanceProtoInclude();
+      break;
+    case "test":
+      protoInclude = await upstream.getTestProtoInclude();
+      break;
+    default:
+      exitUsage();
+  }
+  stdout.write(protoInclude.dir);
 }
 
 /**
  * @return never
  */
 function exitUsage() {
-    stderr.write(`USAGE: upstream-include wkt|conformance|test\n`);
-    exit(1);
+  stderr.write(`USAGE: upstream-include wkt|conformance|test\n`);
+  exit(1);
 }

--- a/packages/upstream-protobuf/bin/upstream-include.mjs
+++ b/packages/upstream-protobuf/bin/upstream-include.mjs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import {argv, exit, stderr, stdout} from "node:process";
-import {UpstreamProtobuf} from "../lib.mjs";
+import {UpstreamProtobuf} from "../index.mjs";
 
 void main(argv.slice(2));
 

--- a/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
+++ b/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {argv, exit, stdout, stderr} from "node:process";
+import {parseArgs} from "node:util";
+import {readFileSync, writeFileSync} from "node:fs";
+import {UpstreamProtobuf} from "../index.mjs";
+
+void main(argv.slice(2));
+
+async function main(args) {
+    let min, max, positionals;
+    try {
+        ({values: {min, max}, positionals} = parseArgs({
+            args,
+            options: {
+                min: { type: 'string' },
+                max: { type: 'string' },
+            },
+            allowPositionals: true,
+        }));
+    } catch {
+        exitUsage();
+    }
+    const upstream = new UpstreamProtobuf();
+    const defaults = await upstream.getFeatureSetDefaults(min, max);
+    stdout.write(`Injecting google.protobuf.FeatureSetDefaults into ${positionals.length} files...\n`);
+    for (const path of positionals) {
+        const content = readFileSync(path, "utf-8");
+        const r = inject(content, `"${defaults.toString("base64url")}"`);
+        if (!r.ok) {
+            stderr.write(`Error injecting into ${path}: ${r.message}\n`);
+            exit(1);
+        }
+        if (r.newContent === content) {
+            stdout.write(`- ${path} - no changes\n`);
+            continue;
+        }
+        writeFileSync(path, r.newContent);
+        stdout.write(`- ${path} - updated\n`);
+    }
+}
+
+/**
+ * @typedef {object} InjectSuccess
+ * @property {true} ok
+ * @property {string} newContent
+ */
+/**
+ * @typedef {object} InjectError
+ * @property {false} ok
+ * @property {string} message
+ */
+/**
+ * @param {string} content
+ * @param {string} contentToInject
+ * @return {InjectSuccess | InjectError}
+ */
+function inject(content, contentToInject) {
+    const tokenStart = "/*upstream-inject-feature-defaults-start*/";
+    const tokenEnd = "/*upstream-inject-feature-defaults-end*/";
+    const indexStart = content.indexOf(tokenStart);
+    const indexEnd = content.indexOf(tokenEnd);
+    if (indexStart < 0 || indexEnd < 0) {
+        return {ok: false, message: "missing comment annotations"};
+    }
+    if (indexEnd < indexStart) {
+        return {ok: false, message: "invalid comment annotations"};
+    }
+    const head = content.substring(0, indexStart + tokenStart.length);
+    const foot = content.substring(indexEnd);
+    const newContent = head + contentToInject + foot;
+    return {ok: true, newContent};
+}
+
+/**
+ * @return never
+ */
+function exitUsage() {
+    stderr.write(`USAGE: upstream-inject-feature-defaults [--min <mininum supported edition>] [--max <maximum supported edition>] <file-to-inject-into>\n`);
+    exit(1);
+}

--- a/packages/upstream-protobuf/bin/upstream-warmup.mjs
+++ b/packages/upstream-protobuf/bin/upstream-warmup.mjs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import {exit, stderr} from "node:process";
-import {UpstreamProtobuf} from "../lib.mjs";
+import {UpstreamProtobuf} from "../index.mjs";
 
 const upstream = new UpstreamProtobuf();
 upstream.warmup().then(() => exit(0), reason => {

--- a/packages/upstream-protobuf/bin/upstream-warmup.mjs
+++ b/packages/upstream-protobuf/bin/upstream-warmup.mjs
@@ -14,11 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {exit, stderr} from "node:process";
-import {UpstreamProtobuf} from "../index.mjs";
+import { exit, stderr } from "node:process";
+import { UpstreamProtobuf } from "../index.mjs";
 
 const upstream = new UpstreamProtobuf();
-upstream.warmup().then(() => exit(0), reason => {
+upstream.warmup().then(
+  () => exit(0),
+  (reason) => {
     stderr.write(`${String(reason)}\n`);
     exit(1);
-})
+  },
+);

--- a/packages/upstream-protobuf/index.d.ts
+++ b/packages/upstream-protobuf/index.d.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Copyright 2021-2023 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { execFileSync } from "node:child_process";
-import { argv, exit, stderr } from "node:process";
-import { UpstreamProtobuf } from "../index.mjs";
+export declare class UpstreamProtobuf {
+  constructor(temp?: string, version?: string);
 
-const upstream = new UpstreamProtobuf();
+  getProtocPath(): Promise<string>;
 
-upstream.getProtocPath()
-    .then(path => {
-        execFileSync(path, argv.slice(2), {
-            shell: false,
-            stdio: "inherit",
-            maxBuffer: 1024 * 1024 * 100,
-        });
-    }).catch(reason => {
-    stderr.write(String(reason) + "\n");
-    exit(1);
-});
+  getFeatureSetDefaults(
+    minimumEdition?: string,
+    maximumEdition?: string,
+  ): Promise<Uint8Array>;
+
+  compileToDescriptorSet(files: Record<string, string>): Promise<Uint8Array>;
+}

--- a/packages/upstream-protobuf/package.json
+++ b/packages/upstream-protobuf/package.json
@@ -10,7 +10,13 @@
     "conformance_test_runner": "bin/conformance_test_runner.mjs",
     "upstream-files": "bin/upstream-files.mjs",
     "upstream-include": "bin/upstream-include.mjs",
-    "upstream-warmup": "bin/upstream-warmup.mjs"
+    "upstream-warmup": "bin/upstream-warmup.mjs",
+    "upstream-inject-feature-defaults": "bin/upstream-inject-feature-defaults.mjs"
+  },
+  "exports": {
+    ".": {
+      "import": "./index.mjs"
+    }
   },
   "dependencies": {
     "fflate": "^0.8.1",


### PR DESCRIPTION
We should not exempt npm binaries from the formatter. But we should not format files in .tmp. This PR fixes both.