### PR TITLE
Add functions for field presence

### DIFF
--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -10,6 +10,7 @@ provided by the library.
   - [Default field values](#default-field-values)
   - [Accessing fields](#accessing-fields)
   - [Accessing oneof groups](#accessing-oneof-groups)
+  - [Field presence](#field-presence)
   - [Cloning messages](#cloning-messages)
   - [Comparing messages](#comparing-messages)
   - [Serializing messages](#serializing-messages)
@@ -231,6 +232,27 @@ narrows down the type. That means the if blocks and switch statements above tell
 the compiler the type of the `value` property. Note that type narrowing requires
 the TypeScript compiler option [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks).
 This option is automatically enabled with the option `strict`, which is recommended.
+
+
+### Field presence
+
+As we explained above, fields have [default values](#default-field-values). To 
+determine whether a field has an actual value, you can use the function `isFieldSet`.
+To reset a field to its initial value, use the function `clearField`.
+
+```typescript
+import { isFieldSet, clearField } from "@bufbuild/protobuf";
+
+const user = new User({
+  active: true,
+});
+
+isFieldSet(user, "active"); // true
+isFieldSet(user, "firstName"); // false
+
+clearField(user, "active");
+isFieldSet(user, "active"); // false
+```
 
 
 ### Cloning messages
@@ -738,6 +760,9 @@ walkFields(user);
 
 For a more practical example that covers all cases, you can take a look at the 
 source of [`toPlainMessage`][src-toPlainMessage].
+
+Not that the functions `isFieldSet` and `clearField` (see [Field presence](#field-presence)) 
+optionally accept a field info object instead of a field name.
 
 
 ### Message types

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 96,999 b      | 41,438 b | 10,763 b |
+| protobuf-es         | 97,073 b      | 41,481 b | 10,747 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/extra/proto3.proto
+++ b/packages/protobuf-test/extra/proto3.proto
@@ -29,17 +29,32 @@ message Proto3UnpackedMessage {
   repeated uint64 unpacked_uint64_field = 203 [packed = false];
 }
 
-message Proto3UnlabelledMessage {
+message Proto3UnspecifiedPackedMessage {
   repeated double double_field = 1;
   repeated uint32 uint32_field = 2;
   repeated uint64 uint64_field = 3;
 }
 
+message Proto3UnlabelledMessage {
+  string string_field = 1;
+  bytes bytes_field = 2;
+  int32 int32_field = 3;
+  int64 int64_field = 4;
+  float float_field = 5;
+  bool bool_field = 6;
+  Proto3Enum enum_field = 7;
+  Proto3OptionalMessage message_field = 8;
+}
+
 message Proto3OptionalMessage {
   optional string string_field = 1;
   optional bytes bytes_field = 2;
-  optional Proto3Enum enum_field = 3;
-  optional Proto3OptionalMessage message_field = 4;
+  optional int32 int32_field = 3;
+  optional int64 int64_field = 4;
+  optional float float_field = 5;
+  optional bool bool_field = 6;
+  optional Proto3Enum enum_field = 7;
+  optional Proto3OptionalMessage message_field = 8;
 }
 
 enum Proto3Enum {

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
@@ -108,9 +108,9 @@ export declare class Proto3UnpackedMessage extends Message<Proto3UnpackedMessage
 }
 
 /**
- * @generated from message spec.Proto3UnlabelledMessage
+ * @generated from message spec.Proto3UnspecifiedPackedMessage
  */
-export declare class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
+export declare class Proto3UnspecifiedPackedMessage extends Message<Proto3UnspecifiedPackedMessage> {
   /**
    * @generated from field: repeated double double_field = 1;
    */
@@ -125,6 +125,65 @@ export declare class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMes
    * @generated from field: repeated uint64 uint64_field = 3;
    */
   uint64Field: bigint[];
+
+  constructor(data?: PartialMessage<Proto3UnspecifiedPackedMessage>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.Proto3UnspecifiedPackedMessage";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto3UnspecifiedPackedMessage;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Proto3UnspecifiedPackedMessage;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Proto3UnspecifiedPackedMessage;
+
+  static equals(a: Proto3UnspecifiedPackedMessage | PlainMessage<Proto3UnspecifiedPackedMessage> | undefined, b: Proto3UnspecifiedPackedMessage | PlainMessage<Proto3UnspecifiedPackedMessage> | undefined): boolean;
+}
+
+/**
+ * @generated from message spec.Proto3UnlabelledMessage
+ */
+export declare class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
+  /**
+   * @generated from field: string string_field = 1;
+   */
+  stringField: string;
+
+  /**
+   * @generated from field: bytes bytes_field = 2;
+   */
+  bytesField: Uint8Array;
+
+  /**
+   * @generated from field: int32 int32_field = 3;
+   */
+  int32Field: number;
+
+  /**
+   * @generated from field: int64 int64_field = 4;
+   */
+  int64Field: bigint;
+
+  /**
+   * @generated from field: float float_field = 5;
+   */
+  floatField: number;
+
+  /**
+   * @generated from field: bool bool_field = 6;
+   */
+  boolField: boolean;
+
+  /**
+   * @generated from field: spec.Proto3Enum enum_field = 7;
+   */
+  enumField: Proto3Enum;
+
+  /**
+   * @generated from field: spec.Proto3OptionalMessage message_field = 8;
+   */
+  messageField?: Proto3OptionalMessage;
 
   constructor(data?: PartialMessage<Proto3UnlabelledMessage>);
 
@@ -156,12 +215,32 @@ export declare class Proto3OptionalMessage extends Message<Proto3OptionalMessage
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: optional spec.Proto3Enum enum_field = 3;
+   * @generated from field: optional int32 int32_field = 3;
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: optional int64 int64_field = 4;
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: optional float float_field = 5;
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: optional bool bool_field = 6;
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: optional spec.Proto3Enum enum_field = 7;
    */
   enumField?: Proto3Enum;
 
   /**
-   * @generated from field: optional spec.Proto3OptionalMessage message_field = 4;
+   * @generated from field: optional spec.Proto3OptionalMessage message_field = 8;
    */
   messageField?: Proto3OptionalMessage;
 

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.js
@@ -55,14 +55,31 @@ export const Proto3UnpackedMessage = proto3.makeMessageType(
 );
 
 /**
+ * @generated from message spec.Proto3UnspecifiedPackedMessage
+ */
+export const Proto3UnspecifiedPackedMessage = proto3.makeMessageType(
+  "spec.Proto3UnspecifiedPackedMessage",
+  () => [
+    { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
+    { no: 2, name: "uint32_field", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },
+    { no: 3, name: "uint64_field", kind: "scalar", T: 4 /* ScalarType.UINT64 */, repeated: true },
+  ],
+);
+
+/**
  * @generated from message spec.Proto3UnlabelledMessage
  */
 export const Proto3UnlabelledMessage = proto3.makeMessageType(
   "spec.Proto3UnlabelledMessage",
   () => [
-    { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
-    { no: 2, name: "uint32_field", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },
-    { no: 3, name: "uint64_field", kind: "scalar", T: 4 /* ScalarType.UINT64 */, repeated: true },
+    { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 7, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum) },
+    { no: 8, name: "message_field", kind: "message", T: Proto3OptionalMessage },
   ],
 );
 
@@ -74,8 +91,12 @@ export const Proto3OptionalMessage = proto3.makeMessageType(
   () => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
-    { no: 3, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum), opt: true },
-    { no: 4, name: "message_field", kind: "message", T: Proto3OptionalMessage, opt: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum), opt: true },
+    { no: 8, name: "message_field", kind: "message", T: Proto3OptionalMessage, opt: true },
   ],
 );
 

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -17,7 +17,7 @@
 /* eslint-disable */
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto3 } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.Proto3Enum
@@ -144,9 +144,9 @@ export class Proto3UnpackedMessage extends Message<Proto3UnpackedMessage> {
 }
 
 /**
- * @generated from message spec.Proto3UnlabelledMessage
+ * @generated from message spec.Proto3UnspecifiedPackedMessage
  */
-export class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
+export class Proto3UnspecifiedPackedMessage extends Message<Proto3UnspecifiedPackedMessage> {
   /**
    * @generated from field: repeated double double_field = 1;
    */
@@ -162,6 +162,80 @@ export class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
    */
   uint64Field: bigint[] = [];
 
+  constructor(data?: PartialMessage<Proto3UnspecifiedPackedMessage>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "spec.Proto3UnspecifiedPackedMessage";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
+    { no: 2, name: "uint32_field", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },
+    { no: 3, name: "uint64_field", kind: "scalar", T: 4 /* ScalarType.UINT64 */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto3UnspecifiedPackedMessage {
+    return new Proto3UnspecifiedPackedMessage().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Proto3UnspecifiedPackedMessage {
+    return new Proto3UnspecifiedPackedMessage().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Proto3UnspecifiedPackedMessage {
+    return new Proto3UnspecifiedPackedMessage().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: Proto3UnspecifiedPackedMessage | PlainMessage<Proto3UnspecifiedPackedMessage> | undefined, b: Proto3UnspecifiedPackedMessage | PlainMessage<Proto3UnspecifiedPackedMessage> | undefined): boolean {
+    return proto3.util.equals(Proto3UnspecifiedPackedMessage, a, b);
+  }
+}
+
+/**
+ * @generated from message spec.Proto3UnlabelledMessage
+ */
+export class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
+  /**
+   * @generated from field: string string_field = 1;
+   */
+  stringField = "";
+
+  /**
+   * @generated from field: bytes bytes_field = 2;
+   */
+  bytesField = new Uint8Array(0);
+
+  /**
+   * @generated from field: int32 int32_field = 3;
+   */
+  int32Field = 0;
+
+  /**
+   * @generated from field: int64 int64_field = 4;
+   */
+  int64Field = protoInt64.zero;
+
+  /**
+   * @generated from field: float float_field = 5;
+   */
+  floatField = 0;
+
+  /**
+   * @generated from field: bool bool_field = 6;
+   */
+  boolField = false;
+
+  /**
+   * @generated from field: spec.Proto3Enum enum_field = 7;
+   */
+  enumField = Proto3Enum.UNSPECIFIED;
+
+  /**
+   * @generated from field: spec.Proto3OptionalMessage message_field = 8;
+   */
+  messageField?: Proto3OptionalMessage;
+
   constructor(data?: PartialMessage<Proto3UnlabelledMessage>) {
     super();
     proto3.util.initPartial(data, this);
@@ -170,9 +244,14 @@ export class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "spec.Proto3UnlabelledMessage";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "double_field", kind: "scalar", T: 1 /* ScalarType.DOUBLE */, repeated: true },
-    { no: 2, name: "uint32_field", kind: "scalar", T: 13 /* ScalarType.UINT32 */, repeated: true },
-    { no: 3, name: "uint64_field", kind: "scalar", T: 4 /* ScalarType.UINT64 */, repeated: true },
+    { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 7, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum) },
+    { no: 8, name: "message_field", kind: "message", T: Proto3OptionalMessage },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto3UnlabelledMessage {
@@ -207,12 +286,32 @@ export class Proto3OptionalMessage extends Message<Proto3OptionalMessage> {
   bytesField?: Uint8Array;
 
   /**
-   * @generated from field: optional spec.Proto3Enum enum_field = 3;
+   * @generated from field: optional int32 int32_field = 3;
+   */
+  int32Field?: number;
+
+  /**
+   * @generated from field: optional int64 int64_field = 4;
+   */
+  int64Field?: bigint;
+
+  /**
+   * @generated from field: optional float float_field = 5;
+   */
+  floatField?: number;
+
+  /**
+   * @generated from field: optional bool bool_field = 6;
+   */
+  boolField?: boolean;
+
+  /**
+   * @generated from field: optional spec.Proto3Enum enum_field = 7;
    */
   enumField?: Proto3Enum;
 
   /**
-   * @generated from field: optional spec.Proto3OptionalMessage message_field = 4;
+   * @generated from field: optional spec.Proto3OptionalMessage message_field = 8;
    */
   messageField?: Proto3OptionalMessage;
 
@@ -226,8 +325,12 @@ export class Proto3OptionalMessage extends Message<Proto3OptionalMessage> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
-    { no: 3, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum), opt: true },
-    { no: 4, name: "message_field", kind: "message", T: Proto3OptionalMessage, opt: true },
+    { no: 3, name: "int32_field", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 4, name: "int64_field", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 5, name: "float_field", kind: "scalar", T: 2 /* ScalarType.FLOAT */, opt: true },
+    { no: 6, name: "bool_field", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 7, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum), opt: true },
+    { no: 8, name: "message_field", kind: "message", T: Proto3OptionalMessage, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto3OptionalMessage {

--- a/packages/protobuf-test/src/msg-maps.test.ts
+++ b/packages/protobuf-test/src/msg-maps.test.ts
@@ -17,7 +17,7 @@ import type { JsonValue, PlainMessage } from "@bufbuild/protobuf";
 import { describeMT } from "./helpers.js";
 import { MapsMessage as TS_MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
 import { MapsMessage as JS_MapsMessage } from "./gen/js/extra/msg-maps_pb.js";
-import { protoInt64 } from "@bufbuild/protobuf";
+import { protoInt64, isFieldSet, clearField } from "@bufbuild/protobuf";
 
 describeMT({ ts: TS_MapsMessage, js: JS_MapsMessage }, (messageType) => {
   const defaultFields: PlainMessage<TS_MapsMessage | JS_MapsMessage> = {
@@ -120,6 +120,33 @@ describeMT({ ts: TS_MapsMessage, js: JS_MapsMessage }, (messageType) => {
       strBytesField: {
         a: new Uint8Array(bytes),
       },
+    });
+  });
+  describe("isFieldSet()", () => {
+    test("returns false for empty map", () => {
+      const msg = new messageType({
+        strStrField: {},
+      });
+      expect(isFieldSet(msg, "strStrField")).toBe(false);
+    });
+    test("returns true for non-empty map", () => {
+      const msg = new messageType({
+        strStrField: {
+          foo: "bar",
+        },
+      });
+      expect(isFieldSet(msg, "strStrField")).toBe(true);
+    });
+  });
+  describe("clearField()", () => {
+    test("clears map", () => {
+      const msg = new messageType({
+        strStrField: {
+          foo: "bar",
+        },
+      });
+      clearField(msg, "strStrField");
+      expect(Object.keys(msg.strStrField).length).toBe(0);
     });
   });
   describe("field info", () => {

--- a/packages/protobuf-test/src/msg-message.test.ts
+++ b/packages/protobuf-test/src/msg-message.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { JsonValue, PlainMessage } from "@bufbuild/protobuf";
+import { clearField, isFieldSet } from "@bufbuild/protobuf";
 import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage as JS_MessageFieldMessage } from "./gen/js/extra/msg-message_pb.js";
 import { describeMT } from "./helpers.js";
@@ -52,6 +53,46 @@ describeMT(
       expect(got.repeatedMessageField.length).toStrictEqual(
         defaultFields.repeatedMessageField.length,
       );
+    });
+    describe("isFieldSet()", () => {
+      test("returns false for empty repeated field", () => {
+        const msg = new messageType({
+          repeatedMessageField: [],
+        });
+        expect(isFieldSet(msg, "repeatedMessageField")).toBe(false);
+      });
+      test("returns false for empty singular field", () => {
+        const msg = new messageType();
+        expect(isFieldSet(msg, "messageField")).toBe(false);
+      });
+      test("returns true for non-empty repeated field", () => {
+        const msg = new messageType({
+          repeatedMessageField: [{}],
+        });
+        expect(isFieldSet(msg, "repeatedMessageField")).toBe(true);
+      });
+      test("returns true for non-empty singular field", () => {
+        const msg = new messageType({
+          messageField: { name: "test" },
+        });
+        expect(isFieldSet(msg, "messageField")).toBe(true);
+      });
+    });
+    describe("clearField()", () => {
+      test("clears repeated field", () => {
+        const msg = new messageType({
+          repeatedMessageField: [{}],
+        });
+        clearField(msg, "repeatedMessageField");
+        expect(msg.repeatedMessageField.length).toBe(0);
+      });
+      test("clears singular field", () => {
+        const msg = new messageType({
+          messageField: { name: "test" },
+        });
+        clearField(msg, "messageField");
+        expect(msg.messageField).toBeUndefined();
+      });
     });
     test("example encodes to JSON", () => {
       /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access */

--- a/packages/protobuf-test/src/msg-oneof.test.ts
+++ b/packages/protobuf-test/src/msg-oneof.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 import type { JsonValue, PlainMessage } from "@bufbuild/protobuf";
+import { clearField, isFieldSet } from "@bufbuild/protobuf";
 import { describeMT } from "./helpers.js";
 import { OneofMessage as TS_OneofMessage } from "./gen/ts/extra/msg-oneof_pb.js";
 import { OneofMessage as JS_OneofMessage } from "./gen/js/extra/msg-oneof_pb.js";
@@ -76,6 +77,42 @@ describeMT({ ts: TS_OneofMessage, js: JS_OneofMessage }, (messageType) => {
     expect(got).toStrictEqual({
       ...defaultFields,
       scalar: { case: "bytes", value: new Uint8Array(bytes) },
+    });
+  });
+  describe("isFieldSet()", () => {
+    test("returns false for unselected oneof", () => {
+      const msg = new messageType({
+        scalar: { case: undefined },
+      });
+      expect(isFieldSet(msg, "value")).toBe(false);
+      expect(isFieldSet(msg, "error")).toBe(false);
+      expect(isFieldSet(msg, "bytes")).toBe(false);
+    });
+    test("returns true for selected oneof", () => {
+      const msg = new messageType({
+        scalar: { case: "value", value: 123 },
+      });
+      expect(isFieldSet(msg, "value")).toBe(true);
+      expect(isFieldSet(msg, "error")).toBe(false);
+      expect(isFieldSet(msg, "bytes")).toBe(false);
+    });
+  });
+  describe("clearField()", () => {
+    test("deselects selected oneof", () => {
+      const msg = new messageType({
+        scalar: { case: "value", value: 123 },
+      });
+      clearField(msg, "value");
+      expect(msg.scalar.case).toBeUndefined();
+      expect(msg.scalar.value).toBeUndefined();
+    });
+    test("skips if field is not selected", () => {
+      const msg = new messageType({
+        scalar: { case: "error", value: "test" },
+      });
+      clearField(msg, "value");
+      expect(msg.scalar.case).toBe("error");
+      expect(msg.scalar.value).toBe("test");
     });
   });
   describe("field info", () => {

--- a/packages/protobuf-test/src/msg-scalar.test.ts
+++ b/packages/protobuf-test/src/msg-scalar.test.ts
@@ -13,23 +13,18 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import {
-  RepeatedScalarValuesMessage as TS_RepeatedScalarValuesMessage,
-  ScalarValuesMessage as TS_ScalarValuesMessage,
-} from "./gen/ts/extra/msg-scalar_pb.js";
-import {
-  RepeatedScalarValuesMessage as JS_RepeatedScalarValuesMessage,
-  ScalarValuesMessage as JS_ScalarValuesMessage,
-} from "./gen/js/extra/msg-scalar_pb.js";
+import * as TS from "./gen/ts/extra/msg-scalar_pb.js";
+import * as JS from "./gen/js/extra/msg-scalar_pb.js";
 import type { JsonValue, PlainMessage } from "@bufbuild/protobuf";
+import { clearField, isFieldSet } from "@bufbuild/protobuf";
 import { protoInt64, ScalarType } from "@bufbuild/protobuf";
 import { describeMT } from "./helpers.js";
 
 describeMT(
-  { ts: TS_ScalarValuesMessage, js: JS_ScalarValuesMessage },
+  { ts: TS.ScalarValuesMessage, js: JS.ScalarValuesMessage },
   (messageType) => {
     const defaultFields: PlainMessage<
-      TS_ScalarValuesMessage | JS_ScalarValuesMessage
+      TS.ScalarValuesMessage | JS.ScalarValuesMessage
     > = {
       doubleField: 0,
       floatField: 0,
@@ -49,7 +44,7 @@ describeMT(
     };
     const defaultJson: JsonValue = {};
     const exampleFields: PlainMessage<
-      TS_ScalarValuesMessage | JS_ScalarValuesMessage
+      TS.ScalarValuesMessage | JS.ScalarValuesMessage
     > = {
       doubleField: 0.75,
       floatField: -0.75,
@@ -143,10 +138,10 @@ describeMT(
 );
 
 describeMT(
-  { ts: TS_RepeatedScalarValuesMessage, js: JS_RepeatedScalarValuesMessage },
+  { ts: TS.RepeatedScalarValuesMessage, js: JS.RepeatedScalarValuesMessage },
   (messageType) => {
     const defaultFields: PlainMessage<
-      TS_RepeatedScalarValuesMessage | JS_RepeatedScalarValuesMessage
+      TS.RepeatedScalarValuesMessage | JS.RepeatedScalarValuesMessage
     > = {
       doubleField: [],
       floatField: [],
@@ -166,7 +161,7 @@ describeMT(
     };
     const defaultJson: JsonValue = {};
     const exampleFields: PlainMessage<
-      TS_RepeatedScalarValuesMessage | JS_RepeatedScalarValuesMessage
+      TS.RepeatedScalarValuesMessage | JS.RepeatedScalarValuesMessage
     > = {
       doubleField: [0.75, 0, 1],
       floatField: [0.75, -0.75],
@@ -242,6 +237,31 @@ describeMT(
       expect(got).toStrictEqual({
         ...defaultFields,
         bytesField: [new Uint8Array(bytes)],
+      });
+    });
+    describe("isFieldSet()", () => {
+      // singular fields are covered in proto3.test.ts
+      test("returns false for repeated field", () => {
+        const msg = new messageType({
+          doubleField: [],
+        });
+        expect(isFieldSet(msg, "doubleField")).toBe(false);
+      });
+      test("returns true for non-empty repeated field", () => {
+        const msg = new messageType({
+          doubleField: [3.14],
+        });
+        expect(isFieldSet(msg, "doubleField")).toBe(true);
+      });
+    });
+    describe("clearField()", () => {
+      // singular fields are covered in proto3.test.ts
+      test("clears repeated field", () => {
+        const msg = new messageType({
+          doubleField: [3.14],
+        });
+        clearField(msg, "doubleField");
+        expect(msg.doubleField.length).toBe(0);
       });
     });
     describe("field info", () => {

--- a/packages/protobuf/src/field-accessor.ts
+++ b/packages/protobuf/src/field-accessor.ts
@@ -1,0 +1,85 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Message } from "./message.js";
+import type { FieldInfo } from "./field.js";
+import {
+  isFieldSet as privateIsFieldSet,
+  clearField as privateClearField,
+} from "./private/reflect.js";
+
+/**
+ * Returns true if the field is set.
+ */
+export function isFieldSet<T extends Message<T>>(
+  target: T,
+  field: MessageFieldNames<T>,
+): boolean;
+export function isFieldSet(target: Message, field: FieldInfo): boolean;
+export function isFieldSet<T extends Message<T>>(
+  target: T,
+  field: MessageFieldNames<T> | FieldInfo,
+): boolean {
+  const fi = getFieldInfo(target, field);
+  if (fi) {
+    return privateIsFieldSet(fi, target);
+  }
+  return false;
+}
+
+/**
+ * Resets the field, so that isFieldSet() will return false.
+ */
+export function clearField<T extends Message<T>>(
+  target: T,
+  field: MessageFieldNames<T>,
+): void;
+export function clearField(target: Message, field: FieldInfo): void;
+export function clearField<T extends Message<T>>(
+  target: T,
+  field: MessageFieldNames<T> | FieldInfo,
+): void {
+  const fi = getFieldInfo(target, field);
+  if (fi) {
+    privateClearField(fi, target);
+  }
+}
+
+function getFieldInfo(
+  message: Message,
+  field: string | FieldInfo,
+): FieldInfo | undefined {
+  if (typeof field == "string") {
+    return message
+      .getType()
+      .fields.list()
+      .find((fi) => fi.localName === field);
+  }
+  return field;
+}
+
+// prettier-ignore
+type MessageFieldNames<T extends Message<T>> = Exclude<keyof {
+  [P in keyof T as
+    T[P] extends Function ? never // eslint-disable-line @typescript-eslint/ban-types
+    : T[P] extends Message ? P
+    : T[P] extends Oneof<infer K> ? K
+    : P
+  ]-?: true;
+}, number | symbol>
+
+type Oneof<K extends string> = {
+  case: K | undefined;
+  value?: unknown;
+};

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -37,6 +37,7 @@ export {
   hasExtension,
   clearExtension,
 } from "./extension-accessor.js";
+export { isFieldSet, clearField } from "./field-accessor.js";
 export type {
   ServiceType,
   MethodInfo,

--- a/packages/protobuf/src/private/reflect.ts
+++ b/packages/protobuf/src/private/reflect.ts
@@ -60,7 +60,12 @@ export function clearField(
   if (field.repeated) {
     target[localName] = [];
   } else if (field.oneof) {
-    target[field.oneof.localName] = { case: undefined };
+    if (
+      (target[field.oneof.localName] as { case: string }).case ===
+      field.localName
+    ) {
+      target[field.oneof.localName] = { case: undefined };
+    }
   } else {
     switch (field.kind) {
       case "map":


### PR DESCRIPTION
Protobuf fields can have [default values](https://github.com/bufbuild/protobuf-es/blob/89777bb0a6e84c8440be0f23bc62a27071683fc9/docs/runtime_api.md#default-field-values). To easily determine whether a field has an actual value, this PR adds the function `isFieldSet`, and the function `clearField` to reset a field to its initial value. 

For example:

```typescript
import { isFieldSet, clearField } from "@bufbuild/protobuf";

const user = new User({
  active: true,
});

isFieldSet(user, "active"); // true
isFieldSet(user, "firstName"); // false

clearField(user, "active");
isFieldSet(user, "active"); // false
```