### PR TITLE
Introduce type ScalarValue and rename function scalarDefaultValue

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 97,101 b      | 41,461 b | 10,746 b |
+| protobuf-es         | 97,081 b      | 41,461 b | 10,754 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 97,081 b      | 41,461 b | 10,754 b |
+| protobuf-es         | 96,999 b      | 41,438 b | 10,763 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf/src/codegen-info.ts
+++ b/packages/protobuf/src/codegen-info.ts
@@ -18,7 +18,7 @@ import {
   safeObjectProperty,
 } from "./private/names.js";
 import { getUnwrappedFieldType } from "./private/field-wrapper.js";
-import { scalarDefaultValue } from "./private/scalars.js";
+import { scalarZeroValue } from "./private/scalars.js";
 import { reifyWkt } from "./private/reify-wkt.js";
 import type {
   DescEnum,
@@ -30,7 +30,8 @@ import type {
   DescOneof,
   DescService,
 } from "./descriptor-set.js";
-import { LongType, ScalarType } from "./field.js";
+import type { ScalarValue } from "./scalar.js";
+import { LongType, ScalarType } from "./scalar.js";
 
 interface CodegenInfo {
   /**
@@ -53,7 +54,14 @@ interface CodegenInfo {
     field: DescField | DescExtension,
   ) => ScalarType | undefined;
   readonly wktSourceFiles: readonly string[];
+  /**
+   * @deprecated please use scalarZeroValue instead
+   */
   readonly scalarDefaultValue: (type: ScalarType, longType: LongType) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  readonly scalarZeroValue: <T extends ScalarType, L extends LongType>(
+    type: T,
+    longType: L,
+  ) => ScalarValue<T, L>;
   /**
    * @deprecated please use reifyWkt from @bufbuild/protoplugin/ecmascript instead
    */
@@ -98,7 +106,8 @@ export const codegenInfo: CodegenInfo = {
   localName,
   reifyWkt,
   getUnwrappedFieldType,
-  scalarDefaultValue,
+  scalarDefaultValue: scalarZeroValue,
+  scalarZeroValue,
   safeIdentifier,
   safeObjectProperty,
   // prettier-ignore
@@ -119,8 +128,8 @@ export const codegenInfo: CodegenInfo = {
     JsonObject:           {typeOnly: true,  privateImportPath: "./json-format.js",   publicImportPath: packageName},
     protoDouble:          {typeOnly: false, privateImportPath: "./proto-double.js",  publicImportPath: packageName},
     protoInt64:           {typeOnly: false, privateImportPath: "./proto-int64.js",   publicImportPath: packageName},
-    ScalarType:           {typeOnly: false, privateImportPath: "./field.js",         publicImportPath: packageName},
-    LongType:             {typeOnly: false, privateImportPath: "./field.js",         publicImportPath: packageName},
+    ScalarType:           {typeOnly: false, privateImportPath: "./scalar.js",        publicImportPath: packageName},
+    LongType:             {typeOnly: false, privateImportPath: "./scalar.js",        publicImportPath: packageName},
     MethodKind:           {typeOnly: false, privateImportPath: "./service-type.js",  publicImportPath: packageName},
     MethodIdempotency:    {typeOnly: false, privateImportPath: "./service-type.js",  publicImportPath: packageName},
     IMessageTypeRegistry: {typeOnly: true,  privateImportPath: "./type-registry.js", publicImportPath: packageName},

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -45,7 +45,6 @@ import type {
   DescriptorSet,
   DescService,
 } from "./descriptor-set.js";
-import { LongType, ScalarType } from "./field.js";
 import { MethodIdempotency, MethodKind } from "./service-type.js";
 import { fieldJsonName, findEnumSharedPrefix } from "./private/names.js";
 import {
@@ -55,6 +54,7 @@ import {
 import type { BinaryReadOptions, BinaryWriteOptions } from "./binary-format.js";
 import type { FeatureResolverFn } from "./private/feature-set.js";
 import { createFeatureResolver } from "./private/feature-set.js";
+import { LongType, ScalarType } from "./scalar.js";
 
 /**
  * Create a DescriptorSet, a convenient interface for working with a set of

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -17,7 +17,7 @@ import type { MessageType } from "./message-type.js";
 import { proto3 } from "./proto3.js";
 import { proto2 } from "./proto2.js";
 import type { FieldInfo } from "./field.js";
-import { ScalarType } from "./field.js";
+import { ScalarType } from "./scalar.js";
 import type { EnumType, EnumValueInfo } from "./enum.js";
 import type {
   IEnumTypeRegistry,

--- a/packages/protobuf/src/descriptor-set.ts
+++ b/packages/protobuf/src/descriptor-set.ts
@@ -23,7 +23,7 @@ import type {
   OneofDescriptorProto,
   ServiceDescriptorProto,
 } from "./google/protobuf/descriptor_pb.js";
-import type { LongType, ScalarType } from "./field.js";
+import { LongType, ScalarType } from "./scalar.js";
 import type { MethodIdempotency, MethodKind } from "./service-type.js";
 import type { MergedFeatureSet } from "./private/feature-set.js";
 

--- a/packages/protobuf/src/field.ts
+++ b/packages/protobuf/src/field.ts
@@ -14,6 +14,7 @@
 
 import type { EnumType } from "./enum.js";
 import type { MessageType } from "./message-type.js";
+import type { LongType, ScalarType } from "./scalar.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -322,70 +323,3 @@ type fiPartialRules<T extends fiScalar|fiMap|fiEnum|fiMessage> = Omit<T, "jsonNa
   | { readonly jsonName?: string; readonly repeated?: false; readonly packed?: false; readonly opt: true; readonly req?: false; readonly oneof?: undefined; default?: T["default"]; L?: LongType; delimited?: boolean; }
   | { readonly jsonName?: string; readonly repeated?: boolean; readonly packed?: boolean; readonly opt?: false; readonly req?: boolean; readonly oneof?: undefined; default?: T["default"]; L?: LongType; delimited?: boolean; }
   | { readonly jsonName?: string; readonly repeated?: false; readonly packed?: false; readonly opt?: false; readonly req?: false; readonly oneof: string; default?: T["default"]; L?: LongType; delimited?: boolean; });
-
-/**
- * Scalar value types. This is a subset of field types declared by protobuf
- * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
- * are omitted, but the numerical values are identical.
- */
-export enum ScalarType {
-  // 0 is reserved for errors.
-  // Order is weird for historical reasons.
-  DOUBLE = 1,
-  FLOAT = 2,
-  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-  // negative values are likely.
-  INT64 = 3,
-  UINT64 = 4,
-  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-  // negative values are likely.
-  INT32 = 5,
-  FIXED64 = 6,
-  FIXED32 = 7,
-  BOOL = 8,
-  STRING = 9,
-  // Tag-delimited aggregate.
-  // Group type is deprecated and not supported in proto3. However, Proto3
-  // implementations should still be able to parse the group wire format and
-  // treat group fields as unknown fields.
-  // TYPE_GROUP = 10,
-  // TYPE_MESSAGE = 11,  // Length-delimited aggregate.
-
-  // New in version 2.
-  BYTES = 12,
-  UINT32 = 13,
-  // TYPE_ENUM = 14,
-  SFIXED32 = 15,
-  SFIXED64 = 16,
-  SINT32 = 17, // Uses ZigZag encoding.
-  SINT64 = 18, // Uses ZigZag encoding.
-}
-
-/**
- * JavaScript representation of fields with 64 bit integral types (int64, uint64,
- * sint64, fixed64, sfixed64).
- *
- * This is a subset of google.protobuf.FieldOptions.JSType, which defines JS_NORMAL,
- * JS_STRING, and JS_NUMBER. Protobuf-ES uses BigInt by default, but will use
- * String if `[jstype = JS_STRING]` is specified.
- *
- * ```protobuf
- * uint64 field_a = 1; // BigInt
- * uint64 field_b = 2 [jstype = JS_NORMAL]; // BigInt
- * uint64 field_b = 2 [jstype = JS_NUMBER]; // BigInt
- * uint64 field_b = 2 [jstype = JS_STRING]; // String
- * ```
- */
-export enum LongType {
-  /**
-   * Use JavaScript BigInt.
-   */
-  BIGINT = 0,
-
-  /**
-   * Use JavaScript String.
-   *
-   * Field option `[jstype = JS_STRING]`.
-   */
-  STRING = 1,
-}

--- a/packages/protobuf/src/google/protobuf/wrappers_pb.ts
+++ b/packages/protobuf/src/google/protobuf/wrappers_pb.ts
@@ -20,7 +20,7 @@ import type { PartialMessage, PlainMessage } from "../../message.js";
 import { Message } from "../../message.js";
 import { proto3 } from "../../proto3.js";
 import type { JsonReadOptions, JsonValue, JsonWriteOptions } from "../../json-format.js";
-import { ScalarType } from "../../field.js";
+import { ScalarType } from "../../scalar.js";
 import type { FieldList } from "../../field-list.js";
 import type { BinaryReadOptions } from "../../binary-format.js";
 import { protoInt64 } from "../../proto-int64.js";

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -25,7 +25,8 @@ export type { AnyMessage, PartialMessage, PlainMessage } from "./message.js";
 
 export type { FieldInfo } from "./field.js";
 export type { FieldList } from "./field-list.js";
-export { ScalarType, LongType } from "./field.js";
+export { LongType, ScalarType } from "./scalar.js";
+export type { ScalarValue } from "./scalar.js";
 
 export type { MessageType } from "./message-type.js";
 export type { EnumType, EnumValueInfo } from "./enum.js";

--- a/packages/protobuf/src/json-format.ts
+++ b/packages/protobuf/src/json-format.ts
@@ -14,8 +14,7 @@
 
 import type { Message } from "./message.js";
 import type { MessageType } from "./message-type.js";
-import type { ScalarType } from "./field.js";
-import { LongType } from "./field.js";
+import type { ScalarType, LongType } from "./scalar.js";
 import type {
   IExtensionRegistry,
   IMessageTypeRegistry,

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -22,7 +22,7 @@ import type {
 import { type AnyMessage, Message } from "../message.js";
 import type { FieldInfo } from "../field.js";
 import { wrapField } from "./field-wrapper.js";
-import { isScalarZeroValue, scalarZeroValue } from "./scalars.js";
+import { scalarZeroValue } from "./scalars.js";
 import { assert } from "./assert.js";
 import { isFieldSet } from "./reflect.js";
 import type { ScalarValue } from "../scalar.js";
@@ -472,7 +472,7 @@ function writeScalar(
   value: unknown,
 ): void {
   assert(value !== undefined);
-  let [wireType, method] = scalarTypeInfo(type, value);
+  let [wireType, method] = scalarTypeInfo(type);
   (writer.tag(fieldNo, wireType)[method] as any)(value);
 }
 
@@ -506,11 +506,9 @@ function writePacked(
 // TODO replace call-sites writeScalar() and writePacked(), then remove
 function scalarTypeInfo(
   type: ScalarType,
-  value?: unknown,
 ): [
   WireType,
   Exclude<keyof IBinaryWriter, "tag" | "raw" | "fork" | "join" | "finish">,
-  boolean,
 ] {
   let wireType = WireType.Varint;
   // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- INT32, UINT32, SINT32 are covered by the defaults
@@ -534,9 +532,5 @@ function scalarTypeInfo(
     keyof IBinaryWriter,
     "tag" | "raw" | "fork" | "join" | "finish"
   >;
-  return [
-    wireType,
-    method,
-    value === undefined || isScalarZeroValue(type, value),
-  ];
+  return [wireType, method];
 }

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -21,12 +21,12 @@ import type {
 } from "../binary-format.js";
 import { type AnyMessage, Message } from "../message.js";
 import type { FieldInfo } from "../field.js";
-import { LongType, ScalarType } from "../field.js";
 import { wrapField } from "./field-wrapper.js";
-import { scalarDefaultValue, scalarTypeInfo } from "./scalars.js";
-import type { ScalarValue } from "./scalars.js";
+import { isScalarZeroValue, scalarZeroValue } from "./scalars.js";
 import { assert } from "./assert.js";
 import { isFieldSet } from "./reflect.js";
+import type { ScalarValue } from "../scalar.js";
+import { LongType, ScalarType } from "../scalar.js";
 
 /* eslint-disable prefer-const,no-case-declarations,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return */
 
@@ -286,7 +286,7 @@ function readMapEntry(
     }
   }
   if (key === undefined) {
-    key = scalarDefaultValue(field.K, LongType.BIGINT) as ScalarValue;
+    key = scalarZeroValue(field.K, LongType.BIGINT);
   }
   if (typeof key != "string" && typeof key != "number") {
     key = key.toString();
@@ -294,7 +294,7 @@ function readMapEntry(
   if (val === undefined) {
     switch (field.V.kind) {
       case "scalar":
-        val = scalarDefaultValue(field.V.T, LongType.BIGINT) as ScalarValue;
+        val = scalarZeroValue(field.V.T, LongType.BIGINT);
         break;
       case "enum":
         val = field.V.T.values[0].no;
@@ -491,4 +491,52 @@ function writePacked(
     (writer[method] as any)(value[i]);
   }
   writer.join();
+}
+
+/**
+ * Get information for writing a scalar value.
+ *
+ * Returns tuple:
+ * [0]: appropriate WireType
+ * [1]: name of the appropriate method of IBinaryWriter
+ * [2]: whether the given value is a default value for proto3 semantics
+ *
+ * If argument `value` is omitted, [2] is always false.
+ */
+// TODO replace call-sites writeScalar() and writePacked(), then remove
+function scalarTypeInfo(
+  type: ScalarType,
+  value?: unknown,
+): [
+  WireType,
+  Exclude<keyof IBinaryWriter, "tag" | "raw" | "fork" | "join" | "finish">,
+  boolean,
+] {
+  let wireType = WireType.Varint;
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- INT32, UINT32, SINT32 are covered by the defaults
+  switch (type) {
+    case ScalarType.BYTES:
+    case ScalarType.STRING:
+      wireType = WireType.LengthDelimited;
+      break;
+    case ScalarType.DOUBLE:
+    case ScalarType.FIXED64:
+    case ScalarType.SFIXED64:
+      wireType = WireType.Bit64;
+      break;
+    case ScalarType.FIXED32:
+    case ScalarType.SFIXED32:
+    case ScalarType.FLOAT:
+      wireType = WireType.Bit32;
+      break;
+  }
+  const method = ScalarType[type].toLowerCase() as Exclude<
+    keyof IBinaryWriter,
+    "tag" | "raw" | "fork" | "join" | "finish"
+  >;
+  return [
+    wireType,
+    method,
+    value === undefined || isScalarZeroValue(type, value),
+  ];
 }

--- a/packages/protobuf/src/private/extensions.ts
+++ b/packages/protobuf/src/private/extensions.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { scalarDefaultValue } from "./scalars.js";
+import { scalarZeroValue } from "./scalars.js";
 import type { Extension } from "../extension.js";
 import type { AnyMessage, Message } from "../message.js";
 import type { FieldInfo, OneofInfo, PartialFieldInfo } from "../field.js";
@@ -88,7 +88,7 @@ function initExtensionField(ext: Extension): unknown {
     case "enum":
       return field.T.values[0].no;
     case "scalar":
-      return scalarDefaultValue(field.T, field.L);
+      return scalarZeroValue(field.T, field.L);
     case "message":
       // eslint-disable-next-line no-case-declarations
       const T = field.T,

--- a/packages/protobuf/src/private/field-normalize.ts
+++ b/packages/protobuf/src/private/field-normalize.ts
@@ -14,9 +14,9 @@
 
 import type { FieldListSource } from "./field-list.js";
 import type { FieldInfo } from "../field.js";
-import { LongType, ScalarType } from "../field.js";
 import { InternalOneofInfo } from "./field.js";
 import { fieldJsonName, localFieldName } from "./names.js";
+import { LongType, ScalarType } from "../scalar.js";
 
 /**
  * Convert a collection of field info to an array of normalized FieldInfo.

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -15,7 +15,7 @@
 import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { DescExtension, DescField } from "../descriptor-set.js";
-import { ScalarType } from "../field.js";
+import { ScalarType } from "../scalar.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- unknown fields are represented with any */
 

--- a/packages/protobuf/src/private/json-format.ts
+++ b/packages/protobuf/src/private/json-format.ts
@@ -24,7 +24,6 @@ import type { AnyMessage } from "../message.js";
 import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { FieldInfo, OneofInfo } from "../field.js";
-import { LongType, ScalarType } from "../field.js";
 import { assert, assertFloat32, assertInt32, assertUInt32 } from "./assert.js";
 import { protoInt64 } from "../proto-int64.js";
 import { protoBase64 } from "../proto-base64.js";
@@ -42,8 +41,10 @@ import type {
 } from "../binary-format.js";
 import { clearField, isFieldSet } from "./reflect.js";
 import { wrapField } from "./field-wrapper.js";
-import type { ScalarValue } from "./scalars.js";
-import { scalarDefaultValue, isScalarZeroValue } from "./scalars.js";
+import { scalarZeroValue } from "./scalars.js";
+import { isScalarZeroValue } from "./scalars.js";
+import type { ScalarValue } from "../scalar.js";
+import { LongType, ScalarType } from "../scalar.js";
 
 /* eslint-disable no-case-declarations,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
 
@@ -475,7 +476,7 @@ function readScalar(
 ): ScalarValue | typeof tokenNull {
   if (json === null) {
     if (nullAsZeroValue) {
-      return scalarDefaultValue(type, longType) as ScalarValue;
+      return scalarZeroValue(type, longType);
     }
     return tokenNull;
   }

--- a/packages/protobuf/src/private/reflect.ts
+++ b/packages/protobuf/src/private/reflect.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { FieldInfo } from "../field.js";
-import { isScalarZeroValue, scalarDefaultValue } from "./scalars.js";
+import { isScalarZeroValue, scalarZeroValue } from "./scalars.js";
 
 /**
  * Returns true if the field is set.
@@ -70,9 +70,8 @@ export function clearField(
         target[localName] = implicitPresence ? field.T.values[0].no : undefined;
         break;
       case "scalar":
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         target[localName] = implicitPresence
-          ? scalarDefaultValue(field.T, field.L)
+          ? scalarZeroValue(field.T, field.L)
           : undefined;
         break;
       case "message":

--- a/packages/protobuf/src/private/reify-wkt.ts
+++ b/packages/protobuf/src/private/reify-wkt.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { DescField, DescMessage, DescOneof } from "../descriptor-set.js";
-import { ScalarType } from "../field.js";
+import { ScalarType } from "../scalar.js";
 
 type DescWkt =
   | {

--- a/packages/protobuf/src/private/text-format.ts
+++ b/packages/protobuf/src/private/text-format.ts
@@ -14,8 +14,8 @@
 
 import type { DescEnum } from "../descriptor-set.js";
 import { assert } from "./assert.js";
-import { ScalarType } from "../field.js";
 import { protoInt64 } from "../proto-int64.js";
+import { ScalarType } from "../scalar.js";
 
 export function parseTextFormatEnumValue(
   descEnum: DescEnum,

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -16,9 +16,9 @@ import { setEnumType } from "./enum.js";
 import { Message } from "../message.js";
 import type { AnyMessage, PartialMessage, PlainMessage } from "../message.js";
 import type { MessageType } from "../message-type.js";
-import { ScalarType } from "../field.js";
 import type { Util } from "./util.js";
 import { scalarEquals } from "./scalars.js";
+import { ScalarType } from "../scalar.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-argument,no-case-declarations */
 

--- a/packages/protobuf/src/proto3.ts
+++ b/packages/protobuf/src/proto3.ts
@@ -17,7 +17,7 @@ import type { FieldListSource } from "./private/field-list.js";
 import { InternalFieldList } from "./private/field-list.js";
 import type { FieldList } from "./field-list.js";
 import type { AnyMessage, Message } from "./message.js";
-import { scalarDefaultValue } from "./private/scalars.js";
+import { scalarZeroValue } from "./private/scalars.js";
 import { normalizeFieldInfos } from "./private/field-normalize.js";
 
 /**
@@ -53,7 +53,7 @@ export const proto3 = makeProtoRuntime(
           t[name] = {};
           break;
         case "scalar":
-          t[name] = scalarDefaultValue(member.T, member.L); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+          t[name] = scalarZeroValue(member.T, member.L);
           break;
         case "message":
           // message fields are always optional in proto3

--- a/packages/protobuf/src/scalar.ts
+++ b/packages/protobuf/src/scalar.ts
@@ -1,0 +1,103 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Scalar value types. This is a subset of field types declared by protobuf
+ * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
+ * are omitted, but the numerical values are identical.
+ */
+export enum ScalarType {
+  // 0 is reserved for errors.
+  // Order is weird for historical reasons.
+  DOUBLE = 1,
+  FLOAT = 2,
+  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+  // negative values are likely.
+  INT64 = 3,
+  UINT64 = 4,
+  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+  // negative values are likely.
+  INT32 = 5,
+  FIXED64 = 6,
+  FIXED32 = 7,
+  BOOL = 8,
+  STRING = 9,
+  // Tag-delimited aggregate.
+  // Group type is deprecated and not supported in proto3. However, Proto3
+  // implementations should still be able to parse the group wire format and
+  // treat group fields as unknown fields.
+  // TYPE_GROUP = 10,
+  // TYPE_MESSAGE = 11,  // Length-delimited aggregate.
+
+  // New in version 2.
+  BYTES = 12,
+  UINT32 = 13,
+  // TYPE_ENUM = 14,
+  SFIXED32 = 15,
+  SFIXED64 = 16,
+  SINT32 = 17, // Uses ZigZag encoding.
+  SINT64 = 18, // Uses ZigZag encoding.
+}
+
+/**
+ * JavaScript representation of fields with 64 bit integral types (int64, uint64,
+ * sint64, fixed64, sfixed64).
+ *
+ * This is a subset of google.protobuf.FieldOptions.JSType, which defines JS_NORMAL,
+ * JS_STRING, and JS_NUMBER. Protobuf-ES uses BigInt by default, but will use
+ * String if `[jstype = JS_STRING]` is specified.
+ *
+ * ```protobuf
+ * uint64 field_a = 1; // BigInt
+ * uint64 field_b = 2 [jstype = JS_NORMAL]; // BigInt
+ * uint64 field_b = 2 [jstype = JS_NUMBER]; // BigInt
+ * uint64 field_b = 2 [jstype = JS_STRING]; // String
+ * ```
+ */
+export enum LongType {
+  /**
+   * Use JavaScript BigInt.
+   */
+  BIGINT = 0,
+
+  /**
+   * Use JavaScript String.
+   *
+   * Field option `[jstype = JS_STRING]`.
+   */
+  STRING = 1,
+}
+
+// prettier-ignore
+/**
+ * ScalarValue maps from a scalar field type to a TypeScript value type.
+ */
+export type ScalarValue<T = ScalarType, L extends LongType = LongType.STRING | LongType.BIGINT> =
+    T extends ScalarType.STRING ? string
+  : T extends ScalarType.INT32 ? number
+  : T extends ScalarType.UINT32 ? number
+  : T extends ScalarType.UINT32 ? number
+  : T extends ScalarType.SINT32 ? number
+  : T extends ScalarType.FIXED32 ? number
+  : T extends ScalarType.SFIXED32 ? number
+  : T extends ScalarType.FLOAT ? number
+  : T extends ScalarType.DOUBLE ? number
+  : T extends ScalarType.INT64 ?    (L extends LongType.STRING ? string : bigint)
+  : T extends ScalarType.SINT64 ?   (L extends LongType.STRING ? string : bigint)
+  : T extends ScalarType.SFIXED64 ? (L extends LongType.STRING ? string : bigint)
+  : T extends ScalarType.UINT64 ?   (L extends LongType.STRING ? string : bigint)
+  : T extends ScalarType.FIXED64 ?  (L extends LongType.STRING ? string : bigint)
+  : T extends ScalarType.BOOL ? boolean
+  : T extends ScalarType.BYTES ? Uint8Array
+  : never;

--- a/packages/protoplugin/src/ecmascript/gencommon.ts
+++ b/packages/protoplugin/src/ecmascript/gencommon.ts
@@ -24,7 +24,7 @@ import {
 import type { GeneratedFile, Printable } from "./generated-file.js";
 import type { ImportSymbol } from "./import-symbol.js";
 
-const { localName, getUnwrappedFieldType, scalarDefaultValue } = codegenInfo;
+const { localName, getUnwrappedFieldType, scalarZeroValue } = codegenInfo;
 
 export function makeFilePreamble(
   file: DescFile,
@@ -298,8 +298,7 @@ export function getFieldIntrinsicDefaultValue(field: DescField): {
           if (field.scalar === ScalarType.STRING) {
             defaultValue = literalString("");
           } else {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
-            defaultValue = scalarDefaultValue(field.scalar, field.longType);
+            defaultValue = scalarZeroValue(field.scalar, field.longType);
             if (typeof defaultValue === "string") {
               defaultValue = literalString(defaultValue);
             }


### PR DESCRIPTION
This PR adds a new type `ScalarValue` to the exports of @bufbuild/protobuf. The type maps from a `ScalarType` to a TypeScript value type. 

The existing function `scalarDefaultValue` is renamed to `scalarZeroValue` to better reflect what it does (zero values are default values in proto3, but not in proto2). The function is updated to return the new `ScalarType`. 

If you have been using `scalarDefaultValue` from the `codeGeninfo` object from @bufbuild/protobuf, please change your code to use `scalarZeroValue` instead. The old property `scalarDefaultValue` has been marked deprecated.
