### PR TITLE
Expose syntax "editions" in descriptor sets

### DIFF
--- a/packages/protobuf-test/editions/edition2023-default-features.proto
+++ b/packages/protobuf-test/editions/edition2023-default-features.proto
@@ -1,0 +1,38 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package spec;
+
+// This file tests the default features in the absence of any dependencies.
+// Also see protobuf/src/google/protobuf/editions/proto/test_editions_default_features.proto
+
+enum EditionsDefaultEnum {
+  EDITIONS_DEFAULT_ENUM_UNKNOWN = 0;
+  EDITIONS_DEFAULT_ENUM_VALUE1 = 1;
+}
+
+message EditionsDefaultMessage {
+  int32 int32_field = 1;
+  string string_field = 2;
+  EditionsDefaultEnum enum_field = 3;
+
+  repeated int32 repeated_int32_field = 4;
+
+  message SubMessage {
+    int32 nested_int32_field = 1;
+  }
+  SubMessage sub_message_field = 6;
+}

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -12,7 +12,7 @@
     "generate:js": "protoc --es_out=src/gen/js --es_opt=ts_nocheck=false,target=js+dts --proto_path=. $(buf ls-files extra) --proto_path=$(upstream-include test) $(upstream-files test) google/protobuf/type.proto",
     "generate:wkt:ts": "protoc --es_out=src/gen/ts --es_opt=ts_nocheck=false,target=ts     $(upstream-files wkt)",
     "generate:wkt:js": "protoc --es_out=src/gen/js --es_opt=ts_nocheck=false,target=js+dts $(upstream-files wkt)",
-    "generate:desc": "protoc --descriptor_set_out descriptorset.bin --include_imports --include_source_info --proto_path=. --proto_path=$(upstream-include test) $(buf ls-files extra) $(upstream-files test)",
+    "generate:desc": "protoc --experimental_editions --descriptor_set_out descriptorset.bin --include_imports --include_source_info --proto_path=. --proto_path=$(upstream-include test) $(buf ls-files extra) $(upstream-files test) --proto_path=. $(buf ls-files editions)",
     "postgenerate": "license-header src/gen",
     "perf": "tsx src/perf.ts",
     "test": "npm run test:bigint && npm run test:string",

--- a/packages/protobuf-test/src/descriptor-set.test.ts
+++ b/packages/protobuf-test/src/descriptor-set.test.ts
@@ -14,7 +14,12 @@
 
 import { describe, expect, test } from "@jest/globals";
 import { readFileSync } from "fs";
