### PR TITLE
Increase test coverage for proto2

### DIFF
--- a/packages/protobuf-test/extra/proto2.proto
+++ b/packages/protobuf-test/extra/proto2.proto
@@ -38,29 +38,41 @@ message Proto2UnspecifiedPackedMessage {
 message Proto2OptionalMessage {
   optional string string_field = 1;
   optional bytes bytes_field = 2;
-  optional Proto2Enum enum_field = 3;
-  optional Proto2ChildMessage message_field = 4;
+  optional int32 int32_field = 3;
+  optional int64 int64_field = 4;
+  optional float float_field = 5;
+  optional bool bool_field = 6;
+  optional Proto2Enum enum_field = 7;
+  optional Proto2ChildMessage message_field = 8;
 }
 
 message Proto2RequiredMessage {
   required string string_field = 1;
   required bytes bytes_field = 2;
-  required Proto2Enum enum_field = 3;
-  required Proto2ChildMessage message_field = 4;
+  required int32 int32_field = 3;
+  required int64 int64_field = 4;
+  required float float_field = 5;
+  required bool bool_field = 6;
+  required Proto2Enum enum_field = 7;
+  required Proto2ChildMessage message_field = 8;
 }
 
 message Proto2RequiredDefaultsMessage {
   required string string_field = 1 [default = "hello \" */ "];
   required bytes bytes_field = 2 [default = "\0x\\x\"x\'A\101\x41\x41\u0041\U00000041\b\f\n\r\t\v"];
-  required Proto2Enum enum_field = 3 [default = PROTO2_ENUM_YES];
-  required Proto2ChildMessage message_field = 4;
+  required int32 int32_field = 3 [default = 128];
+  required int64 int64_field = 4 [default = -256];
+  required float float_field = 5 [default = -512.13];
+  required bool bool_field = 6 [default = true];
+  required Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];
+  required Proto2ChildMessage message_field = 8;
 }
 
 message Proto2DefaultsMessage {
   optional string string_field = 1 [default = "hello \" */ "];
   optional bytes bytes_field = 2 [default = "\0x\\x\"x\'A\101\x41\x41\u0041\U00000041\b\f\n\r\t\v"];
   optional int32 int32_field = 3 [default = 128];
-  optional int64 int46_field = 4 [default = -256];
+  optional int64 int64_field = 4 [default = -256];
   optional float float_field = 5 [default = -512.13];
   optional bool bool_field = 6 [default = true];
   optional Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
@@ -151,12 +151,32 @@ export declare class Proto2OptionalMessage extends Message<Proto2OptionalMessage
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: optional spec.Proto2Enum enum_field = 3;
+   * @generated from field: optional int32 int32_field = 3;
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: optional int64 int64_field = 4;
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: optional float float_field = 5;
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: optional bool bool_field = 6;
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: optional spec.Proto2Enum enum_field = 7;
    */
   enumField?: Proto2Enum;
 
   /**
-   * @generated from field: optional spec.Proto2ChildMessage message_field = 4;
+   * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
    */
   messageField?: Proto2ChildMessage;
 
@@ -190,12 +210,32 @@ export declare class Proto2RequiredMessage extends Message<Proto2RequiredMessage
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: required spec.Proto2Enum enum_field = 3;
+   * @generated from field: required int32 int32_field = 3;
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: required int64 int64_field = 4;
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: required float float_field = 5;
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: required bool bool_field = 6;
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: required spec.Proto2Enum enum_field = 7;
    */
   enumField?: Proto2Enum;
 
   /**
-   * @generated from field: required spec.Proto2ChildMessage message_field = 4;
+   * @generated from field: required spec.Proto2ChildMessage message_field = 8;
    */
   messageField?: Proto2ChildMessage;
 
@@ -229,12 +269,32 @@ export declare class Proto2RequiredDefaultsMessage extends Message<Proto2Require
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: required spec.Proto2Enum enum_field = 3 [default = PROTO2_ENUM_YES];
+   * @generated from field: required int32 int32_field = 3 [default = 128];
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: required int64 int64_field = 4 [default = -256];
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: required float float_field = 5 [default = -512.13];
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: required bool bool_field = 6 [default = true];
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: required spec.Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];
    */
   enumField?: Proto2Enum;
 
   /**
-   * @generated from field: required spec.Proto2ChildMessage message_field = 4;
+   * @generated from field: required spec.Proto2ChildMessage message_field = 8;
    */
   messageField?: Proto2ChildMessage;
 
