### PR TITLE
Fix Edition type modification for the edition property of DescFile

### DIFF
--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -640,7 +640,7 @@ function parseFileSyntax(
   syntax: string | undefined,
   edition: Edition | undefined,
 ) {
-  let e: Omit<
+  let e: Exclude<
     Edition,
     | Edition.EDITION_1_TEST_ONLY
     | Edition.EDITION_2_TEST_ONLY

--- a/packages/protobuf/src/descriptor-set.ts
+++ b/packages/protobuf/src/descriptor-set.ts
@@ -91,7 +91,7 @@ export interface DescFile {
    * The edition of the protobuf file. Will be EDITION_PROTO2 for syntax="proto2",
    * EDITION_PROTO3 for syntax="proto3";
    */
-  readonly edition: Omit<
+  readonly edition: Exclude<
     Edition,
     | Edition.EDITION_1_TEST_ONLY
     | Edition.EDITION_2_TEST_ONLY


### PR DESCRIPTION
https://github.com/bufbuild/protobuf-es/pull/621 introduced a bug. The intention was to strip the enum values for testing from the `edition` property of `DescFile` provided by `createDescriptorSet()` from `@bufbuild/protobuf`. The correct way to do that is with the built-in type `Exclude`, not with `Omit`. 