### PR TITLE
Fix parsing JSON null in proto2

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 95,723 b      | 40,853 b | 10,615 b |
+| protobuf-es         | 96,275 b      | 41,035 b | 10,663 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf/src/private/json-format-proto2.ts
+++ b/packages/protobuf/src/private/json-format-proto2.ts
@@ -27,8 +27,8 @@ import type { Message } from "../message.js";
 /* eslint-disable no-case-declarations, @typescript-eslint/restrict-plus-operands,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument */
 
 export function makeJsonFormatProto2(): JsonFormat {
-  // TODO field presence: merge this function with proto2
-  return makeJsonFormatCommon((writeEnum, writeScalar) => {
+  // TODO field presence: merge this function with proto3. the reading side already switches behavior on the nullAsZeroValue argument.
+  return makeJsonFormatCommon(false, (writeEnum, writeScalar) => {
     return function writeField(
       field: FieldInfo,
       value: any,

--- a/packages/protobuf/src/private/json-format-proto3.ts
+++ b/packages/protobuf/src/private/json-format-proto3.ts
@@ -27,8 +27,8 @@ import type { Message } from "../message.js";
 /* eslint-disable no-case-declarations, @typescript-eslint/restrict-plus-operands,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument */
 
 export function makeJsonFormatProto3(): JsonFormat {
-  // TODO field presence: merge this function with proto2
-  return makeJsonFormatCommon((writeEnum, writeScalar) => {
+  // TODO field presence: merge this function with proto2. the reading side already switches behavior on the nullAsZeroValue argument.
+  return makeJsonFormatCommon(true, (writeEnum, writeScalar) => {
     return function writeField(
       field: FieldInfo,
       value: any,


### PR DESCRIPTION
When JSON `null` is parsed for a field, it must be treated as the default value of the corresponding field type. 

There was a bug in the proto2 implementation, which set the field to it's zero-value - for example `false` for a boolean field. This is correct for proto3 field presence, but incorrect for proto2 field presence, where our default value is `undefined`, not the zero value. 

This PR corrects the issue, so that field presence is correctly preserved with proto2 and JSON.