### PR TITLE
Update example and tests to use the .binpb extension for binary Protobuf data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 /packages/*/dist
 /packages/typescript-compat/*/dist
-/packages/protobuf-test/descriptorset.bin
-/packages/protoplugin-test/descriptorset.bin
+/packages/protobuf-test/descriptorset.binpb
+/packages/protoplugin-test/descriptorset.binpb
 /.tmp
 /packages/*/.tmp

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(GEN)/protobuf-test: $(BUILD)/upstream-protobuf $(BUILD)/protoc-gen-es $(shell 
 	@touch $(@)
 
 $(GEN)/protoplugin-test: $(BUILD)/protoc-gen-es $(shell find packages/protoplugin-test/proto -name '*.proto')
-	@rm -rf packages/protoplugin-test/src/gen/* packages/protoplugin-test/descriptorset.bin
+	@rm -rf packages/protoplugin-test/src/gen/* packages/protoplugin-test/descriptorset.binpb
 	@npm run -w packages/protoplugin-test generate
 	@mkdir -p $(@D)
 	@touch $(@)

--- a/packages/protobuf-example/package.json
+++ b/packages/protobuf-example/package.json
@@ -4,8 +4,8 @@
   "license": "(Apache-2.0 AND BSD-3-Clause)",
   "scripts": {
     "build": "../../node_modules/typescript/bin/tsc --noEmit",
-    "add-person": "tsx src/add-person.ts addressbook.bin",
-    "list-people": "tsx src/list-people.ts addressbook.bin",
+    "add-person": "tsx src/add-person.ts addressbook.binpb",
+    "list-people": "tsx src/list-people.ts addressbook.binpb",
     "pregenerate": "rm -rf src/gen",
     "generate": "buf generate"
   },

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -12,7 +12,7 @@
     "generate:js": "protoc --es_out=src/gen/js --es_opt=ts_nocheck=false,target=js+dts --proto_path=. $(buf ls-files extra) --proto_path=$(upstream-include test) $(upstream-files test) google/protobuf/type.proto",
     "generate:wkt:ts": "protoc --es_out=src/gen/ts --es_opt=ts_nocheck=false,target=ts     $(upstream-files wkt)",
     "generate:wkt:js": "protoc --es_out=src/gen/js --es_opt=ts_nocheck=false,target=js+dts $(upstream-files wkt)",
-    "generate:desc": "protoc --experimental_editions --descriptor_set_out descriptorset.bin --include_imports --include_source_info --proto_path=. --proto_path=$(upstream-include test) $(buf ls-files extra) $(upstream-files test) --proto_path=. $(buf ls-files editions)",
+    "generate:desc": "protoc --experimental_editions --descriptor_set_out descriptorset.binpb --include_imports --include_source_info --proto_path=. --proto_path=$(upstream-include test) $(buf ls-files extra) $(upstream-files test) --proto_path=. $(buf ls-files editions)",
     "postgenerate": "license-header src/gen",
     "perf": "tsx src/perf.ts",
     "test": "npm run test:bigint && npm run test:string",

--- a/packages/protobuf-test/src/descriptor-set.test.ts
+++ b/packages/protobuf-test/src/descriptor-set.test.ts
@@ -47,7 +47,7 @@ import {
 import { UpstreamProtobuf } from "upstream-protobuf";
 import { join } from "node:path";
 
-const fdsBytes = readFileSync("./descriptorset.bin");
+const fdsBytes = readFileSync("./descriptorset.binpb");
 
 describe("DescriptorSet", () => {
   const set = createDescriptorSet(fdsBytes);

--- a/packages/protobuf-test/src/edition-feature-resolver.test.ts
+++ b/packages/protobuf-test/src/edition-feature-resolver.test.ts
@@ -526,7 +526,7 @@ function unescapeBytesDefaultValue(str: string): Uint8Array | false {
 }
 
 describe("FeatureResolver", function () {
-  const set = createDescriptorSet(readFileSync("./descriptorset.bin"));
+  const set = createDescriptorSet(readFileSync("./descriptorset.binpb"));
   const descFeatureSet = set.messages.get(FeatureSet.typeName);
   assert(descFeatureSet !== undefined);
 

--- a/packages/protobuf-test/src/helpers.ts
+++ b/packages/protobuf-test/src/helpers.ts
@@ -75,7 +75,7 @@ let testFileDescriptorSetBytes: Uint8Array | undefined;
 
 export function getTestFileDescriptorSetBytes(): Uint8Array {
   if (!testFileDescriptorSetBytes) {
-    testFileDescriptorSetBytes = readFileSync("./descriptorset.bin");
+    testFileDescriptorSetBytes = readFileSync("./descriptorset.binpb");
   }
   return testFileDescriptorSetBytes;
 }

--- a/packages/protobuf-test/src/jstype.test.ts
+++ b/packages/protobuf-test/src/jstype.test.ts
@@ -163,7 +163,7 @@ describe("jstype=JS_STRING", () => {
 
 describe("createDescriptorSet with jstype", () => {
   const reg = createRegistryFromDescriptors(
-    readFileSync("./descriptorset.bin"),
+    readFileSync("./descriptorset.binpb"),
   );
   testAllFieldsLongType("spec.JSTypeOmittedMessage", LongType.BIGINT);
   testAllFieldsLongType("spec.JSTypeStringMessage", LongType.STRING);
@@ -188,7 +188,7 @@ describe("createDescriptorSet with jstype", () => {
 
 describe("createRegistryFromDescriptors with jstype", () => {
   const descriptorSet = createDescriptorSet(
-    readFileSync("./descriptorset.bin"),
+    readFileSync("./descriptorset.binpb"),
   );
   testAllFieldsLongType("spec.JSTypeOmittedMessage", LongType.BIGINT);
   testAllFieldsLongType("spec.JSTypeStringMessage", LongType.STRING);

--- a/packages/protobuf-test/src/perf.ts
+++ b/packages/protobuf-test/src/perf.ts
@@ -31,7 +31,7 @@ import {
 
 run("Parsing binary", [
   function () {
-    const data = readFileSync("./descriptorset.bin");
+    const data = readFileSync("./descriptorset.binpb");
     return {
       name: `large google.protobuf.FileDescriptorSet (${data.byteLength} bytes)`,
       fn: () => {

--- a/packages/upstream-protobuf/bin/protoc-gen-dumpcodegenreq.mjs
+++ b/packages/upstream-protobuf/bin/protoc-gen-dumpcodegenreq.mjs
@@ -18,7 +18,7 @@ import { createWriteStream } from "node:fs";
 import { stdin, stdout } from "node:process";
 
 // Dump the binary google.protobuf.CodeGenerateRequest from stdin to a file.
-stdin.pipe(createWriteStream("dumpcodegenreq.bin"));
+stdin.pipe(createWriteStream("dumpcodegenreq.binpb"));
 
 // Write a minimal a google.protobuf.CodeGenerateResponse to stdout.
 // This is just the field supported_features set to a bitwise "or" of
@@ -26,13 +26,3 @@ stdin.pipe(createWriteStream("dumpcodegenreq.bin"));
 // below.
 const minimalResponse = new Uint8Array([16, 3]);
 stdout.write(minimalResponse);
-
-/*
-import {CodeGeneratorResponse, CodeGeneratorResponse_Feature} from "@bufbuild/protobuf";
-const bytes = new CodeGeneratorResponse({
-  supportedFeatures: BigInt(
-    CodeGeneratorResponse_Feature.PROTO3_OPTIONAL | CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS
-  ),
-}).toBinary();
-console.log(Array.from(bytes));
-*/