@@ -273,9 +333,9 @@ export declare class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage
   int32Field?: number;
 
   /**
-   * @generated from field: optional int64 int46_field = 4 [default = -256];
+   * @generated from field: optional int64 int64_field = 4 [default = -256];
    */
-  int46Field?: bigint;
+  int64Field?: bigint;
 
   /**
    * @generated from field: optional float float_field = 5 [default = -512.13];

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.js
@@ -73,8 +73,12 @@ export const Proto2OptionalMessage = proto2.makeMessageType(
   () => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
-    { no: 3, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), opt: true },
-    { no: 4, name: "message_field", kind: "message", T: Proto2ChildMessage, opt: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), opt: true },
+    { no: 8, name: "message_field", kind: "message", T: Proto2ChildMessage, opt: true },
   ],
 );
 
@@ -86,8 +90,12 @@ export const Proto2RequiredMessage = proto2.makeMessageType(
   () => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, req: true },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, req: true },
-    { no: 3, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true },
-    { no: 4, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, req: true },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, req: true },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, req: true },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, req: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true },
+    { no: 8, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
   ],
 );
 
@@ -99,8 +107,12 @@ export const Proto2RequiredDefaultsMessage = proto2.makeMessageType(
   () => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, req: true, default: "hello \" */ " },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, req: true, default: new Uint8Array([0x00, 0x78, 0x5C, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B]) },
-    { no: 3, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true, default: Proto2Enum.YES },
-    { no: 4, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, req: true, default: 128 },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, req: true, default: protoInt64.parse("-256") },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, req: true, default: -512.13 },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, req: true, default: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true, default: Proto2Enum.YES },
+    { no: 8, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
   ],
 );
 
@@ -113,7 +125,7 @@ export const Proto2DefaultsMessage = proto2.makeMessageType(
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "hello \" */ " },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true, default: new Uint8Array([0x00, 0x78, 0x5C, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B]) },
     { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true, default: 128 },
-    { no: 4, name: "int46_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true, default: protoInt64.parse("-256") },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true, default: protoInt64.parse("-256") },
     { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: -512.13 },
     { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: true },
     { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), opt: true, default: Proto2Enum.YES },

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -201,12 +201,32 @@ export class Proto2OptionalMessage extends Message<Proto2OptionalMessage> {
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: optional spec.Proto2Enum enum_field = 3;
+   * @generated from field: optional int32 int32_field = 3;
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: optional int64 int64_field = 4;
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: optional float float_field = 5;
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: optional bool bool_field = 6;
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: optional spec.Proto2Enum enum_field = 7;
    */
   enumField?: Proto2Enum;
 
   /**
-   * @generated from field: optional spec.Proto2ChildMessage message_field = 4;
+   * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
    */
   messageField?: Proto2ChildMessage;
 
@@ -220,8 +240,12 @@ export class Proto2OptionalMessage extends Message<Proto2OptionalMessage> {
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
-    { no: 3, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), opt: true },
-    { no: 4, name: "message_field", kind: "message", T: Proto2ChildMessage, opt: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), opt: true },
+    { no: 8, name: "message_field", kind: "message", T: Proto2ChildMessage, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto2OptionalMessage {
@@ -256,12 +280,32 @@ export class Proto2RequiredMessage extends Message<Proto2RequiredMessage> {
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: required spec.Proto2Enum enum_field = 3;
+   * @generated from field: required int32 int32_field = 3;
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: required int64 int64_field = 4;
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: required float float_field = 5;
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: required bool bool_field = 6;
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: required spec.Proto2Enum enum_field = 7;
    */
   enumField?: Proto2Enum;
 
   /**
-   * @generated from field: required spec.Proto2ChildMessage message_field = 4;
+   * @generated from field: required spec.Proto2ChildMessage message_field = 8;
    */
   messageField?: Proto2ChildMessage;
 
@@ -275,8 +319,12 @@ export class Proto2RequiredMessage extends Message<Proto2RequiredMessage> {
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, req: true },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, req: true },
-    { no: 3, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true },
-    { no: 4, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, req: true },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, req: true },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, req: true },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, req: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true },
+    { no: 8, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto2RequiredMessage {
@@ -311,12 +359,32 @@ export class Proto2RequiredDefaultsMessage extends Message<Proto2RequiredDefault
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: required spec.Proto2Enum enum_field = 3 [default = PROTO2_ENUM_YES];
+   * @generated from field: required int32 int32_field = 3 [default = 128];
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: required int64 int64_field = 4 [default = -256];
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: required float float_field = 5 [default = -512.13];
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: required bool bool_field = 6 [default = true];
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: required spec.Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];
    */
   enumField?: Proto2Enum;
 
   /**
-   * @generated from field: required spec.Proto2ChildMessage message_field = 4;
+   * @generated from field: required spec.Proto2ChildMessage message_field = 8;
    */
   messageField?: Proto2ChildMessage;
 
@@ -330,8 +398,12 @@ export class Proto2RequiredDefaultsMessage extends Message<Proto2RequiredDefault
   static readonly fields: FieldList = proto2.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, req: true, default: "hello \" */ " },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, req: true, default: new Uint8Array([0x00, 0x78, 0x5C, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B]) },
