### PR TITLE
Fix proto3 extension presence for singular, non-optional scalar

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 96,275 b      | 41,035 b | 10,663 b |
+| protobuf-es         | 96,441 b      | 41,150 b | 10,720 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/extensions-proto3.test.ts
+++ b/packages/protobuf-test/src/extensions-proto3.test.ts
@@ -55,10 +55,11 @@ describe("setExtension() proto3", () => {
       expect(hasExtension(msg, ext)).toBeTruthy();
       expect(getExtension(msg, ext)).toStrictEqual(123);
     });
-    it("should not set zero value", () => {
+    it("should set zero value, even without optional keyword", () => {
+      // Implicit presence does not apply to extensions, see https://github.com/protocolbuffers/protobuf/issues/8234
       const msg = new FileOptions();
       setExtension(msg, ext, 0);
-      expect(hasExtension(msg, ext)).toBeFalsy();
+      expect(hasExtension(msg, ext)).toBeTruthy();
       expect(getExtension(msg, ext)).toStrictEqual(0);
     });
   });


### PR DESCRIPTION
When setting a proto3 extension, we apply explicit field presence for `optional` extension fields, and implicit presence otherwise. The behavior for non-optional singular scalar fields is incorrect.

For example, given the following definition:

```proto
syntax = "proto3";
import "google/protobuf/descriptor.proto";
extend google.protobuf.FileOptions {
  uint32 uint32_ext = 1001;
}
```

Setting a zero value is effectively a no-op:

```ts
setExtension(msg, uint32_ext, 0);
hasExtension(msg, uint32_ext); // false
```

This PR changes the behavior, treating the non-optional field as if it was `optional`, so that `hasExtension` in the example above returns `true`. 

For context, see https://github.com/protocolbuffers/protobuf/issues/8234