-import { createDescriptorSet, proto3, ScalarType } from "@bufbuild/protobuf";
+import {
+  createDescriptorSet,
+  Edition,
+  proto3,
+  ScalarType,
+} from "@bufbuild/protobuf";
 import { JsonNamesMessage } from "./gen/ts/extra/msg-json-names_pb.js";
 import { MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
 import { RepeatedScalarValuesMessage } from "./gen/ts/extra/msg-scalar_pb.js";
@@ -29,6 +34,26 @@ const fdsBytes = readFileSync("./descriptorset.bin");
 
 describe("DescriptorSet", () => {
   const set = createDescriptorSet(fdsBytes);
+  test("proto2 syntax", () => {
+    const descFile = set.files.find((f) => f.name == "extra/proto2");
+    expect(descFile).toBeDefined();
+    expect(descFile?.syntax).toBe("proto2");
+    expect(descFile?.edition).toBe(Edition.EDITION_PROTO2);
+  });
+  test("proto3 syntax", () => {
+    const descFile = set.files.find((f) => f.name == "extra/proto3");
+    expect(descFile).toBeDefined();
+    expect(descFile?.syntax).toBe("proto3");
+    expect(descFile?.edition).toBe(Edition.EDITION_PROTO3);
+  });
+  test("edition 2023", () => {
+    const descFile = set.files.find(
+      (f) => f.name == "editions/edition2023-default-features",
+    );
+    expect(descFile).toBeDefined();
+    expect(descFile?.syntax).toBe("editions");
+    expect(descFile?.edition).toBe(Edition.EDITION_2023);
+  });
   test("knows extension", () => {
     const ext = set.extensions.get(
       "protobuf_unittest.optional_int32_extension",

--- a/packages/protobuf/src/descriptor-set.ts
+++ b/packages/protobuf/src/descriptor-set.ts
@@ -14,6 +14,7 @@
 
 import type {
   DescriptorProto,
+  Edition,
   EnumDescriptorProto,
   EnumValueDescriptorProto,
   FieldDescriptorProto,
@@ -85,7 +86,19 @@ export interface DescFile {
   /**
    * The syntax specified in the protobuf source.
    */
-  readonly syntax: "proto3" | "proto2";
+  readonly syntax: "proto3" | "proto2" | "editions";
+  /**
+   * The edition of the protobuf file. Will be EDITION_PROTO2 for syntax="proto2",
+   * EDITION_PROTO3 for syntax="proto3";
+   */
+  readonly edition: Omit<
+    Edition,
+    | Edition.EDITION_1_TEST_ONLY
+    | Edition.EDITION_2_TEST_ONLY
+    | Edition.EDITION_99997_TEST_ONLY
+    | Edition.EDITION_99998_TEST_ONLY
+    | Edition.EDITION_99999_TEST_ONLY
+  >;
   /**
    * The name of the file, excluding the .proto suffix.
    * For a protobuf file `foo/bar.proto`, this is `foo/bar`.

--- a/packages/protobuf/src/private/text-format.ts
+++ b/packages/protobuf/src/private/text-format.ts
@@ -1,0 +1,206 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescEnum } from "../descriptor-set.js";
+import { assert } from "./assert.js";
+import { ScalarType } from "../field.js";
+import { protoInt64 } from "../proto-int64.js";
+
+export function parseTextFormatEnumValue(
+  descEnum: DescEnum,
+  value: string,
+): number {
+  const enumValue = descEnum.values.find((v) => v.name === value);
+  assert(enumValue, `cannot parse ${descEnum.name} default value: ${value}`);
+  return enumValue.number;
+}
+
+export function parseTextFormatScalarValue(
+  type: ScalarType,
+  value: string,
+): number | boolean | string | bigint | Uint8Array {
+  switch (type) {
+    case ScalarType.STRING:
+      return value;
+    case ScalarType.BYTES: {
+      const u = unescapeBytesDefaultValue(value);
+      if (u === false) {
+        throw new Error(
+          `cannot parse ${ScalarType[type]} default value: ${value}`,
+        );
+      }
+      return u;
+    }
+    case ScalarType.INT64:
+    case ScalarType.SFIXED64:
+    case ScalarType.SINT64:
+      return protoInt64.parse(value);
+    case ScalarType.UINT64:
+    case ScalarType.FIXED64:
+      return protoInt64.uParse(value);
+    case ScalarType.DOUBLE:
+    case ScalarType.FLOAT:
+      switch (value) {
+        case "inf":
+          return Number.POSITIVE_INFINITY;
+        case "-inf":
+          return Number.NEGATIVE_INFINITY;
+        case "nan":
+          return Number.NaN;
+        default:
+          return parseFloat(value);
+      }
+    case ScalarType.BOOL:
+      return value === "true";
+    case ScalarType.INT32:
+    case ScalarType.UINT32:
+    case ScalarType.SINT32:
+    case ScalarType.FIXED32:
+    case ScalarType.SFIXED32:
+      return parseInt(value, 10);
+  }
+}
+
+/**
+ * Parses a text-encoded default value (proto2) of a BYTES field.
+ */
+function unescapeBytesDefaultValue(str: string): Uint8Array | false {
+  const b: number[] = [];
+  const input = {
+    tail: str,
+    c: "",
+    next(): boolean {
+      if (this.tail.length == 0) {
+        return false;
+      }
+      this.c = this.tail[0];
+      this.tail = this.tail.substring(1);
+      return true;
+    },
+    take(n: number): string | false {
+      if (this.tail.length >= n) {
+        const r = this.tail.substring(0, n);
+        this.tail = this.tail.substring(n);
+        return r;
+      }
+      return false;
+    },
+  };
+  while (input.next()) {
+    switch (input.c) {
+      case "\\":
+        if (input.next()) {
+          switch (input.c as string) {
+            case "\\":
+              b.push(input.c.charCodeAt(0));
+              break;
+            case "b":
+              b.push(0x08);
+              break;
+            case "f":
+              b.push(0x0c);
+              break;
+            case "n":
+              b.push(0x0a);
+              break;
+            case "r":
+              b.push(0x0d);
+              break;
+            case "t":
+              b.push(0x09);
+              break;
+            case "v":
+              b.push(0x0b);
+              break;
+            case "0":
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7": {
+              const s = input.c;
+              const t = input.take(2);
+              if (t === false) {
+                return false;
+              }
+              const n = parseInt(s + t, 8);
+              if (isNaN(n)) {
+                return false;
+              }
+              b.push(n);
+              break;
+            }
+            case "x": {
+              const s = input.c;
+              const t = input.take(2);
+              if (t === false) {
+                return false;
+              }
+              const n = parseInt(s + t, 16);
+              if (isNaN(n)) {
+                return false;
+              }
+              b.push(n);
+              break;
+            }
+            case "u": {
+              const s = input.c;
+              const t = input.take(4);
+              if (t === false) {
+                return false;
+              }
+              const n = parseInt(s + t, 16);
+              if (isNaN(n)) {
+                return false;
+              }
+              const chunk = new Uint8Array(4);
+              const view = new DataView(chunk.buffer);
+              view.setInt32(0, n, true);
+              b.push(chunk[0], chunk[1], chunk[2], chunk[3]);
+              break;
+            }
+            case "U": {
+              const s = input.c;
+              const t = input.take(8);
+              if (t === false) {
+                return false;
+              }
+              const tc = protoInt64.uEnc(s + t);
+              const chunk = new Uint8Array(8);
+              const view = new DataView(chunk.buffer);
+              view.setInt32(0, tc.lo, true);
+              view.setInt32(4, tc.hi, true);
+              b.push(
+                chunk[0],
+                chunk[1],
+                chunk[2],
+                chunk[3],
+                chunk[4],
+                chunk[5],
+                chunk[6],
+                chunk[7],
+              );
+              break;
+            }
+          }
+        }
+        break;
+      default:
+        b.push(input.c.charCodeAt(0));
+    }
+  }
+  return new Uint8Array(b);
+}

--- a/packages/protoc-gen-es/src/declaration.ts
+++ b/packages/protoc-gen-es/src/declaration.ts
@@ -30,6 +30,7 @@ import {
   makeJsDoc,
   reifyWkt,
 } from "@bufbuild/protoplugin/ecmascript";
+import { getNonEditionRuntime } from "./editions.js";
 
 export function generateDts(schema: Schema) {
   for (const file of schema.files) {
@@ -62,7 +63,7 @@ function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
 
 // prettier-ignore
 function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage) {
-  const protoN = schema.runtime[message.file.syntax];
+  const protoN = getNonEditionRuntime(schema, message.file);
   const {
     PartialMessage,
     FieldList,

--- a/packages/protoc-gen-es/src/editions.ts
+++ b/packages/protoc-gen-es/src/editions.ts
@@ -1,0 +1,38 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ImportSymbol, Schema } from "@bufbuild/protoplugin/ecmascript";
+import { DescFile } from "@bufbuild/protobuf";
+
+/**
+ * Temporary function to retrieve the import symbol for the proto2 or proto3
+ * runtime.
+ *
+ * For syntax "editions", this function raises and error.
+ *
+ * Once support for "editions" is implemented in the runtime, this function can
+ * be removed.
+ */
+export function getNonEditionRuntime(
+  schema: Schema,
+  file: DescFile,
+): ImportSymbol {
+  if (file.syntax === "editions") {
+    // TODO support editions
+    throw new Error(
+      `${file.proto.name ?? ""}: syntax "editions" is not supported yet`,
+    );
+  }
+  return schema.runtime[file.syntax];
+}

--- a/packages/protoc-gen-es/src/javascript.ts
+++ b/packages/protoc-gen-es/src/javascript.ts
@@ -26,6 +26,7 @@ import {
   makeJsDoc,
   reifyWkt,
 } from "@bufbuild/protoplugin/ecmascript";
+import { getNonEditionRuntime } from "./editions.js";
 
 export function generateJs(schema: Schema) {
   for (const file of schema.files) {
@@ -43,7 +44,7 @@ export function generateJs(schema: Schema) {
 
 // prettier-ignore
 function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
-  const protoN = schema.runtime[enumeration.file.syntax];
+  const protoN = getNonEditionRuntime(schema, enumeration.file);
   f.print(makeJsDoc(enumeration));
   f.print("export const ", enumeration, " = ", protoN, ".makeEnum(")
   f.print(`  "`, enumeration.typeName, `",`)
@@ -65,7 +66,7 @@ function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
 
 // prettier-ignore
 function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage) {
-  const protoN = schema.runtime[message.file.syntax];
+  const protoN = getNonEditionRuntime(schema, message.file);
   f.print(makeJsDoc(message));
   f.print("export const ", message, " = ", protoN, ".makeMessageType(")
   f.print(`  `, literalString(message.typeName), `,`)
@@ -100,7 +101,7 @@ function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage)
 
 // prettier-ignore
 export function generateFieldInfo(schema: Schema, f: GeneratedFile, field: DescField) {
-  const protoN = schema.runtime[field.parent.file.syntax];
+  const protoN = getNonEditionRuntime(schema, field.parent.file);
   const e: Printable = [];
   e.push("    { no: ", field.number, `, name: "`, field.name, `", `);
   if (field.jsonName !== undefined) {
@@ -168,7 +169,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
     ScalarType: rtScalarType,
     protoInt64,
   } = schema.runtime;
-  const protoN = schema.runtime[message.file.syntax];
+  const protoN = getNonEditionRuntime(schema, message.file);
   switch (ref.typeName) {
     case "google.protobuf.Any":
       f.print(message, ".prototype.toJson = function toJson(options) {")

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -33,6 +33,7 @@ import {
   reifyWkt,
 } from "@bufbuild/protoplugin/ecmascript";
 import { generateFieldInfo } from "./javascript.js";
+import { getNonEditionRuntime } from "./editions.js";
 
 export function generateTs(schema: Schema) {
   for (const file of schema.files) {
@@ -50,7 +51,7 @@ export function generateTs(schema: Schema) {
 
 // prettier-ignore
 function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
-  const protoN = schema.runtime[enumeration.file.syntax];
+  const protoN = getNonEditionRuntime(schema, enumeration.file);
   f.print(makeJsDoc(enumeration));
   f.print("export enum ", enumeration, " {");
   for (const value of enumeration.values) {
@@ -72,7 +73,7 @@ function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
 
 // prettier-ignore
 function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage) {
-  const protoN = schema.runtime[message.file.syntax];
+  const protoN = getNonEditionRuntime(schema, message.file);
   const {
     PartialMessage,
     FieldList,
@@ -191,7 +192,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
     LongType: rtLongType,
     protoInt64,
   } = schema.runtime;
-  const protoN = schema.runtime[message.file.syntax];
+  const protoN = getNonEditionRuntime(schema, message.file);
   switch (ref.typeName) {
     case "google.protobuf.Any":
       f.print("  override toJson(options?: Partial<", JsonWriteOptions, ">): ", JsonValue, " {");

--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { CodeGeneratorRequest, FileDescriptorProto } from "@bufbuild/protobuf";
+import {
+  CodeGeneratorRequest,
+  Edition,
+  FileDescriptorProto,
+} from "@bufbuild/protobuf";
 import type { DescFile } from "@bufbuild/protobuf";
 import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
 import type { Schema } from "@bufbuild/protoplugin/ecmascript";
@@ -108,6 +112,7 @@ describe("transpile", function () {
       kind: "file",
       name: "test",
       syntax: "proto3",
+      edition: Edition.EDITION_PROTO3,
       messages: [],
       deprecated: false,
       enums: [],


### PR DESCRIPTION
This change exposes the editions syntax in a `DescriptorSet`, the wrapper around protobuf file descriptor messages provided by `createDescriptorSet` from `@bufbuild/protobuf`.

The type `DescFile` receives a new property:

```ts
  /**
   * The edition of the protobuf file. Will be EDITION_PROTO2 for syntax="proto2",
   * EDITION_PROTO3 for syntax="proto3";
   */
  readonly edition: Omit<Edition, ...>;
```

The `syntax` property is updated to include `"editions"` in the union type:

```ts
  /**
   * The syntax specified in the protobuf source.
   */
  readonly syntax: "proto3" | "proto2" | "editions";
```

For example, a file with `syntax="proto3"` will have the properties `syntax: "proto3"` and `edition: Edition.EDITION_PROTO3`. A file with `edition="2023"` will have the properties `syntax: "editions"` and `edition: Edition.EDITION_2023`.

FeatureSets are not exposed yet. `protoc-gen-es` cannot generate code for editions yet. This change just allows `createDescriptorSet` to wrap descriptors using editions.