--- a/packages/upstream-protobuf/index.mjs
+++ b/packages/upstream-protobuf/index.mjs
@@ -140,7 +140,7 @@ export class UpstreamProtobuf {
         : filesOrFileContent;
     try {
       writeTree(Object.entries(files), tempDir);
-      const outPath = joinPath(tempDir, "desc.bin");
+      const outPath = joinPath(tempDir, "desc.binpb");
       const args = [
         "--experimental_editions",
         "--descriptor_set_out",
@@ -201,7 +201,7 @@ export class UpstreamProtobuf {
         shell: false,
         cwd: tempDir,
       });
-      const outPath = joinPath(tempDir, "dumpcodegenreq.bin");
+      const outPath = joinPath(tempDir, "dumpcodegenreq.binpb");
       return readFileSync(outPath);
     } finally {
       rmSync(tempDir, { recursive: true });
@@ -232,7 +232,7 @@ export class UpstreamProtobuf {
       writeTree(Object.entries(files), tempDir);
       const args = [
         "--experimental_edition_defaults_out",
-        "defaults.bin",
+        "defaults.binpb",
         "google/protobuf/descriptor.proto",
         ...Object.keys(files),
       ];
@@ -246,7 +246,7 @@ export class UpstreamProtobuf {
         shell: false,
         cwd: tempDir,
       });
-      return readFileSync(joinPath(tempDir, "defaults.bin"));
+      return readFileSync(joinPath(tempDir, "defaults.binpb"));
     } finally {
       rmSync(tempDir, { recursive: true });
     }


### PR DESCRIPTION
In our [example](https://github.com/bufbuild/protobuf-es/tree/main/packages/protobuf-example), we write binary Protobuf data to disk with the file extension `.bin`. 

This PR updates the example to use the file extension `.binpb` instead, which is the new recommendation [added to the documentation](https://github.com/protocolbuffers/protocolbuffers.github.io/commit/e24048571a0f8cc82cccedee21a029eed694fb04#diff-e8f302138161ca35fe47c4748846dab03ec4162461f4b319924fccd38b4505ab) last summer.