### PR TITLE
Save state before using BinaryWriter

### DIFF
--- a/packages/protobuf-test/src/msg-message.test.ts
+++ b/packages/protobuf-test/src/msg-message.test.ts
@@ -14,9 +14,11 @@
 
 import { expect, test } from "@jest/globals";
 import type { JsonValue, PlainMessage } from "@bufbuild/protobuf";
+import { BinaryWriter } from "@bufbuild/protobuf";
 import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage as JS_MessageFieldMessage } from "./gen/js/extra/msg-message_pb.js";
 import { describeMT } from "./helpers.js";
+import assert from "node:assert";
 
 describeMT(
   { ts: TS_MessageFieldMessage, js: JS_MessageFieldMessage },
@@ -100,6 +102,34 @@ describeMT(
         msg.toJsonString({
           emitDefaultValues: true,
         }),
+      );
+    });
+    test("example binary encodes and decodes using same writer instance", () => {
+      const msg = new messageType(exampleFields);
+      const writer = new BinaryWriter();
+
+      let runs = 10;
+      let enc;
+      while (runs > 0) {
+        enc = msg.toBinary({
+          writerFactory: () => writer,
+        });
+        runs--;
+      }
+      assert(enc !== undefined);
+
+      const got = messageType.fromBinary(enc);
+      expect(got.messageField?.name).toStrictEqual(
+        exampleFields.messageField.name,
+      );
+      expect(got.repeatedMessageField.length).toStrictEqual(
+        exampleFields.repeatedMessageField.length,
+      );
+      expect(got.repeatedMessageField[0].name).toStrictEqual(
+        exampleFields.repeatedMessageField[0].name,
+      );
+      expect(got.repeatedMessageField[1].name).toStrictEqual(
+        exampleFields.repeatedMessageField[1].name,
       );
     });
   },

--- a/packages/protobuf/src/extension-accessor.ts
+++ b/packages/protobuf/src/extension-accessor.ts
@@ -87,6 +87,7 @@ export function setExtension<E extends Message<E>, V>(
     }
   }
   const writer = writeOpt.writerFactory();
+  writer.fork();
   extension.runtime.bin.writeField(extension.field, value, writer, writeOpt);
   const reader = readOpt.readerFactory(writer.finish());
   while (reader.pos < reader.len) {

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -109,6 +109,7 @@ export class Message<T extends Message<T> = AnyMessage> {
       bin = type.runtime.bin,
       opt = bin.makeWriteOptions(options),
       writer = opt.writerFactory();
+    writer.fork();
     bin.writeMessage(this, writer, opt);
     return writer.finish();
   }

--- a/packages/protobuf/src/proto-delimited.ts
+++ b/packages/protobuf/src/proto-delimited.ts
@@ -34,7 +34,7 @@ export const protoDelimited = {
    */
   enc(message: Message, options?: BinaryWriteOptions): Uint8Array {
     const opt = makeBinaryFormatCommon().makeWriteOptions(options);
-    return opt.writerFactory().bytes(message.toBinary(opt)).finish();
+    return opt.writerFactory().fork().bytes(message.toBinary(opt)).finish();
   },
 
   /**


### PR DESCRIPTION
This allows returning the same BinaryWriter instance for all calls inside writerFactory().

This does not break previous implementations of IBinaryWriter which do not flush the state inside finish() since they did not work correctly when trying to write nested messages with the same instance anyway.