### PR TITLE
Use functions for field presence in clone, equals, construct

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 97,073 b      | 41,481 b | 10,747 b |
+| protobuf-es         | 97,378 b      | 41,628 b | 10,766 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/clone.test.ts
+++ b/packages/protobuf-test/src/clone.test.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect } from "@jest/globals";
+import { describe, test, expect } from "@jest/globals";
+import { describeMT, testMT } from "./helpers.js";
+import { BoolValue, isFieldSet, protoInt64 } from "@bufbuild/protobuf";
+import { Proto2Enum } from "./gen/ts/extra/proto2_pb.js";
+import { Proto3Enum } from "./gen/ts/extra/proto3_pb.js";
 import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage as JS_MessageFieldMessage } from "./gen/js/extra/msg-message_pb.js";
 import {
@@ -25,8 +29,12 @@ import {
 } from "./gen/js/extra/msg-scalar_pb.js";
 import { WrappersMessage as TS_WrappersMessage } from "./gen/ts/extra/wkt-wrappers_pb.js";
 import { WrappersMessage as JS_WrappersMessage } from "./gen/js/extra/wkt-wrappers_pb.js";
-import { testMT } from "./helpers.js";
-import { BoolValue, protoInt64 } from "@bufbuild/protobuf";
+import { Proto2OptionalMessage as TS_Proto2OptionalMessage } from "./gen/ts/extra/proto2_pb.js";
+import { Proto2OptionalMessage as JS_Proto2OptionalMessage } from "./gen/js/extra/proto2_pb.js";
+import { Proto3UnlabelledMessage as TS_Proto3UnlabelledMessage } from "./gen/ts/extra/proto3_pb.js";
+import { Proto3UnlabelledMessage as JS_Proto3UnlabelledMessage } from "./gen/js/extra/proto3_pb.js";
+import { Proto3OptionalMessage as TS_Proto3OptionalMessage } from "./gen/ts/extra/proto3_pb.js";
+import { Proto3OptionalMessage as JS_Proto3OptionalMessage } from "./gen/js/extra/proto3_pb.js";
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
@@ -146,4 +154,103 @@ describe("clone", function () {
     a.doubleValueField = 0.1;
     expect(b.doubleValueField).not.toBe(a.doubleValueField);
   });
+
+  describe("field presence", () => {
+    describeMT(
+      { ts: TS_Proto2OptionalMessage, js: JS_Proto2OptionalMessage },
+      (messageType) => {
+        test.each(messageType.fields.byNumber())(
+          "cloning set field $name retains presence",
+          (field) => {
+            const msg = new messageType({
+              stringField: "",
+              bytesField: new Uint8Array(),
+              int32Field: 0,
+              int64Field: protoInt64.zero,
+              floatField: 0,
+              boolField: false,
+              enumField: Proto2Enum.YES,
+              messageField: {},
+            });
+            expect(isFieldSet(msg, field)).toBe(true);
+            const clone = msg.clone();
+            expect(isFieldSet(clone, field)).toBe(true);
+          },
+        );
+        test.each(messageType.fields.byNumber())(
+          "cloning unset field $name retains presence",
+          (field) => {
+            const msg = new messageType();
+            expect(isFieldSet(msg, field)).toBe(false);
+            const clone = msg.clone();
+            expect(isFieldSet(clone, field)).toBe(false);
+          },
+        );
+      },
+    );
+  });
+  describeMT(
+    { ts: TS_Proto3OptionalMessage, js: JS_Proto3OptionalMessage },
+    (messageType) => {
+      test.each(messageType.fields.byNumber())(
+        "cloning set field $name retains presence",
+        (field) => {
+          const msg = new messageType({
+            stringField: "test",
+            bytesField: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+            int32Field: 1236,
+            int64Field: protoInt64.parse("123456"),
+            floatField: 3.13,
+            boolField: true,
+            enumField: Proto3Enum.YES,
+            messageField: {},
+          });
+          expect(isFieldSet(msg, field)).toBe(true);
+          const clone = msg.clone();
+          expect(isFieldSet(clone, field)).toBe(true);
+        },
+      );
+      test.each(messageType.fields.byNumber())(
+        "cloning unset field $name retains presence",
+        (field) => {
+          const msg = new messageType();
+          expect(isFieldSet(msg, field)).toBe(false);
+          const clone = msg.clone();
+          expect(isFieldSet(clone, field)).toBe(false);
+        },
+      );
+    },
+  );
+  describeMT(
+    { ts: TS_Proto3UnlabelledMessage, js: JS_Proto3UnlabelledMessage },
+    (messageType) => {
+      test.each(messageType.fields.byNumber())(
+        "cloning set field $name retains presence",
+        (field) => {
+          const msg = new messageType({
+            stringField: "test",
+            bytesField: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+            int32Field: 1236,
+            int64Field: protoInt64.parse("123456"),
+            floatField: 3.13,
+            boolField: true,
+            enumField: Proto3Enum.YES,
+            messageField: {},
+          });
+          expect(isFieldSet(msg, field)).toBe(true);
+          const clone = msg.clone();
+          expect(isFieldSet(clone, field)).toBe(true);
+        },
+      );
+      test.each(messageType.fields.byNumber())(
+        "cloning unset field $name retains presence",
+        (field) => {
+          const msg = new messageType();
+          expect(isFieldSet(msg, field)).toBe(false);
+          const clone = msg.clone();
+          expect(isFieldSet(clone, field)).toBe(false);
+        },
+      );
+    },
+  );
 });

