### PR TITLE
Update dependabot grouping

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,7 +24,6 @@ updates:
       test:
         patterns:
           - "jest"
-          - "@arethetypeswrong/*"
           - "benchmark"
           - "@types/benchmark"
           - "long"
@@ -33,9 +32,11 @@ updates:
           - "google-protobuf"
           - "brotli"
           - "esbuild"
-      eslint:
+      lint-and-format:
         patterns:
           - "@typescript-eslint/*"
           - "eslint-*"
           - "eslint"
-
+          - "prettier"
+          - "@bufbuild/license-header"
+          - "@arethetypeswrong/*"


### PR DESCRIPTION
This renames the group `eslint` to `lint-and-format`, and adds `prettier` and similar deps.