### PR TITLE
Add createCodeGeneratorRequest() to upstream-protobuf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7180,6 +7180,7 @@
       "bin": {
         "conformance_test_runner": "bin/conformance_test_runner.mjs",
         "protoc": "bin/protoc.mjs",
+        "protoc-gen-dumpcodegenreq": "bin/protoc-gen-dumpcodegenreq.mjs",
         "upstream-files": "bin/upstream-files.mjs",
         "upstream-include": "bin/upstream-include.mjs",
         "upstream-inject-feature-defaults": "bin/upstream-inject-feature-defaults.mjs",

--- a/packages/upstream-protobuf/bin/protoc-gen-dumpcodegenreq.mjs
+++ b/packages/upstream-protobuf/bin/protoc-gen-dumpcodegenreq.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createWriteStream } from "node:fs";
+import { stdin, stdout } from "node:process";
+
+// Dump the binary google.protobuf.CodeGenerateRequest from stdin to a file.
+stdin.pipe(createWriteStream("dumpcodegenreq.bin"));
+
+// Write a minimal a google.protobuf.CodeGenerateResponse to stdout.
+// This is just the field supported_features set to a bitwise "or" of
+// FEATURE_PROTO3_OPTIONAL and FEATURE_SUPPORTS_EDITIONS. See the code snippet
+// below.
+const minimalResponse = new Uint8Array([16, 3]);
+stdout.write(minimalResponse);
+
+/*
+import {CodeGeneratorResponse, CodeGeneratorResponse_Feature} from "@bufbuild/protobuf";
+const bytes = new CodeGeneratorResponse({
+  supportedFeatures: BigInt(
+    CodeGeneratorResponse_Feature.PROTO3_OPTIONAL | CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS
+  ),
+}).toBinary();
+console.log(Array.from(bytes));
+*/

--- a/packages/upstream-protobuf/index.d.ts
+++ b/packages/upstream-protobuf/index.d.ts
@@ -30,8 +30,33 @@ export declare class UpstreamProtobuf {
     files: Record<string, string>,
     opt?: CompileToDescriptorSetOptions,
   ): Promise<Uint8Array>;
+
+  createCodeGeneratorRequest(
+    fileContent: string,
+    opt?: CreateCodeGeneratorRequestOptions,
+  ): Promise<Uint8Array>;
+  createCodeGeneratorRequest(
+    files: Record<string, string>,
+    opt?: CreateCodeGeneratorRequestOptions,
+  ): Promise<Uint8Array>;
+}
+
+interface CreateCodeGeneratorRequestOptions {
+  filesToGenerate?: string[];
+  parameter?: string;
 }
 
 interface CompileToDescriptorSetOptions {
+  /**
+   * Also include all dependencies of the input files in the set, so that the set is self-contained.
+   */
+  includeImports?: boolean;
+  /**
+   * Do not strip SourceCodeInfo from the FileDescriptorProto.
+   */
   includeSourceInfo?: boolean;
+  /**
+   * Do not strip any options from the FileDescriptorProto.
+   */
+  retainOptions?: boolean;
 }

--- a/packages/upstream-protobuf/package.json
+++ b/packages/upstream-protobuf/package.json
@@ -7,6 +7,7 @@
   },
   "bin": {
     "protoc": "bin/protoc.mjs",
+    "protoc-gen-dumpcodegenreq": "bin/protoc-gen-dumpcodegenreq.mjs",
     "conformance_test_runner": "bin/conformance_test_runner.mjs",
     "upstream-files": "bin/upstream-files.mjs",
     "upstream-include": "bin/upstream-include.mjs",


### PR DESCRIPTION
This adds the method `createCodeGeneratorRequest` to the internal class `UpstreamProtobuf`. It takes proto files as an argument (optionally also an array of files to generate, and plugin options), and returns a binary `google.protobuf.CodeGeneratorRequest`, by shelling out to `protoc`.

The method allows tests to create complete code generator requests (with correct option retention) on the fly.