### PR TITLE
Fix typing for proto2 required fields with target=dts

### DIFF
--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
@@ -182,17 +182,17 @@ export declare class Proto2RequiredMessage extends Message<Proto2RequiredMessage
   /**
    * @generated from field: required string string_field = 1;
    */
-  stringField: string;
+  stringField?: string;
 
   /**
    * @generated from field: required bytes bytes_field = 2;
    */
-  bytesField: Uint8Array;
+  bytesField?: Uint8Array;
 
   /**
    * @generated from field: required spec.Proto2Enum enum_field = 3;
    */
-  enumField: Proto2Enum;
+  enumField?: Proto2Enum;
 
   /**
    * @generated from field: required spec.Proto2ChildMessage message_field = 4;
@@ -221,17 +221,17 @@ export declare class Proto2RequiredDefaultsMessage extends Message<Proto2Require
   /**
    * @generated from field: required string string_field = 1 [default = "hello \" *\/ "];
    */
-  stringField: string;
+  stringField?: string;
 
   /**
    * @generated from field: required bytes bytes_field = 2 [default = "\000x\\x\\"x\'AAAAAA\010\014\n\r\t\013"];
    */
-  bytesField: Uint8Array;
+  bytesField?: Uint8Array;
 
   /**
    * @generated from field: required spec.Proto2Enum enum_field = 3 [default = PROTO2_ENUM_YES];
    */
-  enumField: Proto2Enum;
+  enumField?: Proto2Enum;
 
   /**
    * @generated from field: required spec.Proto2ChildMessage message_field = 4;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
@@ -2068,12 +2068,12 @@ export declare class UninterpretedOption_NamePart extends Message<UninterpretedO
   /**
    * @generated from field: required string name_part = 1;
    */
-  namePart: string;
+  namePart?: string;
 
   /**
    * @generated from field: required bool is_extension = 2;
    */
