### PR TITLE
Add missing extension to import of descriptor-set for module resolution NodeNext

### DIFF
--- a/packages/protobuf/src/codegen-info.ts
+++ b/packages/protobuf/src/codegen-info.ts
@@ -29,7 +29,7 @@ import type {
   DescMethod,
   DescOneof,
   DescService,
-} from "./descriptor-set";
+} from "./descriptor-set.js";
 import { LongType, ScalarType } from "./field.js";
 
 interface CodegenInfo {


### PR DESCRIPTION
This single `import` was missing the `.js` extension that all the others seem to have ([example](https://github.com/bufbuild/protobuf-es/blob/11e0f56f213870ba0c330a1cb844ca9f70cca12a/packages/protobuf/src/extension-accessor.ts#L15)). This causes TypeScript errors with `"moduleResolution": "NodeNext"`. 