### PR TITLE
Fix printing large 64-bit integers in @bufbuild/protoplugin

### DIFF
--- a/packages/protoplugin-test/src/file-print.test.ts
+++ b/packages/protoplugin-test/src/file-print.test.ts
@@ -13,22 +13,31 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
+import { protoInt64 } from "@bufbuild/protobuf";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 import { createImportSymbol } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("file print", () => {
   test("should print bigint literals", async () => {
     const lines = await testGenerate((f) => {
-      f.print(BigInt(123));
-      f.print(456n);
+      f.print(0n);
+      f.print(-9223372036854775808n); // min signed
+      f.print(18446744073709551615n); // max unsigned
     });
     expect(lines).toStrictEqual([
-      'import { protoInt64 } from "@bufbuild/protobuf";',
-      "",
-      `protoInt64.parse("123")`,
-      `protoInt64.parse("456")`,
+      `import { protoInt64 } from "@bufbuild/protobuf";`,
+      ``,
+      `protoInt64.zero`,
+      `protoInt64.parse("-9223372036854775808")`,
+      `protoInt64.uParse("18446744073709551615")`,
     ]);
+    expect(
+      protoInt64.parse("-9223372036854775808") === -9223372036854775808n,
+    ).toBeTruthy();
+    expect(
+      protoInt64.uParse("18446744073709551615") === 18446744073709551615n,
+    ).toBeTruthy();
   });
 
   test("should print number literals", async () => {

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -553,7 +553,7 @@ function literalBigint(value: bigint, runtimeImports: RuntimeImports): El[] {
   }
   return [
     runtimeImports.protoInt64,
-    ".parse(",
+    value > 0 ? ".uParse(" : ".parse(",
     literalString(value.toString()),
     ")",
   ];


### PR DESCRIPTION
When printing a very large 64-bit integers with @bufbuild/protoplugin, we generate code that fails at runtime. For example:

```ts
declare const f: GeneratedFile;
f.print(18446744073709551615n);
```

The code above will generate the expression `protoInt64.parse("18446744073709551615")`, but the number is outside the range of a signed 64-bit integer, and will raise an error.

This PR fixes the bug by generating a call to `protoInt64.uParse` instead.