### PR TITLE
Prevent code gen and formatter fighting over whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,6 @@ perf: $(BUILD)/protobuf-test
 bootstrap: $(BUILD)/upstream-protobuf $(BUILD)/protoc-gen-es node_modules ## Bootstrap well-known types and edition features-set defaults in @bufbuild/protobuf from upstream protobuf
 	npm run -w packages/protobuf bootstrap:wkt
 	npm run -w packages/protobuf bootstrap:featureset-defaults
-	@# If the generated code differs, use it, and run tests again
-	#npm run -w packages/protobuf bootstrap-diff || $(MAKE) build test format lint
 
 .PHONY: setversion
 setversion: ## Set a new version in for the project, i.e. make setversion SET_VERSION=1.2.3

--- a/packages/protobuf/src/private/feature-set-defaults.ts
+++ b/packages/protobuf/src/private/feature-set-defaults.ts
@@ -17,6 +17,6 @@ import { protoBase64 } from "../proto-base64.js";
 
 export const featureSetDefaults = FeatureSetDefaults.fromBinary(
   protoBase64.dec(
-    /*upstream-inject-feature-defaults-start*/"ChESDAgBEAIYAiABKAEwAhjmBwoREgwIAhABGAEgAigBMAEY5wcKERIMCAEQARgBIAIoATABGOgHIOYHKOgH"/*upstream-inject-feature-defaults-end*/,
+    /*upstream-inject-feature-defaults-start*/ "ChESDAgBEAIYAiABKAEwAhjmBwoREgwIAhABGAEgAigBMAEY5wcKERIMCAEQARgBIAIoATABGOgHIOYHKOgH" /*upstream-inject-feature-defaults-end*/,
   ),
 );

--- a/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
+++ b/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
@@ -45,7 +45,7 @@ async function main(args) {
   );
   for (const path of positionals) {
     const content = readFileSync(path, "utf-8");
-    const r = inject(content, `"${defaults.toString("base64url")}"`);
+    const r = inject(content, ` "${defaults.toString("base64url")}" `);
     if (!r.ok) {
       stderr.write(`Error injecting into ${path}: ${r.message}\n`);
       exit(1);


### PR DESCRIPTION
Noticed that the formatter insists on whitespace in code generation added in https://github.com/bufbuild/protobuf-es/pull/619. This changes code gen to add the whitespace, so the outcome is stable, regardless of build order.