-    { no: 3, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true, default: Proto2Enum.YES },
-    { no: 4, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, req: true, default: 128 },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, req: true, default: protoInt64.parse("-256") },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, req: true, default: -512.13 },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, req: true, default: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), req: true, default: Proto2Enum.YES },
+    { no: 8, name: "message_field", kind: "message", T: Proto2ChildMessage, req: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto2RequiredDefaultsMessage {
@@ -371,9 +443,9 @@ export class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage> {
   int32Field?: number;
 
   /**
-   * @generated from field: optional int64 int46_field = 4 [default = -256];
+   * @generated from field: optional int64 int64_field = 4 [default = -256];
    */
-  int46Field?: bigint;
+  int64Field?: bigint;
 
   /**
    * @generated from field: optional float float_field = 5 [default = -512.13];
@@ -406,7 +478,7 @@ export class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage> {
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true, default: "hello \" */ " },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true, default: new Uint8Array([0x00, 0x78, 0x5C, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B]) },
     { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true, default: 128 },
-    { no: 4, name: "int46_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true, default: protoInt64.parse("-256") },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true, default: protoInt64.parse("-256") },
     { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true, default: -512.13 },
     { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true, default: true },
     { no: 7, name: "enum_field", kind: "enum", T: proto2.getEnumType(Proto2Enum), opt: true, default: Proto2Enum.YES },

--- a/packages/protobuf-test/src/proto2.test.ts
+++ b/packages/protobuf-test/src/proto2.test.ts
@@ -15,8 +15,8 @@
 import { describe, expect, test } from "@jest/globals";
 import * as TS from "./gen/ts/extra/proto2_pb.js";
 import * as JS from "./gen/js/extra/proto2_pb.js";
-import { describeMT, testMT } from "./helpers.js";
-import type { AnyMessage, Message } from "@bufbuild/protobuf";
+import { describeMT } from "./helpers.js";
+import type { AnyMessage } from "@bufbuild/protobuf";
 import {
   BinaryReader,
   BinaryWriter,
@@ -24,210 +24,351 @@ import {
   WireType,
 } from "@bufbuild/protobuf";
 
-function setDefaults(m: AnyMessage): void {
-  for (const f of m.getType().fields.list()) {
-    if (f.kind == "scalar" || f.kind == "enum") {
-      m[f.localName] = f.default;
-    }
+function objectHasOwn(
+  obj: object,
+  property: string | number | symbol,
+): boolean {
+  if ("hasOwn" in Object) {
+    // ES2022
+    return (Object as unknown as { hasOwn: typeof objectHasOwn }).hasOwn(
+      obj,
+      property,
+    );
   }
+  return Object.prototype.hasOwnProperty.call(obj, property);
 }
 
-function verify<T extends Message>(m: T): boolean {
-  return m
-    .getType()
-    .fields.list()
-    .filter((f) => f.req)
-    .every((f) => (m as AnyMessage)[f.localName] !== undefined);
-}
-
-describe("setDefaults", () => {
-  testMT<TS.Proto2DefaultsMessage>(
-    { ts: TS.Proto2DefaultsMessage, js: JS.Proto2DefaultsMessage },
-    (messageType) => {
-      const msg = new messageType();
-      setDefaults(msg);
-      expect(msg.stringField).toBe('hello " */ ');
-      expect(msg.bytesField).toStrictEqual(
-        new Uint8Array([
-          0x00, 0x78, 0x5c, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
-          0x08, 0x0c, 0x0a, 0x0d, 0x09, 0x0b,
-        ]),
-      );
-      expect(msg.int32Field).toBe(128);
-      expect(msg.int46Field).toBe(protoInt64.parse("-256"));
-      expect(msg.floatField).toBe(-512.13);
-      expect(msg.enumField).toBe(TS.Proto2Enum.YES);
-      expect(msg.messageField).toBe(undefined);
-    },
-  );
-});
-
-describe("verify", () => {
-  testMT<TS.Proto2RequiredDefaultsMessage>(
-    {
-      ts: TS.Proto2RequiredDefaultsMessage,
-      js: JS.Proto2RequiredDefaultsMessage,
-    },
-    (messageType) => {
-      const msg = new messageType({
-        messageField: {},
-      });
-      expect(verify(msg)).toBe(false);
-      setDefaults(msg);
-      expect(verify(msg)).toBe(true);
-    },
-  );
-});
-
-describe("proto2 field info packed", () => {
-  describeMT(
-    { ts: TS.Proto2PackedMessage, js: JS.Proto2PackedMessage },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is packed", (field) => {
-        expect(field.packed).toBe(true);
-        expect(field.repeated).toBe(true);
-      });
-    },
-  );
-  describeMT(
-    { ts: TS.Proto2UnpackedMessage, js: JS.Proto2UnpackedMessage },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is unpacked", (field) => {
-        expect(field.packed).toBe(false);
-        expect(field.repeated).toBe(true);
-      });
-    },
-  );
-  describeMT(
-    {
-      ts: TS.Proto2UnspecifiedPackedMessage,
-      js: JS.Proto2UnspecifiedPackedMessage,
-    },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is unpacked", (field) => {
-        expect(field.packed).toBe(false);
-        expect(field.repeated).toBe(true);
-      });
-    },
-  );
-});
-
-describe("proto3 field info optional", () => {
+describe("proto2 required fields", () => {
   describeMT(
     { ts: TS.Proto2RequiredMessage, js: JS.Proto2RequiredMessage },
     (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is required", (field) => {
-        expect(field.opt).toBeFalsy();
+      describe("initially", () => {
+        test("has expected properties", () => {
+          const msg = new messageType();
+          expect(msg.stringField).toBeUndefined();
+          expect(msg.bytesField).toBeUndefined();
+          expect(msg.int32Field).toBeUndefined();
+          expect(msg.int64Field).toBeUndefined();
+          expect(msg.floatField).toBeUndefined();
+          expect(msg.boolField).toBeUndefined();
+          expect(msg.enumField).toBeUndefined();
+          expect(msg.messageField).toBeUndefined();
+        });
+        test.each(messageType.fields.byNumber())(
+          "field $name is not an own property",
+          (field) => {
+            const msg = new messageType();
+            expect(objectHasOwn(msg, field.localName)).toBeFalsy();
+          },
+        );
+      });
+      describe("parse", () => {
+        describe("fromJson", () => {
+          test("does not raise error with unset field", () => {
+            const msg = messageType.fromJson({
+              stringField: "",
+            });
+            expect(msg.enumField).toBeUndefined();
+            expect(objectHasOwn(msg, "enumField")).toBeFalsy();
+            expect(msg.stringField).toBeDefined();
+            expect(objectHasOwn(msg, "stringField")).toBeTruthy();
+          });
+        });
+        describe("fromBinary", () => {
+          test("does not raise error with unset field", () => {
+            const bytes = new BinaryWriter()
+              .tag(1, WireType.LengthDelimited)
+              .string("")
+              .finish();
+            const msg = messageType.fromBinary(bytes);
+            expect(msg.enumField).toBeUndefined();
+            expect(objectHasOwn(msg, "enumField")).toBeFalsy();
+            expect(msg.stringField).toBeDefined();
+            expect(objectHasOwn(msg, "stringField")).toBeTruthy();
+          });
+        });
+      });
+      describe("serialize", () => {
+        const validMsg = new messageType({
+          stringField: "",
+          bytesField: new Uint8Array(0),
+          int32Field: 0,
+          int64Field: protoInt64.zero,
+          floatField: 0,
+          boolField: false,
+          enumField: TS.Proto2Enum.YES,
+          messageField: {},
+        });
+        describe("toJson", () => {
+          test("does not raise error with set fields", () => {
+            const json = validMsg.toJson();
+            expect(json).toBeDefined();
+          });
+          test.each(messageType.fields.byNumber())(
+            "raises error with unset field $name",
+            (field) => {
+              const invalidMsg = validMsg.clone() as AnyMessage;
+              invalidMsg[field.localName] = undefined;
+              expect(() => invalidMsg.toJson()).toThrow(
+                `cannot encode field ${messageType.typeName}.${field.name} to JSON: required field not set`,
+              );
+            },
+          );
+        });
+        describe("toBinary", () => {
+          test("does not raise error with set fields", () => {
+            const json = validMsg.toBinary();
+            expect(json).toBeDefined();
+          });
+          test.each(messageType.fields.byNumber())(
+            "raises error with unset field $name",
+            (field) => {
+              const invalidMsg = validMsg.clone() as AnyMessage;
+              invalidMsg[field.localName] = undefined;
+              expect(() => invalidMsg.toBinary()).toThrow(
+                `cannot encode field ${messageType.typeName}.${field.name} to binary: required field not set`,
+              );
+            },
+          );
+        });
       });
     },
   );
+
+  describe("with default values", () => {
+    describeMT(
+      {
+        ts: TS.Proto2RequiredDefaultsMessage,
+        js: JS.Proto2RequiredDefaultsMessage,
+      },
+      (messageType) => {
+        describe("initially", () => {
+          test("has expected properties", () => {
+            const msg = new messageType();
+            expect(msg.stringField).toBeUndefined();
+            expect(msg.bytesField).toBeUndefined();
+            expect(msg.int32Field).toBeUndefined();
+            expect(msg.int64Field).toBeUndefined();
+            expect(msg.floatField).toBeUndefined();
+            expect(msg.boolField).toBeUndefined();
+            expect(msg.enumField).toBeUndefined();
+            expect(msg.messageField).toBeUndefined();
+          });
+          test.each(messageType.fields.byNumber())(
+            "field $name is not an own property",
+            (field) => {
+              const msg = new messageType();
+              expect(objectHasOwn(msg, field.localName)).toBeFalsy();
+            },
+          );
+        });
+        describe("serialize", () => {
+          const validMsg = new messageType({
+            stringField: "",
+            bytesField: new Uint8Array(0),
+            int32Field: 0,
+            int64Field: protoInt64.zero,
+            floatField: 0,
+            boolField: false,
+            enumField: TS.Proto2Enum.YES,
+            messageField: {},
+          });
+          describe("toJson", () => {
+            test("does not raise error with set fields", () => {
+              const json = validMsg.toJson();
+              expect(json).toBeDefined();
+            });
+            test.each(messageType.fields.byNumber())(
+              "raises error with unset field $name",
+              (field) => {
+                const invalidMsg = validMsg.clone();
+                // @ts-expect-error TS2790
+                delete invalidMsg[field.localName];
+                expect(() => invalidMsg.toJson()).toThrow(
+                  `cannot encode field ${messageType.typeName}.${field.name} to JSON: required field not set`,
+                );
+              },
+            );
+          });
+          describe("toBinary", () => {
+            test("does not raise error with set fields", () => {
+              const json = validMsg.toBinary();
+              expect(json).toBeDefined();
+            });
+            test.each(messageType.fields.byNumber())(
+              "raises error with unset field $name",
+              (field) => {
+                const invalidMsg = validMsg.clone();
+                // @ts-expect-error TS2790
+                delete invalidMsg[field.localName];
+                expect(() => invalidMsg.toBinary()).toThrow(
+                  `cannot encode field ${messageType.typeName}.${field.name} to binary: required field not set`,
+                );
+              },
+            );
+          });
+        });
+      },
+    );
+  });
+});
+
+describe("proto2 optional fields", () => {
   describeMT(
     { ts: TS.Proto2OptionalMessage, js: JS.Proto2OptionalMessage },
     (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is optional", (field) => {
-        expect(field.opt).toBe(true);
+      describe("initially", () => {
+        test("has expected properties", () => {
+          const msg = new messageType();
+          expect(msg.stringField).toBeUndefined();
+          expect(msg.bytesField).toBeUndefined();
+          expect(msg.int32Field).toBeUndefined();
+          expect(msg.int64Field).toBeUndefined();
+          expect(msg.floatField).toBeUndefined();
+          expect(msg.boolField).toBeUndefined();
+          expect(msg.enumField).toBeUndefined();
+          expect(msg.messageField).toBeUndefined();
+        });
+        test.each(messageType.fields.byNumber())(
+          "field $name is not an own property",
+          (field) => {
+            const msg = new messageType();
+            expect(objectHasOwn(msg, field.localName)).toBeFalsy();
+          },
+        );
       });
     },
   );
+
+  describe("with default values", () => {
+    describeMT(
+      { ts: TS.Proto2DefaultsMessage, js: JS.Proto2DefaultsMessage },
+      (messageType) => {
+        describe("initially", () => {
+          test("has expected properties", () => {
+            const msg = new messageType();
+            expect(msg.stringField).toBeUndefined();
+            expect(msg.bytesField).toBeUndefined();
+            expect(msg.int32Field).toBeUndefined();
+            expect(msg.int64Field).toBeUndefined();
+            expect(msg.floatField).toBeUndefined();
+            expect(msg.boolField).toBeUndefined();
+            expect(msg.enumField).toBeUndefined();
+            expect(msg.messageField).toBeUndefined();
+          });
+          test.each(messageType.fields.byNumber())(
+            "field $name is not an own property",
+            (field) => {
+              const msg = new messageType();
+              expect(objectHasOwn(msg, field.localName)).toBeFalsy();
+            },
+          );
+        });
+      },
+    );
+  });
 });
 
-describe("proto2 field info packed", () => {
-  describeMT(
-    { ts: TS.Proto2PackedMessage, js: JS.Proto2PackedMessage },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is packed", (field) => {
-        expect(field.packed).toBe(true);
-        expect(field.repeated).toBe(true);
-      });
-    },
-  );
-  describeMT(
-    { ts: TS.Proto2UnpackedMessage, js: JS.Proto2UnpackedMessage },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is unpacked", (field) => {
-        expect(field.packed).toBe(false);
-        expect(field.repeated).toBe(true);
-      });
-    },
-  );
-  describeMT(
-    {
-      ts: TS.Proto2UnspecifiedPackedMessage,
-      js: JS.Proto2UnspecifiedPackedMessage,
-    },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is unpacked", (field) => {
-        expect(field.packed).toBe(false);
-        expect(field.repeated).toBe(true);
-      });
-    },
-  );
+describe("proto2 field info", () => {
+  describe("packed", () => {
+    describeMT(
+      { ts: TS.Proto2PackedMessage, js: JS.Proto2PackedMessage },
+      (messageType) => {
+        test.each(messageType.fields.byNumber())("$name is packed", (field) => {
+          expect(field.packed).toBe(true);
+          expect(field.repeated).toBe(true);
+        });
+      },
+    );
+    describeMT(
+      { ts: TS.Proto2UnpackedMessage, js: JS.Proto2UnpackedMessage },
+      (messageType) => {
+        test.each(messageType.fields.byNumber())(
+          "$name is unpacked",
+          (field) => {
+            expect(field.packed).toBe(false);
+            expect(field.repeated).toBe(true);
+          },
+        );
+      },
+    );
+    describeMT(
+      {
+        ts: TS.Proto2UnspecifiedPackedMessage,
+        js: JS.Proto2UnspecifiedPackedMessage,
+      },
+      (messageType) => {
+        test.each(messageType.fields.byNumber())(
+          "$name is unpacked",
+          (field) => {
+            expect(field.packed).toBe(false);
+            expect(field.repeated).toBe(true);
+          },
+        );
+      },
+    );
+  });
+
+  describe("default", () => {
+    describeMT(
+      { ts: TS.Proto2DefaultsMessage, js: JS.Proto2DefaultsMessage },
+      (messageType) => {
+        test("", () => {
+          expect(messageType.fields.findJsonName("stringField")?.default).toBe(
+            `hello " */ `,
+          );
+          expect(
+            messageType.fields.findJsonName("bytesField")?.default,
+          ).toStrictEqual(
+            new Uint8Array([
+              0x00, 0x78, 0x5c, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+              0x08, 0x0c, 0x0a, 0x0d, 0x09, 0x0b,
+            ]),
+          );
+          expect(messageType.fields.findJsonName("int32Field")?.default).toBe(
+            128,
+          );
+          expect(messageType.fields.findJsonName("int64Field")?.default).toBe(
+            protoInt64.parse("-256"),
+          );
+          expect(messageType.fields.findJsonName("floatField")?.default).toBe(
+            -512.13,
+          );
+          expect(messageType.fields.findJsonName("enumField")?.default).toBe(
+            TS.Proto2Enum.YES,
+          );
+        });
+      },
+    );
+  });
+
+  describe("optional / required", () => {
+    describeMT(
+      { ts: TS.Proto2RequiredMessage, js: JS.Proto2RequiredMessage },
+      (messageType) => {
+        test.each(messageType.fields.byNumber())(
+          "$name is required",
+          (field) => {
+            expect(field.req).toBe(true);
+            expect(field.opt).toBe(false);
+          },
+        );
+      },
+    );
+    describeMT(
+      { ts: TS.Proto2OptionalMessage, js: JS.Proto2OptionalMessage },
+      (messageType) => {
+        test.each(messageType.fields.byNumber())(
+          "$name is optional",
+          (field) => {
+            expect(field.req).toBe(false);
+            expect(field.opt).toBe(true);
+          },
+        );
+      },
+    );
+  });
 });
