### PR TITLE
Add explicit exports for Node

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -25,9 +25,13 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "node": {
+        "import": "./dist/proxy/index.js",
+        "require": "./dist/cjs/index.js"
+      },
       "module": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/proxy/index.js"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "devDependencies": {

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -21,14 +21,22 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "node": {
+        "import": "./dist/proxy/index.js",
+        "require": "./dist/cjs/index.js"
+      },
       "module": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/proxy/index.js"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     },
     "./ecmascript": {
+      "node": {
+        "import": "./dist/proxy/ecmascript/index.js",
+        "require": "./dist/cjs/ecmascript/index.js"
+      },
       "module": "./dist/esm/ecmascript/index.js",
-      "require": "./dist/cjs/ecmascript/index.js",
-      "import": "./dist/proxy/ecmascript/index.js"
+      "import": "./dist/esm/ecmascript/index.js",
+      "require": "./dist/cjs/ecmascript/index.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
Fixes #610 

This adds explicit exports for node into the package.json for all published packages in Protobuf-ES. In addition, it modifies the path for the top-level import statement to use ESM instead of the proxy.

For additional context, see https://github.com/connectrpc/connect-es/pull/921