### PR TITLE
fix: don't use .fromBinary on import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "protobuf-es-7",
+  "name": "protobuf-es",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -6421,6 +6421,7 @@
     },
     "packages/upstream-protobuf": {
       "dependencies": {
+        "@bufbuild/protobuf": "^1.7.0",
         "fflate": "^0.8.1",
         "micromatch": "^4.0.5"
       },

--- a/packages/protobuf/src/private/feature-set.ts
+++ b/packages/protobuf/src/private/feature-set.ts
@@ -22,7 +22,7 @@ import {
  * Static edition feature defaults supported by @bufbuild/protobuf.
  */
 export const featureSetDefaults = FeatureSetDefaults.fromJsonString(
-  /*upstream-inject-feature-defaults-start*/ '{"defaults":[{"edition":"EDITION_PROTO2","features":{"fieldPresence":"EXPLICIT","enumType":"CLOSED","repeatedFieldEncoding":"EXPANDED","utf8Validation":"NONE","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"LEGACY_BEST_EFFORT"}},{"edition":"EDITION_PROTO3","features":{"fieldPresence":"IMPLICIT","enumType":"OPEN","repeatedFieldEncoding":"PACKED","utf8Validation":"VERIFY","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"ALLOW"}},{"edition":"EDITION_2023","features":{"fieldPresence":"EXPLICIT","enumType":"OPEN","repeatedFieldEncoding":"PACKED","utf8Validation":"VERIFY","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"ALLOW"}}],"minimumEdition":"EDITION_PROTO2","maximumEdition":"EDITION_2023"}' /*upstream-inject-feature-defaults-end*/
+  /*upstream-inject-feature-defaults-start*/ '{"defaults":[{"edition":"EDITION_PROTO2","features":{"fieldPresence":"EXPLICIT","enumType":"CLOSED","repeatedFieldEncoding":"EXPANDED","utf8Validation":"NONE","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"LEGACY_BEST_EFFORT"}},{"edition":"EDITION_PROTO3","features":{"fieldPresence":"IMPLICIT","enumType":"OPEN","repeatedFieldEncoding":"PACKED","utf8Validation":"VERIFY","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"ALLOW"}},{"edition":"EDITION_2023","features":{"fieldPresence":"EXPLICIT","enumType":"OPEN","repeatedFieldEncoding":"PACKED","utf8Validation":"VERIFY","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"ALLOW"}}],"minimumEdition":"EDITION_PROTO2","maximumEdition":"EDITION_2023"}' /*upstream-inject-feature-defaults-end*/,
 );
 
 /**
@@ -39,7 +39,7 @@ export type MergedFeatureSet = FeatureSet & Required<FeatureSet>;
  */
 export type FeatureResolverFn = (
   a?: FeatureSet,
-  b?: FeatureSet
+  b?: FeatureSet,
 ) => MergedFeatureSet;
 
 /**
@@ -47,7 +47,7 @@ export type FeatureResolverFn = (
  */
 export function createFeatureResolver(
   compiledFeatureSetDefaults: FeatureSetDefaults,
-  edition: Edition
+  edition: Edition,
 ): FeatureResolverFn {
   const min = compiledFeatureSetDefaults.minimumEdition;
   const max = compiledFeatureSetDefaults.maximumEdition;
@@ -60,12 +60,12 @@ export function createFeatureResolver(
   }
   if (edition < min) {
     throw new Error(
-      `Edition ${Edition[edition]} is earlier than the minimum supported edition ${Edition[min]}`
+      `Edition ${Edition[edition]} is earlier than the minimum supported edition ${Edition[min]}`,
     );
   }
   if (max < edition) {
     throw new Error(
-      `Edition ${Edition[edition]} is later than the maximum supported edition ${Edition[max]}`
+      `Edition ${Edition[edition]} is later than the maximum supported edition ${Edition[max]}`,
     );
   }
   let highestMatch: { e: Edition; f: FeatureSet } | undefined = undefined;
@@ -118,7 +118,7 @@ export function createFeatureResolver(
 // As a sanity check, we validate that all fields known to our version of
 // FeatureSet are set.
 function validateMergedFeatures(
-  featureSet: FeatureSet
+  featureSet: FeatureSet,
 ): featureSet is MergedFeatureSet {
   for (const fi of FeatureSet.fields.list()) {
     const v = featureSet[fi.localName as keyof FeatureSet] as unknown;

--- a/packages/protobuf/src/private/feature-set.ts
+++ b/packages/protobuf/src/private/feature-set.ts
@@ -17,15 +17,12 @@ import {
   FeatureSet,
   FeatureSetDefaults,
 } from "../google/protobuf/descriptor_pb.js";
-import { protoBase64 } from "../proto-base64.js";
 
 /**
  * Static edition feature defaults supported by @bufbuild/protobuf.
  */
-export const featureSetDefaults = FeatureSetDefaults.fromBinary(
-  protoBase64.dec(
-    /*upstream-inject-feature-defaults-start*/ "ChESDAgBEAIYAiABKAEwAhjmBwoREgwIAhABGAEgAigBMAEY5wcKERIMCAEQARgBIAIoATABGOgHIOYHKOgH" /*upstream-inject-feature-defaults-end*/,
-  ),
+export const featureSetDefaults = FeatureSetDefaults.fromJsonString(
+  /*upstream-inject-feature-defaults-end*/ "" /*upstream-inject-feature-defaults-start*/
 );
 
 /**

--- a/packages/protobuf/src/private/feature-set.ts
+++ b/packages/protobuf/src/private/feature-set.ts
@@ -22,7 +22,7 @@ import {
  * Static edition feature defaults supported by @bufbuild/protobuf.
  */
 export const featureSetDefaults = FeatureSetDefaults.fromJsonString(
-  /*upstream-inject-feature-defaults-end*/ "" /*upstream-inject-feature-defaults-start*/
+  /*upstream-inject-feature-defaults-start*/ '{"defaults":[{"edition":"EDITION_PROTO2","features":{"fieldPresence":"EXPLICIT","enumType":"CLOSED","repeatedFieldEncoding":"EXPANDED","utf8Validation":"NONE","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"LEGACY_BEST_EFFORT"}},{"edition":"EDITION_PROTO3","features":{"fieldPresence":"IMPLICIT","enumType":"OPEN","repeatedFieldEncoding":"PACKED","utf8Validation":"VERIFY","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"ALLOW"}},{"edition":"EDITION_2023","features":{"fieldPresence":"EXPLICIT","enumType":"OPEN","repeatedFieldEncoding":"PACKED","utf8Validation":"VERIFY","messageEncoding":"LENGTH_PREFIXED","jsonFormat":"ALLOW"}}],"minimumEdition":"EDITION_PROTO2","maximumEdition":"EDITION_2023"}' /*upstream-inject-feature-defaults-end*/
 );
 
 /**
@@ -39,7 +39,7 @@ export type MergedFeatureSet = FeatureSet & Required<FeatureSet>;
  */
 export type FeatureResolverFn = (
   a?: FeatureSet,
-  b?: FeatureSet,
+  b?: FeatureSet
 ) => MergedFeatureSet;
 
 /**
@@ -47,7 +47,7 @@ export type FeatureResolverFn = (
  */
 export function createFeatureResolver(
   compiledFeatureSetDefaults: FeatureSetDefaults,
-  edition: Edition,
+  edition: Edition
 ): FeatureResolverFn {
   const min = compiledFeatureSetDefaults.minimumEdition;
   const max = compiledFeatureSetDefaults.maximumEdition;
@@ -60,12 +60,12 @@ export function createFeatureResolver(
   }
   if (edition < min) {
     throw new Error(
-      `Edition ${Edition[edition]} is earlier than the minimum supported edition ${Edition[min]}`,
+      `Edition ${Edition[edition]} is earlier than the minimum supported edition ${Edition[min]}`
     );
   }
   if (max < edition) {
     throw new Error(
-      `Edition ${Edition[edition]} is later than the maximum supported edition ${Edition[max]}`,
+      `Edition ${Edition[edition]} is later than the maximum supported edition ${Edition[max]}`
     );
   }
   let highestMatch: { e: Edition; f: FeatureSet } | undefined = undefined;
@@ -118,7 +118,7 @@ export function createFeatureResolver(
 // As a sanity check, we validate that all fields known to our version of
 // FeatureSet are set.
 function validateMergedFeatures(
-  featureSet: FeatureSet,
+  featureSet: FeatureSet
 ): featureSet is MergedFeatureSet {
   for (const fi of FeatureSet.fields.list()) {
     const v = featureSet[fi.localName as keyof FeatureSet] as unknown;

--- a/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
+++ b/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
@@ -42,7 +42,7 @@ async function main(args) {
   const upstream = new UpstreamProtobuf();
   const defaults = await upstream.getFeatureSetDefaults(min, max);
   stdout.write(
-    `Injecting google.protobuf.FeatureSetDefaults into ${positionals.length} files...\n`
+    `Injecting google.protobuf.FeatureSetDefaults into ${positionals.length} files...\n`,
   );
   for (const path of positionals) {
     const content = readFileSync(path, "utf-8");
@@ -53,7 +53,7 @@ async function main(args) {
     const r = inject(content, ` '${jsonString}' `);
     if (!r.ok) {
       stderr.write(`Error injecting into ${path}: ${r.message}\n`, () =>
-        exit(1)
+        exit(1),
       );
       return;
     }
@@ -104,6 +104,6 @@ function inject(content, contentToInject) {
 function exitUsage() {
   stderr.write(
     `USAGE: upstream-inject-feature-defaults [--min <mininum supported edition>] [--max <maximum supported edition>] <file-to-inject-into>\n`,
-    () => exit(1)
+    () => exit(1),
   );
 }

--- a/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
+++ b/packages/upstream-protobuf/bin/upstream-inject-feature-defaults.mjs
@@ -47,10 +47,10 @@ async function main(args) {
   for (const path of positionals) {
     const content = readFileSync(path, "utf-8");
     const base64String = defaults.toString("base64url");
-    const buffer = protoBase64.decode(base64String);
+    const buffer = protoBase64.dec(base64String);
     const featureSetDefaults = FeatureSetDefaults.fromBinary(buffer);
     const jsonString = featureSetDefaults.toJsonString();
-    const r = inject(content, ` "${jsonString}" `);
+    const r = inject(content, ` '${jsonString}' `);
     if (!r.ok) {
       stderr.write(`Error injecting into ${path}: ${r.message}\n`, () =>
         exit(1)

--- a/packages/upstream-protobuf/package.json
+++ b/packages/upstream-protobuf/package.json
@@ -20,6 +20,7 @@
     }
   },
   "dependencies": {
+    "@bufbuild/protobuf": "*",
     "fflate": "^0.8.1",
     "micromatch": "^4.0.5"
   }


### PR DESCRIPTION
This PR fixes #680, by transforming the b64 feature set to a JSON string describing the message, at buildtime (bootstrap step / `npm run -w packages/protobuf bootstrap:featureset-defaults`).
This allows to import `@bufbuild/protobuf` in a context that doesn't provide a `TextEncoder` globally.
Please let me know if you have any feedback :)