-
-describe("proto3 field info optional / required", () => {
-  describeMT(
-    { ts: TS.Proto2RequiredMessage, js: JS.Proto2RequiredMessage },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is required", (field) => {
-        expect(field.req).toBe(true);
-        expect(field.opt).toBe(false);
-      });
-    },
-  );
-  describeMT(
-    { ts: TS.Proto2OptionalMessage, js: JS.Proto2OptionalMessage },
-    (messageType) => {
-      test.each(messageType.fields.byNumber())("$name is optional", (field) => {
-        expect(field.req).toBe(false);
-        expect(field.opt).toBe(true);
-      });
-    },
-  );
-});
-
-describeMT<TS.Proto2RequiredMessage>(
-  { ts: TS.Proto2RequiredMessage, js: JS.Proto2RequiredMessage },
-  (messageType) => {
-    test("has expected defaults", () => {
-      const got = { ...new messageType() };
-      expect(got).toStrictEqual({});
-    });
-    test("encode to JSON errors on missing required field", () => {
-      expect(() =>
-        new messageType({
-          // enumField: Proto2Enum.PROTO2_ENUM_YES,
-          messageField: {},
-          bytesField: new Uint8Array(0),
-          stringField: "",
-        }).toJson(),
-      ).toThrow(
-        `cannot encode field ${messageType.typeName}.enum_field to JSON: required field not set`,
-      );
-    });
-    test("encode to binary errors on missing required field", () => {
-      expect(() =>
-        new messageType({
-          // enumField: Proto2Enum.PROTO2_ENUM_YES,
-          messageField: {},
-          bytesField: new Uint8Array(0),
-          stringField: "",
-        }).toBinary(),
-      ).toThrow(
-        /^cannot encode field spec.Proto2RequiredMessage.enum_field to binary: required field not set$/,
-      );
-    });
-  },
-);
-
-describeMT(
-  { ts: TS.Proto2DefaultsMessage, js: JS.Proto2DefaultsMessage },
-  (messageType) => {
-    test("has no default values", () => {
-      const got = { ...new messageType() };
-      expect(got).toStrictEqual({});
-    });
-  },
-);
 
 describe("proto2 group", () => {
   const fieldNumbers = {

--- a/packages/protobuf-test/src/proto2.test.ts
+++ b/packages/protobuf-test/src/proto2.test.ts
@@ -108,7 +108,7 @@ describe("proto2 required fields", () => {
             "raises error with unset field $name",
             (field) => {
               const invalidMsg = validMsg.clone() as AnyMessage;
-              invalidMsg[field.localName] = undefined;
+              delete invalidMsg[field.localName];
               expect(() => invalidMsg.toJson()).toThrow(
                 `cannot encode field ${messageType.typeName}.${field.name} to JSON: required field not set`,
               );
@@ -124,7 +124,7 @@ describe("proto2 required fields", () => {
             "raises error with unset field $name",
             (field) => {
               const invalidMsg = validMsg.clone() as AnyMessage;
-              invalidMsg[field.localName] = undefined;
+              delete invalidMsg[field.localName];
               expect(() => invalidMsg.toBinary()).toThrow(
                 `cannot encode field ${messageType.typeName}.${field.name} to binary: required field not set`,
               );
@@ -181,8 +181,7 @@ describe("proto2 required fields", () => {
             test.each(messageType.fields.byNumber())(
               "raises error with unset field $name",
               (field) => {
-                const invalidMsg = validMsg.clone();
-                // @ts-expect-error TS2790
+                const invalidMsg = validMsg.clone() as AnyMessage;
                 delete invalidMsg[field.localName];
                 expect(() => invalidMsg.toJson()).toThrow(
                   `cannot encode field ${messageType.typeName}.${field.name} to JSON: required field not set`,
@@ -198,8 +197,7 @@ describe("proto2 required fields", () => {
             test.each(messageType.fields.byNumber())(
               "raises error with unset field $name",
               (field) => {
-                const invalidMsg = validMsg.clone();
-                // @ts-expect-error TS2790
+                const invalidMsg = validMsg.clone() as AnyMessage;
                 delete invalidMsg[field.localName];
                 expect(() => invalidMsg.toBinary()).toThrow(
                   `cannot encode field ${messageType.typeName}.${field.name} to binary: required field not set`,

--- a/packages/protoplugin-test/src/byo-transpile.test.ts
+++ b/packages/protoplugin-test/src/byo-transpile.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { FileInfo } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("bring your own transpile", () => {
   test("does not transpile target=ts", async () => {

--- a/packages/protoplugin-test/src/deprecated-jsdoc.test.ts
+++ b/packages/protoplugin-test/src/deprecated-jsdoc.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import { createJsDocBlock, makeJsDoc } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("deprecated makeJsDoc() and createJsDocBlock()", () => {
   test("creates JSDoc comment block", async () => {

--- a/packages/protoplugin-test/src/file-export-decl.test.ts
+++ b/packages/protoplugin-test/src/file-export-decl.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, test } from "@jest/globals";
 import type { DescEnum, DescMessage } from "@bufbuild/protobuf";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("file exportDecl", () => {
   test("works as documented", async () => {

--- a/packages/protoplugin-test/src/file-import.test.ts
+++ b/packages/protoplugin-test/src/file-import.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("file import", () => {
   test("should create import symbol for package", async function () {

--- a/packages/protoplugin-test/src/file-jsdoc.test.ts
+++ b/packages/protoplugin-test/src/file-jsdoc.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("file jsDoc", () => {
   test("creates JSDoc comment block", async () => {

--- a/packages/protoplugin-test/src/file-preamble.test.ts
+++ b/packages/protoplugin-test/src/file-preamble.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("file preamble", () => {
   test("contains plugin name and version", async () => {

--- a/packages/protoplugin-test/src/file-string.test.ts
+++ b/packages/protoplugin-test/src/file-string.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { GeneratedFile } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("file string", () => {
   test("surrounds string in quotes", async () => {

--- a/packages/protoplugin-test/src/import_extension.test.ts
+++ b/packages/protoplugin-test/src/import_extension.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("import_extension", function () {
   test("should be replaced with '.ts'", async () => {

--- a/packages/protoplugin-test/src/js_import_style.test.ts
+++ b/packages/protoplugin-test/src/js_import_style.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { Schema } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("js_import_style", () => {
   const linesEsm = [

--- a/packages/protoplugin-test/src/rewrite_imports.test.ts
+++ b/packages/protoplugin-test/src/rewrite_imports.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("rewrite_imports", function () {
   test("example works as documented", async () => {

--- a/packages/protoplugin-test/src/target.test.ts
+++ b/packages/protoplugin-test/src/target.test.ts
@@ -14,7 +14,7 @@
 
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import type { FileInfo, Schema } from "@bufbuild/protoplugin/ecmascript";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
 import { CodeGeneratorResponse } from "@bufbuild/protobuf";
 

--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 
 describe("built-in transpile", () => {
   async function testTranspileToDts(linesTs: string[]) {


### PR DESCRIPTION
This updates the existing tests for proto2 messages to 
- cover all relevant field types, 
- cover behavior when parsing and serializing, for JSON and Protobuf binary
- test initial values after construction, including presence of properties