-  isExtension: boolean;
+  isExtension?: boolean;
 
   constructor(data?: PartialMessage<UninterpretedOption_NamePart>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/map_lite_unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/map_lite_unittest_pb.d.ts
@@ -414,17 +414,17 @@ export declare class TestRequiredLite extends Message<TestRequiredLite> {
   /**
    * @generated from field: required int32 a = 1;
    */
-  a: number;
+  a?: number;
 
   /**
    * @generated from field: required int32 b = 2;
    */
-  b: number;
+  b?: number;
 
   /**
    * @generated from field: required int32 c = 3;
    */
-  c: number;
+  c?: number;
 
   constructor(data?: PartialMessage<TestRequiredLite>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
@@ -1145,77 +1145,77 @@ export declare class TestAllRequiredTypesProto2 extends Message<TestAllRequiredT
    *
    * @generated from field: required int32 required_int32 = 1;
    */
-  requiredInt32: number;
+  requiredInt32?: number;
 
   /**
    * @generated from field: required int64 required_int64 = 2;
    */
-  requiredInt64: bigint;
+  requiredInt64?: bigint;
 
   /**
    * @generated from field: required uint32 required_uint32 = 3;
    */
-  requiredUint32: number;
+  requiredUint32?: number;
 
   /**
    * @generated from field: required uint64 required_uint64 = 4;
    */
-  requiredUint64: bigint;
+  requiredUint64?: bigint;
 
   /**
    * @generated from field: required sint32 required_sint32 = 5;
    */
-  requiredSint32: number;
+  requiredSint32?: number;
 
   /**
    * @generated from field: required sint64 required_sint64 = 6;
    */
-  requiredSint64: bigint;
+  requiredSint64?: bigint;
 
   /**
    * @generated from field: required fixed32 required_fixed32 = 7;
    */
-  requiredFixed32: number;
+  requiredFixed32?: number;
 
   /**
    * @generated from field: required fixed64 required_fixed64 = 8;
    */
-  requiredFixed64: bigint;
+  requiredFixed64?: bigint;
 
   /**
    * @generated from field: required sfixed32 required_sfixed32 = 9;
    */
-  requiredSfixed32: number;
+  requiredSfixed32?: number;
 
   /**
    * @generated from field: required sfixed64 required_sfixed64 = 10;
    */
-  requiredSfixed64: bigint;
+  requiredSfixed64?: bigint;
 
   /**
    * @generated from field: required float required_float = 11;
    */
-  requiredFloat: number;
+  requiredFloat?: number;
 
   /**
    * @generated from field: required double required_double = 12;
    */
-  requiredDouble: number;
+  requiredDouble?: number;
 
   /**
    * @generated from field: required bool required_bool = 13;
    */
-  requiredBool: boolean;
+  requiredBool?: boolean;
 
   /**
    * @generated from field: required string required_string = 14;
    */
-  requiredString: string;
+  requiredString?: string;
 
   /**
    * @generated from field: required bytes required_bytes = 15;
    */
-  requiredBytes: Uint8Array;
+  requiredBytes?: Uint8Array;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
@@ -1230,22 +1230,22 @@ export declare class TestAllRequiredTypesProto2 extends Message<TestAllRequiredT
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
    */
-  requiredNestedEnum: TestAllRequiredTypesProto2_NestedEnum;
+  requiredNestedEnum?: TestAllRequiredTypesProto2_NestedEnum;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignEnumProto2 required_foreign_enum = 22;
    */
-  requiredForeignEnum: ForeignEnumProto2;
+  requiredForeignEnum?: ForeignEnumProto2;
 
   /**
    * @generated from field: required string required_string_piece = 24;
    */
-  requiredStringPiece: string;
+  requiredStringPiece?: string;
 
   /**
    * @generated from field: required string required_cord = 25;
    */
-  requiredCord: string;
+  requiredCord?: string;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
@@ -1267,77 +1267,77 @@ export declare class TestAllRequiredTypesProto2 extends Message<TestAllRequiredT
    *
    * @generated from field: required int32 default_int32 = 241 [default = -123456789];
    */
-  defaultInt32: number;
+  defaultInt32?: number;
 
   /**
    * @generated from field: required int64 default_int64 = 242 [default = -9123456789123456789];
    */
-  defaultInt64: bigint;
+  defaultInt64?: bigint;
 
   /**
    * @generated from field: required uint32 default_uint32 = 243 [default = 2123456789];
    */
-  defaultUint32: number;
+  defaultUint32?: number;
 
   /**
    * @generated from field: required uint64 default_uint64 = 244 [default = 10123456789123456789];
    */
-  defaultUint64: bigint;
+  defaultUint64?: bigint;
 
   /**
    * @generated from field: required sint32 default_sint32 = 245 [default = -123456789];
    */
-  defaultSint32: number;
+  defaultSint32?: number;
 
   /**
    * @generated from field: required sint64 default_sint64 = 246 [default = -9123456789123456789];
    */
-  defaultSint64: bigint;
+  defaultSint64?: bigint;
 
   /**
    * @generated from field: required fixed32 default_fixed32 = 247 [default = 2123456789];
    */
-  defaultFixed32: number;
+  defaultFixed32?: number;
 
   /**
    * @generated from field: required fixed64 default_fixed64 = 248 [default = 10123456789123456789];
    */
-  defaultFixed64: bigint;
+  defaultFixed64?: bigint;
 
   /**
    * @generated from field: required sfixed32 default_sfixed32 = 249 [default = -123456789];
    */
-  defaultSfixed32: number;
+  defaultSfixed32?: number;
 
   /**
    * @generated from field: required sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
    */
-  defaultSfixed64: bigint;
+  defaultSfixed64?: bigint;
 
   /**
    * @generated from field: required float default_float = 251 [default = 9e+09];
    */
-  defaultFloat: number;
+  defaultFloat?: number;
 
   /**
    * @generated from field: required double default_double = 252 [default = 7e+22];
    */
-  defaultDouble: number;
+  defaultDouble?: number;
 
   /**
    * @generated from field: required bool default_bool = 253 [default = true];
    */
-  defaultBool: boolean;
+  defaultBool?: boolean;
 
   /**
    * @generated from field: required string default_string = 254 [default = "Rosebud"];
    */
-  defaultString: string;
+  defaultString?: string;
 
   /**
    * @generated from field: required bytes default_bytes = 255 [default = "joshua"];
    */
-  defaultBytes: Uint8Array;
+  defaultBytes?: Uint8Array;
 
   constructor(data?: PartialMessage<TestAllRequiredTypesProto2>);
 
@@ -1388,7 +1388,7 @@ export declare class TestAllRequiredTypesProto2_NestedMessage extends Message<Te
   /**
    * @generated from field: required int32 a = 1;
    */
-  a: number;
+  a?: number;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
@@ -1424,12 +1424,12 @@ export declare class TestAllRequiredTypesProto2_Data extends Message<TestAllRequ
   /**
    * @generated from field: required int32 group_int32 = 202;
    */
-  groupInt32: number;
+  groupInt32?: number;
 
   /**
    * @generated from field: required uint32 group_uint32 = 203;
    */
-  groupUint32: number;
+  groupUint32?: number;
 
   constructor(data?: PartialMessage<TestAllRequiredTypesProto2_Data>);
 
@@ -1474,7 +1474,7 @@ export declare class TestAllRequiredTypesProto2_MessageSetCorrectExtension1 exte
   /**
    * @generated from field: required string str = 25;
    */
-  str: string;
+  str?: string;
 
   constructor(data?: PartialMessage<TestAllRequiredTypesProto2_MessageSetCorrectExtension1>);
 
@@ -1503,7 +1503,7 @@ export declare class TestAllRequiredTypesProto2_MessageSetCorrectExtension2 exte
   /**
    * @generated from field: required int32 i = 9;
    */
-  i: number;
+  i?: number;
 
   constructor(data?: PartialMessage<TestAllRequiredTypesProto2_MessageSetCorrectExtension2>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -749,7 +749,7 @@ export declare class OldOptionType extends Message<OldOptionType> {
   /**
    * @generated from field: required protobuf_unittest.OldOptionType.TestEnum value = 1;
    */
-  value: OldOptionType_TestEnum;
+  value?: OldOptionType_TestEnum;
 
   constructor(data?: PartialMessage<OldOptionType>);
 
@@ -785,7 +785,7 @@ export declare class NewOptionType extends Message<NewOptionType> {
   /**
    * @generated from field: required protobuf_unittest.NewOptionType.TestEnum value = 1;
    */
-  value: NewOptionType_TestEnum;
+  value?: NewOptionType_TestEnum;
 
   constructor(data?: PartialMessage<NewOptionType>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
@@ -875,7 +875,7 @@ export declare class TestDeprecatedLite extends Message<TestDeprecatedLite> {
    * @generated from field: required int32 deprecated_field2 = 2 [deprecated = true];
    * @deprecated
    */
-  deprecatedField2: number;
+  deprecatedField2?: number;
 
   /**
    * @generated from field: optional string deprecated_field3 = 3 [deprecated = true];
@@ -1187,7 +1187,7 @@ export declare class V1MessageLite extends Message<V1MessageLite> {
   /**
    * @generated from field: required int32 int_field = 1;
    */
-  intField: number;
+  intField?: number;
 
   /**
    * @generated from field: optional protobuf_unittest.V1EnumLite enum_field = 2 [default = V1_FIRST];
@@ -1216,7 +1216,7 @@ export declare class V2MessageLite extends Message<V2MessageLite> {
   /**
    * @generated from field: required int32 int_field = 1;
    */
-  intField: number;
+  intField?: number;
 
   /**
    * @generated from field: optional protobuf_unittest.V2EnumLite enum_field = 2 [default = V2_FIRST];

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
@@ -199,7 +199,7 @@ export declare class TestMessageSetExtension3 extends Message<TestMessageSetExte
   /**
    * @generated from field: required int32 required_int = 36;
    */
-  requiredInt: number;
+  requiredInt?: number;
 
   constructor(data?: PartialMessage<TestMessageSetExtension3>);
 
@@ -254,12 +254,12 @@ export declare class RawMessageSet_Item extends Message<RawMessageSet_Item> {
   /**
    * @generated from field: required int32 type_id = 2;
    */
-  typeId: number;
+  typeId?: number;
 
   /**
    * @generated from field: required bytes message = 3;
    */
-  message: Uint8Array;
+  message?: Uint8Array;
 
   constructor(data?: PartialMessage<RawMessageSet_Item>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
@@ -89,7 +89,7 @@ export declare class TestRequiredOptimizedForSize extends Message<TestRequiredOp
   /**
    * @generated from field: required int32 x = 1;
    */
-  x: number;
+  x?: number;
 
   constructor(data?: PartialMessage<TestRequiredOptimizedForSize>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -1816,7 +1816,7 @@ export declare class TestRequiredEnum extends Message<TestRequiredEnum> {
   /**
    * @generated from field: required protobuf_unittest.ForeignEnum required_enum = 1;
    */
-  requiredEnum: ForeignEnum;
+  requiredEnum?: ForeignEnum;
 
   /**
    * A dummy optional field.
@@ -1849,7 +1849,7 @@ export declare class TestRequiredEnumNoMask extends Message<TestRequiredEnumNoMa
   /**
    * @generated from field: required protobuf_unittest.TestRequiredEnumNoMask.NestedEnum required_enum = 1;
    */
-  requiredEnum: TestRequiredEnumNoMask_NestedEnum;
+  requiredEnum?: TestRequiredEnumNoMask_NestedEnum;
 
   /**
    * A dummy optional field.
@@ -1910,7 +1910,7 @@ export declare class TestRequiredEnumMulti extends Message<TestRequiredEnumMulti
    *
    * @generated from field: required protobuf_unittest.TestRequiredEnumMulti.NestedEnum required_enum_4 = 4;
    */
-  requiredEnum4: TestRequiredEnumMulti_NestedEnum;
+  requiredEnum4?: TestRequiredEnumMulti_NestedEnum;
 
   /**
    * @generated from field: optional int32 a_3 = 3;
@@ -1920,12 +1920,12 @@ export declare class TestRequiredEnumMulti extends Message<TestRequiredEnumMulti
   /**
    * @generated from field: required protobuf_unittest.TestRequiredEnumMulti.NestedEnum required_enum_2 = 2;
    */
-  requiredEnum2: TestRequiredEnumMulti_NestedEnum;
+  requiredEnum2?: TestRequiredEnumMulti_NestedEnum;
 
   /**
    * @generated from field: required protobuf_unittest.ForeignEnum required_enum_1 = 1;
    */
-  requiredEnum1: ForeignEnum;
+  requiredEnum1?: ForeignEnum;
 
   constructor(data?: PartialMessage<TestRequiredEnumMulti>);
 
@@ -1978,22 +1978,22 @@ export declare class TestRequiredNoMaskMulti extends Message<TestRequiredNoMaskM
    *
    * @generated from field: required fixed32 required_fixed32_80 = 80;
    */
-  requiredFixed3280: number;
+  requiredFixed3280?: number;
 
   /**
    * @generated from field: required fixed32 required_fixed32_70 = 70;
    */
-  requiredFixed3270: number;
+  requiredFixed3270?: number;
 
   /**
    * @generated from field: required protobuf_unittest.TestRequiredNoMaskMulti.NestedEnum required_enum_64 = 64;
    */
-  requiredEnum64: TestRequiredNoMaskMulti_NestedEnum;
+  requiredEnum64?: TestRequiredNoMaskMulti_NestedEnum;
 
   /**
    * @generated from field: required protobuf_unittest.TestRequiredNoMaskMulti.NestedEnum required_enum_4 = 4;
    */
-  requiredEnum4: TestRequiredNoMaskMulti_NestedEnum;
+  requiredEnum4?: TestRequiredNoMaskMulti_NestedEnum;
 
   /**
    * @generated from field: optional int32 a_3 = 3;
@@ -2003,12 +2003,12 @@ export declare class TestRequiredNoMaskMulti extends Message<TestRequiredNoMaskM
   /**
    * @generated from field: required protobuf_unittest.TestRequiredNoMaskMulti.NestedEnum required_enum_2 = 2;
    */
-  requiredEnum2: TestRequiredNoMaskMulti_NestedEnum;
+  requiredEnum2?: TestRequiredNoMaskMulti_NestedEnum;
 
   /**
    * @generated from field: required protobuf_unittest.ForeignEnum required_enum_1 = 1;
    */
-  requiredEnum1: ForeignEnum;
+  requiredEnum1?: ForeignEnum;
 
   constructor(data?: PartialMessage<TestRequiredNoMaskMulti>);
 
@@ -2063,7 +2063,7 @@ export declare class TestRequired extends Message<TestRequired> {
   /**
    * @generated from field: required int32 a = 1;
    */
-  a: number;
+  a?: number;
 
   /**
    * @generated from field: optional int32 dummy2 = 2;
@@ -2073,7 +2073,7 @@ export declare class TestRequired extends Message<TestRequired> {
   /**
    * @generated from field: required int32 b = 3;
    */
-  b: number;
+  b?: number;
 
   /**
    * Pad the field count to 32 so that we can test that IsInitialized()
@@ -2226,7 +2226,7 @@ export declare class TestRequired extends Message<TestRequired> {
   /**
    * @generated from field: required int32 c = 33;
    */
-  c: number;
+  c?: number;
 
   /**
    * Add an optional child message to make this non-trivial for go/pdlazy.
@@ -2810,7 +2810,7 @@ export declare class TestIsInitialized_SubMessage_SubGroup extends Message<TestI
   /**
    * @generated from field: required int32 i = 2;
    */
-  i: number;
+  i?: number;
 
   constructor(data?: PartialMessage<TestIsInitialized_SubMessage_SubGroup>);
 
@@ -4383,7 +4383,7 @@ export declare class TestRequiredOneof_NestedMessage extends Message<TestRequire
   /**
    * @generated from field: required double required_double = 1;
    */
-  requiredDouble: number;
+  requiredDouble?: number;
 
   constructor(data?: PartialMessage<TestRequiredOneof_NestedMessage>);
 

--- a/packages/protoc-gen-es/src/declaration.ts
+++ b/packages/protoc-gen-es/src/declaration.ts
@@ -26,6 +26,7 @@ import type {
 } from "@bufbuild/protoplugin/ecmascript";
 import {
   getFieldTyping,
+  getFieldIntrinsicDefaultValue,
   localName,
   reifyWkt,
 } from "@bufbuild/protoplugin/ecmascript";
@@ -138,8 +139,9 @@ function generateField(schema: Schema, f: GeneratedFile, field: DescField) {
   f.print(f.jsDoc(field, "  "));
   const e: Printable = [];
   e.push("  ", localName(field));
+  const { defaultValue } = getFieldIntrinsicDefaultValue(field);
   const { typing, optional } = getFieldTyping(field, f);
-  if (optional) {
+  if (optional || defaultValue === undefined) {
     e.push("?: ", typing);
   } else {
     e.push(": ", typing);


### PR DESCRIPTION
For proto2 required fields, we generate an optional field with target=ts:

```ts
export class Proto2RequiredMessage extends Message<Proto2RequiredMessage> {
  /**
   * @generated from field: required string string_field = 1;
   */
  stringField?: string;
```

But with target=dts, the field is not optional:

```ts
export declare class Proto2RequiredMessage extends Message<Proto2RequiredMessage> {
  /**
   * @generated from field: required string string_field = 1;
   */
  stringField: string;
```

This PR fixes the dts output to generate an optional type as well, which matches the runtime behavior.

We'll add tests soon for better coverage.