--- a/packages/protobuf-test/src/constructor.test.ts
+++ b/packages/protobuf-test/src/constructor.test.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
+import { describeMT, testMT } from "./helpers.js";
+import type { AnyMessage } from "@bufbuild/protobuf";
+import { isFieldSet } from "@bufbuild/protobuf";
 import {
   TestAllTypesProto3 as TS_TestAllTypesProto3,
   TestAllTypesProto3_NestedMessage as TS_TestAllTypesProto3_NestedMessage,
@@ -20,7 +23,8 @@ import {
 import { TestAllTypesProto3 as JS_TestAllTypesProto3 } from "./gen/js/google/protobuf/test_messages_proto3_pb.js";
 import { JSTypeStringMessage as TS_JSTypeStringMessage } from "./gen/ts/extra/jstype_pb.js";
 import { JSTypeStringMessage as JS_JSTypeStringMessage } from "./gen/js/extra/jstype_pb.js";
-import { testMT } from "./helpers.js";
+import { Proto2OptionalMessage as TS_Proto2OptionalMessage } from "./gen/ts/extra/proto2_pb.js";
+import { Proto2OptionalMessage as JS_Proto2OptionalMessage } from "./gen/js/extra/proto2_pb.js";
 
 describe("constructor initializes jstype=JS_STRING with string", function () {
   testMT(
@@ -176,6 +180,29 @@ describe("constructor takes partial message for map value", function () {
         t.repeatedNestedMessage[0]?.corecursive?.repeatedNestedMessage[0]
           ?.corecursive?.repeatedNestedMessage[0]?.a,
       ).toBe(0);
+    },
+  );
+});
+
+describe("constructor field presence", () => {
+  describeMT(
+    { ts: TS_Proto2OptionalMessage, js: JS_Proto2OptionalMessage },
+    (messageType) => {
+      test.each(messageType.fields.byNumber())(
+        "unset input field $name stays unset",
+        (field) => {
+          const msg = new messageType(new messageType());
+          expect(isFieldSet(msg as AnyMessage, field)).toBe(false);
+        },
+      );
+      test("set field carries over", () => {
+        const msg = new messageType(
+          new messageType({
+            stringField: "",
+          }),
+        );
+        expect(isFieldSet(msg, "stringField")).toBe(true);
+      });
     },
   );
 });

--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import { beforeEach, describe, expect, test } from "@jest/globals";
+import { describeMT } from "./helpers.js";
+import { clearField, isFieldSet } from "@bufbuild/protobuf";
 import { MapsMessage as TS_MapsMessage } from "./gen/ts/extra/msg-maps_pb.js";
 import { MapsMessage as JS_MapsMessage } from "./gen/js/extra/msg-maps_pb.js";
 import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
@@ -25,7 +27,16 @@ import { JSTypeStringMessage as TS_JSTypeStringMessage } from "./gen/ts/extra/js
 import { JSTypeStringMessage as JS_JSTypeStringMessage } from "./gen/js/extra/jstype_pb.js";
 import { JSTypeProto2StringMessage as TS_JSTypeProto2StringMessage } from "./gen/ts/extra/jstype-proto2_pb.js";
 import { JSTypeProto2StringMessage as JS_JSTypeProto2StringMessage } from "./gen/js/extra/jstype-proto2_pb.js";
-import { describeMT } from "./helpers.js";
+import { Proto2OptionalMessage as TS_Proto2OptionalMessage } from "./gen/ts/extra/proto2_pb.js";
+import { Proto2OptionalMessage as JS_Proto2OptionalMessage } from "./gen/js/extra/proto2_pb.js";
+import {
+  Proto3OptionalMessage as TS_Proto3OptionalMessage,
+  Proto3UnlabelledMessage as TS_Proto3UnlabelledMessage,
+} from "./gen/ts/extra/proto3_pb";
+import {
+  Proto3OptionalMessage as JS_Proto3OptionalMessage,
+  Proto3UnlabelledMessage as JS_Proto3UnlabelledMessage,
+} from "./gen/js/extra/proto3_pb";
 
 describe("equals", function () {
   describeMT(
@@ -64,7 +75,7 @@ describe("equals", function () {
         expect(a.equals(b)).toBeTruthy();
       });
       test("changed are not equal", () => {
-        a.int64Field = undefined;
+        clearField(a, "int64Field");
         expect(a).not.toStrictEqual(b);
         expect(a.equals(b)).toBeFalsy();
       });
@@ -316,5 +327,50 @@ describe("equals", function () {
         ),
       ).toBeFalsy();
     });
+  });
+
+  describe("field presence", () => {
+    describeMT(
+      { ts: TS_Proto2OptionalMessage, js: JS_Proto2OptionalMessage },
+      (messageType) => {
+        test("set field is not equal unset field", () => {
+          const a = new messageType({
+            stringField: "",
+          });
+          const b = new messageType();
+          expect(isFieldSet(a, "stringField")).toBe(true);
+          expect(isFieldSet(b, "stringField")).toBe(false);
+          expect(a.equals(b)).toBe(false);
+        });
+      },
+    );
+    describeMT(
+      { ts: TS_Proto3OptionalMessage, js: JS_Proto3OptionalMessage },
+      (messageType) => {
+        test("set field is not equal unset field", () => {
+          const a = new messageType({
+            stringField: "",
+          });
+          const b = new messageType();
+          expect(isFieldSet(a, "stringField")).toBe(true);
+          expect(isFieldSet(b, "stringField")).toBe(false);
+          expect(a.equals(b)).toBe(false);
+        });
+      },
+    );
+    describeMT(
+      { ts: TS_Proto3UnlabelledMessage, js: JS_Proto3UnlabelledMessage },
+      (messageType) => {
+        test("set field is not equal unset field", () => {
+          const a = new messageType({
+            stringField: "test",
+          });
+          const b = new messageType();
+          expect(isFieldSet(a, "stringField")).toBe(true);
+          expect(isFieldSet(b, "stringField")).toBe(false);
+          expect(a.equals(b)).toBe(false);
+        });
+      },
+    );
   });
 });

--- a/packages/protoplugin-test/src/file-es_proto_int64.test.ts
+++ b/packages/protoplugin-test/src/file-es_proto_int64.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 import { LongType, ScalarType } from "@bufbuild/protobuf";
 

--- a/packages/protoplugin-test/src/file-es_ref_enum.test.ts
+++ b/packages/protoplugin-test/src/file-es_ref_enum.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 
 describe("file print", () => {

--- a/packages/protoplugin-test/src/file-es_ref_message.test.ts
+++ b/packages/protoplugin-test/src/file-es_ref_message.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 
 describe("file print", () => {

--- a/packages/protoplugin-test/src/file-es_string.test.ts
+++ b/packages/protoplugin-test/src/file-es_string.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 
 describe("file print", () => {

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -35,7 +35,7 @@ import {
   LiteralString,
   RefDescEnum,
   RefDescMessage,
-} from "./opaque-printables";
+} from "./opaque-printables.js";
 
 /**
  * All types that can be passed to GeneratedFile.print()


### PR DESCRIPTION
Respect field presence when cloning, comparing equality, or constructing messages, using the functions for field presence added in #717.