### PR TITLE
Apply new proto2 field presence and default values for optional fields as well

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 98,585 b      | 42,010 b | 10,908 b |
+| protobuf-es         | 98,372 b      | 41,985 b | 10,933 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
+++ b/packages/protobuf-bench/src/gen/protobuf-es/buf/alpha/image/v1/image_pb.ts
@@ -76,12 +76,12 @@ export class ImageFile extends Message<ImageFile> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  declare package: string;
 
   /**
    * @generated from field: repeated string dependency = 3;
@@ -131,7 +131,7 @@ export class ImageFile extends Message<ImageFile> {
   /**
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  declare syntax: string;
 
   /**
    * buf_extension contains buf-specific extensions to FileDescriptorProtos.
@@ -185,6 +185,10 @@ export class ImageFile extends Message<ImageFile> {
   }
 }
 
+ImageFile.prototype.name = "";
+ImageFile.prototype.package = "";
+ImageFile.prototype.syntax = "";
+
 /**
  * ImageFileExtension contains extensions to ImageFiles.
  *
@@ -212,7 +216,7 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
    *
    * @generated from field: optional bool is_import = 1;
    */
-  isImport?: boolean;
+  declare isImport: boolean;
 
   /**
    * ModuleInfo contains information about the Buf module this file belongs to.
@@ -239,7 +243,7 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
    *
    * @generated from field: optional bool is_syntax_unspecified = 3;
    */
-  isSyntaxUnspecified?: boolean;
+  declare isSyntaxUnspecified: boolean;
 
   /**
    * unused_dependency are the indexes within the dependency field on
@@ -283,6 +287,9 @@ export class ImageFileExtension extends Message<ImageFileExtension> {
   }
 }
 
+ImageFileExtension.prototype.isImport = false;
+ImageFileExtension.prototype.isSyntaxUnspecified = false;
+
 /**
  * ModuleInfo contains information about a Buf module that an ImageFile
  * belongs to.
@@ -306,7 +313,7 @@ export class ModuleInfo extends Message<ModuleInfo> {
    *
    * @generated from field: optional string commit = 2;
    */
-  commit?: string;
+  declare commit: string;
 
   constructor(data?: PartialMessage<ModuleInfo>) {
     super();
@@ -337,6 +344,8 @@ export class ModuleInfo extends Message<ModuleInfo> {
   }
 }
 
+ModuleInfo.prototype.commit = "";
+
 /**
  * ModuleName is a module name.
  *
@@ -348,17 +357,17 @@ export class ModuleName extends Message<ModuleName> {
   /**
    * @generated from field: optional string remote = 1;
    */
-  remote?: string;
+  declare remote: string;
 
   /**
    * @generated from field: optional string owner = 2;
    */
-  owner?: string;
+  declare owner: string;
 
   /**
    * @generated from field: optional string repository = 3;
    */
-  repository?: string;
+  declare repository: string;
 
   constructor(data?: PartialMessage<ModuleName>) {
     super();
@@ -389,4 +398,8 @@ export class ModuleName extends Message<ModuleName> {
     return proto2.util.equals(ModuleName, a, b);
   }
 }
+
+ModuleName.prototype.remote = "";
+ModuleName.prototype.owner = "";
+ModuleName.prototype.repository = "";
 

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -64,77 +64,77 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  declare optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  declare optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  declare optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  declare optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  declare optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  declare optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  declare optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  declare optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  declare optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  declare optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  declare optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  declare optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  declare optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
@@ -149,22 +149,22 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesProto2_NestedEnum;
+  declare optionalNestedEnum: TestAllTypesProto2_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignEnumProto2 optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumProto2;
+  declare optionalForeignEnum: ForeignEnumProto2;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  declare optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  declare optionalCord: string;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
@@ -588,77 +588,77 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 default_int32 = 241 [default = -123456789];
    */
-  defaultInt32?: number;
+  declare defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 242 [default = -9123456789123456789];
    */
-  defaultInt64?: bigint;
+  declare defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 243 [default = 2123456789];
    */
-  defaultUint32?: number;
+  declare defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 244 [default = 10123456789123456789];
    */
-  defaultUint64?: bigint;
+  declare defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 245 [default = -123456789];
    */
-  defaultSint32?: number;
+  declare defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 246 [default = -9123456789123456789];
    */
-  defaultSint64?: bigint;
+  declare defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 247 [default = 2123456789];
    */
-  defaultFixed32?: number;
+  declare defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 248 [default = 10123456789123456789];
    */
-  defaultFixed64?: bigint;
+  declare defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 249 [default = -123456789];
    */
-  defaultSfixed32?: number;
+  declare defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
    */
-  defaultSfixed64?: bigint;
+  declare defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 251 [default = 9e+09];
    */
-  defaultFloat?: number;
+  declare defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 252 [default = 7e+22];
    */
-  defaultDouble?: number;
+  declare defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 253 [default = true];
    */
-  defaultBool?: boolean;
+  declare defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 254 [default = "Rosebud"];
    */
-  defaultString?: string;
+  declare defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 255 [default = "joshua"];
    */
-  defaultBytes?: Uint8Array;
+  declare defaultBytes: Uint8Array;
 
   /**
    * Test field-name-to-JSON-name convention.
@@ -666,92 +666,92 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 fieldname1 = 401;
    */
-  fieldname1?: number;
+  declare fieldname1: number;
 
   /**
    * @generated from field: optional int32 field_name2 = 402;
    */
-  fieldName2?: number;
+  declare fieldName2: number;
 
   /**
    * @generated from field: optional int32 _field_name3 = 403;
    */
-  FieldName3?: number;
+  declare FieldName3: number;
 
   /**
    * @generated from field: optional int32 field__name4_ = 404;
    */
-  fieldName4?: number;
+  declare fieldName4: number;
 
   /**
    * @generated from field: optional int32 field0name5 = 405;
    */
-  field0name5?: number;
+  declare field0name5: number;
 
   /**
    * @generated from field: optional int32 field_0_name6 = 406;
    */
-  field0Name6?: number;
+  declare field0Name6: number;
 
   /**
    * @generated from field: optional int32 fieldName7 = 407;
    */
-  fieldName7?: number;
+  declare fieldName7: number;
 
   /**
    * @generated from field: optional int32 FieldName8 = 408;
    */
-  FieldName8?: number;
+  declare FieldName8: number;
 
   /**
    * @generated from field: optional int32 field_Name9 = 409;
    */
-  fieldName9?: number;
+  declare fieldName9: number;
 
   /**
    * @generated from field: optional int32 Field_Name10 = 410;
    */
-  FieldName10?: number;
+  declare FieldName10: number;
 
   /**
    * @generated from field: optional int32 FIELD_NAME11 = 411;
    */
-  FIELDNAME11?: number;
+  declare FIELDNAME11: number;
 
   /**
    * @generated from field: optional int32 FIELD_name12 = 412;
    */
-  FIELDName12?: number;
+  declare FIELDName12: number;
 
   /**
    * @generated from field: optional int32 __field_name13 = 413;
    */
-  FieldName13?: number;
+  declare FieldName13: number;
 
   /**
    * @generated from field: optional int32 __Field_name14 = 414;
    */
-  FieldName14?: number;
+  declare FieldName14: number;
 
   /**
    * @generated from field: optional int32 field__name15 = 415;
    */
-  fieldName15?: number;
+  declare fieldName15: number;
 
   /**
    * @generated from field: optional int32 field__Name16 = 416;
    */
-  fieldName16?: number;
+  declare fieldName16: number;
 
   /**
    * @generated from field: optional int32 field_name17__ = 417;
    */
-  fieldName17?: number;
+  declare fieldName17: number;
 
   /**
    * @generated from field: optional int32 Field_name18__ = 418;
    */
-  FieldName18?: number;
+  declare FieldName18: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2>) {
     super();
@@ -913,6 +913,59 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   }
 }
 
+TestAllTypesProto2.prototype.optionalInt32 = 0;
+TestAllTypesProto2.prototype.optionalInt64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalUint32 = 0;
+TestAllTypesProto2.prototype.optionalUint64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalSint32 = 0;
+TestAllTypesProto2.prototype.optionalSint64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalFixed32 = 0;
+TestAllTypesProto2.prototype.optionalFixed64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalSfixed32 = 0;
+TestAllTypesProto2.prototype.optionalSfixed64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalFloat = 0;
+TestAllTypesProto2.prototype.optionalDouble = 0;
+TestAllTypesProto2.prototype.optionalBool = false;
+TestAllTypesProto2.prototype.optionalString = "";
+TestAllTypesProto2.prototype.optionalBytes = new Uint8Array(0);
+TestAllTypesProto2.prototype.optionalNestedEnum = 0 as TestAllTypesProto2_NestedEnum.FOO;
+TestAllTypesProto2.prototype.optionalForeignEnum = 0 as ForeignEnumProto2.FOREIGN_FOO;
+TestAllTypesProto2.prototype.optionalStringPiece = "";
+TestAllTypesProto2.prototype.optionalCord = "";
+TestAllTypesProto2.prototype.defaultInt32 = -123456789;
+TestAllTypesProto2.prototype.defaultInt64 = protoInt64.parse("-9123456789123456789");
+TestAllTypesProto2.prototype.defaultUint32 = 2123456789;
+TestAllTypesProto2.prototype.defaultUint64 = protoInt64.uParse("10123456789123456789");
+TestAllTypesProto2.prototype.defaultSint32 = -123456789;
+TestAllTypesProto2.prototype.defaultSint64 = protoInt64.parse("-9123456789123456789");
+TestAllTypesProto2.prototype.defaultFixed32 = 2123456789;
+TestAllTypesProto2.prototype.defaultFixed64 = protoInt64.uParse("10123456789123456789");
+TestAllTypesProto2.prototype.defaultSfixed32 = -123456789;
+TestAllTypesProto2.prototype.defaultSfixed64 = protoInt64.parse("-9123456789123456789");
+TestAllTypesProto2.prototype.defaultFloat = 9000000000;
+TestAllTypesProto2.prototype.defaultDouble = 7e+22;
+TestAllTypesProto2.prototype.defaultBool = true;
+TestAllTypesProto2.prototype.defaultString = "Rosebud";
+TestAllTypesProto2.prototype.defaultBytes = new Uint8Array([0x6A, 0x6F, 0x73, 0x68, 0x75, 0x61]);
+TestAllTypesProto2.prototype.fieldname1 = 0;
+TestAllTypesProto2.prototype.fieldName2 = 0;
+TestAllTypesProto2.prototype.FieldName3 = 0;
+TestAllTypesProto2.prototype.fieldName4 = 0;
+TestAllTypesProto2.prototype.field0name5 = 0;
+TestAllTypesProto2.prototype.field0Name6 = 0;
+TestAllTypesProto2.prototype.fieldName7 = 0;
+TestAllTypesProto2.prototype.FieldName8 = 0;
+TestAllTypesProto2.prototype.fieldName9 = 0;
+TestAllTypesProto2.prototype.FieldName10 = 0;
+TestAllTypesProto2.prototype.FIELDNAME11 = 0;
+TestAllTypesProto2.prototype.FIELDName12 = 0;
+TestAllTypesProto2.prototype.FieldName13 = 0;
+TestAllTypesProto2.prototype.FieldName14 = 0;
+TestAllTypesProto2.prototype.fieldName15 = 0;
+TestAllTypesProto2.prototype.fieldName16 = 0;
+TestAllTypesProto2.prototype.fieldName17 = 0;
+TestAllTypesProto2.prototype.FieldName18 = 0;
+
 /**
  * @generated from enum protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum
  */
@@ -954,7 +1007,7 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
@@ -990,6 +1043,8 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
   }
 }
 
+TestAllTypesProto2_NestedMessage.prototype.a = 0;
+
 /**
  * groups
  *
@@ -999,12 +1054,12 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
   /**
    * @generated from field: optional int32 group_int32 = 202;
    */
-  groupInt32?: number;
+  declare groupInt32: number;
 
   /**
    * @generated from field: optional uint32 group_uint32 = 203;
    */
-  groupUint32?: number;
+  declare groupUint32: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_Data>) {
     super();
@@ -1034,6 +1089,9 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
     return proto2.util.equals(TestAllTypesProto2_Data, a, b);
   }
 }
+
+TestAllTypesProto2_Data.prototype.groupInt32 = 0;
+TestAllTypesProto2_Data.prototype.groupUint32 = 0;
 
 /**
  * message_set test case.
@@ -1075,7 +1133,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  declare str: string;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension1>) {
     super();
@@ -1105,6 +1163,8 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
   }
 }
 
+TestAllTypesProto2_MessageSetCorrectExtension1.prototype.str = "";
+
 /**
  * @generated from extension: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1 message_set_extension = 1547769;
  */
@@ -1121,7 +1181,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
   /**
    * @generated from field: optional int32 i = 9;
    */
-  i?: number;
+  declare i: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension2>) {
     super();
@@ -1151,6 +1211,8 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
   }
 }
 
+TestAllTypesProto2_MessageSetCorrectExtension2.prototype.i = 0;
+
 /**
  * @generated from extension: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2 message_set_extension = 4135312;
  */
@@ -1167,7 +1229,7 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  declare c: number;
 
   constructor(data?: PartialMessage<ForeignMessageProto2>) {
     super();
@@ -1197,6 +1259,8 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
   }
 }
 
+ForeignMessageProto2.prototype.c = 0;
+
 /**
  * @generated from message protobuf_test_messages.proto2.UnknownToTestAllTypes
  */
@@ -1204,12 +1268,12 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   /**
    * @generated from field: optional int32 optional_int32 = 1001;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional string optional_string = 1002;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
@@ -1224,7 +1288,7 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   /**
    * @generated from field: optional bool optional_bool = 1006;
    */
-  optionalBool?: boolean;
+  declare optionalBool: boolean;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 1011;
@@ -1264,6 +1328,10 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   }
 }
 
+UnknownToTestAllTypes.prototype.optionalInt32 = 0;
+UnknownToTestAllTypes.prototype.optionalString = "";
+UnknownToTestAllTypes.prototype.optionalBool = false;
+
 /**
  * @generated from message protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup
  */
@@ -1271,7 +1339,7 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<UnknownToTestAllTypes_OptionalGroup>) {
     super();
@@ -1300,6 +1368,8 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
     return proto2.util.equals(UnknownToTestAllTypes_OptionalGroup, a, b);
   }
 }
+
+UnknownToTestAllTypes_OptionalGroup.prototype.a = 0;
 
 /**
  * @generated from message protobuf_test_messages.proto2.NullHypothesisProto2
@@ -1390,7 +1460,7 @@ export class OneStringProto2 extends Message<OneStringProto2> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  declare data: string;
 
   constructor(data?: PartialMessage<OneStringProto2>) {
     super();
@@ -1420,6 +1490,8 @@ export class OneStringProto2 extends Message<OneStringProto2> {
   }
 }
 
+OneStringProto2.prototype.data = "";
+
 /**
  * @generated from message protobuf_test_messages.proto2.ProtoWithKeywords
  */
@@ -1427,12 +1499,12 @@ export class ProtoWithKeywords extends Message<ProtoWithKeywords> {
   /**
    * @generated from field: optional int32 inline = 1;
    */
-  inline?: number;
+  declare inline: number;
 
   /**
    * @generated from field: optional string concept = 2;
    */
-  concept?: string;
+  declare concept: string;
 
   /**
    * @generated from field: repeated string requires = 3;
@@ -1468,6 +1540,9 @@ export class ProtoWithKeywords extends Message<ProtoWithKeywords> {
     return proto2.util.equals(ProtoWithKeywords, a, b);
   }
 }
+
+ProtoWithKeywords.prototype.inline = 0;
+ProtoWithKeywords.prototype.concept = "";
 
 /**
  * @generated from message protobuf_test_messages.proto2.TestAllRequiredTypesProto2

--- a/packages/protobuf-test/src/extensions.test.ts
+++ b/packages/protobuf-test/src/extensions.test.ts
@@ -66,7 +66,7 @@ import { getTestFileDescriptorSetBytes } from "./helpers.js";
 
 // test cases for extensions
 type extensionWithValueCollection = ReadonlyArray<{
-  ext: Extension;
+  ext: Extension<Proto2Extendee>;
   val: unknown;
 }>;
 
@@ -183,7 +183,9 @@ describe("proto2.makeExtension()", () => {
 describe("getExtension()", () => {
   it("should throw error if extendee does not match", () => {
     const msg = new User();
-    expect(() => getExtension(msg as Proto2Extendee, uint32_ext)).toThrow(
+    expect(() =>
+      getExtension(msg as unknown as Proto2Extendee, uint32_ext),
+    ).toThrow(
       /^extension proto2ext.uint32_ext can only be applied to message proto2ext.Proto2Extendee$/,
     );
   });
@@ -695,7 +697,9 @@ describe("clearExtension()", () => {
   });
   it("should throw error if extendee does not match", () => {
     const msg = new User();
-    expect(() => clearExtension(msg as Proto2Extendee, uint32_ext)).toThrow(
+    expect(() =>
+      clearExtension(msg as unknown as Proto2Extendee, uint32_ext),
+    ).toThrow(
       /^extension proto2ext.uint32_ext can only be applied to message proto2ext.Proto2Extendee$/,
     );
   });
@@ -704,7 +708,9 @@ describe("clearExtension()", () => {
 describe("setExtension()", () => {
   it("should throw error if extendee does not match", () => {
     const msg = new User();
-    expect(() => setExtension(msg as Proto2Extendee, uint32_ext, 123)).toThrow(
+    expect(() =>
+      setExtension(msg as unknown as Proto2Extendee, uint32_ext, 123),
+    ).toThrow(
       /^extension proto2ext.uint32_ext can only be applied to message proto2ext.Proto2Extendee$/,
     );
   });

--- a/packages/protobuf-test/src/gen/js/extra/extensions-proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/extensions-proto2_pb.d.ts
@@ -46,7 +46,7 @@ export declare class Proto2Extendee extends Message<Proto2Extendee> {
   /**
    * @generated from field: optional int32 own_field = 1;
    */
-  ownField?: number;
+  ownField: number;
 
   constructor(data?: PartialMessage<Proto2Extendee>);
 
@@ -72,7 +72,7 @@ export declare class Proto2ExtMessage extends Message<Proto2ExtMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField: string;
 
   constructor(data?: PartialMessage<Proto2ExtMessage>);
 
@@ -96,12 +96,12 @@ export declare class GroupExt extends Message<GroupExt> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  b: number;
 
   constructor(data?: PartialMessage<GroupExt>);
 
@@ -125,12 +125,12 @@ export declare class RepeatedGroupExt extends Message<RepeatedGroupExt> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  b: number;
 
   constructor(data?: PartialMessage<RepeatedGroupExt>);
 

--- a/packages/protobuf-test/src/gen/js/extra/jstype-proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/jstype-proto2_pb.d.ts
@@ -26,27 +26,27 @@ export declare class JSTypeProto2OmittedMessage extends Message<JSTypeProto2Omit
   /**
    * @generated from field: optional fixed64 fixed64_field = 1;
    */
-  fixed64Field?: bigint;
+  fixed64Field: bigint;
 
   /**
    * @generated from field: optional int64 int64_field = 3;
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4;
    */
-  sfixed64Field?: bigint;
+  sfixed64Field: bigint;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5;
    */
-  sint64Field?: bigint;
+  sint64Field: bigint;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6;
    */
-  uint64Field?: bigint;
+  uint64Field: bigint;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11;
@@ -95,27 +95,27 @@ export declare class JSTypeProto2NormalMessage extends Message<JSTypeProto2Norma
   /**
    * @generated from field: optional fixed64 fixed64_field = 1 [jstype = JS_NORMAL];
    */
-  fixed64Field?: bigint;
+  fixed64Field: bigint;
 
   /**
    * @generated from field: optional int64 int64_field = 3 [jstype = JS_NORMAL];
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4 [jstype = JS_NORMAL];
    */
-  sfixed64Field?: bigint;
+  sfixed64Field: bigint;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5 [jstype = JS_NORMAL];
    */
-  sint64Field?: bigint;
+  sint64Field: bigint;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6 [jstype = JS_NORMAL];
    */
-  uint64Field?: bigint;
+  uint64Field: bigint;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11 [jstype = JS_NORMAL];
@@ -164,27 +164,27 @@ export declare class JSTypeProto2StringMessage extends Message<JSTypeProto2Strin
   /**
    * @generated from field: optional fixed64 fixed64_field = 1 [jstype = JS_STRING];
    */
-  fixed64Field?: string;
+  fixed64Field: string;
 
   /**
    * @generated from field: optional int64 int64_field = 3 [jstype = JS_STRING];
    */
-  int64Field?: string;
+  int64Field: string;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4 [jstype = JS_STRING];
    */
-  sfixed64Field?: string;
+  sfixed64Field: string;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5 [jstype = JS_STRING];
    */
-  sint64Field?: string;
+  sint64Field: string;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6 [jstype = JS_STRING];
    */
-  uint64Field?: string;
+  uint64Field: string;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11 [jstype = JS_STRING];
@@ -233,27 +233,27 @@ export declare class JSTypeProto2NumberMessage extends Message<JSTypeProto2Numbe
   /**
    * @generated from field: optional fixed64 fixed64_field = 1 [jstype = JS_NUMBER];
    */
-  fixed64Field?: bigint;
+  fixed64Field: bigint;
 
   /**
    * @generated from field: optional int64 int64_field = 3 [jstype = JS_NUMBER];
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4 [jstype = JS_NUMBER];
    */
-  sfixed64Field?: bigint;
+  sfixed64Field: bigint;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5 [jstype = JS_NUMBER];
    */
-  sint64Field?: bigint;
+  sint64Field: bigint;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6 [jstype = JS_NUMBER];
    */
-  uint64Field?: bigint;
+  uint64Field: bigint;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11 [jstype = JS_NUMBER];

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
@@ -143,37 +143,37 @@ export declare class Proto2OptionalMessage extends Message<Proto2OptionalMessage
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField: string;
 
   /**
    * @generated from field: optional bytes bytes_field = 2;
    */
-  bytesField?: Uint8Array;
+  bytesField: Uint8Array;
 
   /**
    * @generated from field: optional int32 int32_field = 3;
    */
-  int32Field?: number;
+  int32Field: number;
 
   /**
    * @generated from field: optional int64 int64_field = 4;
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional float float_field = 5;
    */
-  floatField?: number;
+  floatField: number;
 
   /**
    * @generated from field: optional bool bool_field = 6;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto2Enum enum_field = 7;
    */
-  enumField?: Proto2Enum;
+  enumField: Proto2Enum;
 
   /**
    * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
@@ -320,37 +320,37 @@ export declare class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage
   /**
    * @generated from field: optional string string_field = 1 [default = "hello \" *\/ "];
    */
-  stringField?: string;
+  stringField: string;
 
   /**
    * @generated from field: optional bytes bytes_field = 2 [default = "\000x\\x\\"x\'AAAAAA\010\014\n\r\t\013"];
    */
-  bytesField?: Uint8Array;
+  bytesField: Uint8Array;
 
   /**
    * @generated from field: optional int32 int32_field = 3 [default = 128];
    */
-  int32Field?: number;
+  int32Field: number;
 
   /**
    * @generated from field: optional int64 int64_field = 4 [default = -256];
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional float float_field = 5 [default = -512.13];
    */
-  floatField?: number;
+  floatField: number;
 
   /**
    * @generated from field: optional bool bool_field = 6 [default = true];
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];
    */
-  enumField?: Proto2Enum;
+  enumField: Proto2Enum;
 
   /**
    * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
@@ -379,7 +379,7 @@ export declare class Proto2ChildMessage extends Message<Proto2ChildMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField: string;
 
   constructor(data?: PartialMessage<Proto2ChildMessage>);
 
@@ -453,7 +453,7 @@ export declare class Proto2GroupsMessage_Group extends Message<Proto2GroupsMessa
   /**
    * @generated from field: optional int32 int32_field = 1;
    */
-  int32Field?: number;
+  int32Field: number;
 
   /**
    * @generated from field: optional spec.Proto2GroupsMessage.Group.NestedGroup nestedgroup = 2;
@@ -482,7 +482,7 @@ export declare class Proto2GroupsMessage_Group_NestedGroup extends Message<Proto
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  stringField: string;
 
   constructor(data?: PartialMessage<Proto2GroupsMessage_Group_NestedGroup>);
 
@@ -506,7 +506,7 @@ export declare class Proto2GroupsMessage_RepeatedGroup extends Message<Proto2Gro
   /**
    * @generated from field: optional int32 int32_field = 1;
    */
-  int32Field?: number;
+  int32Field: number;
 
   constructor(data?: PartialMessage<Proto2GroupsMessage_RepeatedGroup>);
 
@@ -530,7 +530,7 @@ export declare class Proto2GroupsMessage_OneofGroup extends Message<Proto2Groups
   /**
    * @generated from field: optional bool bool_field = 1;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   constructor(data?: PartialMessage<Proto2GroupsMessage_OneofGroup>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/compiler/plugin_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/compiler/plugin_pb.d.ts
@@ -42,17 +42,17 @@ export declare class Version extends Message<Version> {
   /**
    * @generated from field: optional int32 major = 1;
    */
-  major?: number;
+  major: number;
 
   /**
    * @generated from field: optional int32 minor = 2;
    */
-  minor?: number;
+  minor: number;
 
   /**
    * @generated from field: optional int32 patch = 3;
    */
-  patch?: number;
+  patch: number;
 
   /**
    * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
@@ -60,7 +60,7 @@ export declare class Version extends Message<Version> {
    *
    * @generated from field: optional string suffix = 4;
    */
-  suffix?: string;
+  suffix: string;
 
   constructor(data?: PartialMessage<Version>);
 
@@ -97,7 +97,7 @@ export declare class CodeGeneratorRequest extends Message<CodeGeneratorRequest> 
    *
    * @generated from field: optional string parameter = 2;
    */
-  parameter?: string;
+  parameter: string;
 
   /**
    * FileDescriptorProtos for all files in files_to_generate and everything
@@ -173,7 +173,7 @@ export declare class CodeGeneratorResponse extends Message<CodeGeneratorResponse
    *
    * @generated from field: optional string error = 1;
    */
-  error?: string;
+  error: string;
 
   /**
    * A bitmask of supported features that the code generator supports.
@@ -181,7 +181,7 @@ export declare class CodeGeneratorResponse extends Message<CodeGeneratorResponse
    *
    * @generated from field: optional uint64 supported_features = 2;
    */
-  supportedFeatures?: bigint;
+  supportedFeatures: bigint;
 
   /**
    * @generated from field: repeated google.protobuf.compiler.CodeGeneratorResponse.File file = 15;
@@ -246,7 +246,7 @@ export declare class CodeGeneratorResponse_File extends Message<CodeGeneratorRes
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * If non-empty, indicates that the named file should already exist, and the
@@ -289,14 +289,14 @@ export declare class CodeGeneratorResponse_File extends Message<CodeGeneratorRes
    *
    * @generated from field: optional string insertion_point = 2;
    */
-  insertionPoint?: string;
+  insertionPoint: string;
 
   /**
    * The file contents.
    *
    * @generated from field: optional string content = 15;
    */
-  content?: string;
+  content: string;
 
   /**
    * Information describing the file content being inserted. If an insertion

--- a/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/descriptor_pb.d.ts
@@ -131,14 +131,14 @@ export declare class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    *
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  package: string;
 
   /**
    * Names of files imported by this file.
@@ -207,14 +207,14 @@ export declare class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  syntax: string;
 
   /**
    * The edition of the proto file.
    *
    * @generated from field: optional google.protobuf.Edition edition = 14;
    */
-  edition?: Edition;
+  edition: Edition;
 
   constructor(data?: PartialMessage<FileDescriptorProto>);
 
@@ -240,7 +240,7 @@ export declare class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto field = 2;
@@ -314,14 +314,14 @@ export declare class DescriptorProto_ExtensionRange extends Message<DescriptorPr
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end: number;
 
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
@@ -356,14 +356,14 @@ export declare class DescriptorProto_ReservedRange extends Message<DescriptorPro
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end: number;
 
   constructor(data?: PartialMessage<DescriptorProto_ReservedRange>);
 
@@ -414,7 +414,7 @@ export declare class ExtensionRangeOptions extends Message<ExtensionRangeOptions
    *
    * @generated from field: optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3 [default = UNVERIFIED];
    */
-  verification?: ExtensionRangeOptions_VerificationState;
+  verification: ExtensionRangeOptions_VerificationState;
 
   constructor(data?: PartialMessage<ExtensionRangeOptions>);
 
@@ -459,7 +459,7 @@ export declare class ExtensionRangeOptions_Declaration extends Message<Extension
    *
    * @generated from field: optional int32 number = 1;
    */
-  number?: number;
+  number: number;
 
   /**
    * The fully-qualified name of the extension field. There must be a leading
@@ -467,7 +467,7 @@ export declare class ExtensionRangeOptions_Declaration extends Message<Extension
    *
    * @generated from field: optional string full_name = 2;
    */
-  fullName?: string;
+  fullName: string;
 
   /**
    * The fully-qualified type name of the extension field. Unlike
@@ -476,7 +476,7 @@ export declare class ExtensionRangeOptions_Declaration extends Message<Extension
    *
    * @generated from field: optional string type = 3;
    */
-  type?: string;
+  type: string;
 
   /**
    * If true, indicates that the number is reserved in the extension range,
@@ -485,7 +485,7 @@ export declare class ExtensionRangeOptions_Declaration extends Message<Extension
    *
    * @generated from field: optional bool reserved = 5;
    */
-  reserved?: boolean;
+  reserved: boolean;
 
   /**
    * If true, indicates that the extension must be defined as repeated.
@@ -493,7 +493,7 @@ export declare class ExtensionRangeOptions_Declaration extends Message<Extension
    *
    * @generated from field: optional bool repeated = 6;
    */
-  repeated?: boolean;
+  repeated: boolean;
 
   constructor(data?: PartialMessage<ExtensionRangeOptions_Declaration>);
 
@@ -519,17 +519,17 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: optional int32 number = 3;
    */
-  number?: number;
+  number: number;
 
   /**
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Label label = 4;
    */
-  label?: FieldDescriptorProto_Label;
+  label: FieldDescriptorProto_Label;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
@@ -537,7 +537,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Type type = 5;
    */
-  type?: FieldDescriptorProto_Type;
+  type: FieldDescriptorProto_Type;
 
   /**
    * For message and enum types, this is the name of the type.  If the name
@@ -548,7 +548,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional string type_name = 6;
    */
-  typeName?: string;
+  typeName: string;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
@@ -556,7 +556,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional string extendee = 2;
    */
-  extendee?: string;
+  extendee: string;
 
   /**
    * For numeric types, contains the original text representation of the value.
@@ -566,7 +566,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional string default_value = 7;
    */
-  defaultValue?: string;
+  defaultValue: string;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
@@ -574,7 +574,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional int32 oneof_index = 9;
    */
-  oneofIndex?: number;
+  oneofIndex: number;
 
   /**
    * JSON name of this field. The value is set by protocol compiler. If the
@@ -584,7 +584,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional string json_name = 10;
    */
-  jsonName?: string;
+  jsonName: string;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
@@ -616,7 +616,7 @@ export declare class FieldDescriptorProto extends Message<FieldDescriptorProto> 
    *
    * @generated from field: optional bool proto3_optional = 17;
    */
-  proto3Optional?: boolean;
+  proto3Optional: boolean;
 
   constructor(data?: PartialMessage<FieldDescriptorProto>);
 
@@ -786,7 +786,7 @@ export declare class OneofDescriptorProto extends Message<OneofDescriptorProto> 
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
@@ -817,7 +817,7 @@ export declare class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: repeated google.protobuf.EnumValueDescriptorProto value = 2;
@@ -877,14 +877,14 @@ export declare class EnumDescriptorProto_EnumReservedRange extends Message<EnumD
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start: number;
 
   /**
    * Inclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end: number;
 
   constructor(data?: PartialMessage<EnumDescriptorProto_EnumReservedRange>);
 
@@ -910,12 +910,12 @@ export declare class EnumValueDescriptorProto extends Message<EnumValueDescripto
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: optional int32 number = 2;
    */
-  number?: number;
+  number: number;
 
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
@@ -946,7 +946,7 @@ export declare class ServiceDescriptorProto extends Message<ServiceDescriptorPro
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: repeated google.protobuf.MethodDescriptorProto method = 2;
@@ -982,7 +982,7 @@ export declare class MethodDescriptorProto extends Message<MethodDescriptorProto
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -990,12 +990,12 @@ export declare class MethodDescriptorProto extends Message<MethodDescriptorProto
    *
    * @generated from field: optional string input_type = 2;
    */
-  inputType?: string;
+  inputType: string;
 
   /**
    * @generated from field: optional string output_type = 3;
    */
-  outputType?: string;
+  outputType: string;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
@@ -1007,14 +1007,14 @@ export declare class MethodDescriptorProto extends Message<MethodDescriptorProto
    *
    * @generated from field: optional bool client_streaming = 5 [default = false];
    */
-  clientStreaming?: boolean;
+  clientStreaming: boolean;
 
   /**
    * Identifies if server streams multiple server messages
    *
    * @generated from field: optional bool server_streaming = 6 [default = false];
    */
-  serverStreaming?: boolean;
+  serverStreaming: boolean;
 
   constructor(data?: PartialMessage<MethodDescriptorProto>);
 
@@ -1043,7 +1043,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_package = 1;
    */
-  javaPackage?: string;
+  javaPackage: string;
 
   /**
    * Controls the name of the wrapper Java class generated for the .proto file.
@@ -1054,7 +1054,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_outer_classname = 8;
    */
-  javaOuterClassname?: string;
+  javaOuterClassname: string;
 
   /**
    * If enabled, then the Java code generator will generate a separate .java
@@ -1066,7 +1066,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_multiple_files = 10 [default = false];
    */
-  javaMultipleFiles?: boolean;
+  javaMultipleFiles: boolean;
 
   /**
    * This option does nothing.
@@ -1074,7 +1074,7 @@ export declare class FileOptions extends Message<FileOptions> {
    * @generated from field: optional bool java_generate_equals_and_hash = 20 [deprecated = true];
    * @deprecated
    */
-  javaGenerateEqualsAndHash?: boolean;
+  javaGenerateEqualsAndHash: boolean;
 
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -1086,12 +1086,12 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_string_check_utf8 = 27 [default = false];
    */
-  javaStringCheckUtf8?: boolean;
+  javaStringCheckUtf8: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9 [default = SPEED];
    */
-  optimizeFor?: FileOptions_OptimizeMode;
+  optimizeFor: FileOptions_OptimizeMode;
 
   /**
    * Sets the Go package where structs generated from this .proto will be
@@ -1102,7 +1102,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string go_package = 11;
    */
-  goPackage?: string;
+  goPackage: string;
 
   /**
    * Should generic services be generated in each language?  "Generic" services
@@ -1118,22 +1118,22 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_generic_services = 16 [default = false];
    */
-  ccGenericServices?: boolean;
+  ccGenericServices: boolean;
 
   /**
    * @generated from field: optional bool java_generic_services = 17 [default = false];
    */
-  javaGenericServices?: boolean;
+  javaGenericServices: boolean;
 
   /**
    * @generated from field: optional bool py_generic_services = 18 [default = false];
    */
-  pyGenericServices?: boolean;
+  pyGenericServices: boolean;
 
   /**
    * @generated from field: optional bool php_generic_services = 42 [default = false];
    */
-  phpGenericServices?: boolean;
+  phpGenericServices: boolean;
 
   /**
    * Is this file deprecated?
@@ -1143,7 +1143,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool deprecated = 23 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
@@ -1151,7 +1151,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_enable_arenas = 31 [default = true];
    */
-  ccEnableArenas?: boolean;
+  ccEnableArenas: boolean;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
@@ -1159,14 +1159,14 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string objc_class_prefix = 36;
    */
-  objcClassPrefix?: string;
+  objcClassPrefix: string;
 
   /**
    * Namespace for generated classes; defaults to the package.
    *
    * @generated from field: optional string csharp_namespace = 37;
    */
-  csharpNamespace?: string;
+  csharpNamespace: string;
 
   /**
    * By default Swift generators will take the proto package and CamelCase it
@@ -1176,7 +1176,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string swift_prefix = 39;
    */
-  swiftPrefix?: string;
+  swiftPrefix: string;
 
   /**
    * Sets the php class prefix which is prepended to all php generated classes
@@ -1184,7 +1184,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_class_prefix = 40;
    */
-  phpClassPrefix?: string;
+  phpClassPrefix: string;
 
   /**
    * Use this option to change the namespace of php generated classes. Default
@@ -1193,7 +1193,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_namespace = 41;
    */
-  phpNamespace?: string;
+  phpNamespace: string;
 
   /**
    * Use this option to change the namespace of php generated metadata classes.
@@ -1202,7 +1202,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_metadata_namespace = 44;
    */
-  phpMetadataNamespace?: string;
+  phpMetadataNamespace: string;
 
   /**
    * Use this option to change the package of ruby generated classes. Default
@@ -1211,7 +1211,7 @@ export declare class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string ruby_package = 45;
    */
-  rubyPackage?: string;
+  rubyPackage: string;
 
   /**
    * Any features defined in the specific edition.
@@ -1299,7 +1299,7 @@ export declare class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool message_set_wire_format = 1 [default = false];
    */
-  messageSetWireFormat?: boolean;
+  messageSetWireFormat: boolean;
 
   /**
    * Disables the generation of the standard "descriptor()" accessor, which can
@@ -1308,7 +1308,7 @@ export declare class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool no_standard_descriptor_accessor = 2 [default = false];
    */
-  noStandardDescriptorAccessor?: boolean;
+  noStandardDescriptorAccessor: boolean;
 
   /**
    * Is this message deprecated?
@@ -1318,7 +1318,7 @@ export declare class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * NOTE: Do not set the option in .proto files. Always use the maps syntax
@@ -1345,7 +1345,7 @@ export declare class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool map_entry = 7;
    */
-  mapEntry?: boolean;
+  mapEntry: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -1362,7 +1362,7 @@ export declare class MessageOptions extends Message<MessageOptions> {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -1407,7 +1407,7 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.CType ctype = 1 [default = STRING];
    */
-  ctype?: FieldOptions_CType;
+  ctype: FieldOptions_CType;
 
   /**
    * The packed option can be enabled for repeated primitive fields to enable
@@ -1420,7 +1420,7 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool packed = 2;
    */
-  packed?: boolean;
+  packed: boolean;
 
   /**
    * The jstype option determines the JavaScript type used for values of the
@@ -1437,7 +1437,7 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL];
    */
-  jstype?: FieldOptions_JSType;
+  jstype: FieldOptions_JSType;
 
   /**
    * Should this field be parsed lazily?  Lazy applies only to message-type
@@ -1473,7 +1473,7 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool lazy = 5 [default = false];
    */
-  lazy?: boolean;
+  lazy: boolean;
 
   /**
    * unverified_lazy does no correctness checks on the byte stream. This should
@@ -1482,7 +1482,7 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool unverified_lazy = 15 [default = false];
    */
-  unverifiedLazy?: boolean;
+  unverifiedLazy: boolean;
 
   /**
    * Is this field deprecated?
@@ -1492,14 +1492,14 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * For Google-internal migration only. Do not use.
    *
    * @generated from field: optional bool weak = 10 [default = false];
    */
-  weak?: boolean;
+  weak: boolean;
 
   /**
    * Indicate that the field value should not be printed out when using debug
@@ -1507,12 +1507,12 @@ export declare class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool debug_redact = 16 [default = false];
    */
-  debugRedact?: boolean;
+  debugRedact: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.OptionRetention retention = 17;
    */
-  retention?: FieldOptions_OptionRetention;
+  retention: FieldOptions_OptionRetention;
 
   /**
    * @generated from field: repeated google.protobuf.FieldOptions.OptionTargetType targets = 19;
@@ -1699,14 +1699,14 @@ export declare class FieldOptions_EditionDefault extends Message<FieldOptions_Ed
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: Edition;
+  edition: Edition;
 
   /**
    * Textproto value.
    *
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value: string;
 
   constructor(data?: PartialMessage<FieldOptions_EditionDefault>);
 
@@ -1766,7 +1766,7 @@ export declare class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool allow_alias = 2;
    */
-  allowAlias?: boolean;
+  allowAlias: boolean;
 
   /**
    * Is this enum deprecated?
@@ -1776,7 +1776,7 @@ export declare class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -1789,7 +1789,7 @@ export declare class EnumOptions extends Message<EnumOptions> {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -1832,7 +1832,7 @@ export declare class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool deprecated = 1 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -1848,7 +1848,7 @@ export declare class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool debug_redact = 3 [default = false];
    */
-  debugRedact?: boolean;
+  debugRedact: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1891,7 +1891,7 @@ export declare class ServiceOptions extends Message<ServiceOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -1927,12 +1927,12 @@ export declare class MethodOptions extends Message<MethodOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
    */
-  idempotencyLevel?: MethodOptions_IdempotencyLevel;
+  idempotencyLevel: MethodOptions_IdempotencyLevel;
 
   /**
    * Any features defined in the specific edition.
@@ -2013,32 +2013,32 @@ export declare class UninterpretedOption extends Message<UninterpretedOption> {
    *
    * @generated from field: optional string identifier_value = 3;
    */
-  identifierValue?: string;
+  identifierValue: string;
 
   /**
    * @generated from field: optional uint64 positive_int_value = 4;
    */
-  positiveIntValue?: bigint;
+  positiveIntValue: bigint;
 
   /**
    * @generated from field: optional int64 negative_int_value = 5;
    */
-  negativeIntValue?: bigint;
+  negativeIntValue: bigint;
 
   /**
    * @generated from field: optional double double_value = 6;
    */
-  doubleValue?: number;
+  doubleValue: number;
 
   /**
    * @generated from field: optional bytes string_value = 7;
    */
-  stringValue?: Uint8Array;
+  stringValue: Uint8Array;
 
   /**
    * @generated from field: optional string aggregate_value = 8;
    */
-  aggregateValue?: string;
+  aggregateValue: string;
 
   constructor(data?: PartialMessage<UninterpretedOption>);
 
@@ -2104,32 +2104,32 @@ export declare class FeatureSet extends Message<FeatureSet> {
   /**
    * @generated from field: optional google.protobuf.FeatureSet.FieldPresence field_presence = 1;
    */
-  fieldPresence?: FeatureSet_FieldPresence;
+  fieldPresence: FeatureSet_FieldPresence;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.EnumType enum_type = 2;
    */
-  enumType?: FeatureSet_EnumType;
+  enumType: FeatureSet_EnumType;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding = 3;
    */
-  repeatedFieldEncoding?: FeatureSet_RepeatedFieldEncoding;
+  repeatedFieldEncoding: FeatureSet_RepeatedFieldEncoding;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.Utf8Validation utf8_validation = 4;
    */
-  utf8Validation?: FeatureSet_Utf8Validation;
+  utf8Validation: FeatureSet_Utf8Validation;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.MessageEncoding message_encoding = 5;
    */
-  messageEncoding?: FeatureSet_MessageEncoding;
+  messageEncoding: FeatureSet_MessageEncoding;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.JsonFormat json_format = 6;
    */
-  jsonFormat?: FeatureSet_JsonFormat;
+  jsonFormat: FeatureSet_JsonFormat;
 
   constructor(data?: PartialMessage<FeatureSet>);
 
@@ -2291,7 +2291,7 @@ export declare class FeatureSetDefaults extends Message<FeatureSetDefaults> {
    *
    * @generated from field: optional google.protobuf.Edition minimum_edition = 4;
    */
-  minimumEdition?: Edition;
+  minimumEdition: Edition;
 
   /**
    * The maximum known edition (inclusive) when this was constructed. Editions
@@ -2299,7 +2299,7 @@ export declare class FeatureSetDefaults extends Message<FeatureSetDefaults> {
    *
    * @generated from field: optional google.protobuf.Edition maximum_edition = 5;
    */
-  maximumEdition?: Edition;
+  maximumEdition: Edition;
 
   constructor(data?: PartialMessage<FeatureSetDefaults>);
 
@@ -2328,7 +2328,7 @@ export declare class FeatureSetDefaults_FeatureSetEditionDefault extends Message
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: Edition;
+  edition: Edition;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet features = 2;
@@ -2516,12 +2516,12 @@ export declare class SourceCodeInfo_Location extends Message<SourceCodeInfo_Loca
    *
    * @generated from field: optional string leading_comments = 3;
    */
-  leadingComments?: string;
+  leadingComments: string;
 
   /**
    * @generated from field: optional string trailing_comments = 4;
    */
-  trailingComments?: string;
+  trailingComments: string;
 
   /**
    * @generated from field: repeated string leading_detached_comments = 6;
@@ -2591,7 +2591,7 @@ export declare class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeI
    *
    * @generated from field: optional string source_file = 2;
    */
-  sourceFile?: string;
+  sourceFile: string;
 
   /**
    * Identifies the starting offset in bytes in the generated code
@@ -2599,7 +2599,7 @@ export declare class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeI
    *
    * @generated from field: optional int32 begin = 3;
    */
-  begin?: number;
+  begin: number;
 
   /**
    * Identifies the ending offset in bytes in the generated code that
@@ -2608,12 +2608,12 @@ export declare class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeI
    *
    * @generated from field: optional int32 end = 4;
    */
-  end?: number;
+  end: number;
 
   /**
    * @generated from field: optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic = 5;
    */
-  semantic?: GeneratedCodeInfo_Annotation_Semantic;
+  semantic: GeneratedCodeInfo_Annotation_Semantic;
 
   constructor(data?: PartialMessage<GeneratedCodeInfo_Annotation>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/map_lite_unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/map_lite_unittest_pb.d.ts
@@ -453,7 +453,7 @@ export declare class ForeignMessageArenaLite extends Message<ForeignMessageArena
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c: number;
 
   constructor(data?: PartialMessage<ForeignMessageArenaLite>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
@@ -58,77 +58,77 @@ export declare class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
@@ -143,22 +143,22 @@ export declare class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesProto2_NestedEnum;
+  optionalNestedEnum: TestAllTypesProto2_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignEnumProto2 optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumProto2;
+  optionalForeignEnum: ForeignEnumProto2;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord: string;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
@@ -582,77 +582,77 @@ export declare class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 default_int32 = 241 [default = -123456789];
    */
-  defaultInt32?: number;
+  defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 242 [default = -9123456789123456789];
    */
-  defaultInt64?: bigint;
+  defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 243 [default = 2123456789];
    */
-  defaultUint32?: number;
+  defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 244 [default = 10123456789123456789];
    */
-  defaultUint64?: bigint;
+  defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 245 [default = -123456789];
    */
-  defaultSint32?: number;
+  defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 246 [default = -9123456789123456789];
    */
-  defaultSint64?: bigint;
+  defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 247 [default = 2123456789];
    */
-  defaultFixed32?: number;
+  defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 248 [default = 10123456789123456789];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 249 [default = -123456789];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 251 [default = 9e+09];
    */
-  defaultFloat?: number;
+  defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 252 [default = 7e+22];
    */
-  defaultDouble?: number;
+  defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 253 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 254 [default = "Rosebud"];
    */
-  defaultString?: string;
+  defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 255 [default = "joshua"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes: Uint8Array;
 
   /**
    * Test field-name-to-JSON-name convention.
@@ -660,92 +660,92 @@ export declare class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 fieldname1 = 401;
    */
-  fieldname1?: number;
+  fieldname1: number;
 
   /**
    * @generated from field: optional int32 field_name2 = 402;
    */
-  fieldName2?: number;
+  fieldName2: number;
 
   /**
    * @generated from field: optional int32 _field_name3 = 403;
    */
-  FieldName3?: number;
+  FieldName3: number;
 
   /**
    * @generated from field: optional int32 field__name4_ = 404;
    */
-  fieldName4?: number;
+  fieldName4: number;
 
   /**
    * @generated from field: optional int32 field0name5 = 405;
    */
-  field0name5?: number;
+  field0name5: number;
 
   /**
    * @generated from field: optional int32 field_0_name6 = 406;
    */
-  field0Name6?: number;
+  field0Name6: number;
 
   /**
    * @generated from field: optional int32 fieldName7 = 407;
    */
-  fieldName7?: number;
+  fieldName7: number;
 
   /**
    * @generated from field: optional int32 FieldName8 = 408;
    */
-  FieldName8?: number;
+  FieldName8: number;
 
   /**
    * @generated from field: optional int32 field_Name9 = 409;
    */
-  fieldName9?: number;
+  fieldName9: number;
 
   /**
    * @generated from field: optional int32 Field_Name10 = 410;
    */
-  FieldName10?: number;
+  FieldName10: number;
 
   /**
    * @generated from field: optional int32 FIELD_NAME11 = 411;
    */
-  FIELDNAME11?: number;
+  FIELDNAME11: number;
 
   /**
    * @generated from field: optional int32 FIELD_name12 = 412;
    */
-  FIELDName12?: number;
+  FIELDName12: number;
 
   /**
    * @generated from field: optional int32 __field_name13 = 413;
    */
-  FieldName13?: number;
+  FieldName13: number;
 
   /**
    * @generated from field: optional int32 __Field_name14 = 414;
    */
-  FieldName14?: number;
+  FieldName14: number;
 
   /**
    * @generated from field: optional int32 field__name15 = 415;
    */
-  fieldName15?: number;
+  fieldName15: number;
 
   /**
    * @generated from field: optional int32 field__Name16 = 416;
    */
-  fieldName16?: number;
+  fieldName16: number;
 
   /**
    * @generated from field: optional int32 field_name17__ = 417;
    */
-  fieldName17?: number;
+  fieldName17: number;
 
   /**
    * @generated from field: optional int32 Field_name18__ = 418;
    */
-  FieldName18?: number;
+  FieldName18: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2>);
 
@@ -796,7 +796,7 @@ export declare class TestAllTypesProto2_NestedMessage extends Message<TestAllTyp
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
@@ -827,12 +827,12 @@ export declare class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_
   /**
    * @generated from field: optional int32 group_int32 = 202;
    */
-  groupInt32?: number;
+  groupInt32: number;
 
   /**
    * @generated from field: optional uint32 group_uint32 = 203;
    */
-  groupUint32?: number;
+  groupUint32: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_Data>);
 
@@ -877,7 +877,7 @@ export declare class TestAllTypesProto2_MessageSetCorrectExtension1 extends Mess
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  str: string;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension1>);
 
@@ -906,7 +906,7 @@ export declare class TestAllTypesProto2_MessageSetCorrectExtension2 extends Mess
   /**
    * @generated from field: optional int32 i = 9;
    */
-  i?: number;
+  i: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension2>);
 
@@ -935,7 +935,7 @@ export declare class ForeignMessageProto2 extends Message<ForeignMessageProto2> 
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c: number;
 
   constructor(data?: PartialMessage<ForeignMessageProto2>);
 
@@ -959,12 +959,12 @@ export declare class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes
   /**
    * @generated from field: optional int32 optional_int32 = 1001;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional string optional_string = 1002;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
@@ -979,7 +979,7 @@ export declare class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes
   /**
    * @generated from field: optional bool optional_bool = 1006;
    */
-  optionalBool?: boolean;
+  optionalBool: boolean;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 1011;
@@ -1008,7 +1008,7 @@ export declare class UnknownToTestAllTypes_OptionalGroup extends Message<Unknown
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<UnknownToTestAllTypes_OptionalGroup>);
 
@@ -1085,7 +1085,7 @@ export declare class OneStringProto2 extends Message<OneStringProto2> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  data: string;
 
   constructor(data?: PartialMessage<OneStringProto2>);
 
@@ -1109,12 +1109,12 @@ export declare class ProtoWithKeywords extends Message<ProtoWithKeywords> {
   /**
    * @generated from field: optional int32 inline = 1;
    */
-  inline?: number;
+  inline: number;
 
   /**
    * @generated from field: optional string concept = 2;
    */
-  concept?: string;
+  concept: string;
 
   /**
    * @generated from field: repeated string requires = 3;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -63,7 +63,7 @@ export declare class TestMessageWithCustomOptions extends Message<TestMessageWit
   /**
    * @generated from field: optional string field1 = 1;
    */
-  field1?: string;
+  field1: string;
 
   /**
    * @generated from oneof protobuf_unittest.TestMessageWithCustomOptions.AnOneof
@@ -345,17 +345,17 @@ export declare class ComplexOptionType1 extends Message<ComplexOptionType1> {
   /**
    * @generated from field: optional int32 foo = 1;
    */
-  foo?: number;
+  foo: number;
 
   /**
    * @generated from field: optional int32 foo2 = 2;
    */
-  foo2?: number;
+  foo2: number;
 
   /**
    * @generated from field: optional int32 foo3 = 3;
    */
-  foo3?: number;
+  foo3: number;
 
   /**
    * @generated from field: repeated int32 foo4 = 4;
@@ -389,7 +389,7 @@ export declare class ComplexOptionType2 extends Message<ComplexOptionType2> {
   /**
    * @generated from field: optional int32 baz = 2;
    */
-  baz?: number;
+  baz: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
@@ -423,7 +423,7 @@ export declare class ComplexOptionType2_ComplexOptionType4 extends Message<Compl
   /**
    * @generated from field: optional int32 waldo = 1;
    */
-  waldo?: number;
+  waldo: number;
 
   constructor(data?: PartialMessage<ComplexOptionType2_ComplexOptionType4>);
 
@@ -452,7 +452,7 @@ export declare class ComplexOptionType3 extends Message<ComplexOptionType3> {
   /**
    * @generated from field: optional int32 moo = 1;
    */
-  moo?: number;
+  moo: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
@@ -481,7 +481,7 @@ export declare class ComplexOptionType3_ComplexOptionType5 extends Message<Compl
   /**
    * @generated from field: optional int32 plugh = 3;
    */
-  plugh?: number;
+  plugh: number;
 
   constructor(data?: PartialMessage<ComplexOptionType3_ComplexOptionType5>);
 
@@ -505,7 +505,7 @@ export declare class ComplexOpt6 extends Message<ComplexOpt6> {
   /**
    * @generated from field: optional int32 xyzzy = 7593951;
    */
-  xyzzy?: number;
+  xyzzy: number;
 
   constructor(data?: PartialMessage<ComplexOpt6>);
 
@@ -569,7 +569,7 @@ export declare class AggregateMessageSetElement extends Message<AggregateMessage
   /**
    * @generated from field: optional string s = 1;
    */
-  s?: string;
+  s: string;
 
   constructor(data?: PartialMessage<AggregateMessageSetElement>);
 
@@ -600,12 +600,12 @@ export declare class Aggregate extends Message<Aggregate> {
   /**
    * @generated from field: optional int32 i = 1;
    */
-  i?: number;
+  i: number;
 
   /**
    * @generated from field: optional string s = 2;
    */
-  s?: string;
+  s: string;
 
   /**
    * A nested object
@@ -662,7 +662,7 @@ export declare class AggregateMessage extends Message<AggregateMessage> {
   /**
    * @generated from field: optional int32 fieldname = 1;
    */
-  fieldname?: number;
+  fieldname: number;
 
   constructor(data?: PartialMessage<AggregateMessage>);
 
@@ -717,7 +717,7 @@ export declare class NestedOptionType_NestedMessage extends Message<NestedOption
   /**
    * @generated from field: optional int32 nested_field = 1;
    */
-  nestedField?: number;
+  nestedField: number;
 
   constructor(data?: PartialMessage<NestedOptionType_NestedMessage>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_enormous_descriptor_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_enormous_descriptor_pb.d.ts
@@ -37,5002 +37,5002 @@ export declare class TestEnormousDescriptor extends Message<TestEnormousDescript
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1 = 1 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_2 = 2 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_3 = 3 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_4 = 4 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_5 = 5 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_6 = 6 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_7 = 7 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_8 = 8 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_9 = 9 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_10 = 10 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_11 = 11 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_12 = 12 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_13 = 13 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_14 = 14 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_15 = 15 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_16 = 16 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_17 = 17 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_18 = 18 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_19 = 19 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_20 = 20 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_21 = 21 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_22 = 22 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_23 = 23 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_24 = 24 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_25 = 25 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_26 = 26 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_27 = 27 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_28 = 28 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_29 = 29 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_30 = 30 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_31 = 31 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_32 = 32 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_33 = 33 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_34 = 34 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_35 = 35 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_36 = 36 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_37 = 37 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_38 = 38 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_39 = 39 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_40 = 40 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_41 = 41 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_42 = 42 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_43 = 43 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_44 = 44 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_45 = 45 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_46 = 46 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_47 = 47 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_48 = 48 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_49 = 49 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_50 = 50 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_51 = 51 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_52 = 52 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_53 = 53 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_54 = 54 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_55 = 55 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_56 = 56 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_57 = 57 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_58 = 58 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_59 = 59 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_60 = 60 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_61 = 61 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_62 = 62 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_63 = 63 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_64 = 64 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_65 = 65 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_66 = 66 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_67 = 67 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_68 = 68 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_69 = 69 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_70 = 70 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_71 = 71 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_72 = 72 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_73 = 73 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_74 = 74 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_75 = 75 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_76 = 76 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_77 = 77 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_78 = 78 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_79 = 79 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_80 = 80 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_81 = 81 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_82 = 82 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_83 = 83 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_84 = 84 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_85 = 85 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_86 = 86 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_87 = 87 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_88 = 88 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_89 = 89 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_90 = 90 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_91 = 91 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_92 = 92 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_93 = 93 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_94 = 94 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_95 = 95 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_96 = 96 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_97 = 97 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_98 = 98 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_99 = 99 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_100 = 100 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_101 = 101 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_102 = 102 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_103 = 103 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_104 = 104 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_105 = 105 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_106 = 106 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_107 = 107 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_108 = 108 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_109 = 109 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_110 = 110 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_111 = 111 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_112 = 112 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_113 = 113 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_114 = 114 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_115 = 115 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_116 = 116 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_117 = 117 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_118 = 118 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_119 = 119 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_120 = 120 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_121 = 121 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_122 = 122 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_123 = 123 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_124 = 124 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_125 = 125 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_126 = 126 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_127 = 127 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_128 = 128 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_129 = 129 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_130 = 130 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_131 = 131 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_132 = 132 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_133 = 133 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_134 = 134 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_135 = 135 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_136 = 136 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_137 = 137 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_138 = 138 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_139 = 139 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_140 = 140 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_141 = 141 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_142 = 142 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_143 = 143 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_144 = 144 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_145 = 145 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_146 = 146 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_147 = 147 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_148 = 148 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_149 = 149 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_150 = 150 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_151 = 151 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_152 = 152 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_153 = 153 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_154 = 154 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_155 = 155 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_156 = 156 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_157 = 157 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_158 = 158 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_159 = 159 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_160 = 160 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_161 = 161 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_162 = 162 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_163 = 163 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_164 = 164 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_165 = 165 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_166 = 166 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_167 = 167 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_168 = 168 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_169 = 169 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_170 = 170 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_171 = 171 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_172 = 172 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_173 = 173 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_174 = 174 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_175 = 175 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_176 = 176 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_177 = 177 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_178 = 178 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_179 = 179 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_180 = 180 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_181 = 181 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_182 = 182 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_183 = 183 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_184 = 184 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_185 = 185 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_186 = 186 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_187 = 187 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_188 = 188 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_189 = 189 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_190 = 190 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_191 = 191 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_192 = 192 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_193 = 193 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_194 = 194 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_195 = 195 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_196 = 196 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_197 = 197 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_198 = 198 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_199 = 199 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_200 = 200 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_201 = 201 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_202 = 202 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_203 = 203 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_204 = 204 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_205 = 205 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_206 = 206 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_207 = 207 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_208 = 208 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_209 = 209 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_210 = 210 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_211 = 211 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_212 = 212 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_213 = 213 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_214 = 214 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_215 = 215 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_216 = 216 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_217 = 217 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_218 = 218 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_219 = 219 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_220 = 220 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_221 = 221 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_222 = 222 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_223 = 223 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_224 = 224 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_225 = 225 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_226 = 226 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_227 = 227 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_228 = 228 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_229 = 229 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_230 = 230 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_231 = 231 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_232 = 232 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_233 = 233 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_234 = 234 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_235 = 235 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_236 = 236 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_237 = 237 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_238 = 238 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_239 = 239 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_240 = 240 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_241 = 241 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_242 = 242 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_243 = 243 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_244 = 244 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_245 = 245 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_246 = 246 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_247 = 247 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_248 = 248 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_249 = 249 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_250 = 250 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_251 = 251 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_252 = 252 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_253 = 253 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_254 = 254 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_255 = 255 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_256 = 256 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_257 = 257 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_258 = 258 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_259 = 259 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_260 = 260 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_261 = 261 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_262 = 262 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_263 = 263 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_264 = 264 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_265 = 265 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_266 = 266 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_267 = 267 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_268 = 268 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_269 = 269 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_270 = 270 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_271 = 271 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_272 = 272 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_273 = 273 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_274 = 274 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_275 = 275 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_276 = 276 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_277 = 277 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_278 = 278 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_279 = 279 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_280 = 280 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_281 = 281 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_282 = 282 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_283 = 283 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_284 = 284 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_285 = 285 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_286 = 286 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_287 = 287 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_288 = 288 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_289 = 289 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_290 = 290 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_291 = 291 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_292 = 292 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_293 = 293 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_294 = 294 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_295 = 295 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_296 = 296 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_297 = 297 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_298 = 298 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_299 = 299 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_300 = 300 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_301 = 301 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_302 = 302 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_303 = 303 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_304 = 304 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_305 = 305 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_306 = 306 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_307 = 307 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_308 = 308 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_309 = 309 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_310 = 310 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_311 = 311 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_312 = 312 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_313 = 313 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_314 = 314 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_315 = 315 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_316 = 316 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_317 = 317 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_318 = 318 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_319 = 319 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_320 = 320 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_321 = 321 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_322 = 322 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_323 = 323 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_324 = 324 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_325 = 325 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_326 = 326 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_327 = 327 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_328 = 328 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_329 = 329 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_330 = 330 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_331 = 331 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_332 = 332 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_333 = 333 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_334 = 334 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_335 = 335 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_336 = 336 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_337 = 337 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_338 = 338 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_339 = 339 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_340 = 340 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_341 = 341 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_342 = 342 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_343 = 343 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_344 = 344 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_345 = 345 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_346 = 346 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_347 = 347 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_348 = 348 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_349 = 349 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_350 = 350 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_351 = 351 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_352 = 352 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_353 = 353 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_354 = 354 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_355 = 355 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_356 = 356 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_357 = 357 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_358 = 358 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_359 = 359 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_360 = 360 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_361 = 361 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_362 = 362 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_363 = 363 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_364 = 364 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_365 = 365 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_366 = 366 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_367 = 367 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_368 = 368 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_369 = 369 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_370 = 370 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_371 = 371 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_372 = 372 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_373 = 373 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_374 = 374 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_375 = 375 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_376 = 376 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_377 = 377 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_378 = 378 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_379 = 379 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_380 = 380 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_381 = 381 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_382 = 382 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_383 = 383 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_384 = 384 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_385 = 385 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_386 = 386 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_387 = 387 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_388 = 388 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_389 = 389 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_390 = 390 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_391 = 391 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_392 = 392 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_393 = 393 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_394 = 394 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_395 = 395 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_396 = 396 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_397 = 397 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_398 = 398 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_399 = 399 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_400 = 400 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_401 = 401 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_402 = 402 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_403 = 403 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_404 = 404 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_405 = 405 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_406 = 406 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_407 = 407 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_408 = 408 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_409 = 409 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_410 = 410 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_411 = 411 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_412 = 412 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_413 = 413 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_414 = 414 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_415 = 415 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_416 = 416 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_417 = 417 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_418 = 418 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_419 = 419 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_420 = 420 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_421 = 421 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_422 = 422 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_423 = 423 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_424 = 424 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_425 = 425 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_426 = 426 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_427 = 427 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_428 = 428 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_429 = 429 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_430 = 430 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_431 = 431 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_432 = 432 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_433 = 433 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_434 = 434 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_435 = 435 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_436 = 436 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_437 = 437 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_438 = 438 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_439 = 439 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_440 = 440 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_441 = 441 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_442 = 442 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_443 = 443 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_444 = 444 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_445 = 445 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_446 = 446 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_447 = 447 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_448 = 448 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_449 = 449 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_450 = 450 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_451 = 451 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_452 = 452 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_453 = 453 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_454 = 454 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_455 = 455 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_456 = 456 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_457 = 457 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_458 = 458 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_459 = 459 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_460 = 460 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_461 = 461 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_462 = 462 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_463 = 463 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_464 = 464 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_465 = 465 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_466 = 466 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_467 = 467 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_468 = 468 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_469 = 469 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_470 = 470 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_471 = 471 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_472 = 472 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_473 = 473 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_474 = 474 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_475 = 475 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_476 = 476 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_477 = 477 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_478 = 478 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_479 = 479 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_480 = 480 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_481 = 481 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_482 = 482 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_483 = 483 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_484 = 484 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_485 = 485 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_486 = 486 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_487 = 487 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_488 = 488 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_489 = 489 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_490 = 490 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_491 = 491 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_492 = 492 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_493 = 493 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_494 = 494 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_495 = 495 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_496 = 496 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_497 = 497 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_498 = 498 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_499 = 499 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_500 = 500 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_501 = 501 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_502 = 502 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_503 = 503 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_504 = 504 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_505 = 505 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_506 = 506 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_507 = 507 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_508 = 508 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_509 = 509 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_510 = 510 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_511 = 511 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_512 = 512 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_513 = 513 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_514 = 514 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_515 = 515 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_516 = 516 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_517 = 517 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_518 = 518 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_519 = 519 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_520 = 520 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_521 = 521 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_522 = 522 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_523 = 523 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_524 = 524 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_525 = 525 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_526 = 526 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_527 = 527 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_528 = 528 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_529 = 529 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_530 = 530 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_531 = 531 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_532 = 532 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_533 = 533 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_534 = 534 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_535 = 535 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_536 = 536 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_537 = 537 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_538 = 538 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_539 = 539 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_540 = 540 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_541 = 541 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_542 = 542 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_543 = 543 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_544 = 544 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_545 = 545 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_546 = 546 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_547 = 547 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_548 = 548 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_549 = 549 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_550 = 550 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_551 = 551 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_552 = 552 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_553 = 553 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_554 = 554 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_555 = 555 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_556 = 556 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_557 = 557 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_558 = 558 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_559 = 559 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_560 = 560 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_561 = 561 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_562 = 562 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_563 = 563 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_564 = 564 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_565 = 565 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_566 = 566 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_567 = 567 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_568 = 568 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_569 = 569 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_570 = 570 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_571 = 571 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_572 = 572 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_573 = 573 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_574 = 574 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_575 = 575 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_576 = 576 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_577 = 577 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_578 = 578 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_579 = 579 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_580 = 580 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_581 = 581 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_582 = 582 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_583 = 583 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_584 = 584 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_585 = 585 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_586 = 586 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_587 = 587 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_588 = 588 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_589 = 589 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_590 = 590 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_591 = 591 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_592 = 592 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_593 = 593 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_594 = 594 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_595 = 595 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_596 = 596 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_597 = 597 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_598 = 598 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_599 = 599 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_600 = 600 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_601 = 601 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_602 = 602 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_603 = 603 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_604 = 604 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_605 = 605 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_606 = 606 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_607 = 607 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_608 = 608 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_609 = 609 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_610 = 610 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_611 = 611 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_612 = 612 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_613 = 613 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_614 = 614 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_615 = 615 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_616 = 616 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_617 = 617 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_618 = 618 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_619 = 619 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_620 = 620 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_621 = 621 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_622 = 622 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_623 = 623 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_624 = 624 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_625 = 625 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_626 = 626 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_627 = 627 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_628 = 628 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_629 = 629 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_630 = 630 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_631 = 631 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_632 = 632 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_633 = 633 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_634 = 634 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_635 = 635 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_636 = 636 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_637 = 637 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_638 = 638 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_639 = 639 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_640 = 640 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_641 = 641 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_642 = 642 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_643 = 643 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_644 = 644 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_645 = 645 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_646 = 646 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_647 = 647 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_648 = 648 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_649 = 649 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_650 = 650 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_651 = 651 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_652 = 652 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_653 = 653 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_654 = 654 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_655 = 655 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_656 = 656 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_657 = 657 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_658 = 658 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_659 = 659 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_660 = 660 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_661 = 661 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_662 = 662 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_663 = 663 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_664 = 664 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_665 = 665 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_666 = 666 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_667 = 667 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_668 = 668 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_669 = 669 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_670 = 670 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_671 = 671 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_672 = 672 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_673 = 673 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_674 = 674 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_675 = 675 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_676 = 676 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_677 = 677 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_678 = 678 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_679 = 679 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_680 = 680 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_681 = 681 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_682 = 682 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_683 = 683 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_684 = 684 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_685 = 685 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_686 = 686 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_687 = 687 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_688 = 688 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_689 = 689 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_690 = 690 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_691 = 691 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_692 = 692 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_693 = 693 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_694 = 694 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_695 = 695 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_696 = 696 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_697 = 697 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_698 = 698 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_699 = 699 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_700 = 700 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_701 = 701 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_702 = 702 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_703 = 703 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_704 = 704 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_705 = 705 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_706 = 706 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_707 = 707 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_708 = 708 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_709 = 709 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_710 = 710 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_711 = 711 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_712 = 712 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_713 = 713 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_714 = 714 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_715 = 715 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_716 = 716 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_717 = 717 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_718 = 718 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_719 = 719 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_720 = 720 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_721 = 721 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_722 = 722 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_723 = 723 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_724 = 724 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_725 = 725 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_726 = 726 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_727 = 727 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_728 = 728 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_729 = 729 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_730 = 730 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_731 = 731 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_732 = 732 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_733 = 733 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_734 = 734 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_735 = 735 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_736 = 736 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_737 = 737 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_738 = 738 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_739 = 739 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_740 = 740 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_741 = 741 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_742 = 742 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_743 = 743 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_744 = 744 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_745 = 745 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_746 = 746 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_747 = 747 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_748 = 748 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_749 = 749 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_750 = 750 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_751 = 751 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_752 = 752 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_753 = 753 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_754 = 754 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_755 = 755 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_756 = 756 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_757 = 757 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_758 = 758 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_759 = 759 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_760 = 760 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_761 = 761 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_762 = 762 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_763 = 763 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_764 = 764 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_765 = 765 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_766 = 766 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_767 = 767 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_768 = 768 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_769 = 769 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_770 = 770 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_771 = 771 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_772 = 772 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_773 = 773 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_774 = 774 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_775 = 775 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_776 = 776 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_777 = 777 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_778 = 778 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_779 = 779 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_780 = 780 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_781 = 781 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_782 = 782 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_783 = 783 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_784 = 784 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_785 = 785 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_786 = 786 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_787 = 787 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_788 = 788 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_789 = 789 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_790 = 790 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_791 = 791 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_792 = 792 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_793 = 793 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_794 = 794 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_795 = 795 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_796 = 796 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_797 = 797 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_798 = 798 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_799 = 799 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_800 = 800 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_801 = 801 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_802 = 802 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_803 = 803 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_804 = 804 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_805 = 805 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_806 = 806 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_807 = 807 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_808 = 808 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_809 = 809 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_810 = 810 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_811 = 811 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_812 = 812 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_813 = 813 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_814 = 814 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_815 = 815 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_816 = 816 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_817 = 817 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_818 = 818 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_819 = 819 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_820 = 820 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_821 = 821 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_822 = 822 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_823 = 823 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_824 = 824 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_825 = 825 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_826 = 826 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_827 = 827 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_828 = 828 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_829 = 829 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_830 = 830 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_831 = 831 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_832 = 832 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_833 = 833 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_834 = 834 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_835 = 835 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_836 = 836 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_837 = 837 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_838 = 838 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_839 = 839 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_840 = 840 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_841 = 841 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_842 = 842 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_843 = 843 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_844 = 844 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_845 = 845 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_846 = 846 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_847 = 847 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_848 = 848 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_849 = 849 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_850 = 850 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_851 = 851 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_852 = 852 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_853 = 853 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_854 = 854 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_855 = 855 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_856 = 856 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_857 = 857 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_858 = 858 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_859 = 859 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_860 = 860 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_861 = 861 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_862 = 862 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_863 = 863 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_864 = 864 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_865 = 865 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_866 = 866 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_867 = 867 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_868 = 868 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_869 = 869 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_870 = 870 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_871 = 871 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_872 = 872 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_873 = 873 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_874 = 874 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_875 = 875 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_876 = 876 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_877 = 877 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_878 = 878 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_879 = 879 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_880 = 880 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_881 = 881 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_882 = 882 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_883 = 883 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_884 = 884 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_885 = 885 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_886 = 886 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_887 = 887 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_888 = 888 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_889 = 889 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_890 = 890 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_891 = 891 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_892 = 892 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_893 = 893 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_894 = 894 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_895 = 895 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_896 = 896 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_897 = 897 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_898 = 898 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_899 = 899 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_900 = 900 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_901 = 901 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_902 = 902 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_903 = 903 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_904 = 904 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_905 = 905 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_906 = 906 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_907 = 907 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_908 = 908 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_909 = 909 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_910 = 910 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_911 = 911 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_912 = 912 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_913 = 913 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_914 = 914 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_915 = 915 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_916 = 916 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_917 = 917 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_918 = 918 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_919 = 919 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_920 = 920 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_921 = 921 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_922 = 922 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_923 = 923 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_924 = 924 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_925 = 925 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_926 = 926 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_927 = 927 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_928 = 928 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_929 = 929 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_930 = 930 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_931 = 931 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_932 = 932 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_933 = 933 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_934 = 934 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_935 = 935 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_936 = 936 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_937 = 937 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_938 = 938 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_939 = 939 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_940 = 940 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_941 = 941 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_942 = 942 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_943 = 943 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_944 = 944 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_945 = 945 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_946 = 946 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_947 = 947 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_948 = 948 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_949 = 949 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_950 = 950 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_951 = 951 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_952 = 952 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_953 = 953 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_954 = 954 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_955 = 955 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_956 = 956 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_957 = 957 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_958 = 958 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_959 = 959 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_960 = 960 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_961 = 961 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_962 = 962 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_963 = 963 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_964 = 964 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_965 = 965 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_966 = 966 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_967 = 967 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_968 = 968 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_969 = 969 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_970 = 970 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_971 = 971 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_972 = 972 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_973 = 973 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_974 = 974 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_975 = 975 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_976 = 976 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_977 = 977 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_978 = 978 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_979 = 979 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_980 = 980 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_981 = 981 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_982 = 982 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_983 = 983 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_984 = 984 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_985 = 985 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_986 = 986 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_987 = 987 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_988 = 988 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_989 = 989 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_990 = 990 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_991 = 991 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_992 = 992 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_993 = 993 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_994 = 994 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_995 = 995 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_996 = 996 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_997 = 997 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_998 = 998 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_999 = 999 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1000 = 1000 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000?: string;
+  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000: string;
 
   constructor(data?: PartialMessage<TestEnormousDescriptor>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_features_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_features_pb.d.ts
@@ -74,62 +74,62 @@ export declare class TestFeatures extends Message<TestFeatures> {
   /**
    * @generated from field: optional int32 int_file_feature = 1;
    */
-  intFileFeature?: number;
+  intFileFeature: number;
 
   /**
    * @generated from field: optional int32 int_extension_range_feature = 2;
    */
-  intExtensionRangeFeature?: number;
+  intExtensionRangeFeature: number;
 
   /**
    * @generated from field: optional int32 int_message_feature = 3;
    */
-  intMessageFeature?: number;
+  intMessageFeature: number;
 
   /**
    * @generated from field: optional int32 int_field_feature = 4;
    */
-  intFieldFeature?: number;
+  intFieldFeature: number;
 
   /**
    * @generated from field: optional int32 int_oneof_feature = 5;
    */
-  intOneofFeature?: number;
+  intOneofFeature: number;
 
   /**
    * @generated from field: optional int32 int_enum_feature = 6;
    */
-  intEnumFeature?: number;
+  intEnumFeature: number;
 
   /**
    * @generated from field: optional int32 int_enum_entry_feature = 7;
    */
-  intEnumEntryFeature?: number;
+  intEnumEntryFeature: number;
 
   /**
    * @generated from field: optional int32 int_service_feature = 8;
    */
-  intServiceFeature?: number;
+  intServiceFeature: number;
 
   /**
    * @generated from field: optional int32 int_method_feature = 9;
    */
-  intMethodFeature?: number;
+  intMethodFeature: number;
 
   /**
    * @generated from field: optional int32 int_multiple_feature = 10;
    */
-  intMultipleFeature?: number;
+  intMultipleFeature: number;
 
   /**
    * @generated from field: optional bool bool_field_feature = 11;
    */
-  boolFieldFeature?: boolean;
+  boolFieldFeature: boolean;
 
   /**
    * @generated from field: optional float float_field_feature = 12;
    */
-  floatFieldFeature?: number;
+  floatFieldFeature: number;
 
   /**
    * @generated from field: optional pb.TestFeatures.MessageFeature message_field_feature = 13;
@@ -139,17 +139,17 @@ export declare class TestFeatures extends Message<TestFeatures> {
   /**
    * @generated from field: optional pb.TestFeatures.EnumFeature enum_field_feature = 14;
    */
-  enumFieldFeature?: TestFeatures_EnumFeature;
+  enumFieldFeature: TestFeatures_EnumFeature;
 
   /**
    * @generated from field: optional int32 int_source_feature = 15;
    */
-  intSourceFeature?: number;
+  intSourceFeature: number;
 
   /**
    * @generated from field: optional string string_source_feature = 16;
    */
-  stringSourceFeature?: string;
+  stringSourceFeature: string;
 
   constructor(data?: PartialMessage<TestFeatures>);
 
@@ -208,22 +208,22 @@ export declare class TestFeatures_MessageFeature extends Message<TestFeatures_Me
   /**
    * @generated from field: optional bool bool_field = 1;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: optional int32 int_field = 2;
    */
-  intField?: number;
+  intField: number;
 
   /**
    * @generated from field: optional float float_field = 3;
    */
-  floatField?: number;
+  floatField: number;
 
   /**
    * @generated from field: optional string string_field = 4;
    */
-  stringField?: string;
+  stringField: string;
 
   constructor(data?: PartialMessage<TestFeatures_MessageFeature>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_lite_pb.d.ts
@@ -50,7 +50,7 @@ export declare class ImportMessageLite extends Message<ImportMessageLite> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  d: number;
 
   constructor(data?: PartialMessage<ImportMessageLite>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_pb.d.ts
@@ -79,7 +79,7 @@ export declare class ImportMessage extends Message<ImportMessage> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  d: number;
 
   constructor(data?: PartialMessage<ImportMessage>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_lite_pb.d.ts
@@ -28,7 +28,7 @@ export declare class PublicImportMessageLite extends Message<PublicImportMessage
   /**
    * @generated from field: optional int32 e = 1;
    */
-  e?: number;
+  e: number;
 
   constructor(data?: PartialMessage<PublicImportMessageLite>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_import_public_pb.d.ts
@@ -28,7 +28,7 @@ export declare class PublicImportMessage extends Message<PublicImportMessage> {
   /**
    * @generated from field: optional int32 e = 1;
    */
-  e?: number;
+  e: number;
 
   constructor(data?: PartialMessage<PublicImportMessage>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_pb.d.ts
@@ -81,77 +81,77 @@ export declare class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.OptionalGroup optionalgroup = 16;
@@ -176,27 +176,27 @@ export declare class TestAllTypesLite extends Message<TestAllTypesLite> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesLite_NestedEnum;
+  optionalNestedEnum: TestAllTypesLite_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumLite;
+  optionalForeignEnum: ForeignEnumLite;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnumLite optional_import_enum = 23;
    */
-  optionalImportEnum?: ImportEnumLite;
+  optionalImportEnum: ImportEnumLite;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord: string;
 
   /**
    * Defined in unittest_import_public.proto
@@ -347,102 +347,102 @@ export declare class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 default_int32 = 61 [default = 41];
    */
-  defaultInt32?: number;
+  defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 62 [default = 42];
    */
-  defaultInt64?: bigint;
+  defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 63 [default = 43];
    */
-  defaultUint32?: number;
+  defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 64 [default = 44];
    */
-  defaultUint64?: bigint;
+  defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 65 [default = -45];
    */
-  defaultSint32?: number;
+  defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 66 [default = 46];
    */
-  defaultSint64?: bigint;
+  defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 67 [default = 47];
    */
-  defaultFixed32?: number;
+  defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 68 [default = 48];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 69 [default = 49];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 70 [default = -50];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 71 [default = 51.5];
    */
-  defaultFloat?: number;
+  defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 72 [default = 52000];
    */
-  defaultDouble?: number;
+  defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 73 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 74 [default = "hello"];
    */
-  defaultString?: string;
+  defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 75 [default = "world"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedEnum default_nested_enum = 81 [default = BAR];
    */
-  defaultNestedEnum?: TestAllTypesLite_NestedEnum;
+  defaultNestedEnum: TestAllTypesLite_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite default_foreign_enum = 82 [default = FOREIGN_LITE_BAR];
    */
-  defaultForeignEnum?: ForeignEnumLite;
+  defaultForeignEnum: ForeignEnumLite;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnumLite default_import_enum = 83 [default = IMPORT_LITE_BAR];
    */
-  defaultImportEnum?: ImportEnumLite;
+  defaultImportEnum: ImportEnumLite;
 
   /**
    * @generated from field: optional string default_string_piece = 84 [default = "abc"];
    */
-  defaultStringPiece?: string;
+  defaultStringPiece: string;
 
   /**
    * @generated from field: optional string default_cord = 85 [default = "123"];
    */
-  defaultCord?: string;
+  defaultCord: string;
 
   /**
    * For oneof test
@@ -492,7 +492,7 @@ export declare class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 deceptively_named_list = 116;
    */
-  deceptivelyNamedList?: number;
+  deceptivelyNamedList: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite>);
 
@@ -536,12 +536,12 @@ export declare class TestAllTypesLite_NestedMessage extends Message<TestAllTypes
   /**
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb: number;
 
   /**
    * @generated from field: optional int64 cc = 2;
    */
-  cc?: bigint;
+  cc: bigint;
 
   /**
    * @generated from field: repeated int32 dd = 3 [packed = true];
@@ -570,7 +570,7 @@ export declare class TestAllTypesLite_NestedMessage2 extends Message<TestAllType
   /**
    * @generated from field: optional int32 dd = 1;
    */
-  dd?: number;
+  dd: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite_NestedMessage2>);
 
@@ -594,7 +594,7 @@ export declare class TestAllTypesLite_OptionalGroup extends Message<TestAllTypes
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite_OptionalGroup>);
 
@@ -618,7 +618,7 @@ export declare class TestAllTypesLite_RepeatedGroup extends Message<TestAllTypes
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite_RepeatedGroup>);
 
@@ -642,7 +642,7 @@ export declare class ForeignMessageLite extends Message<ForeignMessageLite> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c: number;
 
   constructor(data?: PartialMessage<ForeignMessageLite>);
 
@@ -774,7 +774,7 @@ export declare class OptionalGroup_extension_lite extends Message<OptionalGroup_
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<OptionalGroup_extension_lite>);
 
@@ -798,7 +798,7 @@ export declare class RepeatedGroup_extension_lite extends Message<RepeatedGroup_
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<RepeatedGroup_extension_lite>);
 
@@ -869,7 +869,7 @@ export declare class TestDeprecatedLite extends Message<TestDeprecatedLite> {
    * @generated from field: optional int32 deprecated_field = 1 [deprecated = true];
    * @deprecated
    */
-  deprecatedField?: number;
+  deprecatedField: number;
 
   /**
    * @generated from field: required int32 deprecated_field2 = 2 [deprecated = true];
@@ -881,7 +881,7 @@ export declare class TestDeprecatedLite extends Message<TestDeprecatedLite> {
    * @generated from field: optional string deprecated_field3 = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedField3?: string;
+  deprecatedField3: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDeprecatedLite deprecated_field4 = 4 [deprecated = true];
@@ -1192,7 +1192,7 @@ export declare class V1MessageLite extends Message<V1MessageLite> {
   /**
    * @generated from field: optional protobuf_unittest.V1EnumLite enum_field = 2 [default = V1_FIRST];
    */
-  enumField?: V1EnumLite;
+  enumField: V1EnumLite;
 
   constructor(data?: PartialMessage<V1MessageLite>);
 
@@ -1221,7 +1221,7 @@ export declare class V2MessageLite extends Message<V2MessageLite> {
   /**
    * @generated from field: optional protobuf_unittest.V2EnumLite enum_field = 2 [default = V2_FIRST];
    */
-  enumField?: V2EnumLite;
+  enumField: V2EnumLite;
 
   constructor(data?: PartialMessage<V2MessageLite>);
 
@@ -1245,12 +1245,12 @@ export declare class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbe
   /**
    * @generated from field: optional int32 optional_int32 = 536870000;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int32 fixed_32 = 536870001;
    */
-  fixed32?: number;
+  fixed32: number;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 536870002 [packed = false];
@@ -1265,17 +1265,17 @@ export declare class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbe
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite optional_enum = 536870004;
    */
-  optionalEnum?: ForeignEnumLite;
+  optionalEnum: ForeignEnumLite;
 
   /**
    * @generated from field: optional string optional_string = 536870005;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 536870006;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessageLite optional_message = 536870007;
@@ -1343,7 +1343,7 @@ export declare class TestHugeFieldNumbersLite_OptionalGroup extends Message<Test
   /**
    * @generated from field: optional int32 group_a = 536870009;
    */
-  groupA?: number;
+  groupA: number;
 
   constructor(data?: PartialMessage<TestHugeFieldNumbersLite_OptionalGroup>);
 
@@ -1620,7 +1620,7 @@ export declare class RecursiveMessage extends Message<RecursiveMessage> {
   /**
    * @generated from field: optional bytes payload = 2;
    */
-  payload?: Uint8Array;
+  payload: Uint8Array;
 
   constructor(data?: PartialMessage<RecursiveMessage>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
@@ -92,12 +92,12 @@ export declare class NestedTestInt extends Message<NestedTestInt> {
   /**
    * @generated from field: optional fixed32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional int32 b = 3;
    */
-  b?: number;
+  b: number;
 
   /**
    * @generated from field: optional protobuf_unittest.NestedTestInt child = 2;
@@ -126,7 +126,7 @@ export declare class TestMessageSetExtension1 extends Message<TestMessageSetExte
   /**
    * @generated from field: optional int32 i = 15;
    */
-  i?: number;
+  i: number;
 
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
@@ -136,7 +136,7 @@ export declare class TestMessageSetExtension1 extends Message<TestMessageSetExte
   /**
    * @generated from field: optional string test_aliasing = 17;
    */
-  testAliasing?: string;
+  testAliasing: string;
 
   constructor(data?: PartialMessage<TestMessageSetExtension1>);
 
@@ -165,7 +165,7 @@ export declare class TestMessageSetExtension2 extends Message<TestMessageSetExte
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  str: string;
 
   constructor(data?: PartialMessage<TestMessageSetExtension2>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
@@ -38,7 +38,7 @@ export declare class TestMessage extends Message<TestMessage> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestMessage>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
@@ -33,7 +33,7 @@ export declare class TestOptimizedForSize extends Message<TestOptimizedForSize> 
   /**
    * @generated from field: optional int32 i = 1;
    */
-  i?: number;
+  i: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage msg = 19;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -666,77 +666,77 @@ export declare class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.OptionalGroup optionalgroup = 16;
@@ -761,27 +761,27 @@ export declare class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypes_NestedEnum;
+  optionalNestedEnum: TestAllTypes_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnum;
+  optionalForeignEnum: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnum optional_import_enum = 23;
    */
-  optionalImportEnum?: ImportEnum;
+  optionalImportEnum: ImportEnum;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  optionalCord: string;
 
   /**
    * Defined in unittest_import_public.proto
@@ -932,102 +932,102 @@ export declare class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 default_int32 = 61 [default = 41];
    */
-  defaultInt32?: number;
+  defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 62 [default = 42];
    */
-  defaultInt64?: bigint;
+  defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 63 [default = 43];
    */
-  defaultUint32?: number;
+  defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 64 [default = 44];
    */
-  defaultUint64?: bigint;
+  defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 65 [default = -45];
    */
-  defaultSint32?: number;
+  defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 66 [default = 46];
    */
-  defaultSint64?: bigint;
+  defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 67 [default = 47];
    */
-  defaultFixed32?: number;
+  defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 68 [default = 48];
    */
-  defaultFixed64?: bigint;
+  defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 69 [default = 49];
    */
-  defaultSfixed32?: number;
+  defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 70 [default = -50];
    */
-  defaultSfixed64?: bigint;
+  defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 71 [default = 51.5];
    */
-  defaultFloat?: number;
+  defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 72 [default = 52000];
    */
-  defaultDouble?: number;
+  defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 73 [default = true];
    */
-  defaultBool?: boolean;
+  defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 74 [default = "hello"];
    */
-  defaultString?: string;
+  defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 75 [default = "world"];
    */
-  defaultBytes?: Uint8Array;
+  defaultBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedEnum default_nested_enum = 81 [default = BAR];
    */
-  defaultNestedEnum?: TestAllTypes_NestedEnum;
+  defaultNestedEnum: TestAllTypes_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum default_foreign_enum = 82 [default = FOREIGN_BAR];
    */
-  defaultForeignEnum?: ForeignEnum;
+  defaultForeignEnum: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnum default_import_enum = 83 [default = IMPORT_BAR];
    */
-  defaultImportEnum?: ImportEnum;
+  defaultImportEnum: ImportEnum;
 
   /**
    * @generated from field: optional string default_string_piece = 84 [default = "abc"];
    */
-  defaultStringPiece?: string;
+  defaultStringPiece: string;
 
   /**
    * @generated from field: optional string default_cord = 85 [default = "123"];
    */
-  defaultCord?: string;
+  defaultCord: string;
 
   /**
    * For oneof test
@@ -1131,7 +1131,7 @@ export declare class TestAllTypes_NestedMessage extends Message<TestAllTypes_Nes
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb: number;
 
   constructor(data?: PartialMessage<TestAllTypes_NestedMessage>);
 
@@ -1155,7 +1155,7 @@ export declare class TestAllTypes_OptionalGroup extends Message<TestAllTypes_Opt
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestAllTypes_OptionalGroup>);
 
@@ -1179,7 +1179,7 @@ export declare class TestAllTypes_RepeatedGroup extends Message<TestAllTypes_Rep
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestAllTypes_RepeatedGroup>);
 
@@ -1250,7 +1250,7 @@ export declare class TestDeprecatedFields extends Message<TestDeprecatedFields> 
    * @generated from field: optional int32 deprecated_int32 = 1 [deprecated = true];
    * @deprecated
    */
-  deprecatedInt32?: number;
+  deprecatedInt32: number;
 
   /**
    * @generated from field: repeated string deprecated_repeated_string = 4 [deprecated = true];
@@ -1326,12 +1326,12 @@ export declare class ForeignMessage extends Message<ForeignMessage> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  c: number;
 
   /**
    * @generated from field: optional int32 d = 2;
    */
-  d?: number;
+  d: number;
 
   constructor(data?: PartialMessage<ForeignMessage>);
 
@@ -1393,7 +1393,7 @@ export declare class OptionalGroup_extension extends Message<OptionalGroup_exten
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<OptionalGroup_extension>);
 
@@ -1417,7 +1417,7 @@ export declare class RepeatedGroup_extension extends Message<RepeatedGroup_exten
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<RepeatedGroup_extension>);
 
@@ -1441,7 +1441,7 @@ export declare class TestMixedFieldsAndExtensions extends Message<TestMixedField
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: repeated fixed32 b = 3;
@@ -1485,7 +1485,7 @@ export declare class TestGroup extends Message<TestGroup> {
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnum;
+  optionalForeignEnum: ForeignEnum;
 
   constructor(data?: PartialMessage<TestGroup>);
 
@@ -1509,14 +1509,14 @@ export declare class TestGroup_OptionalGroup extends Message<TestGroup_OptionalG
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a: number;
 
   /**
    * fast table size must be at least 16, for this
    *
    * @generated from field: optional int32 zz = 89;
    */
-  zz?: number;
+  zz: number;
 
   constructor(data?: PartialMessage<TestGroup_OptionalGroup>);
 
@@ -1578,7 +1578,7 @@ export declare class TestNestedExtension_OptionalGroup_extension extends Message
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestNestedExtension_OptionalGroup_extension>);
 
@@ -1628,12 +1628,12 @@ export declare class TestChildExtension extends Message<TestChildExtension> {
   /**
    * @generated from field: optional string a = 1;
    */
-  a?: string;
+  a: string;
 
   /**
    * @generated from field: optional string b = 2;
    */
-  b?: string;
+  b: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllExtensions optional_extension = 3;
@@ -1665,12 +1665,12 @@ export declare class TestChildExtensionData extends Message<TestChildExtensionDa
   /**
    * @generated from field: optional string a = 1;
    */
-  a?: string;
+  a: string;
 
   /**
    * @generated from field: optional string b = 2;
    */
-  b?: string;
+  b: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
@@ -1723,12 +1723,12 @@ export declare class TestChildExtensionData_NestedTestAllExtensionsData_NestedDy
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  b: number;
 
   constructor(data?: PartialMessage<TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions>);
 
@@ -1752,7 +1752,7 @@ export declare class TestNestedChildExtension extends Message<TestNestedChildExt
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtension child = 2;
@@ -1784,7 +1784,7 @@ export declare class TestNestedChildExtensionData extends Message<TestNestedChil
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData child = 2;
@@ -1823,7 +1823,7 @@ export declare class TestRequiredEnum extends Message<TestRequiredEnum> {
    *
    * @generated from field: optional int32 a = 2;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestRequiredEnum>);
 
@@ -1856,7 +1856,7 @@ export declare class TestRequiredEnumNoMask extends Message<TestRequiredEnumNoMa
    *
    * @generated from field: optional int32 a = 2;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestRequiredEnumNoMask>);
 
@@ -1915,7 +1915,7 @@ export declare class TestRequiredEnumMulti extends Message<TestRequiredEnumMulti
   /**
    * @generated from field: optional int32 a_3 = 3;
    */
-  a3?: number;
+  a3: number;
 
   /**
    * @generated from field: required protobuf_unittest.TestRequiredEnumMulti.NestedEnum required_enum_2 = 2;
@@ -1998,7 +1998,7 @@ export declare class TestRequiredNoMaskMulti extends Message<TestRequiredNoMaskM
   /**
    * @generated from field: optional int32 a_3 = 3;
    */
-  a3?: number;
+  a3: number;
 
   /**
    * @generated from field: required protobuf_unittest.TestRequiredNoMaskMulti.NestedEnum required_enum_2 = 2;
@@ -2068,7 +2068,7 @@ export declare class TestRequired extends Message<TestRequired> {
   /**
    * @generated from field: optional int32 dummy2 = 2;
    */
-  dummy2?: number;
+  dummy2: number;
 
   /**
    * @generated from field: required int32 b = 3;
@@ -2081,147 +2081,147 @@ export declare class TestRequired extends Message<TestRequired> {
    *
    * @generated from field: optional int32 dummy4 = 4;
    */
-  dummy4?: number;
+  dummy4: number;
 
   /**
    * @generated from field: optional int32 dummy5 = 5;
    */
-  dummy5?: number;
+  dummy5: number;
 
   /**
    * @generated from field: optional int32 dummy6 = 6;
    */
-  dummy6?: number;
+  dummy6: number;
 
   /**
    * @generated from field: optional int32 dummy7 = 7;
    */
-  dummy7?: number;
+  dummy7: number;
 
   /**
    * @generated from field: optional int32 dummy8 = 8;
    */
-  dummy8?: number;
+  dummy8: number;
 
   /**
    * @generated from field: optional int32 dummy9 = 9;
    */
-  dummy9?: number;
+  dummy9: number;
 
   /**
    * @generated from field: optional int32 dummy10 = 10;
    */
-  dummy10?: number;
+  dummy10: number;
 
   /**
    * @generated from field: optional int32 dummy11 = 11;
    */
-  dummy11?: number;
+  dummy11: number;
 
   /**
    * @generated from field: optional int32 dummy12 = 12;
    */
-  dummy12?: number;
+  dummy12: number;
 
   /**
    * @generated from field: optional int32 dummy13 = 13;
    */
-  dummy13?: number;
+  dummy13: number;
 
   /**
    * @generated from field: optional int32 dummy14 = 14;
    */
-  dummy14?: number;
+  dummy14: number;
 
   /**
    * @generated from field: optional int32 dummy15 = 15;
    */
-  dummy15?: number;
+  dummy15: number;
 
   /**
    * @generated from field: optional int32 dummy16 = 16;
    */
-  dummy16?: number;
+  dummy16: number;
 
   /**
    * @generated from field: optional int32 dummy17 = 17;
    */
-  dummy17?: number;
+  dummy17: number;
 
   /**
    * @generated from field: optional int32 dummy18 = 18;
    */
-  dummy18?: number;
+  dummy18: number;
 
   /**
    * @generated from field: optional int32 dummy19 = 19;
    */
-  dummy19?: number;
+  dummy19: number;
 
   /**
    * @generated from field: optional int32 dummy20 = 20;
    */
-  dummy20?: number;
+  dummy20: number;
 
   /**
    * @generated from field: optional int32 dummy21 = 21;
    */
-  dummy21?: number;
+  dummy21: number;
 
   /**
    * @generated from field: optional int32 dummy22 = 22;
    */
-  dummy22?: number;
+  dummy22: number;
 
   /**
    * @generated from field: optional int32 dummy23 = 23;
    */
-  dummy23?: number;
+  dummy23: number;
 
   /**
    * @generated from field: optional int32 dummy24 = 24;
    */
-  dummy24?: number;
+  dummy24: number;
 
   /**
    * @generated from field: optional int32 dummy25 = 25;
    */
-  dummy25?: number;
+  dummy25: number;
 
   /**
    * @generated from field: optional int32 dummy26 = 26;
    */
-  dummy26?: number;
+  dummy26: number;
 
   /**
    * @generated from field: optional int32 dummy27 = 27;
    */
-  dummy27?: number;
+  dummy27: number;
 
   /**
    * @generated from field: optional int32 dummy28 = 28;
    */
-  dummy28?: number;
+  dummy28: number;
 
   /**
    * @generated from field: optional int32 dummy29 = 29;
    */
-  dummy29?: number;
+  dummy29: number;
 
   /**
    * @generated from field: optional int32 dummy30 = 30;
    */
-  dummy30?: number;
+  dummy30: number;
 
   /**
    * @generated from field: optional int32 dummy31 = 31;
    */
-  dummy31?: number;
+  dummy31: number;
 
   /**
    * @generated from field: optional int32 dummy32 = 32;
    */
-  dummy32?: number;
+  dummy32: number;
 
   /**
    * @generated from field: required int32 c = 33;
@@ -2277,7 +2277,7 @@ export declare class TestRequiredForeign extends Message<TestRequiredForeign> {
   /**
    * @generated from field: optional int32 dummy = 3;
    */
-  dummy?: number;
+  dummy: number;
 
   /**
    * Missing required fields must not affect verification of child messages.
@@ -2352,7 +2352,7 @@ export declare class TestNestedRequiredForeign extends Message<TestNestedRequire
   /**
    * @generated from field: optional int32 dummy = 3;
    */
-  dummy?: number;
+  dummy: number;
 
   /**
    * optional message to test required closed enum.
@@ -2488,7 +2488,7 @@ export declare class TestPickleNestedMessage_NestedMessage extends Message<TestP
   /**
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb: number;
 
   constructor(data?: PartialMessage<TestPickleNestedMessage_NestedMessage>);
 
@@ -2512,7 +2512,7 @@ export declare class TestPickleNestedMessage_NestedMessage_NestedNestedMessage e
   /**
    * @generated from field: optional int32 cc = 1;
    */
-  cc?: number;
+  cc: number;
 
   constructor(data?: PartialMessage<TestPickleNestedMessage_NestedMessage_NestedNestedMessage>);
 
@@ -2560,12 +2560,12 @@ export declare class TestReallyLargeTagNumber extends Message<TestReallyLargeTag
    *
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional int32 bb = 268435455;
    */
-  bb?: number;
+  bb: number;
 
   constructor(data?: PartialMessage<TestReallyLargeTagNumber>);
 
@@ -2594,7 +2594,7 @@ export declare class TestRecursiveMessage extends Message<TestRecursiveMessage> 
   /**
    * @generated from field: optional int32 i = 2;
    */
-  i?: number;
+  i: number;
 
   constructor(data?: PartialMessage<TestRecursiveMessage>);
 
@@ -2738,7 +2738,7 @@ export declare class TestMutualRecursionB extends Message<TestMutualRecursionB> 
   /**
    * @generated from field: optional int32 optional_int32 = 2;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   constructor(data?: PartialMessage<TestMutualRecursionB>);
 
@@ -2843,7 +2843,7 @@ export declare class TestDupFieldNumber extends Message<TestDupFieldNumber> {
    *
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDupFieldNumber.Foo foo = 2;
@@ -2877,7 +2877,7 @@ export declare class TestDupFieldNumber_Foo extends Message<TestDupFieldNumber_F
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestDupFieldNumber_Foo>);
 
@@ -2901,7 +2901,7 @@ export declare class TestDupFieldNumber_Bar extends Message<TestDupFieldNumber_B
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  a: number;
 
   constructor(data?: PartialMessage<TestDupFieldNumber_Bar>);
 
@@ -3115,17 +3115,17 @@ export declare class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldN
   /**
    * @generated from field: optional int32 PrimitiveField = 1;
    */
-  PrimitiveField?: number;
+  PrimitiveField: number;
 
   /**
    * @generated from field: optional string StringField = 2;
    */
-  StringField?: string;
+  StringField: string;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum EnumField = 3;
    */
-  EnumField?: ForeignEnum;
+  EnumField: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage MessageField = 4;
@@ -3135,12 +3135,12 @@ export declare class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldN
   /**
    * @generated from field: optional string StringPieceField = 5;
    */
-  StringPieceField?: string;
+  StringPieceField: string;
 
   /**
    * @generated from field: optional string CordField = 6;
    */
-  CordField?: string;
+  CordField: string;
 
   /**
    * @generated from field: repeated int32 RepeatedPrimitiveField = 7;
@@ -3197,17 +3197,17 @@ export declare class TestFieldOrderings extends Message<TestFieldOrderings> {
   /**
    * @generated from field: optional string my_string = 11;
    */
-  myString?: string;
+  myString: string;
 
   /**
    * @generated from field: optional int64 my_int = 1;
    */
-  myInt?: bigint;
+  myInt: bigint;
 
   /**
    * @generated from field: optional float my_float = 101;
    */
-  myFloat?: number;
+  myFloat: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
@@ -3236,7 +3236,7 @@ export declare class TestFieldOrderings_NestedMessage extends Message<TestFieldO
   /**
    * @generated from field: optional int64 oo = 2;
    */
-  oo?: bigint;
+  oo: bigint;
 
   /**
    * The field name "b" fails to compile in proto1 because it conflicts with
@@ -3245,7 +3245,7 @@ export declare class TestFieldOrderings_NestedMessage extends Message<TestFieldO
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb: number;
 
   constructor(data?: PartialMessage<TestFieldOrderings_NestedMessage>);
 
@@ -3269,7 +3269,7 @@ export declare class TestExtensionOrderings1 extends Message<TestExtensionOrderi
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  myString: string;
 
   constructor(data?: PartialMessage<TestExtensionOrderings1>);
 
@@ -3298,7 +3298,7 @@ export declare class TestExtensionOrderings2 extends Message<TestExtensionOrderi
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  myString: string;
 
   constructor(data?: PartialMessage<TestExtensionOrderings2>);
 
@@ -3322,7 +3322,7 @@ export declare class TestExtensionOrderings2_TestExtensionOrderings3 extends Mes
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  myString: string;
 
   constructor(data?: PartialMessage<TestExtensionOrderings2_TestExtensionOrderings3>);
 
@@ -3356,37 +3356,37 @@ export declare class TestExtremeDefaultValues extends Message<TestExtremeDefault
   /**
    * @generated from field: optional bytes escaped_bytes = 1 [default = "\000\001\007\010\014\n\r\t\013\\\'\\"\376"];
    */
-  escapedBytes?: Uint8Array;
+  escapedBytes: Uint8Array;
 
   /**
    * @generated from field: optional uint32 large_uint32 = 2 [default = 4294967295];
    */
-  largeUint32?: number;
+  largeUint32: number;
 
   /**
    * @generated from field: optional uint64 large_uint64 = 3 [default = 18446744073709551615];
    */
-  largeUint64?: bigint;
+  largeUint64: bigint;
 
   /**
    * @generated from field: optional int32 small_int32 = 4 [default = -2147483647];
    */
-  smallInt32?: number;
+  smallInt32: number;
 
   /**
    * @generated from field: optional int64 small_int64 = 5 [default = -9223372036854775807];
    */
-  smallInt64?: bigint;
+  smallInt64: bigint;
 
   /**
    * @generated from field: optional int32 really_small_int32 = 21 [default = -2147483648];
    */
-  reallySmallInt32?: number;
+  reallySmallInt32: number;
 
   /**
    * @generated from field: optional int64 really_small_int64 = 22 [default = -9223372036854775808];
    */
-  reallySmallInt64?: bigint;
+  reallySmallInt64: bigint;
 
   /**
    * The default value here is UTF-8 for "\u1234".  (We could also just type
@@ -3395,78 +3395,78 @@ export declare class TestExtremeDefaultValues extends Message<TestExtremeDefault
    *
    * @generated from field: optional string utf8_string = 6 [default = "ሴ"];
    */
-  utf8String?: string;
+  utf8String: string;
 
   /**
    * Tests for single-precision floating-point values.
    *
    * @generated from field: optional float zero_float = 7 [default = 0];
    */
-  zeroFloat?: number;
+  zeroFloat: number;
 
   /**
    * @generated from field: optional float one_float = 8 [default = 1];
    */
-  oneFloat?: number;
+  oneFloat: number;
 
   /**
    * @generated from field: optional float small_float = 9 [default = 1.5];
    */
-  smallFloat?: number;
+  smallFloat: number;
 
   /**
    * @generated from field: optional float negative_one_float = 10 [default = -1];
    */
-  negativeOneFloat?: number;
+  negativeOneFloat: number;
 
   /**
    * @generated from field: optional float negative_float = 11 [default = -1.5];
    */
-  negativeFloat?: number;
+  negativeFloat: number;
 
   /**
    * Using exponents
    *
    * @generated from field: optional float large_float = 12 [default = 2e+08];
    */
-  largeFloat?: number;
+  largeFloat: number;
 
   /**
    * @generated from field: optional float small_negative_float = 13 [default = -8e-28];
    */
-  smallNegativeFloat?: number;
+  smallNegativeFloat: number;
 
   /**
    * Text for nonfinite floating-point values.
    *
    * @generated from field: optional double inf_double = 14 [default = inf];
    */
-  infDouble?: number;
+  infDouble: number;
 
   /**
    * @generated from field: optional double neg_inf_double = 15 [default = -inf];
    */
-  negInfDouble?: number;
+  negInfDouble: number;
 
   /**
    * @generated from field: optional double nan_double = 16 [default = nan];
    */
-  nanDouble?: number;
+  nanDouble: number;
 
   /**
    * @generated from field: optional float inf_float = 17 [default = inf];
    */
-  infFloat?: number;
+  infFloat: number;
 
   /**
    * @generated from field: optional float neg_inf_float = 18 [default = -inf];
    */
-  negInfFloat?: number;
+  negInfFloat: number;
 
   /**
    * @generated from field: optional float nan_float = 19 [default = nan];
    */
-  nanFloat?: number;
+  nanFloat: number;
 
   /**
    * Tests for C++ trigraphs.
@@ -3477,34 +3477,34 @@ export declare class TestExtremeDefaultValues extends Message<TestExtremeDefault
    *
    * @generated from field: optional string cpp_trigraph = 20 [default = "? ? ?? ?? ??? ??/ ??-"];
    */
-  cppTrigraph?: string;
+  cppTrigraph: string;
 
   /**
    * String defaults containing the character '\000'
    *
    * @generated from field: optional string string_with_zero = 23 [default = "hel lo"];
    */
-  stringWithZero?: string;
+  stringWithZero: string;
 
   /**
    * @generated from field: optional bytes bytes_with_zero = 24 [default = "wor\000ld"];
    */
-  bytesWithZero?: Uint8Array;
+  bytesWithZero: Uint8Array;
 
   /**
    * @generated from field: optional string string_piece_with_zero = 25 [default = "ab c"];
    */
-  stringPieceWithZero?: string;
+  stringPieceWithZero: string;
 
   /**
    * @generated from field: optional string cord_with_zero = 26 [default = "12 3"];
    */
-  cordWithZero?: string;
+  cordWithZero: string;
 
   /**
    * @generated from field: optional string replacement_string = 27 [default = "${unknown}"];
    */
-  replacementString?: string;
+  replacementString: string;
 
   constructor(data?: PartialMessage<TestExtremeDefaultValues>);
 
@@ -3528,7 +3528,7 @@ export declare class SparseEnumMessage extends Message<SparseEnumMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestSparseEnum sparse_enum = 1;
    */
-  sparseEnum?: TestSparseEnum;
+  sparseEnum: TestSparseEnum;
 
   constructor(data?: PartialMessage<SparseEnumMessage>);
 
@@ -3554,7 +3554,7 @@ export declare class OneString extends Message<OneString> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  data: string;
 
   constructor(data?: PartialMessage<OneString>);
 
@@ -3602,7 +3602,7 @@ export declare class OneBytes extends Message<OneBytes> {
   /**
    * @generated from field: optional bytes data = 1;
    */
-  data?: Uint8Array;
+  data: Uint8Array;
 
   constructor(data?: PartialMessage<OneBytes>);
 
@@ -3650,162 +3650,162 @@ export declare class ManyOptionalString extends Message<ManyOptionalString> {
   /**
    * @generated from field: optional string str1 = 1;
    */
-  str1?: string;
+  str1: string;
 
   /**
    * @generated from field: optional string str2 = 2;
    */
-  str2?: string;
+  str2: string;
 
   /**
    * @generated from field: optional string str3 = 3;
    */
-  str3?: string;
+  str3: string;
 
   /**
    * @generated from field: optional string str4 = 4;
    */
-  str4?: string;
+  str4: string;
 
   /**
    * @generated from field: optional string str5 = 5;
    */
-  str5?: string;
+  str5: string;
 
   /**
    * @generated from field: optional string str6 = 6;
    */
-  str6?: string;
+  str6: string;
 
   /**
    * @generated from field: optional string str7 = 7;
    */
-  str7?: string;
+  str7: string;
 
   /**
    * @generated from field: optional string str8 = 8;
    */
-  str8?: string;
+  str8: string;
 
   /**
    * @generated from field: optional string str9 = 9;
    */
-  str9?: string;
+  str9: string;
 
   /**
    * @generated from field: optional string str10 = 10;
    */
-  str10?: string;
+  str10: string;
 
   /**
    * @generated from field: optional string str11 = 11;
    */
-  str11?: string;
+  str11: string;
 
   /**
    * @generated from field: optional string str12 = 12;
    */
-  str12?: string;
+  str12: string;
 
   /**
    * @generated from field: optional string str13 = 13;
    */
-  str13?: string;
+  str13: string;
 
   /**
    * @generated from field: optional string str14 = 14;
    */
-  str14?: string;
+  str14: string;
 
   /**
    * @generated from field: optional string str15 = 15;
    */
-  str15?: string;
+  str15: string;
 
   /**
    * @generated from field: optional string str16 = 16;
    */
-  str16?: string;
+  str16: string;
 
   /**
    * @generated from field: optional string str17 = 17;
    */
-  str17?: string;
+  str17: string;
 
   /**
    * @generated from field: optional string str18 = 18;
    */
-  str18?: string;
+  str18: string;
 
   /**
    * @generated from field: optional string str19 = 19;
    */
-  str19?: string;
+  str19: string;
 
   /**
    * @generated from field: optional string str20 = 20;
    */
-  str20?: string;
+  str20: string;
 
   /**
    * @generated from field: optional string str21 = 21;
    */
-  str21?: string;
+  str21: string;
 
   /**
    * @generated from field: optional string str22 = 22;
    */
-  str22?: string;
+  str22: string;
 
   /**
    * @generated from field: optional string str23 = 23;
    */
-  str23?: string;
+  str23: string;
 
   /**
    * @generated from field: optional string str24 = 24;
    */
-  str24?: string;
+  str24: string;
 
   /**
    * @generated from field: optional string str25 = 25;
    */
-  str25?: string;
+  str25: string;
 
   /**
    * @generated from field: optional string str26 = 26;
    */
-  str26?: string;
+  str26: string;
 
   /**
    * @generated from field: optional string str27 = 27;
    */
-  str27?: string;
+  str27: string;
 
   /**
    * @generated from field: optional string str28 = 28;
    */
-  str28?: string;
+  str28: string;
 
   /**
    * @generated from field: optional string str29 = 29;
    */
-  str29?: string;
+  str29: string;
 
   /**
    * @generated from field: optional string str30 = 30;
    */
-  str30?: string;
+  str30: string;
 
   /**
    * @generated from field: optional string str31 = 31;
    */
-  str31?: string;
+  str31: string;
 
   /**
    * @generated from field: optional string str32 = 32;
    */
-  str32?: string;
+  str32: string;
 
   constructor(data?: PartialMessage<ManyOptionalString>);
 
@@ -3831,7 +3831,7 @@ export declare class Int32Message extends Message<Int32Message> {
   /**
    * @generated from field: optional int32 data = 1;
    */
-  data?: number;
+  data: number;
 
   constructor(data?: PartialMessage<Int32Message>);
 
@@ -3855,7 +3855,7 @@ export declare class Uint32Message extends Message<Uint32Message> {
   /**
    * @generated from field: optional uint32 data = 1;
    */
-  data?: number;
+  data: number;
 
   constructor(data?: PartialMessage<Uint32Message>);
 
@@ -3879,7 +3879,7 @@ export declare class Int64Message extends Message<Int64Message> {
   /**
    * @generated from field: optional int64 data = 1;
    */
-  data?: bigint;
+  data: bigint;
 
   constructor(data?: PartialMessage<Int64Message>);
 
@@ -3903,7 +3903,7 @@ export declare class Uint64Message extends Message<Uint64Message> {
   /**
    * @generated from field: optional uint64 data = 1;
    */
-  data?: bigint;
+  data: bigint;
 
   constructor(data?: PartialMessage<Uint64Message>);
 
@@ -3927,7 +3927,7 @@ export declare class BoolMessage extends Message<BoolMessage> {
   /**
    * @generated from field: optional bool data = 1;
    */
-  data?: boolean;
+  data: boolean;
 
   constructor(data?: PartialMessage<BoolMessage>);
 
@@ -4001,12 +4001,12 @@ export declare class TestOneof_FooGroup extends Message<TestOneof_FooGroup> {
   /**
    * @generated from field: optional int32 a = 5;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional string b = 6;
    */
-  b?: string;
+  b: string;
 
   constructor(data?: PartialMessage<TestOneof_FooGroup>);
 
@@ -4030,12 +4030,12 @@ export declare class TestOneofBackwardsCompatible extends Message<TestOneofBackw
   /**
    * @generated from field: optional int32 foo_int = 1;
    */
-  fooInt?: number;
+  fooInt: number;
 
   /**
    * @generated from field: optional string foo_string = 2;
    */
-  fooString?: string;
+  fooString: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes foo_message = 3;
@@ -4069,12 +4069,12 @@ export declare class TestOneofBackwardsCompatible_FooGroup extends Message<TestO
   /**
    * @generated from field: optional int32 a = 5;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional string b = 6;
    */
-  b?: string;
+  b: string;
 
   constructor(data?: PartialMessage<TestOneofBackwardsCompatible_FooGroup>);
 
@@ -4228,12 +4228,12 @@ export declare class TestOneof2 extends Message<TestOneof2> {
   /**
    * @generated from field: optional int32 baz_int = 18;
    */
-  bazInt?: number;
+  bazInt: number;
 
   /**
    * @generated from field: optional string baz_string = 19 [default = "BAZ"];
    */
-  bazString?: string;
+  bazString: string;
 
   constructor(data?: PartialMessage<TestOneof2>);
 
@@ -4277,12 +4277,12 @@ export declare class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
   /**
    * @generated from field: optional int32 a = 9;
    */
-  a?: number;
+  a: number;
 
   /**
    * @generated from field: optional string b = 10;
    */
-  b?: string;
+  b: string;
 
   constructor(data?: PartialMessage<TestOneof2_FooGroup>);
 
@@ -4306,7 +4306,7 @@ export declare class TestOneof2_NestedMessage extends Message<TestOneof2_NestedM
   /**
    * @generated from field: optional int64 moo_int = 1;
    */
-  mooInt?: bigint;
+  mooInt: bigint;
 
   /**
    * @generated from field: repeated int32 corge_int = 2;
@@ -4630,17 +4630,17 @@ export declare class TestDynamicExtensions extends Message<TestDynamicExtensions
   /**
    * @generated from field: optional fixed32 scalar_extension = 2000;
    */
-  scalarExtension?: number;
+  scalarExtension: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum enum_extension = 2001;
    */
-  enumExtension?: ForeignEnum;
+  enumExtension: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDynamicExtensions.DynamicEnumType dynamic_enum_extension = 2002;
    */
-  dynamicEnumExtension?: TestDynamicExtensions_DynamicEnumType;
+  dynamicEnumExtension: TestDynamicExtensions_DynamicEnumType;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage message_extension = 2003;
@@ -4704,7 +4704,7 @@ export declare class TestDynamicExtensions_DynamicMessageType extends Message<Te
   /**
    * @generated from field: optional int32 dynamic_field = 2100;
    */
-  dynamicField?: number;
+  dynamicField: number;
 
   constructor(data?: PartialMessage<TestDynamicExtensions_DynamicMessageType>);
 
@@ -5068,7 +5068,7 @@ export declare class TestCommentInjectionMessage extends Message<TestCommentInje
    *
    * @generated from field: optional string a = 1 [default = "*\/ <- Neither should this."];
    */
-  a?: string;
+  a: string;
 
   constructor(data?: PartialMessage<TestCommentInjectionMessage>);
 
@@ -5095,32 +5095,32 @@ export declare class TestMessageSize extends Message<TestMessageSize> {
   /**
    * @generated from field: optional bool m1 = 1;
    */
-  m1?: boolean;
+  m1: boolean;
 
   /**
    * @generated from field: optional int64 m2 = 2;
    */
-  m2?: bigint;
+  m2: bigint;
 
   /**
    * @generated from field: optional bool m3 = 3;
    */
-  m3?: boolean;
+  m3: boolean;
 
   /**
    * @generated from field: optional string m4 = 4;
    */
-  m4?: string;
+  m4: string;
 
   /**
    * @generated from field: optional int32 m5 = 5;
    */
-  m5?: number;
+  m5: number;
 
   /**
    * @generated from field: optional int64 m6 = 6;
    */
-  m6?: bigint;
+  m6: bigint;
 
   constructor(data?: PartialMessage<TestMessageSize>);
 
@@ -5260,37 +5260,37 @@ export declare class TestJsonName extends Message<TestJsonName> {
   /**
    * @generated from field: optional int32 field_name1 = 1;
    */
-  fieldName1?: number;
+  fieldName1: number;
 
   /**
    * @generated from field: optional int32 fieldName2 = 2;
    */
-  fieldName2?: number;
+  fieldName2: number;
 
   /**
    * @generated from field: optional int32 FieldName3 = 3;
    */
-  FieldName3?: number;
+  FieldName3: number;
 
   /**
    * @generated from field: optional int32 _field_name4 = 4;
    */
-  FieldName4?: number;
+  FieldName4: number;
 
   /**
    * @generated from field: optional int32 FIELD_NAME5 = 5;
    */
-  FIELDNAME5?: number;
+  FIELDNAME5: number;
 
   /**
    * @generated from field: optional int32 field_name6 = 6 [json_name = "@type"];
    */
-  fieldName6?: number;
+  fieldName6: number;
 
   /**
    * @generated from field: optional int32 fieldname7 = 7;
    */
-  fieldname7?: number;
+  fieldname7: number;
 
   constructor(data?: PartialMessage<TestJsonName>);
 
@@ -5314,12 +5314,12 @@ export declare class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> 
   /**
    * @generated from field: optional int32 optional_int32 = 536870000;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int32 fixed_32 = 536870001;
    */
-  fixed32?: number;
+  fixed32: number;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 536870002 [packed = false];
@@ -5334,17 +5334,17 @@ export declare class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_enum = 536870004;
    */
-  optionalEnum?: ForeignEnum;
+  optionalEnum: ForeignEnum;
 
   /**
    * @generated from field: optional string optional_string = 536870005;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 536870006;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage optional_message = 536870007;
@@ -5412,7 +5412,7 @@ export declare class TestHugeFieldNumbers_OptionalGroup extends Message<TestHuge
   /**
    * @generated from field: optional int32 group_a = 536870009;
    */
-  groupA?: number;
+  groupA: number;
 
   constructor(data?: PartialMessage<TestHugeFieldNumbers_OptionalGroup>);
 
@@ -5436,47 +5436,47 @@ export declare class TestExtensionInsideTable extends Message<TestExtensionInsid
   /**
    * @generated from field: optional int32 field1 = 1;
    */
-  field1?: number;
+  field1: number;
 
   /**
    * @generated from field: optional int32 field2 = 2;
    */
-  field2?: number;
+  field2: number;
 
   /**
    * @generated from field: optional int32 field3 = 3;
    */
-  field3?: number;
+  field3: number;
 
   /**
    * @generated from field: optional int32 field4 = 4;
    */
-  field4?: number;
+  field4: number;
 
   /**
    * @generated from field: optional int32 field6 = 6;
    */
-  field6?: number;
+  field6: number;
 
   /**
    * @generated from field: optional int32 field7 = 7;
    */
-  field7?: number;
+  field7: number;
 
   /**
    * @generated from field: optional int32 field8 = 8;
    */
-  field8?: number;
+  field8: number;
 
   /**
    * @generated from field: optional int32 field9 = 9;
    */
-  field9?: number;
+  field9: number;
 
   /**
    * @generated from field: optional int32 field10 = 10;
    */
-  field10?: number;
+  field10: number;
 
   constructor(data?: PartialMessage<TestExtensionInsideTable>);
 
@@ -5555,7 +5555,7 @@ export declare class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2Rep
   /**
    * @generated from field: optional string another_field = 6;
    */
-  anotherField?: string;
+  anotherField: string;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGroup>);
 
@@ -5579,7 +5579,7 @@ export declare class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2Ano
   /**
    * @generated from field: optional string but_why_tho = 5;
    */
-  butWhyTho?: string;
+  butWhyTho: string;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOptionalRepeatedGroup>);
 
@@ -5603,7 +5603,7 @@ export declare class TestNestedGroupExtensionInnerExtension extends Message<Test
   /**
    * @generated from field: optional string inner_name = 1;
    */
-  innerName?: string;
+  innerName: string;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionInnerExtension>);
 
@@ -5627,22 +5627,22 @@ export declare class TestExtensionRangeSerialize extends Message<TestExtensionRa
   /**
    * @generated from field: optional int32 foo_one = 1;
    */
-  fooOne?: number;
+  fooOne: number;
 
   /**
    * @generated from field: optional int32 foo_two = 6;
    */
-  fooTwo?: number;
+  fooTwo: number;
 
   /**
    * @generated from field: optional int32 foo_three = 7;
    */
-  fooThree?: number;
+  fooThree: number;
 
   /**
    * @generated from field: optional int32 foo_four = 13;
    */
-  fooFour?: number;
+  fooFour: number;
 
   constructor(data?: PartialMessage<TestExtensionRangeSerialize>);
 
@@ -5691,22 +5691,22 @@ export declare class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264: number;
 
   constructor(data?: PartialMessage<TestVerifyInt32Simple>);
 
@@ -5730,22 +5730,22 @@ export declare class TestVerifyInt32 extends Message<TestVerifyInt32> {
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -5779,37 +5779,37 @@ export declare class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32
   /**
    * @generated from field: optional int64 optional_int64_30 = 30;
    */
-  optionalInt6430?: bigint;
+  optionalInt6430: bigint;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_3 = 3;
    */
-  optionalInt323?: number;
+  optionalInt323: number;
 
   /**
    * @generated from field: optional int32 optional_int32_4 = 4;
    */
-  optionalInt324?: number;
+  optionalInt324: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -5843,42 +5843,42 @@ export declare class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVer
   /**
    * @generated from field: optional int64 optional_int64_30 = 30;
    */
-  optionalInt6430?: bigint;
+  optionalInt6430: bigint;
 
   /**
    * @generated from field: optional int32 optional_int32_300 = 300;
    */
-  optionalInt32300?: number;
+  optionalInt32300: number;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_3 = 3;
    */
-  optionalInt323?: number;
+  optionalInt323: number;
 
   /**
    * @generated from field: optional int32 optional_int32_4 = 4;
    */
-  optionalInt324?: number;
+  optionalInt324: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -5912,22 +5912,22 @@ export declare class TestVerifyUint32Simple extends Message<TestVerifyUint32Simp
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264: number;
 
   constructor(data?: PartialMessage<TestVerifyUint32Simple>);
 
@@ -5951,22 +5951,22 @@ export declare class TestVerifyUint32 extends Message<TestVerifyUint32> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -6000,22 +6000,22 @@ export declare class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -6049,27 +6049,27 @@ export declare class TestVerifyOneInt32BigFieldNumber extends Message<TestVerify
   /**
    * @generated from field: optional int32 optional_int32_65 = 65;
    */
-  optionalInt3265?: number;
+  optionalInt3265: number;
 
   /**
    * @generated from field: optional int64 optional_int64_1 = 1;
    */
-  optionalInt641?: bigint;
+  optionalInt641: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_2 = 2;
    */
-  optionalInt642?: bigint;
+  optionalInt642: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_63 = 63;
    */
-  optionalInt6463?: bigint;
+  optionalInt6463: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_64 = 64;
    */
-  optionalInt6464?: bigint;
+  optionalInt6464: bigint;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -6103,32 +6103,32 @@ export declare class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt
   /**
    * @generated from field: optional int32 optional_int32_1000 = 1000;
    */
-  optionalInt321000?: number;
+  optionalInt321000: number;
 
   /**
    * @generated from field: optional int32 optional_int32_65 = 65;
    */
-  optionalInt3265?: number;
+  optionalInt3265: number;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -6162,32 +6162,32 @@ export declare class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUi
   /**
    * @generated from field: optional uint32 optional_uint32_1000 = 1000;
    */
-  optionalUint321000?: number;
+  optionalUint321000: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_65 = 65;
    */
-  optionalUint3265?: number;
+  optionalUint3265: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -6245,42 +6245,42 @@ export declare class TestVerifyBigFieldNumberUint32_Nested extends Message<TestV
   /**
    * @generated from field: optional uint32 optional_uint32_5000 = 5000;
    */
-  optionalUint325000?: number;
+  optionalUint325000: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1000 = 1000;
    */
-  optionalUint321000?: number;
+  optionalUint321000: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_66 = 66;
    */
-  optionalUint3266?: number;
+  optionalUint3266: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_65 = 65;
    */
-  optionalUint3265?: number;
+  optionalUint3265: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  optionalUint3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
@@ -6317,17 +6317,17 @@ export declare class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall0 optional_seq_small_0_lowfield = 1;
    */
-  optionalSeqSmall0Lowfield?: EnumParseTester_SeqSmall0;
+  optionalSeqSmall0Lowfield: EnumParseTester_SeqSmall0;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall0 optional_seq_small_0_midfield = 1001;
    */
-  optionalSeqSmall0Midfield?: EnumParseTester_SeqSmall0;
+  optionalSeqSmall0Midfield: EnumParseTester_SeqSmall0;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall0 optional_seq_small_0_hifield = 1000001;
    */
-  optionalSeqSmall0Hifield?: EnumParseTester_SeqSmall0;
+  optionalSeqSmall0Hifield: EnumParseTester_SeqSmall0;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.SeqSmall0 repeated_seq_small_0_lowfield = 2;
@@ -6362,17 +6362,17 @@ export declare class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall1 optional_seq_small_1_lowfield = 4;
    */
-  optionalSeqSmall1Lowfield?: EnumParseTester_SeqSmall1;
+  optionalSeqSmall1Lowfield: EnumParseTester_SeqSmall1;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall1 optional_seq_small_1_midfield = 1004;
    */
-  optionalSeqSmall1Midfield?: EnumParseTester_SeqSmall1;
+  optionalSeqSmall1Midfield: EnumParseTester_SeqSmall1;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall1 optional_seq_small_1_hifield = 1000004;
    */
-  optionalSeqSmall1Hifield?: EnumParseTester_SeqSmall1;
+  optionalSeqSmall1Hifield: EnumParseTester_SeqSmall1;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.SeqSmall1 repeated_seq_small_1_lowfield = 5;
@@ -6407,17 +6407,17 @@ export declare class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqLarge optional_seq_large_lowfield = 7;
    */
-  optionalSeqLargeLowfield?: EnumParseTester_SeqLarge;
+  optionalSeqLargeLowfield: EnumParseTester_SeqLarge;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqLarge optional_seq_large_midfield = 1007;
    */
-  optionalSeqLargeMidfield?: EnumParseTester_SeqLarge;
+  optionalSeqLargeMidfield: EnumParseTester_SeqLarge;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqLarge optional_seq_large_hifield = 1000007;
    */
-  optionalSeqLargeHifield?: EnumParseTester_SeqLarge;
+  optionalSeqLargeHifield: EnumParseTester_SeqLarge;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.SeqLarge repeated_seq_large_lowfield = 8;
@@ -6452,17 +6452,17 @@ export declare class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.Arbitrary optional_arbitrary_lowfield = 10;
    */
-  optionalArbitraryLowfield?: EnumParseTester_Arbitrary;
+  optionalArbitraryLowfield: EnumParseTester_Arbitrary;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.Arbitrary optional_arbitrary_midfield = 1010;
    */
-  optionalArbitraryMidfield?: EnumParseTester_Arbitrary;
+  optionalArbitraryMidfield: EnumParseTester_Arbitrary;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.Arbitrary optional_arbitrary_hifield = 1000010;
    */
-  optionalArbitraryHifield?: EnumParseTester_Arbitrary;
+  optionalArbitraryHifield: EnumParseTester_Arbitrary;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.Arbitrary repeated_arbitrary_lowfield = 11;
@@ -6499,7 +6499,7 @@ export declare class EnumParseTester extends Message<EnumParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  otherField: number;
 
   constructor(data?: PartialMessage<EnumParseTester>);
 
@@ -6796,17 +6796,17 @@ export declare class BoolParseTester extends Message<BoolParseTester> {
   /**
    * @generated from field: optional bool optional_bool_lowfield = 1;
    */
-  optionalBoolLowfield?: boolean;
+  optionalBoolLowfield: boolean;
 
   /**
    * @generated from field: optional bool optional_bool_midfield = 1001;
    */
-  optionalBoolMidfield?: boolean;
+  optionalBoolMidfield: boolean;
 
   /**
    * @generated from field: optional bool optional_bool_hifield = 1000001;
    */
-  optionalBoolHifield?: boolean;
+  optionalBoolHifield: boolean;
 
   /**
    * @generated from field: repeated bool repeated_bool_lowfield = 2;
@@ -6843,7 +6843,7 @@ export declare class BoolParseTester extends Message<BoolParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  otherField: number;
 
   constructor(data?: PartialMessage<BoolParseTester>);
 
@@ -6882,17 +6882,17 @@ export declare class Int32ParseTester extends Message<Int32ParseTester> {
   /**
    * @generated from field: optional int32 optional_int32_lowfield = 1;
    */
-  optionalInt32Lowfield?: number;
+  optionalInt32Lowfield: number;
 
   /**
    * @generated from field: optional int32 optional_int32_midfield = 1001;
    */
-  optionalInt32Midfield?: number;
+  optionalInt32Midfield: number;
 
   /**
    * @generated from field: optional int32 optional_int32_hifield = 1000001;
    */
-  optionalInt32Hifield?: number;
+  optionalInt32Hifield: number;
 
   /**
    * @generated from field: repeated int32 repeated_int32_lowfield = 2;
@@ -6929,7 +6929,7 @@ export declare class Int32ParseTester extends Message<Int32ParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  otherField: number;
 
   constructor(data?: PartialMessage<Int32ParseTester>);
 
@@ -6968,17 +6968,17 @@ export declare class Int64ParseTester extends Message<Int64ParseTester> {
   /**
    * @generated from field: optional int64 optional_int64_lowfield = 1;
    */
-  optionalInt64Lowfield?: bigint;
+  optionalInt64Lowfield: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_midfield = 1001;
    */
-  optionalInt64Midfield?: bigint;
+  optionalInt64Midfield: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_hifield = 1000001;
    */
-  optionalInt64Hifield?: bigint;
+  optionalInt64Hifield: bigint;
 
   /**
    * @generated from field: repeated int64 repeated_int64_lowfield = 2;
@@ -7015,7 +7015,7 @@ export declare class Int64ParseTester extends Message<Int64ParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  otherField: number;
 
   constructor(data?: PartialMessage<Int64ParseTester>);
 
@@ -7057,7 +7057,7 @@ export declare class InlinedStringIdxRegressionProto extends Message<InlinedStri
    *
    * @generated from field: optional string str1 = 1;
    */
-  str1?: string;
+  str1: string;
 
   /**
    * aux_idx == 2
@@ -7071,14 +7071,14 @@ export declare class InlinedStringIdxRegressionProto extends Message<InlinedStri
    *
    * @generated from field: optional string str2 = 3;
    */
-  str2?: string;
+  str2: string;
 
   /**
    * aux_idx == 4, inlined_string_idx == 3
    *
    * @generated from field: optional bytes str3 = 4;
    */
-  str3?: Uint8Array;
+  str3: Uint8Array;
 
   constructor(data?: PartialMessage<InlinedStringIdxRegressionProto>);
 
@@ -7102,17 +7102,17 @@ export declare class StringParseTester extends Message<StringParseTester> {
   /**
    * @generated from field: optional string optional_string_lowfield = 1;
    */
-  optionalStringLowfield?: string;
+  optionalStringLowfield: string;
 
   /**
    * @generated from field: optional string optional_string_midfield = 1001;
    */
-  optionalStringMidfield?: string;
+  optionalStringMidfield: string;
 
   /**
    * @generated from field: optional string optional_string_hifield = 1000001;
    */
-  optionalStringHifield?: string;
+  optionalStringHifield: string;
 
   /**
    * @generated from field: repeated string repeated_string_lowfield = 2;
@@ -7161,12 +7161,12 @@ export declare class BadFieldNames extends Message<BadFieldNames> {
   /**
    * @generated from field: optional int32 OptionalInt32 = 1;
    */
-  OptionalInt32?: number;
+  OptionalInt32: number;
 
   /**
    * @generated from field: optional int32 for = 2;
    */
-  for?: number;
+  for: number;
 
   constructor(data?: PartialMessage<BadFieldNames>);
 
@@ -7190,12 +7190,12 @@ export declare class TestNestedMessageRedaction extends Message<TestNestedMessag
   /**
    * @generated from field: optional string optional_unredacted_nested_string = 1;
    */
-  optionalUnredactedNestedString?: string;
+  optionalUnredactedNestedString: string;
 
   /**
    * @generated from field: optional string optional_redacted_nested_string = 2;
    */
-  optionalRedactedNestedString?: string;
+  optionalRedactedNestedString: string;
 
   constructor(data?: PartialMessage<TestNestedMessageRedaction>);
 
@@ -7219,12 +7219,12 @@ export declare class RedactedFields extends Message<RedactedFields> {
   /**
    * @generated from field: optional string optional_redacted_string = 1;
    */
-  optionalRedactedString?: string;
+  optionalRedactedString: string;
 
   /**
    * @generated from field: optional string optional_unredacted_string = 2;
    */
-  optionalUnredactedString?: string;
+  optionalUnredactedString: string;
 
   /**
    * @generated from field: repeated string repeated_redacted_string = 3;
@@ -7288,12 +7288,12 @@ export declare class TestCord extends Message<TestCord> {
   /**
    * @generated from field: optional bytes optional_bytes_cord = 1;
    */
-  optionalBytesCord?: Uint8Array;
+  optionalBytesCord: Uint8Array;
 
   /**
    * @generated from field: optional bytes optional_bytes_cord_default = 2 [default = "hello"];
    */
-  optionalBytesCordDefault?: Uint8Array;
+  optionalBytesCordDefault: Uint8Array;
 
   constructor(data?: PartialMessage<TestCord>);
 

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
@@ -38,17 +38,17 @@ export declare class OptionsMessage extends Message<OptionsMessage> {
   /**
    * @generated from field: optional int32 plain_field = 1;
    */
-  plainField?: number;
+  plainField: number;
 
   /**
    * @generated from field: optional int32 runtime_retention_field = 2;
    */
-  runtimeRetentionField?: number;
+  runtimeRetentionField: number;
 
   /**
    * @generated from field: optional int32 source_retention_field = 3;
    */
-  sourceRetentionField?: number;
+  sourceRetentionField: number;
 
   constructor(data?: PartialMessage<OptionsMessage>);
 
@@ -91,7 +91,7 @@ export declare class TopLevelMessage extends Message<TopLevelMessage> {
   /**
    * @generated from field: optional float f = 1;
    */
-  f?: number;
+  f: number;
 
   /**
    * @generated from oneof protobuf_unittest.TopLevelMessage.o

--- a/packages/protobuf-test/src/gen/ts/extra/extensions-proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/extensions-proto2_pb.ts
@@ -51,7 +51,7 @@ export class Proto2Extendee extends Message<Proto2Extendee> {
   /**
    * @generated from field: optional int32 own_field = 1;
    */
-  ownField?: number;
+  declare ownField: number;
 
   constructor(data?: PartialMessage<Proto2Extendee>) {
     super();
@@ -81,6 +81,8 @@ export class Proto2Extendee extends Message<Proto2Extendee> {
   }
 }
 
+Proto2Extendee.prototype.ownField = 0;
+
 /**
  * A message used in extensions
  *
@@ -90,7 +92,7 @@ export class Proto2ExtMessage extends Message<Proto2ExtMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  declare stringField: string;
 
   constructor(data?: PartialMessage<Proto2ExtMessage>) {
     super();
@@ -120,6 +122,8 @@ export class Proto2ExtMessage extends Message<Proto2ExtMessage> {
   }
 }
 
+Proto2ExtMessage.prototype.stringField = "";
+
 /**
  * @generated from message proto2ext.GroupExt
  */
@@ -127,12 +131,12 @@ export class GroupExt extends Message<GroupExt> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  declare b: number;
 
   constructor(data?: PartialMessage<GroupExt>) {
     super();
@@ -163,6 +167,9 @@ export class GroupExt extends Message<GroupExt> {
   }
 }
 
+GroupExt.prototype.a = 0;
+GroupExt.prototype.b = 0;
+
 /**
  * @generated from message proto2ext.RepeatedGroupExt
  */
@@ -170,12 +177,12 @@ export class RepeatedGroupExt extends Message<RepeatedGroupExt> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  declare b: number;
 
   constructor(data?: PartialMessage<RepeatedGroupExt>) {
     super();
@@ -205,6 +212,9 @@ export class RepeatedGroupExt extends Message<RepeatedGroupExt> {
     return proto2.util.equals(RepeatedGroupExt, a, b);
   }
 }
+
+RepeatedGroupExt.prototype.a = 0;
+RepeatedGroupExt.prototype.b = 0;
 
 /**
  * A container for nested extensions

--- a/packages/protobuf-test/src/gen/ts/extra/jstype-proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/jstype-proto2_pb.ts
@@ -17,7 +17,7 @@
 /* eslint-disable */
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto2 } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message spec.JSTypeProto2OmittedMessage
@@ -26,27 +26,27 @@ export class JSTypeProto2OmittedMessage extends Message<JSTypeProto2OmittedMessa
   /**
    * @generated from field: optional fixed64 fixed64_field = 1;
    */
-  fixed64Field?: bigint;
+  declare fixed64Field: bigint;
 
   /**
    * @generated from field: optional int64 int64_field = 3;
    */
-  int64Field?: bigint;
+  declare int64Field: bigint;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4;
    */
-  sfixed64Field?: bigint;
+  declare sfixed64Field: bigint;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5;
    */
-  sint64Field?: bigint;
+  declare sint64Field: bigint;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6;
    */
-  uint64Field?: bigint;
+  declare uint64Field: bigint;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11;
@@ -110,6 +110,12 @@ export class JSTypeProto2OmittedMessage extends Message<JSTypeProto2OmittedMessa
   }
 }
 
+JSTypeProto2OmittedMessage.prototype.fixed64Field = protoInt64.zero;
+JSTypeProto2OmittedMessage.prototype.int64Field = protoInt64.zero;
+JSTypeProto2OmittedMessage.prototype.sfixed64Field = protoInt64.zero;
+JSTypeProto2OmittedMessage.prototype.sint64Field = protoInt64.zero;
+JSTypeProto2OmittedMessage.prototype.uint64Field = protoInt64.zero;
+
 /**
  * @generated from message spec.JSTypeProto2NormalMessage
  */
@@ -117,27 +123,27 @@ export class JSTypeProto2NormalMessage extends Message<JSTypeProto2NormalMessage
   /**
    * @generated from field: optional fixed64 fixed64_field = 1 [jstype = JS_NORMAL];
    */
-  fixed64Field?: bigint;
+  declare fixed64Field: bigint;
 
   /**
    * @generated from field: optional int64 int64_field = 3 [jstype = JS_NORMAL];
    */
-  int64Field?: bigint;
+  declare int64Field: bigint;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4 [jstype = JS_NORMAL];
    */
-  sfixed64Field?: bigint;
+  declare sfixed64Field: bigint;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5 [jstype = JS_NORMAL];
    */
-  sint64Field?: bigint;
+  declare sint64Field: bigint;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6 [jstype = JS_NORMAL];
    */
-  uint64Field?: bigint;
+  declare uint64Field: bigint;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11 [jstype = JS_NORMAL];
@@ -201,6 +207,12 @@ export class JSTypeProto2NormalMessage extends Message<JSTypeProto2NormalMessage
   }
 }
 
+JSTypeProto2NormalMessage.prototype.fixed64Field = protoInt64.zero;
+JSTypeProto2NormalMessage.prototype.int64Field = protoInt64.zero;
+JSTypeProto2NormalMessage.prototype.sfixed64Field = protoInt64.zero;
+JSTypeProto2NormalMessage.prototype.sint64Field = protoInt64.zero;
+JSTypeProto2NormalMessage.prototype.uint64Field = protoInt64.zero;
+
 /**
  * @generated from message spec.JSTypeProto2StringMessage
  */
@@ -208,27 +220,27 @@ export class JSTypeProto2StringMessage extends Message<JSTypeProto2StringMessage
   /**
    * @generated from field: optional fixed64 fixed64_field = 1 [jstype = JS_STRING];
    */
-  fixed64Field?: string;
+  declare fixed64Field: string;
 
   /**
    * @generated from field: optional int64 int64_field = 3 [jstype = JS_STRING];
    */
-  int64Field?: string;
+  declare int64Field: string;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4 [jstype = JS_STRING];
    */
-  sfixed64Field?: string;
+  declare sfixed64Field: string;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5 [jstype = JS_STRING];
    */
-  sint64Field?: string;
+  declare sint64Field: string;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6 [jstype = JS_STRING];
    */
-  uint64Field?: string;
+  declare uint64Field: string;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11 [jstype = JS_STRING];
@@ -292,6 +304,12 @@ export class JSTypeProto2StringMessage extends Message<JSTypeProto2StringMessage
   }
 }
 
+JSTypeProto2StringMessage.prototype.fixed64Field = "0";
+JSTypeProto2StringMessage.prototype.int64Field = "0";
+JSTypeProto2StringMessage.prototype.sfixed64Field = "0";
+JSTypeProto2StringMessage.prototype.sint64Field = "0";
+JSTypeProto2StringMessage.prototype.uint64Field = "0";
+
 /**
  * @generated from message spec.JSTypeProto2NumberMessage
  */
@@ -299,27 +317,27 @@ export class JSTypeProto2NumberMessage extends Message<JSTypeProto2NumberMessage
   /**
    * @generated from field: optional fixed64 fixed64_field = 1 [jstype = JS_NUMBER];
    */
-  fixed64Field?: bigint;
+  declare fixed64Field: bigint;
 
   /**
    * @generated from field: optional int64 int64_field = 3 [jstype = JS_NUMBER];
    */
-  int64Field?: bigint;
+  declare int64Field: bigint;
 
   /**
    * @generated from field: optional sfixed64 sfixed64_field = 4 [jstype = JS_NUMBER];
    */
-  sfixed64Field?: bigint;
+  declare sfixed64Field: bigint;
 
   /**
    * @generated from field: optional sint64 sint64_field = 5 [jstype = JS_NUMBER];
    */
-  sint64Field?: bigint;
+  declare sint64Field: bigint;
 
   /**
    * @generated from field: optional uint64 uint64_field = 6 [jstype = JS_NUMBER];
    */
-  uint64Field?: bigint;
+  declare uint64Field: bigint;
 
   /**
    * @generated from field: repeated fixed64 repeated_fixed64_field = 11 [jstype = JS_NUMBER];
@@ -382,4 +400,10 @@ export class JSTypeProto2NumberMessage extends Message<JSTypeProto2NumberMessage
     return proto2.util.equals(JSTypeProto2NumberMessage, a, b);
   }
 }
+
+JSTypeProto2NumberMessage.prototype.fixed64Field = protoInt64.zero;
+JSTypeProto2NumberMessage.prototype.int64Field = protoInt64.zero;
+JSTypeProto2NumberMessage.prototype.sfixed64Field = protoInt64.zero;
+JSTypeProto2NumberMessage.prototype.sint64Field = protoInt64.zero;
+JSTypeProto2NumberMessage.prototype.uint64Field = protoInt64.zero;
 

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -193,37 +193,37 @@ export class Proto2OptionalMessage extends Message<Proto2OptionalMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  declare stringField: string;
 
   /**
    * @generated from field: optional bytes bytes_field = 2;
    */
-  bytesField?: Uint8Array;
+  declare bytesField: Uint8Array;
 
   /**
    * @generated from field: optional int32 int32_field = 3;
    */
-  int32Field?: number;
+  declare int32Field: number;
 
   /**
    * @generated from field: optional int64 int64_field = 4;
    */
-  int64Field?: bigint;
+  declare int64Field: bigint;
 
   /**
    * @generated from field: optional float float_field = 5;
    */
-  floatField?: number;
+  declare floatField: number;
 
   /**
    * @generated from field: optional bool bool_field = 6;
    */
-  boolField?: boolean;
+  declare boolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto2Enum enum_field = 7;
    */
-  enumField?: Proto2Enum;
+  declare enumField: Proto2Enum;
 
   /**
    * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
@@ -264,6 +264,14 @@ export class Proto2OptionalMessage extends Message<Proto2OptionalMessage> {
     return proto2.util.equals(Proto2OptionalMessage, a, b);
   }
 }
+
+Proto2OptionalMessage.prototype.stringField = "";
+Proto2OptionalMessage.prototype.bytesField = new Uint8Array(0);
+Proto2OptionalMessage.prototype.int32Field = 0;
+Proto2OptionalMessage.prototype.int64Field = protoInt64.zero;
+Proto2OptionalMessage.prototype.floatField = 0;
+Proto2OptionalMessage.prototype.boolField = false;
+Proto2OptionalMessage.prototype.enumField = 1 as Proto2Enum.YES;
 
 /**
  * @generated from message spec.Proto2RequiredMessage
@@ -446,37 +454,37 @@ export class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage> {
   /**
    * @generated from field: optional string string_field = 1 [default = "hello \" *\/ "];
    */
-  stringField?: string;
+  declare stringField: string;
 
   /**
    * @generated from field: optional bytes bytes_field = 2 [default = "\000x\\x\\"x\'AAAAAA\010\014\n\r\t\013"];
    */
-  bytesField?: Uint8Array;
+  declare bytesField: Uint8Array;
 
   /**
    * @generated from field: optional int32 int32_field = 3 [default = 128];
    */
-  int32Field?: number;
+  declare int32Field: number;
 
   /**
    * @generated from field: optional int64 int64_field = 4 [default = -256];
    */
-  int64Field?: bigint;
+  declare int64Field: bigint;
 
   /**
    * @generated from field: optional float float_field = 5 [default = -512.13];
    */
-  floatField?: number;
+  declare floatField: number;
 
   /**
    * @generated from field: optional bool bool_field = 6 [default = true];
    */
-  boolField?: boolean;
+  declare boolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto2Enum enum_field = 7 [default = PROTO2_ENUM_YES];
    */
-  enumField?: Proto2Enum;
+  declare enumField: Proto2Enum;
 
   /**
    * @generated from field: optional spec.Proto2ChildMessage message_field = 8;
@@ -518,6 +526,14 @@ export class Proto2DefaultsMessage extends Message<Proto2DefaultsMessage> {
   }
 }
 
+Proto2DefaultsMessage.prototype.stringField = "hello \" */ ";
+Proto2DefaultsMessage.prototype.bytesField = new Uint8Array([0x00, 0x78, 0x5C, 0x78, 0x78, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B]);
+Proto2DefaultsMessage.prototype.int32Field = 128;
+Proto2DefaultsMessage.prototype.int64Field = protoInt64.parse("-256");
+Proto2DefaultsMessage.prototype.floatField = -512.13;
+Proto2DefaultsMessage.prototype.boolField = true;
+Proto2DefaultsMessage.prototype.enumField = 1 as Proto2Enum.YES;
+
 /**
  * @generated from message spec.Proto2ChildMessage
  */
@@ -525,7 +541,7 @@ export class Proto2ChildMessage extends Message<Proto2ChildMessage> {
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  declare stringField: string;
 
   constructor(data?: PartialMessage<Proto2ChildMessage>) {
     super();
@@ -554,6 +570,8 @@ export class Proto2ChildMessage extends Message<Proto2ChildMessage> {
     return proto2.util.equals(Proto2ChildMessage, a, b);
   }
 }
+
+Proto2ChildMessage.prototype.stringField = "";
 
 /**
  * @generated from message spec.Proto2GroupsMessage
@@ -629,7 +647,7 @@ export class Proto2GroupsMessage_Group extends Message<Proto2GroupsMessage_Group
   /**
    * @generated from field: optional int32 int32_field = 1;
    */
-  int32Field?: number;
+  declare int32Field: number;
 
   /**
    * @generated from field: optional spec.Proto2GroupsMessage.Group.NestedGroup nestedgroup = 2;
@@ -665,6 +683,8 @@ export class Proto2GroupsMessage_Group extends Message<Proto2GroupsMessage_Group
   }
 }
 
+Proto2GroupsMessage_Group.prototype.int32Field = 0;
+
 /**
  * @generated from message spec.Proto2GroupsMessage.Group.NestedGroup
  */
@@ -672,7 +692,7 @@ export class Proto2GroupsMessage_Group_NestedGroup extends Message<Proto2GroupsM
   /**
    * @generated from field: optional string string_field = 1;
    */
-  stringField?: string;
+  declare stringField: string;
 
   constructor(data?: PartialMessage<Proto2GroupsMessage_Group_NestedGroup>) {
     super();
@@ -702,6 +722,8 @@ export class Proto2GroupsMessage_Group_NestedGroup extends Message<Proto2GroupsM
   }
 }
 
+Proto2GroupsMessage_Group_NestedGroup.prototype.stringField = "";
+
 /**
  * @generated from message spec.Proto2GroupsMessage.RepeatedGroup
  */
@@ -709,7 +731,7 @@ export class Proto2GroupsMessage_RepeatedGroup extends Message<Proto2GroupsMessa
   /**
    * @generated from field: optional int32 int32_field = 1;
    */
-  int32Field?: number;
+  declare int32Field: number;
 
   constructor(data?: PartialMessage<Proto2GroupsMessage_RepeatedGroup>) {
     super();
@@ -739,6 +761,8 @@ export class Proto2GroupsMessage_RepeatedGroup extends Message<Proto2GroupsMessa
   }
 }
 
+Proto2GroupsMessage_RepeatedGroup.prototype.int32Field = 0;
+
 /**
  * @generated from message spec.Proto2GroupsMessage.OneofGroup
  */
@@ -746,7 +770,7 @@ export class Proto2GroupsMessage_OneofGroup extends Message<Proto2GroupsMessage_
   /**
    * @generated from field: optional bool bool_field = 1;
    */
-  boolField?: boolean;
+  declare boolField: boolean;
 
   constructor(data?: PartialMessage<Proto2GroupsMessage_OneofGroup>) {
     super();
@@ -775,4 +799,6 @@ export class Proto2GroupsMessage_OneofGroup extends Message<Proto2GroupsMessage_
     return proto2.util.equals(Proto2GroupsMessage_OneofGroup, a, b);
   }
 }
+
+Proto2GroupsMessage_OneofGroup.prototype.boolField = false;
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/compiler/plugin_pb.ts
@@ -30,7 +30,7 @@
 /* eslint-disable */
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto2 } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
 import { FileDescriptorProto, GeneratedCodeInfo } from "../descriptor_pb.js";
 
 /**
@@ -42,17 +42,17 @@ export class Version extends Message<Version> {
   /**
    * @generated from field: optional int32 major = 1;
    */
-  major?: number;
+  declare major: number;
 
   /**
    * @generated from field: optional int32 minor = 2;
    */
-  minor?: number;
+  declare minor: number;
 
   /**
    * @generated from field: optional int32 patch = 3;
    */
-  patch?: number;
+  declare patch: number;
 
   /**
    * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
@@ -60,7 +60,7 @@ export class Version extends Message<Version> {
    *
    * @generated from field: optional string suffix = 4;
    */
-  suffix?: string;
+  declare suffix: string;
 
   constructor(data?: PartialMessage<Version>) {
     super();
@@ -93,6 +93,11 @@ export class Version extends Message<Version> {
   }
 }
 
+Version.prototype.major = 0;
+Version.prototype.minor = 0;
+Version.prototype.patch = 0;
+Version.prototype.suffix = "";
+
 /**
  * An encoded CodeGeneratorRequest is written to the plugin's stdin.
  *
@@ -113,7 +118,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
    *
    * @generated from field: optional string parameter = 2;
    */
-  parameter?: string;
+  declare parameter: string;
 
   /**
    * FileDescriptorProtos for all files in files_to_generate and everything
@@ -188,6 +193,8 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
   }
 }
 
+CodeGeneratorRequest.prototype.parameter = "";
+
 /**
  * The plugin writes an encoded CodeGeneratorResponse to stdout.
  *
@@ -206,7 +213,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional string error = 1;
    */
-  error?: string;
+  declare error: string;
 
   /**
    * A bitmask of supported features that the code generator supports.
@@ -214,7 +221,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional uint64 supported_features = 2;
    */
-  supportedFeatures?: bigint;
+  declare supportedFeatures: bigint;
 
   /**
    * @generated from field: repeated google.protobuf.compiler.CodeGeneratorResponse.File file = 15;
@@ -250,6 +257,9 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
     return proto2.util.equals(CodeGeneratorResponse, a, b);
   }
 }
+
+CodeGeneratorResponse.prototype.error = "";
+CodeGeneratorResponse.prototype.supportedFeatures = protoInt64.zero;
 
 /**
  * Sync with code_generator.h.
@@ -300,7 +310,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * If non-empty, indicates that the named file should already exist, and the
@@ -343,14 +353,14 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string insertion_point = 2;
    */
-  insertionPoint?: string;
+  declare insertionPoint: string;
 
   /**
    * The file contents.
    *
    * @generated from field: optional string content = 15;
    */
-  content?: string;
+  declare content: string;
 
   /**
    * Information describing the file content being inserted. If an insertion
@@ -391,4 +401,8 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
     return proto2.util.equals(CodeGeneratorResponse_File, a, b);
   }
 }
+
+CodeGeneratorResponse_File.prototype.name = "";
+CodeGeneratorResponse_File.prototype.insertionPoint = "";
+CodeGeneratorResponse_File.prototype.content = "";
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/descriptor_pb.ts
@@ -25,7 +25,7 @@
 /* eslint-disable */
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto2 } from "@bufbuild/protobuf";
+import { Message, proto2, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * The full set of known editions.
@@ -156,14 +156,14 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    *
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  declare package: string;
 
   /**
    * Names of files imported by this file.
@@ -232,14 +232,14 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  declare syntax: string;
 
   /**
    * The edition of the proto file.
    *
    * @generated from field: optional google.protobuf.Edition edition = 14;
    */
-  edition?: Edition;
+  declare edition: Edition;
 
   constructor(data?: PartialMessage<FileDescriptorProto>) {
     super();
@@ -281,6 +281,11 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
   }
 }
 
+FileDescriptorProto.prototype.name = "";
+FileDescriptorProto.prototype.package = "";
+FileDescriptorProto.prototype.syntax = "";
+FileDescriptorProto.prototype.edition = 0 as Edition.EDITION_UNKNOWN;
+
 /**
  * Describes a message type.
  *
@@ -290,7 +295,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto field = 2;
@@ -377,6 +382,8 @@ export class DescriptorProto extends Message<DescriptorProto> {
   }
 }
 
+DescriptorProto.prototype.name = "";
+
 /**
  * @generated from message google.protobuf.DescriptorProto.ExtensionRange
  */
@@ -386,14 +393,14 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  declare start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  declare end: number;
 
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
@@ -430,6 +437,9 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
   }
 }
 
+DescriptorProto_ExtensionRange.prototype.start = 0;
+DescriptorProto_ExtensionRange.prototype.end = 0;
+
 /**
  * Range of reserved tag numbers. Reserved tag numbers may not be used by
  * fields or extension ranges in the same message. Reserved ranges may
@@ -443,14 +453,14 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  declare start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  declare end: number;
 
   constructor(data?: PartialMessage<DescriptorProto_ReservedRange>) {
     super();
@@ -480,6 +490,9 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
     return proto2.util.equals(DescriptorProto_ReservedRange, a, b);
   }
 }
+
+DescriptorProto_ReservedRange.prototype.start = 0;
+DescriptorProto_ReservedRange.prototype.end = 0;
 
 /**
  * @generated from message google.protobuf.ExtensionRangeOptions
@@ -515,7 +528,7 @@ export class ExtensionRangeOptions extends Message<ExtensionRangeOptions> {
    *
    * @generated from field: optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3 [default = UNVERIFIED];
    */
-  verification?: ExtensionRangeOptions_VerificationState;
+  declare verification: ExtensionRangeOptions_VerificationState;
 
   constructor(data?: PartialMessage<ExtensionRangeOptions>) {
     super();
@@ -547,6 +560,8 @@ export class ExtensionRangeOptions extends Message<ExtensionRangeOptions> {
     return proto2.util.equals(ExtensionRangeOptions, a, b);
   }
 }
+
+ExtensionRangeOptions.prototype.verification = 1 as ExtensionRangeOptions_VerificationState.UNVERIFIED;
 
 /**
  * The verification state of the extension range.
@@ -581,7 +596,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional int32 number = 1;
    */
-  number?: number;
+  declare number: number;
 
   /**
    * The fully-qualified name of the extension field. There must be a leading
@@ -589,7 +604,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional string full_name = 2;
    */
-  fullName?: string;
+  declare fullName: string;
 
   /**
    * The fully-qualified type name of the extension field. Unlike
@@ -598,7 +613,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional string type = 3;
    */
-  type?: string;
+  declare type: string;
 
   /**
    * If true, indicates that the number is reserved in the extension range,
@@ -607,7 +622,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional bool reserved = 5;
    */
-  reserved?: boolean;
+  declare reserved: boolean;
 
   /**
    * If true, indicates that the extension must be defined as repeated.
@@ -615,7 +630,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional bool repeated = 6;
    */
-  repeated?: boolean;
+  declare repeated: boolean;
 
   constructor(data?: PartialMessage<ExtensionRangeOptions_Declaration>) {
     super();
@@ -649,6 +664,12 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
   }
 }
 
+ExtensionRangeOptions_Declaration.prototype.number = 0;
+ExtensionRangeOptions_Declaration.prototype.fullName = "";
+ExtensionRangeOptions_Declaration.prototype.type = "";
+ExtensionRangeOptions_Declaration.prototype.reserved = false;
+ExtensionRangeOptions_Declaration.prototype.repeated = false;
+
 /**
  * Describes a field within a message.
  *
@@ -658,17 +679,17 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional int32 number = 3;
    */
-  number?: number;
+  declare number: number;
 
   /**
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Label label = 4;
    */
-  label?: FieldDescriptorProto_Label;
+  declare label: FieldDescriptorProto_Label;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
@@ -676,7 +697,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Type type = 5;
    */
-  type?: FieldDescriptorProto_Type;
+  declare type: FieldDescriptorProto_Type;
 
   /**
    * For message and enum types, this is the name of the type.  If the name
@@ -687,7 +708,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string type_name = 6;
    */
-  typeName?: string;
+  declare typeName: string;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
@@ -695,7 +716,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string extendee = 2;
    */
-  extendee?: string;
+  declare extendee: string;
 
   /**
    * For numeric types, contains the original text representation of the value.
@@ -705,7 +726,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string default_value = 7;
    */
-  defaultValue?: string;
+  declare defaultValue: string;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
@@ -713,7 +734,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional int32 oneof_index = 9;
    */
-  oneofIndex?: number;
+  declare oneofIndex: number;
 
   /**
    * JSON name of this field. The value is set by protocol compiler. If the
@@ -723,7 +744,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string json_name = 10;
    */
-  jsonName?: string;
+  declare jsonName: string;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
@@ -755,7 +776,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional bool proto3_optional = 17;
    */
-  proto3Optional?: boolean;
+  declare proto3Optional: boolean;
 
   constructor(data?: PartialMessage<FieldDescriptorProto>) {
     super();
@@ -794,6 +815,17 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     return proto2.util.equals(FieldDescriptorProto, a, b);
   }
 }
+
+FieldDescriptorProto.prototype.name = "";
+FieldDescriptorProto.prototype.number = 0;
+FieldDescriptorProto.prototype.label = 1 as FieldDescriptorProto_Label.OPTIONAL;
+FieldDescriptorProto.prototype.type = 1 as FieldDescriptorProto_Type.DOUBLE;
+FieldDescriptorProto.prototype.typeName = "";
+FieldDescriptorProto.prototype.extendee = "";
+FieldDescriptorProto.prototype.defaultValue = "";
+FieldDescriptorProto.prototype.oneofIndex = 0;
+FieldDescriptorProto.prototype.jsonName = "";
+FieldDescriptorProto.prototype.proto3Optional = false;
 
 /**
  * @generated from enum google.protobuf.FieldDescriptorProto.Type
@@ -975,7 +1007,7 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
@@ -1011,6 +1043,8 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
   }
 }
 
+OneofDescriptorProto.prototype.name = "";
+
 /**
  * Describes an enum type.
  *
@@ -1020,7 +1054,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: repeated google.protobuf.EnumValueDescriptorProto value = 2;
@@ -1081,6 +1115,8 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   }
 }
 
+EnumDescriptorProto.prototype.name = "";
+
 /**
  * Range of reserved numeric values. Reserved values may not be used by
  * entries in the same enum. Reserved ranges may not overlap.
@@ -1097,14 +1133,14 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  declare start: number;
 
   /**
    * Inclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  declare end: number;
 
   constructor(data?: PartialMessage<EnumDescriptorProto_EnumReservedRange>) {
     super();
@@ -1135,6 +1171,9 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
   }
 }
 
+EnumDescriptorProto_EnumReservedRange.prototype.start = 0;
+EnumDescriptorProto_EnumReservedRange.prototype.end = 0;
+
 /**
  * Describes a value within an enum.
  *
@@ -1144,12 +1183,12 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional int32 number = 2;
    */
-  number?: number;
+  declare number: number;
 
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
@@ -1186,6 +1225,9 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
   }
 }
 
+EnumValueDescriptorProto.prototype.name = "";
+EnumValueDescriptorProto.prototype.number = 0;
+
 /**
  * Describes a service.
  *
@@ -1195,7 +1237,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: repeated google.protobuf.MethodDescriptorProto method = 2;
@@ -1237,6 +1279,8 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   }
 }
 
+ServiceDescriptorProto.prototype.name = "";
+
 /**
  * Describes a method of a service.
  *
@@ -1246,7 +1290,7 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -1254,12 +1298,12 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
    *
    * @generated from field: optional string input_type = 2;
    */
-  inputType?: string;
+  declare inputType: string;
 
   /**
    * @generated from field: optional string output_type = 3;
    */
-  outputType?: string;
+  declare outputType: string;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
@@ -1271,14 +1315,14 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
    *
    * @generated from field: optional bool client_streaming = 5 [default = false];
    */
-  clientStreaming?: boolean;
+  declare clientStreaming: boolean;
 
   /**
    * Identifies if server streams multiple server messages
    *
    * @generated from field: optional bool server_streaming = 6 [default = false];
    */
-  serverStreaming?: boolean;
+  declare serverStreaming: boolean;
 
   constructor(data?: PartialMessage<MethodDescriptorProto>) {
     super();
@@ -1313,6 +1357,12 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
   }
 }
 
+MethodDescriptorProto.prototype.name = "";
+MethodDescriptorProto.prototype.inputType = "";
+MethodDescriptorProto.prototype.outputType = "";
+MethodDescriptorProto.prototype.clientStreaming = false;
+MethodDescriptorProto.prototype.serverStreaming = false;
+
 /**
  * @generated from message google.protobuf.FileOptions
  */
@@ -1325,7 +1375,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_package = 1;
    */
-  javaPackage?: string;
+  declare javaPackage: string;
 
   /**
    * Controls the name of the wrapper Java class generated for the .proto file.
@@ -1336,7 +1386,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_outer_classname = 8;
    */
-  javaOuterClassname?: string;
+  declare javaOuterClassname: string;
 
   /**
    * If enabled, then the Java code generator will generate a separate .java
@@ -1348,7 +1398,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_multiple_files = 10 [default = false];
    */
-  javaMultipleFiles?: boolean;
+  declare javaMultipleFiles: boolean;
 
   /**
    * This option does nothing.
@@ -1356,7 +1406,7 @@ export class FileOptions extends Message<FileOptions> {
    * @generated from field: optional bool java_generate_equals_and_hash = 20 [deprecated = true];
    * @deprecated
    */
-  javaGenerateEqualsAndHash?: boolean;
+  declare javaGenerateEqualsAndHash: boolean;
 
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -1368,12 +1418,12 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_string_check_utf8 = 27 [default = false];
    */
-  javaStringCheckUtf8?: boolean;
+  declare javaStringCheckUtf8: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9 [default = SPEED];
    */
-  optimizeFor?: FileOptions_OptimizeMode;
+  declare optimizeFor: FileOptions_OptimizeMode;
 
   /**
    * Sets the Go package where structs generated from this .proto will be
@@ -1384,7 +1434,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string go_package = 11;
    */
-  goPackage?: string;
+  declare goPackage: string;
 
   /**
    * Should generic services be generated in each language?  "Generic" services
@@ -1400,22 +1450,22 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_generic_services = 16 [default = false];
    */
-  ccGenericServices?: boolean;
+  declare ccGenericServices: boolean;
 
   /**
    * @generated from field: optional bool java_generic_services = 17 [default = false];
    */
-  javaGenericServices?: boolean;
+  declare javaGenericServices: boolean;
 
   /**
    * @generated from field: optional bool py_generic_services = 18 [default = false];
    */
-  pyGenericServices?: boolean;
+  declare pyGenericServices: boolean;
 
   /**
    * @generated from field: optional bool php_generic_services = 42 [default = false];
    */
-  phpGenericServices?: boolean;
+  declare phpGenericServices: boolean;
 
   /**
    * Is this file deprecated?
@@ -1425,7 +1475,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool deprecated = 23 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
@@ -1433,7 +1483,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_enable_arenas = 31 [default = true];
    */
-  ccEnableArenas?: boolean;
+  declare ccEnableArenas: boolean;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
@@ -1441,14 +1491,14 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string objc_class_prefix = 36;
    */
-  objcClassPrefix?: string;
+  declare objcClassPrefix: string;
 
   /**
    * Namespace for generated classes; defaults to the package.
    *
    * @generated from field: optional string csharp_namespace = 37;
    */
-  csharpNamespace?: string;
+  declare csharpNamespace: string;
 
   /**
    * By default Swift generators will take the proto package and CamelCase it
@@ -1458,7 +1508,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string swift_prefix = 39;
    */
-  swiftPrefix?: string;
+  declare swiftPrefix: string;
 
   /**
    * Sets the php class prefix which is prepended to all php generated classes
@@ -1466,7 +1516,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_class_prefix = 40;
    */
-  phpClassPrefix?: string;
+  declare phpClassPrefix: string;
 
   /**
    * Use this option to change the namespace of php generated classes. Default
@@ -1475,7 +1525,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_namespace = 41;
    */
-  phpNamespace?: string;
+  declare phpNamespace: string;
 
   /**
    * Use this option to change the namespace of php generated metadata classes.
@@ -1484,7 +1534,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_metadata_namespace = 44;
    */
-  phpMetadataNamespace?: string;
+  declare phpMetadataNamespace: string;
 
   /**
    * Use this option to change the package of ruby generated classes. Default
@@ -1493,7 +1543,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string ruby_package = 45;
    */
-  rubyPackage?: string;
+  declare rubyPackage: string;
 
   /**
    * Any features defined in the specific edition.
@@ -1559,6 +1609,27 @@ export class FileOptions extends Message<FileOptions> {
   }
 }
 
+FileOptions.prototype.javaPackage = "";
+FileOptions.prototype.javaOuterClassname = "";
+FileOptions.prototype.javaMultipleFiles = false;
+FileOptions.prototype.javaGenerateEqualsAndHash = false;
+FileOptions.prototype.javaStringCheckUtf8 = false;
+FileOptions.prototype.optimizeFor = 1 as FileOptions_OptimizeMode.SPEED;
+FileOptions.prototype.goPackage = "";
+FileOptions.prototype.ccGenericServices = false;
+FileOptions.prototype.javaGenericServices = false;
+FileOptions.prototype.pyGenericServices = false;
+FileOptions.prototype.phpGenericServices = false;
+FileOptions.prototype.deprecated = false;
+FileOptions.prototype.ccEnableArenas = true;
+FileOptions.prototype.objcClassPrefix = "";
+FileOptions.prototype.csharpNamespace = "";
+FileOptions.prototype.swiftPrefix = "";
+FileOptions.prototype.phpClassPrefix = "";
+FileOptions.prototype.phpNamespace = "";
+FileOptions.prototype.phpMetadataNamespace = "";
+FileOptions.prototype.rubyPackage = "";
+
 /**
  * Generated classes can be optimized for speed or code size.
  *
@@ -1621,7 +1692,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool message_set_wire_format = 1 [default = false];
    */
-  messageSetWireFormat?: boolean;
+  declare messageSetWireFormat: boolean;
 
   /**
    * Disables the generation of the standard "descriptor()" accessor, which can
@@ -1630,7 +1701,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool no_standard_descriptor_accessor = 2 [default = false];
    */
-  noStandardDescriptorAccessor?: boolean;
+  declare noStandardDescriptorAccessor: boolean;
 
   /**
    * Is this message deprecated?
@@ -1640,7 +1711,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * NOTE: Do not set the option in .proto files. Always use the maps syntax
@@ -1667,7 +1738,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool map_entry = 7;
    */
-  mapEntry?: boolean;
+  declare mapEntry: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -1684,7 +1755,7 @@ export class MessageOptions extends Message<MessageOptions> {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  declare deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -1734,6 +1805,12 @@ export class MessageOptions extends Message<MessageOptions> {
   }
 }
 
+MessageOptions.prototype.messageSetWireFormat = false;
+MessageOptions.prototype.noStandardDescriptorAccessor = false;
+MessageOptions.prototype.deprecated = false;
+MessageOptions.prototype.mapEntry = false;
+MessageOptions.prototype.deprecatedLegacyJsonFieldConflicts = false;
+
 /**
  * @generated from message google.protobuf.FieldOptions
  */
@@ -1748,7 +1825,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.CType ctype = 1 [default = STRING];
    */
-  ctype?: FieldOptions_CType;
+  declare ctype: FieldOptions_CType;
 
   /**
    * The packed option can be enabled for repeated primitive fields to enable
@@ -1761,7 +1838,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool packed = 2;
    */
-  packed?: boolean;
+  declare packed: boolean;
 
   /**
    * The jstype option determines the JavaScript type used for values of the
@@ -1778,7 +1855,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL];
    */
-  jstype?: FieldOptions_JSType;
+  declare jstype: FieldOptions_JSType;
 
   /**
    * Should this field be parsed lazily?  Lazy applies only to message-type
@@ -1814,7 +1891,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool lazy = 5 [default = false];
    */
-  lazy?: boolean;
+  declare lazy: boolean;
 
   /**
    * unverified_lazy does no correctness checks on the byte stream. This should
@@ -1823,7 +1900,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool unverified_lazy = 15 [default = false];
    */
-  unverifiedLazy?: boolean;
+  declare unverifiedLazy: boolean;
 
   /**
    * Is this field deprecated?
@@ -1833,14 +1910,14 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * For Google-internal migration only. Do not use.
    *
    * @generated from field: optional bool weak = 10 [default = false];
    */
-  weak?: boolean;
+  declare weak: boolean;
 
   /**
    * Indicate that the field value should not be printed out when using debug
@@ -1848,12 +1925,12 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool debug_redact = 16 [default = false];
    */
-  debugRedact?: boolean;
+  declare debugRedact: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.OptionRetention retention = 17;
    */
-  retention?: FieldOptions_OptionRetention;
+  declare retention: FieldOptions_OptionRetention;
 
   /**
    * @generated from field: repeated google.protobuf.FieldOptions.OptionTargetType targets = 19;
@@ -1918,6 +1995,16 @@ export class FieldOptions extends Message<FieldOptions> {
     return proto2.util.equals(FieldOptions, a, b);
   }
 }
+
+FieldOptions.prototype.ctype = 0 as FieldOptions_CType.STRING;
+FieldOptions.prototype.packed = false;
+FieldOptions.prototype.jstype = 0 as FieldOptions_JSType.JS_NORMAL;
+FieldOptions.prototype.lazy = false;
+FieldOptions.prototype.unverifiedLazy = false;
+FieldOptions.prototype.deprecated = false;
+FieldOptions.prototype.weak = false;
+FieldOptions.prototype.debugRedact = false;
+FieldOptions.prototype.retention = 0 as FieldOptions_OptionRetention.RETENTION_UNKNOWN;
 
 /**
  * @generated from enum google.protobuf.FieldOptions.CType
@@ -2096,14 +2183,14 @@ export class FieldOptions_EditionDefault extends Message<FieldOptions_EditionDef
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: Edition;
+  declare edition: Edition;
 
   /**
    * Textproto value.
    *
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  declare value: string;
 
   constructor(data?: PartialMessage<FieldOptions_EditionDefault>) {
     super();
@@ -2133,6 +2220,9 @@ export class FieldOptions_EditionDefault extends Message<FieldOptions_EditionDef
     return proto2.util.equals(FieldOptions_EditionDefault, a, b);
   }
 }
+
+FieldOptions_EditionDefault.prototype.edition = 0 as Edition.EDITION_UNKNOWN;
+FieldOptions_EditionDefault.prototype.value = "";
 
 /**
  * @generated from message google.protobuf.OneofOptions
@@ -2191,7 +2281,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool allow_alias = 2;
    */
-  allowAlias?: boolean;
+  declare allowAlias: boolean;
 
   /**
    * Is this enum deprecated?
@@ -2201,7 +2291,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -2214,7 +2304,7 @@ export class EnumOptions extends Message<EnumOptions> {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  declare deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -2262,6 +2352,10 @@ export class EnumOptions extends Message<EnumOptions> {
   }
 }
 
+EnumOptions.prototype.allowAlias = false;
+EnumOptions.prototype.deprecated = false;
+EnumOptions.prototype.deprecatedLegacyJsonFieldConflicts = false;
+
 /**
  * @generated from message google.protobuf.EnumValueOptions
  */
@@ -2274,7 +2368,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool deprecated = 1 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -2290,7 +2384,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool debug_redact = 3 [default = false];
    */
-  debugRedact?: boolean;
+  declare debugRedact: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2330,6 +2424,9 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
   }
 }
 
+EnumValueOptions.prototype.deprecated = false;
+EnumValueOptions.prototype.debugRedact = false;
+
 /**
  * @generated from message google.protobuf.ServiceOptions
  */
@@ -2349,7 +2446,7 @@ export class ServiceOptions extends Message<ServiceOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2388,6 +2485,8 @@ export class ServiceOptions extends Message<ServiceOptions> {
   }
 }
 
+ServiceOptions.prototype.deprecated = false;
+
 /**
  * @generated from message google.protobuf.MethodOptions
  */
@@ -2400,12 +2499,12 @@ export class MethodOptions extends Message<MethodOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
    */
-  idempotencyLevel?: MethodOptions_IdempotencyLevel;
+  declare idempotencyLevel: MethodOptions_IdempotencyLevel;
 
   /**
    * Any features defined in the specific edition.
@@ -2451,6 +2550,9 @@ export class MethodOptions extends Message<MethodOptions> {
     return proto2.util.equals(MethodOptions, a, b);
   }
 }
+
+MethodOptions.prototype.deprecated = false;
+MethodOptions.prototype.idempotencyLevel = 0 as MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN;
 
 /**
  * Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
@@ -2508,32 +2610,32 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
    *
    * @generated from field: optional string identifier_value = 3;
    */
-  identifierValue?: string;
+  declare identifierValue: string;
 
   /**
    * @generated from field: optional uint64 positive_int_value = 4;
    */
-  positiveIntValue?: bigint;
+  declare positiveIntValue: bigint;
 
   /**
    * @generated from field: optional int64 negative_int_value = 5;
    */
-  negativeIntValue?: bigint;
+  declare negativeIntValue: bigint;
 
   /**
    * @generated from field: optional double double_value = 6;
    */
-  doubleValue?: number;
+  declare doubleValue: number;
 
   /**
    * @generated from field: optional bytes string_value = 7;
    */
-  stringValue?: Uint8Array;
+  declare stringValue: Uint8Array;
 
   /**
    * @generated from field: optional string aggregate_value = 8;
    */
-  aggregateValue?: string;
+  declare aggregateValue: string;
 
   constructor(data?: PartialMessage<UninterpretedOption>) {
     super();
@@ -2568,6 +2670,13 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
     return proto2.util.equals(UninterpretedOption, a, b);
   }
 }
+
+UninterpretedOption.prototype.identifierValue = "";
+UninterpretedOption.prototype.positiveIntValue = protoInt64.zero;
+UninterpretedOption.prototype.negativeIntValue = protoInt64.zero;
+UninterpretedOption.prototype.doubleValue = 0;
+UninterpretedOption.prototype.stringValue = new Uint8Array(0);
+UninterpretedOption.prototype.aggregateValue = "";
 
 /**
  * The name of the uninterpreted option.  Each string represents a segment in
@@ -2635,32 +2744,32 @@ export class FeatureSet extends Message<FeatureSet> {
   /**
    * @generated from field: optional google.protobuf.FeatureSet.FieldPresence field_presence = 1;
    */
-  fieldPresence?: FeatureSet_FieldPresence;
+  declare fieldPresence: FeatureSet_FieldPresence;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.EnumType enum_type = 2;
    */
-  enumType?: FeatureSet_EnumType;
+  declare enumType: FeatureSet_EnumType;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding = 3;
    */
-  repeatedFieldEncoding?: FeatureSet_RepeatedFieldEncoding;
+  declare repeatedFieldEncoding: FeatureSet_RepeatedFieldEncoding;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.Utf8Validation utf8_validation = 4;
    */
-  utf8Validation?: FeatureSet_Utf8Validation;
+  declare utf8Validation: FeatureSet_Utf8Validation;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.MessageEncoding message_encoding = 5;
    */
-  messageEncoding?: FeatureSet_MessageEncoding;
+  declare messageEncoding: FeatureSet_MessageEncoding;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.JsonFormat json_format = 6;
    */
-  jsonFormat?: FeatureSet_JsonFormat;
+  declare jsonFormat: FeatureSet_JsonFormat;
 
   constructor(data?: PartialMessage<FeatureSet>) {
     super();
@@ -2694,6 +2803,13 @@ export class FeatureSet extends Message<FeatureSet> {
     return proto2.util.equals(FeatureSet, a, b);
   }
 }
+
+FeatureSet.prototype.fieldPresence = 0 as FeatureSet_FieldPresence.FIELD_PRESENCE_UNKNOWN;
+FeatureSet.prototype.enumType = 0 as FeatureSet_EnumType.ENUM_TYPE_UNKNOWN;
+FeatureSet.prototype.repeatedFieldEncoding = 0 as FeatureSet_RepeatedFieldEncoding.REPEATED_FIELD_ENCODING_UNKNOWN;
+FeatureSet.prototype.utf8Validation = 0 as FeatureSet_Utf8Validation.UTF8_VALIDATION_UNKNOWN;
+FeatureSet.prototype.messageEncoding = 0 as FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN;
+FeatureSet.prototype.jsonFormat = 0 as FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN;
 
 /**
  * @generated from enum google.protobuf.FeatureSet.FieldPresence
@@ -2877,7 +2993,7 @@ export class FeatureSetDefaults extends Message<FeatureSetDefaults> {
    *
    * @generated from field: optional google.protobuf.Edition minimum_edition = 4;
    */
-  minimumEdition?: Edition;
+  declare minimumEdition: Edition;
 
   /**
    * The maximum known edition (inclusive) when this was constructed. Editions
@@ -2885,7 +3001,7 @@ export class FeatureSetDefaults extends Message<FeatureSetDefaults> {
    *
    * @generated from field: optional google.protobuf.Edition maximum_edition = 5;
    */
-  maximumEdition?: Edition;
+  declare maximumEdition: Edition;
 
   constructor(data?: PartialMessage<FeatureSetDefaults>) {
     super();
@@ -2917,6 +3033,9 @@ export class FeatureSetDefaults extends Message<FeatureSetDefaults> {
   }
 }
 
+FeatureSetDefaults.prototype.minimumEdition = 0 as Edition.EDITION_UNKNOWN;
+FeatureSetDefaults.prototype.maximumEdition = 0 as Edition.EDITION_UNKNOWN;
+
 /**
  * A map from every known edition with a unique set of defaults to its
  * defaults. Not all editions may be contained here.  For a given edition,
@@ -2929,7 +3048,7 @@ export class FeatureSetDefaults_FeatureSetEditionDefault extends Message<Feature
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: Edition;
+  declare edition: Edition;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet features = 2;
@@ -2964,6 +3083,8 @@ export class FeatureSetDefaults_FeatureSetEditionDefault extends Message<Feature
     return proto2.util.equals(FeatureSetDefaults_FeatureSetEditionDefault, a, b);
   }
 }
+
+FeatureSetDefaults_FeatureSetEditionDefault.prototype.edition = 0 as Edition.EDITION_UNKNOWN;
 
 /**
  * Encapsulates information about the original source file from which a
@@ -3144,12 +3265,12 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
    *
    * @generated from field: optional string leading_comments = 3;
    */
-  leadingComments?: string;
+  declare leadingComments: string;
 
   /**
    * @generated from field: optional string trailing_comments = 4;
    */
-  trailingComments?: string;
+  declare trailingComments: string;
 
   /**
    * @generated from field: repeated string leading_detached_comments = 6;
@@ -3187,6 +3308,9 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
     return proto2.util.equals(SourceCodeInfo_Location, a, b);
   }
 }
+
+SourceCodeInfo_Location.prototype.leadingComments = "";
+SourceCodeInfo_Location.prototype.trailingComments = "";
 
 /**
  * Describes the relationship between generated code and its original source
@@ -3249,7 +3373,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional string source_file = 2;
    */
-  sourceFile?: string;
+  declare sourceFile: string;
 
   /**
    * Identifies the starting offset in bytes in the generated code
@@ -3257,7 +3381,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 begin = 3;
    */
-  begin?: number;
+  declare begin: number;
 
   /**
    * Identifies the ending offset in bytes in the generated code that
@@ -3266,12 +3390,12 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 end = 4;
    */
-  end?: number;
+  declare end: number;
 
   /**
    * @generated from field: optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic = 5;
    */
-  semantic?: GeneratedCodeInfo_Annotation_Semantic;
+  declare semantic: GeneratedCodeInfo_Annotation_Semantic;
 
   constructor(data?: PartialMessage<GeneratedCodeInfo_Annotation>) {
     super();
@@ -3304,6 +3428,11 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
     return proto2.util.equals(GeneratedCodeInfo_Annotation, a, b);
   }
 }
+
+GeneratedCodeInfo_Annotation.prototype.sourceFile = "";
+GeneratedCodeInfo_Annotation.prototype.begin = 0;
+GeneratedCodeInfo_Annotation.prototype.end = 0;
+GeneratedCodeInfo_Annotation.prototype.semantic = 0 as GeneratedCodeInfo_Annotation_Semantic.NONE;
 
 /**
  * Represents the identified object's effect on the element in the original

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/map_lite_unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/map_lite_unittest_pb.ts
@@ -607,7 +607,7 @@ export class ForeignMessageArenaLite extends Message<ForeignMessageArenaLite> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  declare c: number;
 
   constructor(data?: PartialMessage<ForeignMessageArenaLite>) {
     super();
@@ -636,4 +636,6 @@ export class ForeignMessageArenaLite extends Message<ForeignMessageArenaLite> {
     return proto2.util.equals(ForeignMessageArenaLite, a, b);
   }
 }
+
+ForeignMessageArenaLite.prototype.c = 0;
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
@@ -64,77 +64,77 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  declare optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  declare optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  declare optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  declare optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  declare optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  declare optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  declare optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  declare optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  declare optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  declare optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  declare optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  declare optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  declare optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
@@ -149,22 +149,22 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesProto2_NestedEnum;
+  declare optionalNestedEnum: TestAllTypesProto2_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignEnumProto2 optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumProto2;
+  declare optionalForeignEnum: ForeignEnumProto2;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  declare optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  declare optionalCord: string;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
@@ -588,77 +588,77 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 default_int32 = 241 [default = -123456789];
    */
-  defaultInt32?: number;
+  declare defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 242 [default = -9123456789123456789];
    */
-  defaultInt64?: bigint;
+  declare defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 243 [default = 2123456789];
    */
-  defaultUint32?: number;
+  declare defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 244 [default = 10123456789123456789];
    */
-  defaultUint64?: bigint;
+  declare defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 245 [default = -123456789];
    */
-  defaultSint32?: number;
+  declare defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 246 [default = -9123456789123456789];
    */
-  defaultSint64?: bigint;
+  declare defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 247 [default = 2123456789];
    */
-  defaultFixed32?: number;
+  declare defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 248 [default = 10123456789123456789];
    */
-  defaultFixed64?: bigint;
+  declare defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 249 [default = -123456789];
    */
-  defaultSfixed32?: number;
+  declare defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
    */
-  defaultSfixed64?: bigint;
+  declare defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 251 [default = 9e+09];
    */
-  defaultFloat?: number;
+  declare defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 252 [default = 7e+22];
    */
-  defaultDouble?: number;
+  declare defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 253 [default = true];
    */
-  defaultBool?: boolean;
+  declare defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 254 [default = "Rosebud"];
    */
-  defaultString?: string;
+  declare defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 255 [default = "joshua"];
    */
-  defaultBytes?: Uint8Array;
+  declare defaultBytes: Uint8Array;
 
   /**
    * Test field-name-to-JSON-name convention.
@@ -666,92 +666,92 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
    *
    * @generated from field: optional int32 fieldname1 = 401;
    */
-  fieldname1?: number;
+  declare fieldname1: number;
 
   /**
    * @generated from field: optional int32 field_name2 = 402;
    */
-  fieldName2?: number;
+  declare fieldName2: number;
 
   /**
    * @generated from field: optional int32 _field_name3 = 403;
    */
-  FieldName3?: number;
+  declare FieldName3: number;
 
   /**
    * @generated from field: optional int32 field__name4_ = 404;
    */
-  fieldName4?: number;
+  declare fieldName4: number;
 
   /**
    * @generated from field: optional int32 field0name5 = 405;
    */
-  field0name5?: number;
+  declare field0name5: number;
 
   /**
    * @generated from field: optional int32 field_0_name6 = 406;
    */
-  field0Name6?: number;
+  declare field0Name6: number;
 
   /**
    * @generated from field: optional int32 fieldName7 = 407;
    */
-  fieldName7?: number;
+  declare fieldName7: number;
 
   /**
    * @generated from field: optional int32 FieldName8 = 408;
    */
-  FieldName8?: number;
+  declare FieldName8: number;
 
   /**
    * @generated from field: optional int32 field_Name9 = 409;
    */
-  fieldName9?: number;
+  declare fieldName9: number;
 
   /**
    * @generated from field: optional int32 Field_Name10 = 410;
    */
-  FieldName10?: number;
+  declare FieldName10: number;
 
   /**
    * @generated from field: optional int32 FIELD_NAME11 = 411;
    */
-  FIELDNAME11?: number;
+  declare FIELDNAME11: number;
 
   /**
    * @generated from field: optional int32 FIELD_name12 = 412;
    */
-  FIELDName12?: number;
+  declare FIELDName12: number;
 
   /**
    * @generated from field: optional int32 __field_name13 = 413;
    */
-  FieldName13?: number;
+  declare FieldName13: number;
 
   /**
    * @generated from field: optional int32 __Field_name14 = 414;
    */
-  FieldName14?: number;
+  declare FieldName14: number;
 
   /**
    * @generated from field: optional int32 field__name15 = 415;
    */
-  fieldName15?: number;
+  declare fieldName15: number;
 
   /**
    * @generated from field: optional int32 field__Name16 = 416;
    */
-  fieldName16?: number;
+  declare fieldName16: number;
 
   /**
    * @generated from field: optional int32 field_name17__ = 417;
    */
-  fieldName17?: number;
+  declare fieldName17: number;
 
   /**
    * @generated from field: optional int32 Field_name18__ = 418;
    */
-  FieldName18?: number;
+  declare FieldName18: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2>) {
     super();
@@ -913,6 +913,59 @@ export class TestAllTypesProto2 extends Message<TestAllTypesProto2> {
   }
 }
 
+TestAllTypesProto2.prototype.optionalInt32 = 0;
+TestAllTypesProto2.prototype.optionalInt64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalUint32 = 0;
+TestAllTypesProto2.prototype.optionalUint64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalSint32 = 0;
+TestAllTypesProto2.prototype.optionalSint64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalFixed32 = 0;
+TestAllTypesProto2.prototype.optionalFixed64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalSfixed32 = 0;
+TestAllTypesProto2.prototype.optionalSfixed64 = protoInt64.zero;
+TestAllTypesProto2.prototype.optionalFloat = 0;
+TestAllTypesProto2.prototype.optionalDouble = 0;
+TestAllTypesProto2.prototype.optionalBool = false;
+TestAllTypesProto2.prototype.optionalString = "";
+TestAllTypesProto2.prototype.optionalBytes = new Uint8Array(0);
+TestAllTypesProto2.prototype.optionalNestedEnum = 0 as TestAllTypesProto2_NestedEnum.FOO;
+TestAllTypesProto2.prototype.optionalForeignEnum = 0 as ForeignEnumProto2.FOREIGN_FOO;
+TestAllTypesProto2.prototype.optionalStringPiece = "";
+TestAllTypesProto2.prototype.optionalCord = "";
+TestAllTypesProto2.prototype.defaultInt32 = -123456789;
+TestAllTypesProto2.prototype.defaultInt64 = protoInt64.parse("-9123456789123456789");
+TestAllTypesProto2.prototype.defaultUint32 = 2123456789;
+TestAllTypesProto2.prototype.defaultUint64 = protoInt64.uParse("10123456789123456789");
+TestAllTypesProto2.prototype.defaultSint32 = -123456789;
+TestAllTypesProto2.prototype.defaultSint64 = protoInt64.parse("-9123456789123456789");
+TestAllTypesProto2.prototype.defaultFixed32 = 2123456789;
+TestAllTypesProto2.prototype.defaultFixed64 = protoInt64.uParse("10123456789123456789");
+TestAllTypesProto2.prototype.defaultSfixed32 = -123456789;
+TestAllTypesProto2.prototype.defaultSfixed64 = protoInt64.parse("-9123456789123456789");
+TestAllTypesProto2.prototype.defaultFloat = 9000000000;
+TestAllTypesProto2.prototype.defaultDouble = 7e+22;
+TestAllTypesProto2.prototype.defaultBool = true;
+TestAllTypesProto2.prototype.defaultString = "Rosebud";
+TestAllTypesProto2.prototype.defaultBytes = new Uint8Array([0x6A, 0x6F, 0x73, 0x68, 0x75, 0x61]);
+TestAllTypesProto2.prototype.fieldname1 = 0;
+TestAllTypesProto2.prototype.fieldName2 = 0;
+TestAllTypesProto2.prototype.FieldName3 = 0;
+TestAllTypesProto2.prototype.fieldName4 = 0;
+TestAllTypesProto2.prototype.field0name5 = 0;
+TestAllTypesProto2.prototype.field0Name6 = 0;
+TestAllTypesProto2.prototype.fieldName7 = 0;
+TestAllTypesProto2.prototype.FieldName8 = 0;
+TestAllTypesProto2.prototype.fieldName9 = 0;
+TestAllTypesProto2.prototype.FieldName10 = 0;
+TestAllTypesProto2.prototype.FIELDNAME11 = 0;
+TestAllTypesProto2.prototype.FIELDName12 = 0;
+TestAllTypesProto2.prototype.FieldName13 = 0;
+TestAllTypesProto2.prototype.FieldName14 = 0;
+TestAllTypesProto2.prototype.fieldName15 = 0;
+TestAllTypesProto2.prototype.fieldName16 = 0;
+TestAllTypesProto2.prototype.fieldName17 = 0;
+TestAllTypesProto2.prototype.FieldName18 = 0;
+
 /**
  * @generated from enum protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum
  */
@@ -954,7 +1007,7 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
@@ -990,6 +1043,8 @@ export class TestAllTypesProto2_NestedMessage extends Message<TestAllTypesProto2
   }
 }
 
+TestAllTypesProto2_NestedMessage.prototype.a = 0;
+
 /**
  * groups
  *
@@ -999,12 +1054,12 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
   /**
    * @generated from field: optional int32 group_int32 = 202;
    */
-  groupInt32?: number;
+  declare groupInt32: number;
 
   /**
    * @generated from field: optional uint32 group_uint32 = 203;
    */
-  groupUint32?: number;
+  declare groupUint32: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_Data>) {
     super();
@@ -1034,6 +1089,9 @@ export class TestAllTypesProto2_Data extends Message<TestAllTypesProto2_Data> {
     return proto2.util.equals(TestAllTypesProto2_Data, a, b);
   }
 }
+
+TestAllTypesProto2_Data.prototype.groupInt32 = 0;
+TestAllTypesProto2_Data.prototype.groupUint32 = 0;
 
 /**
  * message_set test case.
@@ -1075,7 +1133,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  declare str: string;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension1>) {
     super();
@@ -1105,6 +1163,8 @@ export class TestAllTypesProto2_MessageSetCorrectExtension1 extends Message<Test
   }
 }
 
+TestAllTypesProto2_MessageSetCorrectExtension1.prototype.str = "";
+
 /**
  * @generated from extension: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1 message_set_extension = 1547769;
  */
@@ -1121,7 +1181,7 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
   /**
    * @generated from field: optional int32 i = 9;
    */
-  i?: number;
+  declare i: number;
 
   constructor(data?: PartialMessage<TestAllTypesProto2_MessageSetCorrectExtension2>) {
     super();
@@ -1151,6 +1211,8 @@ export class TestAllTypesProto2_MessageSetCorrectExtension2 extends Message<Test
   }
 }
 
+TestAllTypesProto2_MessageSetCorrectExtension2.prototype.i = 0;
+
 /**
  * @generated from extension: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2 message_set_extension = 4135312;
  */
@@ -1167,7 +1229,7 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  declare c: number;
 
   constructor(data?: PartialMessage<ForeignMessageProto2>) {
     super();
@@ -1197,6 +1259,8 @@ export class ForeignMessageProto2 extends Message<ForeignMessageProto2> {
   }
 }
 
+ForeignMessageProto2.prototype.c = 0;
+
 /**
  * @generated from message protobuf_test_messages.proto2.UnknownToTestAllTypes
  */
@@ -1204,12 +1268,12 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   /**
    * @generated from field: optional int32 optional_int32 = 1001;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional string optional_string = 1002;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
@@ -1224,7 +1288,7 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   /**
    * @generated from field: optional bool optional_bool = 1006;
    */
-  optionalBool?: boolean;
+  declare optionalBool: boolean;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 1011;
@@ -1264,6 +1328,10 @@ export class UnknownToTestAllTypes extends Message<UnknownToTestAllTypes> {
   }
 }
 
+UnknownToTestAllTypes.prototype.optionalInt32 = 0;
+UnknownToTestAllTypes.prototype.optionalString = "";
+UnknownToTestAllTypes.prototype.optionalBool = false;
+
 /**
  * @generated from message protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup
  */
@@ -1271,7 +1339,7 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<UnknownToTestAllTypes_OptionalGroup>) {
     super();
@@ -1300,6 +1368,8 @@ export class UnknownToTestAllTypes_OptionalGroup extends Message<UnknownToTestAl
     return proto2.util.equals(UnknownToTestAllTypes_OptionalGroup, a, b);
   }
 }
+
+UnknownToTestAllTypes_OptionalGroup.prototype.a = 0;
 
 /**
  * @generated from message protobuf_test_messages.proto2.NullHypothesisProto2
@@ -1390,7 +1460,7 @@ export class OneStringProto2 extends Message<OneStringProto2> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  declare data: string;
 
   constructor(data?: PartialMessage<OneStringProto2>) {
     super();
@@ -1420,6 +1490,8 @@ export class OneStringProto2 extends Message<OneStringProto2> {
   }
 }
 
+OneStringProto2.prototype.data = "";
+
 /**
  * @generated from message protobuf_test_messages.proto2.ProtoWithKeywords
  */
@@ -1427,12 +1499,12 @@ export class ProtoWithKeywords extends Message<ProtoWithKeywords> {
   /**
    * @generated from field: optional int32 inline = 1;
    */
-  inline?: number;
+  declare inline: number;
 
   /**
    * @generated from field: optional string concept = 2;
    */
-  concept?: string;
+  declare concept: string;
 
   /**
    * @generated from field: repeated string requires = 3;
@@ -1468,6 +1540,9 @@ export class ProtoWithKeywords extends Message<ProtoWithKeywords> {
     return proto2.util.equals(ProtoWithKeywords, a, b);
   }
 }
+
+ProtoWithKeywords.prototype.inline = 0;
+ProtoWithKeywords.prototype.concept = "";
 
 /**
  * @generated from message protobuf_test_messages.proto2.TestAllRequiredTypesProto2

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -72,7 +72,7 @@ export class TestMessageWithCustomOptions extends Message<TestMessageWithCustomO
   /**
    * @generated from field: optional string field1 = 1;
    */
-  field1?: string;
+  declare field1: string;
 
   /**
    * @generated from oneof protobuf_unittest.TestMessageWithCustomOptions.AnOneof
@@ -119,6 +119,8 @@ export class TestMessageWithCustomOptions extends Message<TestMessageWithCustomO
     return proto2.util.equals(TestMessageWithCustomOptions, a, b);
   }
 }
+
+TestMessageWithCustomOptions.prototype.field1 = "";
 
 /**
  * @generated from enum protobuf_unittest.TestMessageWithCustomOptions.AnEnum
@@ -511,17 +513,17 @@ export class ComplexOptionType1 extends Message<ComplexOptionType1> {
   /**
    * @generated from field: optional int32 foo = 1;
    */
-  foo?: number;
+  declare foo: number;
 
   /**
    * @generated from field: optional int32 foo2 = 2;
    */
-  foo2?: number;
+  declare foo2: number;
 
   /**
    * @generated from field: optional int32 foo3 = 3;
    */
-  foo3?: number;
+  declare foo3: number;
 
   /**
    * @generated from field: repeated int32 foo4 = 4;
@@ -559,6 +561,10 @@ export class ComplexOptionType1 extends Message<ComplexOptionType1> {
   }
 }
 
+ComplexOptionType1.prototype.foo = 0;
+ComplexOptionType1.prototype.foo2 = 0;
+ComplexOptionType1.prototype.foo3 = 0;
+
 /**
  * @generated from message protobuf_unittest.ComplexOptionType2
  */
@@ -571,7 +577,7 @@ export class ComplexOptionType2 extends Message<ComplexOptionType2> {
   /**
    * @generated from field: optional int32 baz = 2;
    */
-  baz?: number;
+  declare baz: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
@@ -614,6 +620,8 @@ export class ComplexOptionType2 extends Message<ComplexOptionType2> {
   }
 }
 
+ComplexOptionType2.prototype.baz = 0;
+
 /**
  * @generated from message protobuf_unittest.ComplexOptionType2.ComplexOptionType4
  */
@@ -621,7 +629,7 @@ export class ComplexOptionType2_ComplexOptionType4 extends Message<ComplexOption
   /**
    * @generated from field: optional int32 waldo = 1;
    */
-  waldo?: number;
+  declare waldo: number;
 
   constructor(data?: PartialMessage<ComplexOptionType2_ComplexOptionType4>) {
     super();
@@ -651,6 +659,8 @@ export class ComplexOptionType2_ComplexOptionType4 extends Message<ComplexOption
   }
 }
 
+ComplexOptionType2_ComplexOptionType4.prototype.waldo = 0;
+
 /**
  * @generated from extension: optional protobuf_unittest.ComplexOptionType2.ComplexOptionType4 complex_opt4 = 7633546;
  */
@@ -667,7 +677,7 @@ export class ComplexOptionType3 extends Message<ComplexOptionType3> {
   /**
    * @generated from field: optional int32 moo = 1;
    */
-  moo?: number;
+  declare moo: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
@@ -703,6 +713,8 @@ export class ComplexOptionType3 extends Message<ComplexOptionType3> {
   }
 }
 
+ComplexOptionType3.prototype.moo = 0;
+
 /**
  * @generated from message protobuf_unittest.ComplexOptionType3.ComplexOptionType5
  */
@@ -710,7 +722,7 @@ export class ComplexOptionType3_ComplexOptionType5 extends Message<ComplexOption
   /**
    * @generated from field: optional int32 plugh = 3;
    */
-  plugh?: number;
+  declare plugh: number;
 
   constructor(data?: PartialMessage<ComplexOptionType3_ComplexOptionType5>) {
     super();
@@ -740,6 +752,8 @@ export class ComplexOptionType3_ComplexOptionType5 extends Message<ComplexOption
   }
 }
 
+ComplexOptionType3_ComplexOptionType5.prototype.plugh = 0;
+
 /**
  * @generated from message protobuf_unittest.ComplexOpt6
  */
@@ -747,7 +761,7 @@ export class ComplexOpt6 extends Message<ComplexOpt6> {
   /**
    * @generated from field: optional int32 xyzzy = 7593951;
    */
-  xyzzy?: number;
+  declare xyzzy: number;
 
   constructor(data?: PartialMessage<ComplexOpt6>) {
     super();
@@ -776,6 +790,8 @@ export class ComplexOpt6 extends Message<ComplexOpt6> {
     return proto2.util.equals(ComplexOpt6, a, b);
   }
 }
+
+ComplexOpt6.prototype.xyzzy = 0;
 
 /**
  * Note that we try various different ways of naming the same extension.
@@ -848,7 +864,7 @@ export class AggregateMessageSetElement extends Message<AggregateMessageSetEleme
   /**
    * @generated from field: optional string s = 1;
    */
-  s?: string;
+  declare s: string;
 
   constructor(data?: PartialMessage<AggregateMessageSetElement>) {
     super();
@@ -878,6 +894,8 @@ export class AggregateMessageSetElement extends Message<AggregateMessageSetEleme
   }
 }
 
+AggregateMessageSetElement.prototype.s = "";
+
 /**
  * @generated from extension: optional protobuf_unittest.AggregateMessageSetElement message_set_extension = 15447542;
  */
@@ -896,12 +914,12 @@ export class Aggregate extends Message<Aggregate> {
   /**
    * @generated from field: optional int32 i = 1;
    */
-  i?: number;
+  declare i: number;
 
   /**
    * @generated from field: optional string s = 2;
    */
-  s?: string;
+  declare s: string;
 
   /**
    * A nested object
@@ -964,6 +982,9 @@ export class Aggregate extends Message<Aggregate> {
   }
 }
 
+Aggregate.prototype.i = 0;
+Aggregate.prototype.s = "";
+
 /**
  * @generated from extension: optional protobuf_unittest.Aggregate nested = 15476903;
  */
@@ -980,7 +1001,7 @@ export class AggregateMessage extends Message<AggregateMessage> {
   /**
    * @generated from field: optional int32 fieldname = 1;
    */
-  fieldname?: number;
+  declare fieldname: number;
 
   constructor(data?: PartialMessage<AggregateMessage>) {
     super();
@@ -1009,6 +1030,8 @@ export class AggregateMessage extends Message<AggregateMessage> {
     return proto2.util.equals(AggregateMessage, a, b);
   }
 }
+
+AggregateMessage.prototype.fieldname = 0;
 
 /**
  * Test custom options for nested type.
@@ -1064,7 +1087,7 @@ export class NestedOptionType_NestedMessage extends Message<NestedOptionType_Nes
   /**
    * @generated from field: optional int32 nested_field = 1;
    */
-  nestedField?: number;
+  declare nestedField: number;
 
   constructor(data?: PartialMessage<NestedOptionType_NestedMessage>) {
     super();
@@ -1093,6 +1116,8 @@ export class NestedOptionType_NestedMessage extends Message<NestedOptionType_Nes
     return proto2.util.equals(NestedOptionType_NestedMessage, a, b);
   }
 }
+
+NestedOptionType_NestedMessage.prototype.nestedField = 0;
 
 /**
  * @generated from extension: optional int32 nested_extension = 7912573;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_enormous_descriptor_pb.ts
@@ -37,5002 +37,5002 @@ export class TestEnormousDescriptor extends Message<TestEnormousDescriptor> {
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1 = 1 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_2 = 2 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_3 = 3 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_4 = 4 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_5 = 5 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_6 = 6 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_7 = 7 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_8 = 8 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_9 = 9 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_10 = 10 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_11 = 11 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_12 = 12 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_13 = 13 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_14 = 14 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_15 = 15 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_16 = 16 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_17 = 17 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_18 = 18 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_19 = 19 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_20 = 20 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_21 = 21 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_22 = 22 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_23 = 23 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_24 = 24 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_25 = 25 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_26 = 26 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_27 = 27 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_28 = 28 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_29 = 29 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_30 = 30 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_31 = 31 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_32 = 32 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_33 = 33 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_34 = 34 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_35 = 35 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_36 = 36 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_37 = 37 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_38 = 38 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_39 = 39 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_40 = 40 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_41 = 41 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_42 = 42 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_43 = 43 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_44 = 44 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_45 = 45 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_46 = 46 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_47 = 47 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_48 = 48 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_49 = 49 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_50 = 50 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_51 = 51 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_52 = 52 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_53 = 53 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_54 = 54 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_55 = 55 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_56 = 56 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_57 = 57 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_58 = 58 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_59 = 59 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_60 = 60 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_61 = 61 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_62 = 62 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_63 = 63 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_64 = 64 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_65 = 65 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_66 = 66 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_67 = 67 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_68 = 68 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_69 = 69 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_70 = 70 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_71 = 71 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_72 = 72 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_73 = 73 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_74 = 74 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_75 = 75 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_76 = 76 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_77 = 77 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_78 = 78 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_79 = 79 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_80 = 80 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_81 = 81 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_82 = 82 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_83 = 83 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_84 = 84 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_85 = 85 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_86 = 86 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_87 = 87 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_88 = 88 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_89 = 89 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_90 = 90 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_91 = 91 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_92 = 92 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_93 = 93 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_94 = 94 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_95 = 95 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_96 = 96 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_97 = 97 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_98 = 98 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_99 = 99 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_100 = 100 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_101 = 101 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_102 = 102 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_103 = 103 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_104 = 104 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_105 = 105 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_106 = 106 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_107 = 107 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_108 = 108 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_109 = 109 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_110 = 110 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_111 = 111 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_112 = 112 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_113 = 113 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_114 = 114 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_115 = 115 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_116 = 116 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_117 = 117 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_118 = 118 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_119 = 119 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_120 = 120 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_121 = 121 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_122 = 122 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_123 = 123 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_124 = 124 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_125 = 125 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_126 = 126 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_127 = 127 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_128 = 128 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_129 = 129 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_130 = 130 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_131 = 131 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_132 = 132 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_133 = 133 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_134 = 134 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_135 = 135 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_136 = 136 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_137 = 137 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_138 = 138 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_139 = 139 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_140 = 140 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_141 = 141 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_142 = 142 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_143 = 143 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_144 = 144 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_145 = 145 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_146 = 146 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_147 = 147 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_148 = 148 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_149 = 149 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_150 = 150 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_151 = 151 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_152 = 152 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_153 = 153 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_154 = 154 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_155 = 155 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_156 = 156 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_157 = 157 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_158 = 158 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_159 = 159 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_160 = 160 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_161 = 161 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_162 = 162 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_163 = 163 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_164 = 164 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_165 = 165 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_166 = 166 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_167 = 167 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_168 = 168 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_169 = 169 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_170 = 170 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_171 = 171 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_172 = 172 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_173 = 173 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_174 = 174 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_175 = 175 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_176 = 176 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_177 = 177 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_178 = 178 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_179 = 179 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_180 = 180 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_181 = 181 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_182 = 182 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_183 = 183 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_184 = 184 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_185 = 185 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_186 = 186 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_187 = 187 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_188 = 188 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_189 = 189 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_190 = 190 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_191 = 191 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_192 = 192 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_193 = 193 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_194 = 194 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_195 = 195 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_196 = 196 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_197 = 197 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_198 = 198 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_199 = 199 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_200 = 200 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_201 = 201 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_202 = 202 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_203 = 203 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_204 = 204 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_205 = 205 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_206 = 206 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_207 = 207 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_208 = 208 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_209 = 209 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_210 = 210 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_211 = 211 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_212 = 212 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_213 = 213 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_214 = 214 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_215 = 215 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_216 = 216 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_217 = 217 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_218 = 218 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_219 = 219 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_220 = 220 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_221 = 221 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_222 = 222 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_223 = 223 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_224 = 224 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_225 = 225 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_226 = 226 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_227 = 227 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_228 = 228 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_229 = 229 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_230 = 230 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_231 = 231 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_232 = 232 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_233 = 233 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_234 = 234 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_235 = 235 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_236 = 236 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_237 = 237 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_238 = 238 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_239 = 239 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_240 = 240 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_241 = 241 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_242 = 242 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_243 = 243 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_244 = 244 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_245 = 245 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_246 = 246 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_247 = 247 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_248 = 248 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_249 = 249 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_250 = 250 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_251 = 251 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_252 = 252 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_253 = 253 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_254 = 254 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_255 = 255 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_256 = 256 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_257 = 257 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_258 = 258 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_259 = 259 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_260 = 260 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_261 = 261 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_262 = 262 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_263 = 263 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_264 = 264 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_265 = 265 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_266 = 266 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_267 = 267 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_268 = 268 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_269 = 269 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_270 = 270 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_271 = 271 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_272 = 272 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_273 = 273 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_274 = 274 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_275 = 275 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_276 = 276 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_277 = 277 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_278 = 278 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_279 = 279 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_280 = 280 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_281 = 281 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_282 = 282 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_283 = 283 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_284 = 284 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_285 = 285 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_286 = 286 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_287 = 287 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_288 = 288 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_289 = 289 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_290 = 290 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_291 = 291 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_292 = 292 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_293 = 293 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_294 = 294 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_295 = 295 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_296 = 296 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_297 = 297 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_298 = 298 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_299 = 299 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_300 = 300 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_301 = 301 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_302 = 302 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_303 = 303 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_304 = 304 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_305 = 305 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_306 = 306 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_307 = 307 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_308 = 308 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_309 = 309 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_310 = 310 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_311 = 311 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_312 = 312 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_313 = 313 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_314 = 314 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_315 = 315 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_316 = 316 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_317 = 317 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_318 = 318 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_319 = 319 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_320 = 320 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_321 = 321 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_322 = 322 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_323 = 323 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_324 = 324 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_325 = 325 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_326 = 326 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_327 = 327 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_328 = 328 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_329 = 329 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_330 = 330 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_331 = 331 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_332 = 332 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_333 = 333 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_334 = 334 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_335 = 335 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_336 = 336 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_337 = 337 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_338 = 338 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_339 = 339 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_340 = 340 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_341 = 341 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_342 = 342 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_343 = 343 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_344 = 344 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_345 = 345 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_346 = 346 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_347 = 347 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_348 = 348 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_349 = 349 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_350 = 350 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_351 = 351 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_352 = 352 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_353 = 353 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_354 = 354 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_355 = 355 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_356 = 356 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_357 = 357 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_358 = 358 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_359 = 359 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_360 = 360 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_361 = 361 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_362 = 362 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_363 = 363 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_364 = 364 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_365 = 365 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_366 = 366 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_367 = 367 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_368 = 368 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_369 = 369 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_370 = 370 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_371 = 371 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_372 = 372 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_373 = 373 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_374 = 374 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_375 = 375 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_376 = 376 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_377 = 377 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_378 = 378 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_379 = 379 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_380 = 380 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_381 = 381 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_382 = 382 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_383 = 383 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_384 = 384 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_385 = 385 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_386 = 386 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_387 = 387 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_388 = 388 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_389 = 389 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_390 = 390 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_391 = 391 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_392 = 392 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_393 = 393 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_394 = 394 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_395 = 395 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_396 = 396 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_397 = 397 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_398 = 398 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_399 = 399 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_400 = 400 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_401 = 401 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_402 = 402 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_403 = 403 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_404 = 404 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_405 = 405 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_406 = 406 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_407 = 407 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_408 = 408 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_409 = 409 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_410 = 410 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_411 = 411 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_412 = 412 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_413 = 413 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_414 = 414 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_415 = 415 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_416 = 416 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_417 = 417 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_418 = 418 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_419 = 419 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_420 = 420 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_421 = 421 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_422 = 422 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_423 = 423 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_424 = 424 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_425 = 425 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_426 = 426 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_427 = 427 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_428 = 428 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_429 = 429 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_430 = 430 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_431 = 431 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_432 = 432 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_433 = 433 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_434 = 434 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_435 = 435 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_436 = 436 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_437 = 437 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_438 = 438 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_439 = 439 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_440 = 440 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_441 = 441 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_442 = 442 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_443 = 443 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_444 = 444 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_445 = 445 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_446 = 446 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_447 = 447 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_448 = 448 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_449 = 449 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_450 = 450 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_451 = 451 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_452 = 452 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_453 = 453 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_454 = 454 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_455 = 455 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_456 = 456 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_457 = 457 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_458 = 458 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_459 = 459 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_460 = 460 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_461 = 461 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_462 = 462 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_463 = 463 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_464 = 464 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_465 = 465 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_466 = 466 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_467 = 467 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_468 = 468 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_469 = 469 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_470 = 470 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_471 = 471 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_472 = 472 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_473 = 473 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_474 = 474 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_475 = 475 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_476 = 476 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_477 = 477 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_478 = 478 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_479 = 479 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_480 = 480 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_481 = 481 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_482 = 482 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_483 = 483 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_484 = 484 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_485 = 485 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_486 = 486 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_487 = 487 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_488 = 488 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_489 = 489 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_490 = 490 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_491 = 491 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_492 = 492 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_493 = 493 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_494 = 494 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_495 = 495 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_496 = 496 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_497 = 497 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_498 = 498 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_499 = 499 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_500 = 500 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_501 = 501 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_502 = 502 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_503 = 503 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_504 = 504 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_505 = 505 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_506 = 506 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_507 = 507 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_508 = 508 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_509 = 509 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_510 = 510 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_511 = 511 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_512 = 512 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_513 = 513 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_514 = 514 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_515 = 515 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_516 = 516 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_517 = 517 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_518 = 518 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_519 = 519 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_520 = 520 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_521 = 521 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_522 = 522 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_523 = 523 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_524 = 524 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_525 = 525 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_526 = 526 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_527 = 527 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_528 = 528 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_529 = 529 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_530 = 530 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_531 = 531 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_532 = 532 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_533 = 533 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_534 = 534 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_535 = 535 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_536 = 536 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_537 = 537 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_538 = 538 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_539 = 539 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_540 = 540 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_541 = 541 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_542 = 542 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_543 = 543 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_544 = 544 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_545 = 545 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_546 = 546 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_547 = 547 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_548 = 548 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_549 = 549 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_550 = 550 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_551 = 551 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_552 = 552 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_553 = 553 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_554 = 554 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_555 = 555 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_556 = 556 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_557 = 557 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_558 = 558 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_559 = 559 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_560 = 560 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_561 = 561 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_562 = 562 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_563 = 563 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_564 = 564 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_565 = 565 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_566 = 566 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_567 = 567 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_568 = 568 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_569 = 569 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_570 = 570 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_571 = 571 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_572 = 572 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_573 = 573 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_574 = 574 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_575 = 575 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_576 = 576 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_577 = 577 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_578 = 578 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_579 = 579 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_580 = 580 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_581 = 581 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_582 = 582 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_583 = 583 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_584 = 584 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_585 = 585 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_586 = 586 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_587 = 587 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_588 = 588 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_589 = 589 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_590 = 590 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_591 = 591 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_592 = 592 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_593 = 593 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_594 = 594 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_595 = 595 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_596 = 596 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_597 = 597 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_598 = 598 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_599 = 599 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_600 = 600 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_601 = 601 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_602 = 602 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_603 = 603 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_604 = 604 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_605 = 605 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_606 = 606 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_607 = 607 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_608 = 608 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_609 = 609 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_610 = 610 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_611 = 611 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_612 = 612 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_613 = 613 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_614 = 614 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_615 = 615 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_616 = 616 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_617 = 617 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_618 = 618 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_619 = 619 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_620 = 620 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_621 = 621 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_622 = 622 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_623 = 623 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_624 = 624 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_625 = 625 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_626 = 626 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_627 = 627 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_628 = 628 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_629 = 629 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_630 = 630 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_631 = 631 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_632 = 632 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_633 = 633 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_634 = 634 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_635 = 635 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_636 = 636 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_637 = 637 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_638 = 638 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_639 = 639 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_640 = 640 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_641 = 641 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_642 = 642 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_643 = 643 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_644 = 644 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_645 = 645 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_646 = 646 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_647 = 647 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_648 = 648 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_649 = 649 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_650 = 650 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_651 = 651 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_652 = 652 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_653 = 653 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_654 = 654 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_655 = 655 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_656 = 656 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_657 = 657 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_658 = 658 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_659 = 659 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_660 = 660 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_661 = 661 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_662 = 662 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_663 = 663 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_664 = 664 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_665 = 665 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_666 = 666 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_667 = 667 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_668 = 668 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_669 = 669 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_670 = 670 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_671 = 671 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_672 = 672 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_673 = 673 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_674 = 674 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_675 = 675 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_676 = 676 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_677 = 677 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_678 = 678 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_679 = 679 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_680 = 680 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_681 = 681 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_682 = 682 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_683 = 683 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_684 = 684 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_685 = 685 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_686 = 686 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_687 = 687 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_688 = 688 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_689 = 689 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_690 = 690 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_691 = 691 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_692 = 692 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_693 = 693 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_694 = 694 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_695 = 695 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_696 = 696 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_697 = 697 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_698 = 698 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_699 = 699 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_700 = 700 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_701 = 701 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_702 = 702 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_703 = 703 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_704 = 704 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_705 = 705 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_706 = 706 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_707 = 707 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_708 = 708 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_709 = 709 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_710 = 710 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_711 = 711 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_712 = 712 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_713 = 713 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_714 = 714 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_715 = 715 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_716 = 716 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_717 = 717 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_718 = 718 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_719 = 719 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_720 = 720 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_721 = 721 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_722 = 722 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_723 = 723 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_724 = 724 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_725 = 725 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_726 = 726 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_727 = 727 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_728 = 728 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_729 = 729 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_730 = 730 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_731 = 731 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_732 = 732 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_733 = 733 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_734 = 734 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_735 = 735 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_736 = 736 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_737 = 737 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_738 = 738 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_739 = 739 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_740 = 740 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_741 = 741 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_742 = 742 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_743 = 743 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_744 = 744 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_745 = 745 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_746 = 746 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_747 = 747 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_748 = 748 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_749 = 749 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_750 = 750 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_751 = 751 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_752 = 752 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_753 = 753 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_754 = 754 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_755 = 755 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_756 = 756 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_757 = 757 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_758 = 758 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_759 = 759 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_760 = 760 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_761 = 761 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_762 = 762 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_763 = 763 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_764 = 764 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_765 = 765 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_766 = 766 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_767 = 767 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_768 = 768 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_769 = 769 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_770 = 770 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_771 = 771 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_772 = 772 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_773 = 773 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_774 = 774 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_775 = 775 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_776 = 776 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_777 = 777 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_778 = 778 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_779 = 779 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_780 = 780 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_781 = 781 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_782 = 782 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_783 = 783 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_784 = 784 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_785 = 785 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_786 = 786 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_787 = 787 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_788 = 788 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_789 = 789 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_790 = 790 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_791 = 791 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_792 = 792 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_793 = 793 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_794 = 794 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_795 = 795 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_796 = 796 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_797 = 797 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_798 = 798 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_799 = 799 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_800 = 800 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_801 = 801 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_802 = 802 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_803 = 803 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_804 = 804 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_805 = 805 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_806 = 806 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_807 = 807 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_808 = 808 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_809 = 809 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_810 = 810 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_811 = 811 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_812 = 812 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_813 = 813 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_814 = 814 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_815 = 815 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_816 = 816 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_817 = 817 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_818 = 818 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_819 = 819 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_820 = 820 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_821 = 821 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_822 = 822 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_823 = 823 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_824 = 824 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_825 = 825 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_826 = 826 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_827 = 827 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_828 = 828 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_829 = 829 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_830 = 830 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_831 = 831 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_832 = 832 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_833 = 833 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_834 = 834 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_835 = 835 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_836 = 836 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_837 = 837 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_838 = 838 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_839 = 839 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_840 = 840 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_841 = 841 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_842 = 842 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_843 = 843 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_844 = 844 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_845 = 845 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_846 = 846 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_847 = 847 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_848 = 848 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_849 = 849 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_850 = 850 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_851 = 851 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_852 = 852 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_853 = 853 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_854 = 854 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_855 = 855 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_856 = 856 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_857 = 857 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_858 = 858 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_859 = 859 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_860 = 860 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_861 = 861 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_862 = 862 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_863 = 863 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_864 = 864 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_865 = 865 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_866 = 866 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_867 = 867 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_868 = 868 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_869 = 869 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_870 = 870 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_871 = 871 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_872 = 872 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_873 = 873 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_874 = 874 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_875 = 875 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_876 = 876 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_877 = 877 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_878 = 878 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_879 = 879 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_880 = 880 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_881 = 881 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_882 = 882 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_883 = 883 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_884 = 884 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_885 = 885 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_886 = 886 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_887 = 887 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_888 = 888 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_889 = 889 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_890 = 890 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_891 = 891 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_892 = 892 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_893 = 893 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_894 = 894 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_895 = 895 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_896 = 896 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_897 = 897 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_898 = 898 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_899 = 899 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_900 = 900 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_901 = 901 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_902 = 902 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_903 = 903 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_904 = 904 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_905 = 905 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_906 = 906 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_907 = 907 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_908 = 908 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_909 = 909 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_910 = 910 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_911 = 911 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_912 = 912 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_913 = 913 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_914 = 914 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_915 = 915 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_916 = 916 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_917 = 917 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_918 = 918 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_919 = 919 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_920 = 920 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_921 = 921 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_922 = 922 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_923 = 923 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_924 = 924 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_925 = 925 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_926 = 926 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_927 = 927 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_928 = 928 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_929 = 929 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_930 = 930 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_931 = 931 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_932 = 932 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_933 = 933 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_934 = 934 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_935 = 935 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_936 = 936 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_937 = 937 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_938 = 938 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_939 = 939 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_940 = 940 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_941 = 941 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_942 = 942 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_943 = 943 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_944 = 944 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_945 = 945 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_946 = 946 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_947 = 947 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_948 = 948 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_949 = 949 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_950 = 950 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_951 = 951 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_952 = 952 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_953 = 953 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_954 = 954 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_955 = 955 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_956 = 956 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_957 = 957 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_958 = 958 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_959 = 959 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_960 = 960 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_961 = 961 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_962 = 962 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_963 = 963 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_964 = 964 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_965 = 965 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_966 = 966 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_967 = 967 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_968 = 968 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_969 = 969 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_970 = 970 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_971 = 971 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_972 = 972 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_973 = 973 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_974 = 974 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_975 = 975 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_976 = 976 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_977 = 977 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_978 = 978 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_979 = 979 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_980 = 980 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_981 = 981 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_982 = 982 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_983 = 983 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_984 = 984 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_985 = 985 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_986 = 986 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_987 = 987 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_988 = 988 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_989 = 989 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_990 = 990 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_991 = 991 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_992 = 992 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_993 = 993 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_994 = 994 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_995 = 995 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_996 = 996 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_997 = 997 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_998 = 998 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_999 = 999 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999: string;
 
   /**
    * @generated from field: optional string long_field_name_is_looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_1000 = 1000 [default = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"];
    */
-  longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000?: string;
+  declare longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000: string;
 
   constructor(data?: PartialMessage<TestEnormousDescriptor>) {
     super();
@@ -6060,4 +6060,1005 @@ export class TestEnormousDescriptor extends Message<TestEnormousDescriptor> {
     return proto2.util.equals(TestEnormousDescriptor, a, b);
   }
 }
+
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
+TestEnormousDescriptor.prototype.longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000 = "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong";
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_features_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_features_pb.ts
@@ -106,62 +106,62 @@ export class TestFeatures extends Message<TestFeatures> {
   /**
    * @generated from field: optional int32 int_file_feature = 1;
    */
-  intFileFeature?: number;
+  declare intFileFeature: number;
 
   /**
    * @generated from field: optional int32 int_extension_range_feature = 2;
    */
-  intExtensionRangeFeature?: number;
+  declare intExtensionRangeFeature: number;
 
   /**
    * @generated from field: optional int32 int_message_feature = 3;
    */
-  intMessageFeature?: number;
+  declare intMessageFeature: number;
 
   /**
    * @generated from field: optional int32 int_field_feature = 4;
    */
-  intFieldFeature?: number;
+  declare intFieldFeature: number;
 
   /**
    * @generated from field: optional int32 int_oneof_feature = 5;
    */
-  intOneofFeature?: number;
+  declare intOneofFeature: number;
 
   /**
    * @generated from field: optional int32 int_enum_feature = 6;
    */
-  intEnumFeature?: number;
+  declare intEnumFeature: number;
 
   /**
    * @generated from field: optional int32 int_enum_entry_feature = 7;
    */
-  intEnumEntryFeature?: number;
+  declare intEnumEntryFeature: number;
 
   /**
    * @generated from field: optional int32 int_service_feature = 8;
    */
-  intServiceFeature?: number;
+  declare intServiceFeature: number;
 
   /**
    * @generated from field: optional int32 int_method_feature = 9;
    */
-  intMethodFeature?: number;
+  declare intMethodFeature: number;
 
   /**
    * @generated from field: optional int32 int_multiple_feature = 10;
    */
-  intMultipleFeature?: number;
+  declare intMultipleFeature: number;
 
   /**
    * @generated from field: optional bool bool_field_feature = 11;
    */
-  boolFieldFeature?: boolean;
+  declare boolFieldFeature: boolean;
 
   /**
    * @generated from field: optional float float_field_feature = 12;
    */
-  floatFieldFeature?: number;
+  declare floatFieldFeature: number;
 
   /**
    * @generated from field: optional pb.TestFeatures.MessageFeature message_field_feature = 13;
@@ -171,17 +171,17 @@ export class TestFeatures extends Message<TestFeatures> {
   /**
    * @generated from field: optional pb.TestFeatures.EnumFeature enum_field_feature = 14;
    */
-  enumFieldFeature?: TestFeatures_EnumFeature;
+  declare enumFieldFeature: TestFeatures_EnumFeature;
 
   /**
    * @generated from field: optional int32 int_source_feature = 15;
    */
-  intSourceFeature?: number;
+  declare intSourceFeature: number;
 
   /**
    * @generated from field: optional string string_source_feature = 16;
    */
-  stringSourceFeature?: string;
+  declare stringSourceFeature: string;
 
   constructor(data?: PartialMessage<TestFeatures>) {
     super();
@@ -225,6 +225,22 @@ export class TestFeatures extends Message<TestFeatures> {
     return proto2.util.equals(TestFeatures, a, b);
   }
 }
+
+TestFeatures.prototype.intFileFeature = 0;
+TestFeatures.prototype.intExtensionRangeFeature = 0;
+TestFeatures.prototype.intMessageFeature = 0;
+TestFeatures.prototype.intFieldFeature = 0;
+TestFeatures.prototype.intOneofFeature = 0;
+TestFeatures.prototype.intEnumFeature = 0;
+TestFeatures.prototype.intEnumEntryFeature = 0;
+TestFeatures.prototype.intServiceFeature = 0;
+TestFeatures.prototype.intMethodFeature = 0;
+TestFeatures.prototype.intMultipleFeature = 0;
+TestFeatures.prototype.boolFieldFeature = false;
+TestFeatures.prototype.floatFieldFeature = 0;
+TestFeatures.prototype.enumFieldFeature = 0 as TestFeatures_EnumFeature.TEST_ENUM_FEATURE_UNKNOWN;
+TestFeatures.prototype.intSourceFeature = 0;
+TestFeatures.prototype.stringSourceFeature = "";
 
 /**
  * @generated from enum pb.TestFeatures.EnumFeature
@@ -277,22 +293,22 @@ export class TestFeatures_MessageFeature extends Message<TestFeatures_MessageFea
   /**
    * @generated from field: optional bool bool_field = 1;
    */
-  boolField?: boolean;
+  declare boolField: boolean;
 
   /**
    * @generated from field: optional int32 int_field = 2;
    */
-  intField?: number;
+  declare intField: number;
 
   /**
    * @generated from field: optional float float_field = 3;
    */
-  floatField?: number;
+  declare floatField: number;
 
   /**
    * @generated from field: optional string string_field = 4;
    */
-  stringField?: string;
+  declare stringField: string;
 
   constructor(data?: PartialMessage<TestFeatures_MessageFeature>) {
     super();
@@ -324,6 +340,11 @@ export class TestFeatures_MessageFeature extends Message<TestFeatures_MessageFea
     return proto2.util.equals(TestFeatures_MessageFeature, a, b);
   }
 }
+
+TestFeatures_MessageFeature.prototype.boolField = false;
+TestFeatures_MessageFeature.prototype.intField = 0;
+TestFeatures_MessageFeature.prototype.floatField = 0;
+TestFeatures_MessageFeature.prototype.stringField = "";
 
 /**
  * @generated from extension: optional pb.TestFeatures test = 9999;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_lite_pb.ts
@@ -56,7 +56,7 @@ export class ImportMessageLite extends Message<ImportMessageLite> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  declare d: number;
 
   constructor(data?: PartialMessage<ImportMessageLite>) {
     super();
@@ -85,4 +85,6 @@ export class ImportMessageLite extends Message<ImportMessageLite> {
     return proto2.util.equals(ImportMessageLite, a, b);
   }
 }
+
+ImportMessageLite.prototype.d = 0;
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_pb.ts
@@ -91,7 +91,7 @@ export class ImportMessage extends Message<ImportMessage> {
   /**
    * @generated from field: optional int32 d = 1;
    */
-  d?: number;
+  declare d: number;
 
   constructor(data?: PartialMessage<ImportMessage>) {
     super();
@@ -120,4 +120,6 @@ export class ImportMessage extends Message<ImportMessage> {
     return proto2.util.equals(ImportMessage, a, b);
   }
 }
+
+ImportMessage.prototype.d = 0;
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_lite_pb.ts
@@ -28,7 +28,7 @@ export class PublicImportMessageLite extends Message<PublicImportMessageLite> {
   /**
    * @generated from field: optional int32 e = 1;
    */
-  e?: number;
+  declare e: number;
 
   constructor(data?: PartialMessage<PublicImportMessageLite>) {
     super();
@@ -57,4 +57,6 @@ export class PublicImportMessageLite extends Message<PublicImportMessageLite> {
     return proto2.util.equals(PublicImportMessageLite, a, b);
   }
 }
+
+PublicImportMessageLite.prototype.e = 0;
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_import_public_pb.ts
@@ -28,7 +28,7 @@ export class PublicImportMessage extends Message<PublicImportMessage> {
   /**
    * @generated from field: optional int32 e = 1;
    */
-  e?: number;
+  declare e: number;
 
   constructor(data?: PartialMessage<PublicImportMessage>) {
     super();
@@ -57,4 +57,6 @@ export class PublicImportMessage extends Message<PublicImportMessage> {
     return proto2.util.equals(PublicImportMessage, a, b);
   }
 }
+
+PublicImportMessage.prototype.e = 0;
 

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_pb.ts
@@ -96,77 +96,77 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  declare optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  declare optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  declare optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  declare optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  declare optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  declare optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  declare optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  declare optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  declare optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  declare optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  declare optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  declare optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  declare optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.OptionalGroup optionalgroup = 16;
@@ -191,27 +191,27 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypesLite_NestedEnum;
+  declare optionalNestedEnum: TestAllTypesLite_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnumLite;
+  declare optionalForeignEnum: ForeignEnumLite;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnumLite optional_import_enum = 23;
    */
-  optionalImportEnum?: ImportEnumLite;
+  declare optionalImportEnum: ImportEnumLite;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  declare optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  declare optionalCord: string;
 
   /**
    * Defined in unittest_import_public.proto
@@ -362,102 +362,102 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 default_int32 = 61 [default = 41];
    */
-  defaultInt32?: number;
+  declare defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 62 [default = 42];
    */
-  defaultInt64?: bigint;
+  declare defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 63 [default = 43];
    */
-  defaultUint32?: number;
+  declare defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 64 [default = 44];
    */
-  defaultUint64?: bigint;
+  declare defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 65 [default = -45];
    */
-  defaultSint32?: number;
+  declare defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 66 [default = 46];
    */
-  defaultSint64?: bigint;
+  declare defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 67 [default = 47];
    */
-  defaultFixed32?: number;
+  declare defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 68 [default = 48];
    */
-  defaultFixed64?: bigint;
+  declare defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 69 [default = 49];
    */
-  defaultSfixed32?: number;
+  declare defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 70 [default = -50];
    */
-  defaultSfixed64?: bigint;
+  declare defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 71 [default = 51.5];
    */
-  defaultFloat?: number;
+  declare defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 72 [default = 52000];
    */
-  defaultDouble?: number;
+  declare defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 73 [default = true];
    */
-  defaultBool?: boolean;
+  declare defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 74 [default = "hello"];
    */
-  defaultString?: string;
+  declare defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 75 [default = "world"];
    */
-  defaultBytes?: Uint8Array;
+  declare defaultBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypesLite.NestedEnum default_nested_enum = 81 [default = BAR];
    */
-  defaultNestedEnum?: TestAllTypesLite_NestedEnum;
+  declare defaultNestedEnum: TestAllTypesLite_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite default_foreign_enum = 82 [default = FOREIGN_LITE_BAR];
    */
-  defaultForeignEnum?: ForeignEnumLite;
+  declare defaultForeignEnum: ForeignEnumLite;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnumLite default_import_enum = 83 [default = IMPORT_LITE_BAR];
    */
-  defaultImportEnum?: ImportEnumLite;
+  declare defaultImportEnum: ImportEnumLite;
 
   /**
    * @generated from field: optional string default_string_piece = 84 [default = "abc"];
    */
-  defaultStringPiece?: string;
+  declare defaultStringPiece: string;
 
   /**
    * @generated from field: optional string default_cord = 85 [default = "123"];
    */
-  defaultCord?: string;
+  declare defaultCord: string;
 
   /**
    * For oneof test
@@ -507,7 +507,7 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
    *
    * @generated from field: optional int32 deceptively_named_list = 116;
    */
-  deceptivelyNamedList?: number;
+  declare deceptivelyNamedList: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite>) {
     super();
@@ -615,6 +615,48 @@ export class TestAllTypesLite extends Message<TestAllTypesLite> {
   }
 }
 
+TestAllTypesLite.prototype.optionalInt32 = 0;
+TestAllTypesLite.prototype.optionalInt64 = protoInt64.zero;
+TestAllTypesLite.prototype.optionalUint32 = 0;
+TestAllTypesLite.prototype.optionalUint64 = protoInt64.zero;
+TestAllTypesLite.prototype.optionalSint32 = 0;
+TestAllTypesLite.prototype.optionalSint64 = protoInt64.zero;
+TestAllTypesLite.prototype.optionalFixed32 = 0;
+TestAllTypesLite.prototype.optionalFixed64 = protoInt64.zero;
+TestAllTypesLite.prototype.optionalSfixed32 = 0;
+TestAllTypesLite.prototype.optionalSfixed64 = protoInt64.zero;
+TestAllTypesLite.prototype.optionalFloat = 0;
+TestAllTypesLite.prototype.optionalDouble = 0;
+TestAllTypesLite.prototype.optionalBool = false;
+TestAllTypesLite.prototype.optionalString = "";
+TestAllTypesLite.prototype.optionalBytes = new Uint8Array(0);
+TestAllTypesLite.prototype.optionalNestedEnum = 1 as TestAllTypesLite_NestedEnum.FOO;
+TestAllTypesLite.prototype.optionalForeignEnum = 4 as ForeignEnumLite.FOREIGN_LITE_FOO;
+TestAllTypesLite.prototype.optionalImportEnum = 7 as ImportEnumLite.IMPORT_LITE_FOO;
+TestAllTypesLite.prototype.optionalStringPiece = "";
+TestAllTypesLite.prototype.optionalCord = "";
+TestAllTypesLite.prototype.defaultInt32 = 41;
+TestAllTypesLite.prototype.defaultInt64 = protoInt64.parse("42");
+TestAllTypesLite.prototype.defaultUint32 = 43;
+TestAllTypesLite.prototype.defaultUint64 = protoInt64.uParse("44");
+TestAllTypesLite.prototype.defaultSint32 = -45;
+TestAllTypesLite.prototype.defaultSint64 = protoInt64.parse("46");
+TestAllTypesLite.prototype.defaultFixed32 = 47;
+TestAllTypesLite.prototype.defaultFixed64 = protoInt64.uParse("48");
+TestAllTypesLite.prototype.defaultSfixed32 = 49;
+TestAllTypesLite.prototype.defaultSfixed64 = protoInt64.parse("-50");
+TestAllTypesLite.prototype.defaultFloat = 51.5;
+TestAllTypesLite.prototype.defaultDouble = 52000;
+TestAllTypesLite.prototype.defaultBool = true;
+TestAllTypesLite.prototype.defaultString = "hello";
+TestAllTypesLite.prototype.defaultBytes = new Uint8Array([0x77, 0x6F, 0x72, 0x6C, 0x64]);
+TestAllTypesLite.prototype.defaultNestedEnum = 2 as TestAllTypesLite_NestedEnum.BAR;
+TestAllTypesLite.prototype.defaultForeignEnum = 5 as ForeignEnumLite.FOREIGN_LITE_BAR;
+TestAllTypesLite.prototype.defaultImportEnum = 8 as ImportEnumLite.IMPORT_LITE_BAR;
+TestAllTypesLite.prototype.defaultStringPiece = "abc";
+TestAllTypesLite.prototype.defaultCord = "123";
+TestAllTypesLite.prototype.deceptivelyNamedList = 0;
+
 /**
  * @generated from enum protobuf_unittest.TestAllTypesLite.NestedEnum
  */
@@ -648,12 +690,12 @@ export class TestAllTypesLite_NestedMessage extends Message<TestAllTypesLite_Nes
   /**
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  declare bb: number;
 
   /**
    * @generated from field: optional int64 cc = 2;
    */
-  cc?: bigint;
+  declare cc: bigint;
 
   /**
    * @generated from field: repeated int32 dd = 3 [packed = true];
@@ -690,6 +732,9 @@ export class TestAllTypesLite_NestedMessage extends Message<TestAllTypesLite_Nes
   }
 }
 
+TestAllTypesLite_NestedMessage.prototype.bb = 0;
+TestAllTypesLite_NestedMessage.prototype.cc = protoInt64.zero;
+
 /**
  * @generated from message protobuf_unittest.TestAllTypesLite.NestedMessage2
  */
@@ -697,7 +742,7 @@ export class TestAllTypesLite_NestedMessage2 extends Message<TestAllTypesLite_Ne
   /**
    * @generated from field: optional int32 dd = 1;
    */
-  dd?: number;
+  declare dd: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite_NestedMessage2>) {
     super();
@@ -727,6 +772,8 @@ export class TestAllTypesLite_NestedMessage2 extends Message<TestAllTypesLite_Ne
   }
 }
 
+TestAllTypesLite_NestedMessage2.prototype.dd = 0;
+
 /**
  * @generated from message protobuf_unittest.TestAllTypesLite.OptionalGroup
  */
@@ -734,7 +781,7 @@ export class TestAllTypesLite_OptionalGroup extends Message<TestAllTypesLite_Opt
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite_OptionalGroup>) {
     super();
@@ -764,6 +811,8 @@ export class TestAllTypesLite_OptionalGroup extends Message<TestAllTypesLite_Opt
   }
 }
 
+TestAllTypesLite_OptionalGroup.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.TestAllTypesLite.RepeatedGroup
  */
@@ -771,7 +820,7 @@ export class TestAllTypesLite_RepeatedGroup extends Message<TestAllTypesLite_Rep
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestAllTypesLite_RepeatedGroup>) {
     super();
@@ -801,6 +850,8 @@ export class TestAllTypesLite_RepeatedGroup extends Message<TestAllTypesLite_Rep
   }
 }
 
+TestAllTypesLite_RepeatedGroup.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.ForeignMessageLite
  */
@@ -808,7 +859,7 @@ export class ForeignMessageLite extends Message<ForeignMessageLite> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  declare c: number;
 
   constructor(data?: PartialMessage<ForeignMessageLite>) {
     super();
@@ -837,6 +888,8 @@ export class ForeignMessageLite extends Message<ForeignMessageLite> {
     return proto2.util.equals(ForeignMessageLite, a, b);
   }
 }
+
+ForeignMessageLite.prototype.c = 0;
 
 /**
  * @generated from message protobuf_unittest.TestPackedTypesLite
@@ -991,7 +1044,7 @@ export class OptionalGroup_extension_lite extends Message<OptionalGroup_extensio
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<OptionalGroup_extension_lite>) {
     super();
@@ -1021,6 +1074,8 @@ export class OptionalGroup_extension_lite extends Message<OptionalGroup_extensio
   }
 }
 
+OptionalGroup_extension_lite.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.RepeatedGroup_extension_lite
  */
@@ -1028,7 +1083,7 @@ export class RepeatedGroup_extension_lite extends Message<RepeatedGroup_extensio
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<RepeatedGroup_extension_lite>) {
     super();
@@ -1057,6 +1112,8 @@ export class RepeatedGroup_extension_lite extends Message<RepeatedGroup_extensio
     return proto2.util.equals(RepeatedGroup_extension_lite, a, b);
   }
 }
+
+RepeatedGroup_extension_lite.prototype.a = 0;
 
 /**
  * @generated from message protobuf_unittest.TestPackedExtensionsLite
@@ -1140,7 +1197,7 @@ export class TestDeprecatedLite extends Message<TestDeprecatedLite> {
    * @generated from field: optional int32 deprecated_field = 1 [deprecated = true];
    * @deprecated
    */
-  deprecatedField?: number;
+  declare deprecatedField: number;
 
   /**
    * @generated from field: required int32 deprecated_field2 = 2 [deprecated = true];
@@ -1152,7 +1209,7 @@ export class TestDeprecatedLite extends Message<TestDeprecatedLite> {
    * @generated from field: optional string deprecated_field3 = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedField3?: string;
+  declare deprecatedField3: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDeprecatedLite deprecated_field4 = 4 [deprecated = true];
@@ -1191,7 +1248,9 @@ export class TestDeprecatedLite extends Message<TestDeprecatedLite> {
   }
 }
 
+TestDeprecatedLite.prototype.deprecatedField = 0;
 TestDeprecatedLite.prototype.deprecatedField2 = 0;
+TestDeprecatedLite.prototype.deprecatedField3 = "";
 
 /**
  * See the comments of the same type in unittest.proto.
@@ -1614,7 +1673,7 @@ export class V1MessageLite extends Message<V1MessageLite> {
   /**
    * @generated from field: optional protobuf_unittest.V1EnumLite enum_field = 2 [default = V1_FIRST];
    */
-  enumField?: V1EnumLite;
+  declare enumField: V1EnumLite;
 
   constructor(data?: PartialMessage<V1MessageLite>) {
     super();
@@ -1646,6 +1705,7 @@ export class V1MessageLite extends Message<V1MessageLite> {
 }
 
 V1MessageLite.prototype.intField = 0;
+V1MessageLite.prototype.enumField = 1 as V1EnumLite.V1_FIRST;
 
 /**
  * @generated from message protobuf_unittest.V2MessageLite
@@ -1659,7 +1719,7 @@ export class V2MessageLite extends Message<V2MessageLite> {
   /**
    * @generated from field: optional protobuf_unittest.V2EnumLite enum_field = 2 [default = V2_FIRST];
    */
-  enumField?: V2EnumLite;
+  declare enumField: V2EnumLite;
 
   constructor(data?: PartialMessage<V2MessageLite>) {
     super();
@@ -1691,6 +1751,7 @@ export class V2MessageLite extends Message<V2MessageLite> {
 }
 
 V2MessageLite.prototype.intField = 0;
+V2MessageLite.prototype.enumField = 1 as V2EnumLite.V2_FIRST;
 
 /**
  * @generated from message protobuf_unittest.TestHugeFieldNumbersLite
@@ -1699,12 +1760,12 @@ export class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbersLite> 
   /**
    * @generated from field: optional int32 optional_int32 = 536870000;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional int32 fixed_32 = 536870001;
    */
-  fixed32?: number;
+  declare fixed32: number;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 536870002 [packed = false];
@@ -1719,17 +1780,17 @@ export class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbersLite> 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnumLite optional_enum = 536870004;
    */
-  optionalEnum?: ForeignEnumLite;
+  declare optionalEnum: ForeignEnumLite;
 
   /**
    * @generated from field: optional string optional_string = 536870005;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 536870006;
    */
-  optionalBytes?: Uint8Array;
+  declare optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessageLite optional_message = 536870007;
@@ -1816,6 +1877,12 @@ export class TestHugeFieldNumbersLite extends Message<TestHugeFieldNumbersLite> 
   }
 }
 
+TestHugeFieldNumbersLite.prototype.optionalInt32 = 0;
+TestHugeFieldNumbersLite.prototype.fixed32 = 0;
+TestHugeFieldNumbersLite.prototype.optionalEnum = 4 as ForeignEnumLite.FOREIGN_LITE_FOO;
+TestHugeFieldNumbersLite.prototype.optionalString = "";
+TestHugeFieldNumbersLite.prototype.optionalBytes = new Uint8Array(0);
+
 /**
  * @generated from message protobuf_unittest.TestHugeFieldNumbersLite.OptionalGroup
  */
@@ -1823,7 +1890,7 @@ export class TestHugeFieldNumbersLite_OptionalGroup extends Message<TestHugeFiel
   /**
    * @generated from field: optional int32 group_a = 536870009;
    */
-  groupA?: number;
+  declare groupA: number;
 
   constructor(data?: PartialMessage<TestHugeFieldNumbersLite_OptionalGroup>) {
     super();
@@ -1852,6 +1919,8 @@ export class TestHugeFieldNumbersLite_OptionalGroup extends Message<TestHugeFiel
     return proto2.util.equals(TestHugeFieldNumbersLite_OptionalGroup, a, b);
   }
 }
+
+TestHugeFieldNumbersLite_OptionalGroup.prototype.groupA = 0;
 
 /**
  * @generated from message protobuf_unittest.TestOneofParsingLite
@@ -2218,7 +2287,7 @@ export class RecursiveMessage extends Message<RecursiveMessage> {
   /**
    * @generated from field: optional bytes payload = 2;
    */
-  payload?: Uint8Array;
+  declare payload: Uint8Array;
 
   constructor(data?: PartialMessage<RecursiveMessage>) {
     super();
@@ -2248,6 +2317,8 @@ export class RecursiveMessage extends Message<RecursiveMessage> {
     return proto2.util.equals(RecursiveMessage, a, b);
   }
 }
+
+RecursiveMessage.prototype.payload = new Uint8Array(0);
 
 /**
  * Singular

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
@@ -120,12 +120,12 @@ export class NestedTestInt extends Message<NestedTestInt> {
   /**
    * @generated from field: optional fixed32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional int32 b = 3;
    */
-  b?: number;
+  declare b: number;
 
   /**
    * @generated from field: optional protobuf_unittest.NestedTestInt child = 2;
@@ -162,6 +162,9 @@ export class NestedTestInt extends Message<NestedTestInt> {
   }
 }
 
+NestedTestInt.prototype.a = 0;
+NestedTestInt.prototype.b = 0;
+
 /**
  * @generated from message protobuf_unittest.TestMessageSetExtension1
  */
@@ -169,7 +172,7 @@ export class TestMessageSetExtension1 extends Message<TestMessageSetExtension1> 
   /**
    * @generated from field: optional int32 i = 15;
    */
-  i?: number;
+  declare i: number;
 
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
@@ -179,7 +182,7 @@ export class TestMessageSetExtension1 extends Message<TestMessageSetExtension1> 
   /**
    * @generated from field: optional string test_aliasing = 17;
    */
-  testAliasing?: string;
+  declare testAliasing: string;
 
   constructor(data?: PartialMessage<TestMessageSetExtension1>) {
     super();
@@ -211,6 +214,9 @@ export class TestMessageSetExtension1 extends Message<TestMessageSetExtension1> 
   }
 }
 
+TestMessageSetExtension1.prototype.i = 0;
+TestMessageSetExtension1.prototype.testAliasing = "";
+
 /**
  * @generated from extension: optional protobuf_unittest.TestMessageSetExtension1 message_set_extension = 1545008;
  */
@@ -227,7 +233,7 @@ export class TestMessageSetExtension2 extends Message<TestMessageSetExtension2> 
   /**
    * @generated from field: optional string str = 25;
    */
-  str?: string;
+  declare str: string;
 
   constructor(data?: PartialMessage<TestMessageSetExtension2>) {
     super();
@@ -256,6 +262,8 @@ export class TestMessageSetExtension2 extends Message<TestMessageSetExtension2> 
     return proto2.util.equals(TestMessageSetExtension2, a, b);
   }
 }
+
+TestMessageSetExtension2.prototype.str = "";
 
 /**
  * @generated from extension: optional protobuf_unittest.TestMessageSetExtension2 message_set_extension = 1547769;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
@@ -42,7 +42,7 @@ export class TestMessage extends Message<TestMessage> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestMessage>) {
     super();
@@ -71,6 +71,8 @@ export class TestMessage extends Message<TestMessage> {
     return proto2.util.equals(TestMessage, a, b);
   }
 }
+
+TestMessage.prototype.a = 0;
 
 /**
  * @generated from extension: optional int32 test_extension = 1000;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
@@ -33,7 +33,7 @@ export class TestOptimizedForSize extends Message<TestOptimizedForSize> {
   /**
    * @generated from field: optional int32 i = 1;
    */
-  i?: number;
+  declare i: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage msg = 19;
@@ -87,6 +87,8 @@ export class TestOptimizedForSize extends Message<TestOptimizedForSize> {
     return proto2.util.equals(TestOptimizedForSize, a, b);
   }
 }
+
+TestOptimizedForSize.prototype.i = 0;
 
 /**
  * @generated from extension: optional int32 test_extension = 1234;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -799,77 +799,77 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  declare optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  declare optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  declare optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  declare optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  declare optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  declare optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  declare optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  declare optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  declare optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  declare optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  declare optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  declare optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  declare optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.OptionalGroup optionalgroup = 16;
@@ -894,27 +894,27 @@ export class TestAllTypes extends Message<TestAllTypes> {
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestAllTypes_NestedEnum;
+  declare optionalNestedEnum: TestAllTypes_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnum;
+  declare optionalForeignEnum: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnum optional_import_enum = 23;
    */
-  optionalImportEnum?: ImportEnum;
+  declare optionalImportEnum: ImportEnum;
 
   /**
    * @generated from field: optional string optional_string_piece = 24;
    */
-  optionalStringPiece?: string;
+  declare optionalStringPiece: string;
 
   /**
    * @generated from field: optional string optional_cord = 25;
    */
-  optionalCord?: string;
+  declare optionalCord: string;
 
   /**
    * Defined in unittest_import_public.proto
@@ -1065,102 +1065,102 @@ export class TestAllTypes extends Message<TestAllTypes> {
    *
    * @generated from field: optional int32 default_int32 = 61 [default = 41];
    */
-  defaultInt32?: number;
+  declare defaultInt32: number;
 
   /**
    * @generated from field: optional int64 default_int64 = 62 [default = 42];
    */
-  defaultInt64?: bigint;
+  declare defaultInt64: bigint;
 
   /**
    * @generated from field: optional uint32 default_uint32 = 63 [default = 43];
    */
-  defaultUint32?: number;
+  declare defaultUint32: number;
 
   /**
    * @generated from field: optional uint64 default_uint64 = 64 [default = 44];
    */
-  defaultUint64?: bigint;
+  declare defaultUint64: bigint;
 
   /**
    * @generated from field: optional sint32 default_sint32 = 65 [default = -45];
    */
-  defaultSint32?: number;
+  declare defaultSint32: number;
 
   /**
    * @generated from field: optional sint64 default_sint64 = 66 [default = 46];
    */
-  defaultSint64?: bigint;
+  declare defaultSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 default_fixed32 = 67 [default = 47];
    */
-  defaultFixed32?: number;
+  declare defaultFixed32: number;
 
   /**
    * @generated from field: optional fixed64 default_fixed64 = 68 [default = 48];
    */
-  defaultFixed64?: bigint;
+  declare defaultFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 default_sfixed32 = 69 [default = 49];
    */
-  defaultSfixed32?: number;
+  declare defaultSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 default_sfixed64 = 70 [default = -50];
    */
-  defaultSfixed64?: bigint;
+  declare defaultSfixed64: bigint;
 
   /**
    * @generated from field: optional float default_float = 71 [default = 51.5];
    */
-  defaultFloat?: number;
+  declare defaultFloat: number;
 
   /**
    * @generated from field: optional double default_double = 72 [default = 52000];
    */
-  defaultDouble?: number;
+  declare defaultDouble: number;
 
   /**
    * @generated from field: optional bool default_bool = 73 [default = true];
    */
-  defaultBool?: boolean;
+  declare defaultBool: boolean;
 
   /**
    * @generated from field: optional string default_string = 74 [default = "hello"];
    */
-  defaultString?: string;
+  declare defaultString: string;
 
   /**
    * @generated from field: optional bytes default_bytes = 75 [default = "world"];
    */
-  defaultBytes?: Uint8Array;
+  declare defaultBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes.NestedEnum default_nested_enum = 81 [default = BAR];
    */
-  defaultNestedEnum?: TestAllTypes_NestedEnum;
+  declare defaultNestedEnum: TestAllTypes_NestedEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum default_foreign_enum = 82 [default = FOREIGN_BAR];
    */
-  defaultForeignEnum?: ForeignEnum;
+  declare defaultForeignEnum: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest_import.ImportEnum default_import_enum = 83 [default = IMPORT_BAR];
    */
-  defaultImportEnum?: ImportEnum;
+  declare defaultImportEnum: ImportEnum;
 
   /**
    * @generated from field: optional string default_string_piece = 84 [default = "abc"];
    */
-  defaultStringPiece?: string;
+  declare defaultStringPiece: string;
 
   /**
    * @generated from field: optional string default_cord = 85 [default = "123"];
    */
-  defaultCord?: string;
+  declare defaultCord: string;
 
   /**
    * For oneof test
@@ -1317,6 +1317,47 @@ export class TestAllTypes extends Message<TestAllTypes> {
   }
 }
 
+TestAllTypes.prototype.optionalInt32 = 0;
+TestAllTypes.prototype.optionalInt64 = protoInt64.zero;
+TestAllTypes.prototype.optionalUint32 = 0;
+TestAllTypes.prototype.optionalUint64 = protoInt64.zero;
+TestAllTypes.prototype.optionalSint32 = 0;
+TestAllTypes.prototype.optionalSint64 = protoInt64.zero;
+TestAllTypes.prototype.optionalFixed32 = 0;
+TestAllTypes.prototype.optionalFixed64 = protoInt64.zero;
+TestAllTypes.prototype.optionalSfixed32 = 0;
+TestAllTypes.prototype.optionalSfixed64 = protoInt64.zero;
+TestAllTypes.prototype.optionalFloat = 0;
+TestAllTypes.prototype.optionalDouble = 0;
+TestAllTypes.prototype.optionalBool = false;
+TestAllTypes.prototype.optionalString = "";
+TestAllTypes.prototype.optionalBytes = new Uint8Array(0);
+TestAllTypes.prototype.optionalNestedEnum = 1 as TestAllTypes_NestedEnum.FOO;
+TestAllTypes.prototype.optionalForeignEnum = 4 as ForeignEnum.FOREIGN_FOO;
+TestAllTypes.prototype.optionalImportEnum = 7 as ImportEnum.IMPORT_FOO;
+TestAllTypes.prototype.optionalStringPiece = "";
+TestAllTypes.prototype.optionalCord = "";
+TestAllTypes.prototype.defaultInt32 = 41;
+TestAllTypes.prototype.defaultInt64 = protoInt64.parse("42");
+TestAllTypes.prototype.defaultUint32 = 43;
+TestAllTypes.prototype.defaultUint64 = protoInt64.uParse("44");
+TestAllTypes.prototype.defaultSint32 = -45;
+TestAllTypes.prototype.defaultSint64 = protoInt64.parse("46");
+TestAllTypes.prototype.defaultFixed32 = 47;
+TestAllTypes.prototype.defaultFixed64 = protoInt64.uParse("48");
+TestAllTypes.prototype.defaultSfixed32 = 49;
+TestAllTypes.prototype.defaultSfixed64 = protoInt64.parse("-50");
+TestAllTypes.prototype.defaultFloat = 51.5;
+TestAllTypes.prototype.defaultDouble = 52000;
+TestAllTypes.prototype.defaultBool = true;
+TestAllTypes.prototype.defaultString = "hello";
+TestAllTypes.prototype.defaultBytes = new Uint8Array([0x77, 0x6F, 0x72, 0x6C, 0x64]);
+TestAllTypes.prototype.defaultNestedEnum = 2 as TestAllTypes_NestedEnum.BAR;
+TestAllTypes.prototype.defaultForeignEnum = 5 as ForeignEnum.FOREIGN_BAR;
+TestAllTypes.prototype.defaultImportEnum = 8 as ImportEnum.IMPORT_BAR;
+TestAllTypes.prototype.defaultStringPiece = "abc";
+TestAllTypes.prototype.defaultCord = "123";
+
 /**
  * @generated from enum protobuf_unittest.TestAllTypes.NestedEnum
  */
@@ -1362,7 +1403,7 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  declare bb: number;
 
   constructor(data?: PartialMessage<TestAllTypes_NestedMessage>) {
     super();
@@ -1392,6 +1433,8 @@ export class TestAllTypes_NestedMessage extends Message<TestAllTypes_NestedMessa
   }
 }
 
+TestAllTypes_NestedMessage.prototype.bb = 0;
+
 /**
  * @generated from message protobuf_unittest.TestAllTypes.OptionalGroup
  */
@@ -1399,7 +1442,7 @@ export class TestAllTypes_OptionalGroup extends Message<TestAllTypes_OptionalGro
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestAllTypes_OptionalGroup>) {
     super();
@@ -1429,6 +1472,8 @@ export class TestAllTypes_OptionalGroup extends Message<TestAllTypes_OptionalGro
   }
 }
 
+TestAllTypes_OptionalGroup.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.TestAllTypes.RepeatedGroup
  */
@@ -1436,7 +1481,7 @@ export class TestAllTypes_RepeatedGroup extends Message<TestAllTypes_RepeatedGro
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestAllTypes_RepeatedGroup>) {
     super();
@@ -1465,6 +1510,8 @@ export class TestAllTypes_RepeatedGroup extends Message<TestAllTypes_RepeatedGro
     return proto2.util.equals(TestAllTypes_RepeatedGroup, a, b);
   }
 }
+
+TestAllTypes_RepeatedGroup.prototype.a = 0;
 
 /**
  * This proto includes a recursively nested message.
@@ -1537,7 +1584,7 @@ export class TestDeprecatedFields extends Message<TestDeprecatedFields> {
    * @generated from field: optional int32 deprecated_int32 = 1 [deprecated = true];
    * @deprecated
    */
-  deprecatedInt32?: number;
+  declare deprecatedInt32: number;
 
   /**
    * @generated from field: repeated string deprecated_repeated_string = 4 [deprecated = true];
@@ -1600,6 +1647,8 @@ export class TestDeprecatedFields extends Message<TestDeprecatedFields> {
   }
 }
 
+TestDeprecatedFields.prototype.deprecatedInt32 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestDeprecatedMessage
  * @deprecated
@@ -1642,12 +1691,12 @@ export class ForeignMessage extends Message<ForeignMessage> {
   /**
    * @generated from field: optional int32 c = 1;
    */
-  c?: number;
+  declare c: number;
 
   /**
    * @generated from field: optional int32 d = 2;
    */
-  d?: number;
+  declare d: number;
 
   constructor(data?: PartialMessage<ForeignMessage>) {
     super();
@@ -1677,6 +1726,9 @@ export class ForeignMessage extends Message<ForeignMessage> {
     return proto2.util.equals(ForeignMessage, a, b);
   }
 }
+
+ForeignMessage.prototype.c = 0;
+ForeignMessage.prototype.d = 0;
 
 /**
  * @generated from message protobuf_unittest.TestReservedFields
@@ -1747,7 +1799,7 @@ export class OptionalGroup_extension extends Message<OptionalGroup_extension> {
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<OptionalGroup_extension>) {
     super();
@@ -1777,6 +1829,8 @@ export class OptionalGroup_extension extends Message<OptionalGroup_extension> {
   }
 }
 
+OptionalGroup_extension.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.RepeatedGroup_extension
  */
@@ -1784,7 +1838,7 @@ export class RepeatedGroup_extension extends Message<RepeatedGroup_extension> {
   /**
    * @generated from field: optional int32 a = 47;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<RepeatedGroup_extension>) {
     super();
@@ -1814,6 +1868,8 @@ export class RepeatedGroup_extension extends Message<RepeatedGroup_extension> {
   }
 }
 
+RepeatedGroup_extension.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.TestMixedFieldsAndExtensions
  */
@@ -1821,7 +1877,7 @@ export class TestMixedFieldsAndExtensions extends Message<TestMixedFieldsAndExte
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: repeated fixed32 b = 3;
@@ -1857,6 +1913,8 @@ export class TestMixedFieldsAndExtensions extends Message<TestMixedFieldsAndExte
   }
 }
 
+TestMixedFieldsAndExtensions.prototype.a = 0;
+
 /**
  * @generated from extension: optional int32 c = 2;
  */
@@ -1887,7 +1945,7 @@ export class TestGroup extends Message<TestGroup> {
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_foreign_enum = 22;
    */
-  optionalForeignEnum?: ForeignEnum;
+  declare optionalForeignEnum: ForeignEnum;
 
   constructor(data?: PartialMessage<TestGroup>) {
     super();
@@ -1918,6 +1976,8 @@ export class TestGroup extends Message<TestGroup> {
   }
 }
 
+TestGroup.prototype.optionalForeignEnum = 4 as ForeignEnum.FOREIGN_FOO;
+
 /**
  * @generated from message protobuf_unittest.TestGroup.OptionalGroup
  */
@@ -1925,14 +1985,14 @@ export class TestGroup_OptionalGroup extends Message<TestGroup_OptionalGroup> {
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * fast table size must be at least 16, for this
    *
    * @generated from field: optional int32 zz = 89;
    */
-  zz?: number;
+  declare zz: number;
 
   constructor(data?: PartialMessage<TestGroup_OptionalGroup>) {
     super();
@@ -1962,6 +2022,9 @@ export class TestGroup_OptionalGroup extends Message<TestGroup_OptionalGroup> {
     return proto2.util.equals(TestGroup_OptionalGroup, a, b);
   }
 }
+
+TestGroup_OptionalGroup.prototype.a = 0;
+TestGroup_OptionalGroup.prototype.zz = 0;
 
 /**
  * @generated from message protobuf_unittest.TestGroupExtension
@@ -2032,7 +2095,7 @@ export class TestNestedExtension_OptionalGroup_extension extends Message<TestNes
   /**
    * @generated from field: optional int32 a = 17;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestNestedExtension_OptionalGroup_extension>) {
     super();
@@ -2061,6 +2124,8 @@ export class TestNestedExtension_OptionalGroup_extension extends Message<TestNes
     return proto2.util.equals(TestNestedExtension_OptionalGroup_extension, a, b);
   }
 }
+
+TestNestedExtension_OptionalGroup_extension.prototype.a = 0;
 
 /**
  * Check for bug where string extensions declared in tested scope did not
@@ -2111,12 +2176,12 @@ export class TestChildExtension extends Message<TestChildExtension> {
   /**
    * @generated from field: optional string a = 1;
    */
-  a?: string;
+  declare a: string;
 
   /**
    * @generated from field: optional string b = 2;
    */
-  b?: string;
+  declare b: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllExtensions optional_extension = 3;
@@ -2153,6 +2218,9 @@ export class TestChildExtension extends Message<TestChildExtension> {
   }
 }
 
+TestChildExtension.prototype.a = "";
+TestChildExtension.prototype.b = "";
+
 /**
  * Emulates wireformat data of TestChildExtension with dynamic extension
  * (DynamicExtension).
@@ -2163,12 +2231,12 @@ export class TestChildExtensionData extends Message<TestChildExtensionData> {
   /**
    * @generated from field: optional string a = 1;
    */
-  a?: string;
+  declare a: string;
 
   /**
    * @generated from field: optional string b = 2;
    */
-  b?: string;
+  declare b: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
@@ -2204,6 +2272,9 @@ export class TestChildExtensionData extends Message<TestChildExtensionData> {
     return proto2.util.equals(TestChildExtensionData, a, b);
   }
 }
+
+TestChildExtensionData.prototype.a = "";
+TestChildExtensionData.prototype.b = "";
 
 /**
  * @generated from message protobuf_unittest.TestChildExtensionData.NestedTestAllExtensionsData
@@ -2249,12 +2320,12 @@ export class TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExt
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional int32 b = 2;
    */
-  b?: number;
+  declare b: number;
 
   constructor(data?: PartialMessage<TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions>) {
     super();
@@ -2285,6 +2356,9 @@ export class TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExt
   }
 }
 
+TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions.prototype.a = 0;
+TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions.prototype.b = 0;
+
 /**
  * @generated from message protobuf_unittest.TestNestedChildExtension
  */
@@ -2292,7 +2366,7 @@ export class TestNestedChildExtension extends Message<TestNestedChildExtension> 
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtension child = 2;
@@ -2328,6 +2402,8 @@ export class TestNestedChildExtension extends Message<TestNestedChildExtension> 
   }
 }
 
+TestNestedChildExtension.prototype.a = 0;
+
 /**
  * Emulates wireformat data of TestNestedChildExtension with dynamic extension
  * (DynamicExtension).
@@ -2338,7 +2414,7 @@ export class TestNestedChildExtensionData extends Message<TestNestedChildExtensi
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestChildExtensionData child = 2;
@@ -2374,6 +2450,8 @@ export class TestNestedChildExtensionData extends Message<TestNestedChildExtensi
   }
 }
 
+TestNestedChildExtensionData.prototype.a = 0;
+
 /**
  * Required and closed enum fields are considered unknown fields if the value is
  * not valid. We need to make sure it functions as expected.
@@ -2391,7 +2469,7 @@ export class TestRequiredEnum extends Message<TestRequiredEnum> {
    *
    * @generated from field: optional int32 a = 2;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestRequiredEnum>) {
     super();
@@ -2423,6 +2501,7 @@ export class TestRequiredEnum extends Message<TestRequiredEnum> {
 }
 
 TestRequiredEnum.prototype.requiredEnum = 4 as ForeignEnum.FOREIGN_FOO;
+TestRequiredEnum.prototype.a = 0;
 
 /**
  * TestRequiredEnum + using enum values that won't fit to 64 bitmask.
@@ -2440,7 +2519,7 @@ export class TestRequiredEnumNoMask extends Message<TestRequiredEnumNoMask> {
    *
    * @generated from field: optional int32 a = 2;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestRequiredEnumNoMask>) {
     super();
@@ -2472,6 +2551,7 @@ export class TestRequiredEnumNoMask extends Message<TestRequiredEnumNoMask> {
 }
 
 TestRequiredEnumNoMask.prototype.requiredEnum = 0 as TestRequiredEnumNoMask_NestedEnum.UNSPECIFIED;
+TestRequiredEnumNoMask.prototype.a = 0;
 
 /**
  * @generated from enum protobuf_unittest.TestRequiredEnumNoMask.NestedEnum
@@ -2522,7 +2602,7 @@ export class TestRequiredEnumMulti extends Message<TestRequiredEnumMulti> {
   /**
    * @generated from field: optional int32 a_3 = 3;
    */
-  a3?: number;
+  declare a3: number;
 
   /**
    * @generated from field: required protobuf_unittest.TestRequiredEnumMulti.NestedEnum required_enum_2 = 2;
@@ -2566,6 +2646,7 @@ export class TestRequiredEnumMulti extends Message<TestRequiredEnumMulti> {
 }
 
 TestRequiredEnumMulti.prototype.requiredEnum4 = 0 as TestRequiredEnumMulti_NestedEnum.UNSPECIFIED;
+TestRequiredEnumMulti.prototype.a3 = 0;
 TestRequiredEnumMulti.prototype.requiredEnum2 = 0 as TestRequiredEnumMulti_NestedEnum.UNSPECIFIED;
 TestRequiredEnumMulti.prototype.requiredEnum1 = 4 as ForeignEnum.FOREIGN_FOO;
 
@@ -2632,7 +2713,7 @@ export class TestRequiredNoMaskMulti extends Message<TestRequiredNoMaskMulti> {
   /**
    * @generated from field: optional int32 a_3 = 3;
    */
-  a3?: number;
+  declare a3: number;
 
   /**
    * @generated from field: required protobuf_unittest.TestRequiredNoMaskMulti.NestedEnum required_enum_2 = 2;
@@ -2682,6 +2763,7 @@ TestRequiredNoMaskMulti.prototype.requiredFixed3280 = 0;
 TestRequiredNoMaskMulti.prototype.requiredFixed3270 = 0;
 TestRequiredNoMaskMulti.prototype.requiredEnum64 = 0 as TestRequiredNoMaskMulti_NestedEnum.UNSPECIFIED;
 TestRequiredNoMaskMulti.prototype.requiredEnum4 = 0 as TestRequiredNoMaskMulti_NestedEnum.UNSPECIFIED;
+TestRequiredNoMaskMulti.prototype.a3 = 0;
 TestRequiredNoMaskMulti.prototype.requiredEnum2 = 0 as TestRequiredNoMaskMulti_NestedEnum.UNSPECIFIED;
 TestRequiredNoMaskMulti.prototype.requiredEnum1 = 4 as ForeignEnum.FOREIGN_FOO;
 
@@ -2735,7 +2817,7 @@ export class TestRequired extends Message<TestRequired> {
   /**
    * @generated from field: optional int32 dummy2 = 2;
    */
-  dummy2?: number;
+  declare dummy2: number;
 
   /**
    * @generated from field: required int32 b = 3;
@@ -2748,147 +2830,147 @@ export class TestRequired extends Message<TestRequired> {
    *
    * @generated from field: optional int32 dummy4 = 4;
    */
-  dummy4?: number;
+  declare dummy4: number;
 
   /**
    * @generated from field: optional int32 dummy5 = 5;
    */
-  dummy5?: number;
+  declare dummy5: number;
 
   /**
    * @generated from field: optional int32 dummy6 = 6;
    */
-  dummy6?: number;
+  declare dummy6: number;
 
   /**
    * @generated from field: optional int32 dummy7 = 7;
    */
-  dummy7?: number;
+  declare dummy7: number;
 
   /**
    * @generated from field: optional int32 dummy8 = 8;
    */
-  dummy8?: number;
+  declare dummy8: number;
 
   /**
    * @generated from field: optional int32 dummy9 = 9;
    */
-  dummy9?: number;
+  declare dummy9: number;
 
   /**
    * @generated from field: optional int32 dummy10 = 10;
    */
-  dummy10?: number;
+  declare dummy10: number;
 
   /**
    * @generated from field: optional int32 dummy11 = 11;
    */
-  dummy11?: number;
+  declare dummy11: number;
 
   /**
    * @generated from field: optional int32 dummy12 = 12;
    */
-  dummy12?: number;
+  declare dummy12: number;
 
   /**
    * @generated from field: optional int32 dummy13 = 13;
    */
-  dummy13?: number;
+  declare dummy13: number;
 
   /**
    * @generated from field: optional int32 dummy14 = 14;
    */
-  dummy14?: number;
+  declare dummy14: number;
 
   /**
    * @generated from field: optional int32 dummy15 = 15;
    */
-  dummy15?: number;
+  declare dummy15: number;
 
   /**
    * @generated from field: optional int32 dummy16 = 16;
    */
-  dummy16?: number;
+  declare dummy16: number;
 
   /**
    * @generated from field: optional int32 dummy17 = 17;
    */
-  dummy17?: number;
+  declare dummy17: number;
 
   /**
    * @generated from field: optional int32 dummy18 = 18;
    */
-  dummy18?: number;
+  declare dummy18: number;
 
   /**
    * @generated from field: optional int32 dummy19 = 19;
    */
-  dummy19?: number;
+  declare dummy19: number;
 
   /**
    * @generated from field: optional int32 dummy20 = 20;
    */
-  dummy20?: number;
+  declare dummy20: number;
 
   /**
    * @generated from field: optional int32 dummy21 = 21;
    */
-  dummy21?: number;
+  declare dummy21: number;
 
   /**
    * @generated from field: optional int32 dummy22 = 22;
    */
-  dummy22?: number;
+  declare dummy22: number;
 
   /**
    * @generated from field: optional int32 dummy23 = 23;
    */
-  dummy23?: number;
+  declare dummy23: number;
 
   /**
    * @generated from field: optional int32 dummy24 = 24;
    */
-  dummy24?: number;
+  declare dummy24: number;
 
   /**
    * @generated from field: optional int32 dummy25 = 25;
    */
-  dummy25?: number;
+  declare dummy25: number;
 
   /**
    * @generated from field: optional int32 dummy26 = 26;
    */
-  dummy26?: number;
+  declare dummy26: number;
 
   /**
    * @generated from field: optional int32 dummy27 = 27;
    */
-  dummy27?: number;
+  declare dummy27: number;
 
   /**
    * @generated from field: optional int32 dummy28 = 28;
    */
-  dummy28?: number;
+  declare dummy28: number;
 
   /**
    * @generated from field: optional int32 dummy29 = 29;
    */
-  dummy29?: number;
+  declare dummy29: number;
 
   /**
    * @generated from field: optional int32 dummy30 = 30;
    */
-  dummy30?: number;
+  declare dummy30: number;
 
   /**
    * @generated from field: optional int32 dummy31 = 31;
    */
-  dummy31?: number;
+  declare dummy31: number;
 
   /**
    * @generated from field: optional int32 dummy32 = 32;
    */
-  dummy32?: number;
+  declare dummy32: number;
 
   /**
    * @generated from field: required int32 c = 33;
@@ -2964,7 +3046,37 @@ export class TestRequired extends Message<TestRequired> {
 }
 
 TestRequired.prototype.a = 0;
+TestRequired.prototype.dummy2 = 0;
 TestRequired.prototype.b = 0;
+TestRequired.prototype.dummy4 = 0;
+TestRequired.prototype.dummy5 = 0;
+TestRequired.prototype.dummy6 = 0;
+TestRequired.prototype.dummy7 = 0;
+TestRequired.prototype.dummy8 = 0;
+TestRequired.prototype.dummy9 = 0;
+TestRequired.prototype.dummy10 = 0;
+TestRequired.prototype.dummy11 = 0;
+TestRequired.prototype.dummy12 = 0;
+TestRequired.prototype.dummy13 = 0;
+TestRequired.prototype.dummy14 = 0;
+TestRequired.prototype.dummy15 = 0;
+TestRequired.prototype.dummy16 = 0;
+TestRequired.prototype.dummy17 = 0;
+TestRequired.prototype.dummy18 = 0;
+TestRequired.prototype.dummy19 = 0;
+TestRequired.prototype.dummy20 = 0;
+TestRequired.prototype.dummy21 = 0;
+TestRequired.prototype.dummy22 = 0;
+TestRequired.prototype.dummy23 = 0;
+TestRequired.prototype.dummy24 = 0;
+TestRequired.prototype.dummy25 = 0;
+TestRequired.prototype.dummy26 = 0;
+TestRequired.prototype.dummy27 = 0;
+TestRequired.prototype.dummy28 = 0;
+TestRequired.prototype.dummy29 = 0;
+TestRequired.prototype.dummy30 = 0;
+TestRequired.prototype.dummy31 = 0;
+TestRequired.prototype.dummy32 = 0;
 TestRequired.prototype.c = 0;
 
 /**
@@ -3002,7 +3114,7 @@ export class TestRequiredForeign extends Message<TestRequiredForeign> {
   /**
    * @generated from field: optional int32 dummy = 3;
    */
-  dummy?: number;
+  declare dummy: number;
 
   /**
    * Missing required fields must not affect verification of child messages.
@@ -3041,6 +3153,8 @@ export class TestRequiredForeign extends Message<TestRequiredForeign> {
     return proto2.util.equals(TestRequiredForeign, a, b);
   }
 }
+
+TestRequiredForeign.prototype.dummy = 0;
 
 /**
  * @generated from message protobuf_unittest.TestRequiredMessage
@@ -3108,7 +3222,7 @@ export class TestNestedRequiredForeign extends Message<TestNestedRequiredForeign
   /**
    * @generated from field: optional int32 dummy = 3;
    */
-  dummy?: number;
+  declare dummy: number;
 
   /**
    * optional message to test required closed enum.
@@ -3165,6 +3279,8 @@ export class TestNestedRequiredForeign extends Message<TestNestedRequiredForeign
     return proto2.util.equals(TestNestedRequiredForeign, a, b);
   }
 }
+
+TestNestedRequiredForeign.prototype.dummy = 0;
 
 /**
  * Test that we can use NestedMessage from outside TestAllTypes.
@@ -3312,7 +3428,7 @@ export class TestPickleNestedMessage_NestedMessage extends Message<TestPickleNes
   /**
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  declare bb: number;
 
   constructor(data?: PartialMessage<TestPickleNestedMessage_NestedMessage>) {
     super();
@@ -3342,6 +3458,8 @@ export class TestPickleNestedMessage_NestedMessage extends Message<TestPickleNes
   }
 }
 
+TestPickleNestedMessage_NestedMessage.prototype.bb = 0;
+
 /**
  * @generated from message protobuf_unittest.TestPickleNestedMessage.NestedMessage.NestedNestedMessage
  */
@@ -3349,7 +3467,7 @@ export class TestPickleNestedMessage_NestedMessage_NestedNestedMessage extends M
   /**
    * @generated from field: optional int32 cc = 1;
    */
-  cc?: number;
+  declare cc: number;
 
   constructor(data?: PartialMessage<TestPickleNestedMessage_NestedMessage_NestedNestedMessage>) {
     super();
@@ -3378,6 +3496,8 @@ export class TestPickleNestedMessage_NestedMessage_NestedNestedMessage extends M
     return proto2.util.equals(TestPickleNestedMessage_NestedMessage_NestedNestedMessage, a, b);
   }
 }
+
+TestPickleNestedMessage_NestedMessage_NestedNestedMessage.prototype.cc = 0;
 
 /**
  * @generated from message protobuf_unittest.TestMultipleExtensionRanges
@@ -3422,12 +3542,12 @@ export class TestReallyLargeTagNumber extends Message<TestReallyLargeTagNumber> 
    *
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional int32 bb = 268435455;
    */
-  bb?: number;
+  declare bb: number;
 
   constructor(data?: PartialMessage<TestReallyLargeTagNumber>) {
     super();
@@ -3458,6 +3578,9 @@ export class TestReallyLargeTagNumber extends Message<TestReallyLargeTagNumber> 
   }
 }
 
+TestReallyLargeTagNumber.prototype.a = 0;
+TestReallyLargeTagNumber.prototype.bb = 0;
+
 /**
  * @generated from message protobuf_unittest.TestRecursiveMessage
  */
@@ -3470,7 +3593,7 @@ export class TestRecursiveMessage extends Message<TestRecursiveMessage> {
   /**
    * @generated from field: optional int32 i = 2;
    */
-  i?: number;
+  declare i: number;
 
   constructor(data?: PartialMessage<TestRecursiveMessage>) {
     super();
@@ -3500,6 +3623,8 @@ export class TestRecursiveMessage extends Message<TestRecursiveMessage> {
     return proto2.util.equals(TestRecursiveMessage, a, b);
   }
 }
+
+TestRecursiveMessage.prototype.i = 0;
 
 /**
  * Test that mutual recursion works.
@@ -3683,7 +3808,7 @@ export class TestMutualRecursionB extends Message<TestMutualRecursionB> {
   /**
    * @generated from field: optional int32 optional_int32 = 2;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   constructor(data?: PartialMessage<TestMutualRecursionB>) {
     super();
@@ -3713,6 +3838,8 @@ export class TestMutualRecursionB extends Message<TestMutualRecursionB> {
     return proto2.util.equals(TestMutualRecursionB, a, b);
   }
 }
+
+TestMutualRecursionB.prototype.optionalInt32 = 0;
 
 /**
  * @generated from message protobuf_unittest.TestIsInitialized
@@ -3843,7 +3970,7 @@ export class TestDupFieldNumber extends Message<TestDupFieldNumber> {
    *
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDupFieldNumber.Foo foo = 2;
@@ -3885,6 +4012,8 @@ export class TestDupFieldNumber extends Message<TestDupFieldNumber> {
   }
 }
 
+TestDupFieldNumber.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.TestDupFieldNumber.Foo
  */
@@ -3892,7 +4021,7 @@ export class TestDupFieldNumber_Foo extends Message<TestDupFieldNumber_Foo> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestDupFieldNumber_Foo>) {
     super();
@@ -3922,6 +4051,8 @@ export class TestDupFieldNumber_Foo extends Message<TestDupFieldNumber_Foo> {
   }
 }
 
+TestDupFieldNumber_Foo.prototype.a = 0;
+
 /**
  * @generated from message protobuf_unittest.TestDupFieldNumber.Bar
  */
@@ -3929,7 +4060,7 @@ export class TestDupFieldNumber_Bar extends Message<TestDupFieldNumber_Bar> {
   /**
    * @generated from field: optional int32 a = 1;
    */
-  a?: number;
+  declare a: number;
 
   constructor(data?: PartialMessage<TestDupFieldNumber_Bar>) {
     super();
@@ -3958,6 +4089,8 @@ export class TestDupFieldNumber_Bar extends Message<TestDupFieldNumber_Bar> {
     return proto2.util.equals(TestDupFieldNumber_Bar, a, b);
   }
 }
+
+TestDupFieldNumber_Bar.prototype.a = 0;
 
 /**
  * Additional messages for testing lazy fields.
@@ -4250,17 +4383,17 @@ export class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldNames> {
   /**
    * @generated from field: optional int32 PrimitiveField = 1;
    */
-  PrimitiveField?: number;
+  declare PrimitiveField: number;
 
   /**
    * @generated from field: optional string StringField = 2;
    */
-  StringField?: string;
+  declare StringField: string;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum EnumField = 3;
    */
-  EnumField?: ForeignEnum;
+  declare EnumField: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage MessageField = 4;
@@ -4270,12 +4403,12 @@ export class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldNames> {
   /**
    * @generated from field: optional string StringPieceField = 5;
    */
-  StringPieceField?: string;
+  declare StringPieceField: string;
 
   /**
    * @generated from field: optional string CordField = 6;
    */
-  CordField?: string;
+  declare CordField: string;
 
   /**
    * @generated from field: repeated int32 RepeatedPrimitiveField = 7;
@@ -4346,6 +4479,12 @@ export class TestCamelCaseFieldNames extends Message<TestCamelCaseFieldNames> {
   }
 }
 
+TestCamelCaseFieldNames.prototype.PrimitiveField = 0;
+TestCamelCaseFieldNames.prototype.StringField = "";
+TestCamelCaseFieldNames.prototype.EnumField = 4 as ForeignEnum.FOREIGN_FOO;
+TestCamelCaseFieldNames.prototype.StringPieceField = "";
+TestCamelCaseFieldNames.prototype.CordField = "";
+
 /**
  * We list fields out of order, to ensure that we're using field number and not
  * field index to determine serialization order.
@@ -4356,17 +4495,17 @@ export class TestFieldOrderings extends Message<TestFieldOrderings> {
   /**
    * @generated from field: optional string my_string = 11;
    */
-  myString?: string;
+  declare myString: string;
 
   /**
    * @generated from field: optional int64 my_int = 1;
    */
-  myInt?: bigint;
+  declare myInt: bigint;
 
   /**
    * @generated from field: optional float my_float = 101;
    */
-  myFloat?: number;
+  declare myFloat: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
@@ -4404,6 +4543,10 @@ export class TestFieldOrderings extends Message<TestFieldOrderings> {
   }
 }
 
+TestFieldOrderings.prototype.myString = "";
+TestFieldOrderings.prototype.myInt = protoInt64.zero;
+TestFieldOrderings.prototype.myFloat = 0;
+
 /**
  * @generated from message protobuf_unittest.TestFieldOrderings.NestedMessage
  */
@@ -4411,7 +4554,7 @@ export class TestFieldOrderings_NestedMessage extends Message<TestFieldOrderings
   /**
    * @generated from field: optional int64 oo = 2;
    */
-  oo?: bigint;
+  declare oo: bigint;
 
   /**
    * The field name "b" fails to compile in proto1 because it conflicts with
@@ -4420,7 +4563,7 @@ export class TestFieldOrderings_NestedMessage extends Message<TestFieldOrderings
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  declare bb: number;
 
   constructor(data?: PartialMessage<TestFieldOrderings_NestedMessage>) {
     super();
@@ -4451,6 +4594,9 @@ export class TestFieldOrderings_NestedMessage extends Message<TestFieldOrderings
   }
 }
 
+TestFieldOrderings_NestedMessage.prototype.oo = protoInt64.zero;
+TestFieldOrderings_NestedMessage.prototype.bb = 0;
+
 /**
  * @generated from message protobuf_unittest.TestExtensionOrderings1
  */
@@ -4458,7 +4604,7 @@ export class TestExtensionOrderings1 extends Message<TestExtensionOrderings1> {
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  declare myString: string;
 
   constructor(data?: PartialMessage<TestExtensionOrderings1>) {
     super();
@@ -4488,6 +4634,8 @@ export class TestExtensionOrderings1 extends Message<TestExtensionOrderings1> {
   }
 }
 
+TestExtensionOrderings1.prototype.myString = "";
+
 /**
  * @generated from extension: optional protobuf_unittest.TestExtensionOrderings1 test_ext_orderings1 = 13;
  */
@@ -4504,7 +4652,7 @@ export class TestExtensionOrderings2 extends Message<TestExtensionOrderings2> {
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  declare myString: string;
 
   constructor(data?: PartialMessage<TestExtensionOrderings2>) {
     super();
@@ -4534,6 +4682,8 @@ export class TestExtensionOrderings2 extends Message<TestExtensionOrderings2> {
   }
 }
 
+TestExtensionOrderings2.prototype.myString = "";
+
 /**
  * @generated from message protobuf_unittest.TestExtensionOrderings2.TestExtensionOrderings3
  */
@@ -4541,7 +4691,7 @@ export class TestExtensionOrderings2_TestExtensionOrderings3 extends Message<Tes
   /**
    * @generated from field: optional string my_string = 1;
    */
-  myString?: string;
+  declare myString: string;
 
   constructor(data?: PartialMessage<TestExtensionOrderings2_TestExtensionOrderings3>) {
     super();
@@ -4571,6 +4721,8 @@ export class TestExtensionOrderings2_TestExtensionOrderings3 extends Message<Tes
   }
 }
 
+TestExtensionOrderings2_TestExtensionOrderings3.prototype.myString = "";
+
 /**
  * @generated from extension: optional protobuf_unittest.TestExtensionOrderings2.TestExtensionOrderings3 test_ext_orderings3 = 14;
  */
@@ -4596,37 +4748,37 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
   /**
    * @generated from field: optional bytes escaped_bytes = 1 [default = "\000\001\007\010\014\n\r\t\013\\\'\\"\376"];
    */
-  escapedBytes?: Uint8Array;
+  declare escapedBytes: Uint8Array;
 
   /**
    * @generated from field: optional uint32 large_uint32 = 2 [default = 4294967295];
    */
-  largeUint32?: number;
+  declare largeUint32: number;
 
   /**
    * @generated from field: optional uint64 large_uint64 = 3 [default = 18446744073709551615];
    */
-  largeUint64?: bigint;
+  declare largeUint64: bigint;
 
   /**
    * @generated from field: optional int32 small_int32 = 4 [default = -2147483647];
    */
-  smallInt32?: number;
+  declare smallInt32: number;
 
   /**
    * @generated from field: optional int64 small_int64 = 5 [default = -9223372036854775807];
    */
-  smallInt64?: bigint;
+  declare smallInt64: bigint;
 
   /**
    * @generated from field: optional int32 really_small_int32 = 21 [default = -2147483648];
    */
-  reallySmallInt32?: number;
+  declare reallySmallInt32: number;
 
   /**
    * @generated from field: optional int64 really_small_int64 = 22 [default = -9223372036854775808];
    */
-  reallySmallInt64?: bigint;
+  declare reallySmallInt64: bigint;
 
   /**
    * The default value here is UTF-8 for "\u1234".  (We could also just type
@@ -4635,78 +4787,78 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
    *
    * @generated from field: optional string utf8_string = 6 [default = "ሴ"];
    */
-  utf8String?: string;
+  declare utf8String: string;
 
   /**
    * Tests for single-precision floating-point values.
    *
    * @generated from field: optional float zero_float = 7 [default = 0];
    */
-  zeroFloat?: number;
+  declare zeroFloat: number;
 
   /**
    * @generated from field: optional float one_float = 8 [default = 1];
    */
-  oneFloat?: number;
+  declare oneFloat: number;
 
   /**
    * @generated from field: optional float small_float = 9 [default = 1.5];
    */
-  smallFloat?: number;
+  declare smallFloat: number;
 
   /**
    * @generated from field: optional float negative_one_float = 10 [default = -1];
    */
-  negativeOneFloat?: number;
+  declare negativeOneFloat: number;
 
   /**
    * @generated from field: optional float negative_float = 11 [default = -1.5];
    */
-  negativeFloat?: number;
+  declare negativeFloat: number;
 
   /**
    * Using exponents
    *
    * @generated from field: optional float large_float = 12 [default = 2e+08];
    */
-  largeFloat?: number;
+  declare largeFloat: number;
 
   /**
    * @generated from field: optional float small_negative_float = 13 [default = -8e-28];
    */
-  smallNegativeFloat?: number;
+  declare smallNegativeFloat: number;
 
   /**
    * Text for nonfinite floating-point values.
    *
    * @generated from field: optional double inf_double = 14 [default = inf];
    */
-  infDouble?: number;
+  declare infDouble: number;
 
   /**
    * @generated from field: optional double neg_inf_double = 15 [default = -inf];
    */
-  negInfDouble?: number;
+  declare negInfDouble: number;
 
   /**
    * @generated from field: optional double nan_double = 16 [default = nan];
    */
-  nanDouble?: number;
+  declare nanDouble: number;
 
   /**
    * @generated from field: optional float inf_float = 17 [default = inf];
    */
-  infFloat?: number;
+  declare infFloat: number;
 
   /**
    * @generated from field: optional float neg_inf_float = 18 [default = -inf];
    */
-  negInfFloat?: number;
+  declare negInfFloat: number;
 
   /**
    * @generated from field: optional float nan_float = 19 [default = nan];
    */
-  nanFloat?: number;
+  declare nanFloat: number;
 
   /**
    * Tests for C++ trigraphs.
@@ -4717,34 +4869,34 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
    *
    * @generated from field: optional string cpp_trigraph = 20 [default = "? ? ?? ?? ??? ??/ ??-"];
    */
-  cppTrigraph?: string;
+  declare cppTrigraph: string;
 
   /**
    * String defaults containing the character '\000'
    *
    * @generated from field: optional string string_with_zero = 23 [default = "hel lo"];
    */
-  stringWithZero?: string;
+  declare stringWithZero: string;
 
   /**
    * @generated from field: optional bytes bytes_with_zero = 24 [default = "wor\000ld"];
    */
-  bytesWithZero?: Uint8Array;
+  declare bytesWithZero: Uint8Array;
 
   /**
    * @generated from field: optional string string_piece_with_zero = 25 [default = "ab c"];
    */
-  stringPieceWithZero?: string;
+  declare stringPieceWithZero: string;
 
   /**
    * @generated from field: optional string cord_with_zero = 26 [default = "12 3"];
    */
-  cordWithZero?: string;
+  declare cordWithZero: string;
 
   /**
    * @generated from field: optional string replacement_string = 27 [default = "${unknown}"];
    */
-  replacementString?: string;
+  declare replacementString: string;
 
   constructor(data?: PartialMessage<TestExtremeDefaultValues>) {
     super();
@@ -4800,6 +4952,34 @@ export class TestExtremeDefaultValues extends Message<TestExtremeDefaultValues> 
   }
 }
 
+TestExtremeDefaultValues.prototype.escapedBytes = new Uint8Array([0x00, 0x01, 0x07, 0x08, 0x0C, 0x0A, 0x0D, 0x09, 0x0B, 0x5C, 0xFE]);
+TestExtremeDefaultValues.prototype.largeUint32 = 4294967295;
+TestExtremeDefaultValues.prototype.largeUint64 = protoInt64.uParse("18446744073709551615");
+TestExtremeDefaultValues.prototype.smallInt32 = -2147483647;
+TestExtremeDefaultValues.prototype.smallInt64 = protoInt64.parse("-9223372036854775807");
+TestExtremeDefaultValues.prototype.reallySmallInt32 = -2147483648;
+TestExtremeDefaultValues.prototype.reallySmallInt64 = protoInt64.parse("-9223372036854775808");
+TestExtremeDefaultValues.prototype.utf8String = "ሴ";
+TestExtremeDefaultValues.prototype.zeroFloat = 0;
+TestExtremeDefaultValues.prototype.oneFloat = 1;
+TestExtremeDefaultValues.prototype.smallFloat = 1.5;
+TestExtremeDefaultValues.prototype.negativeOneFloat = -1;
+TestExtremeDefaultValues.prototype.negativeFloat = -1.5;
+TestExtremeDefaultValues.prototype.largeFloat = 200000000;
+TestExtremeDefaultValues.prototype.smallNegativeFloat = -8e-28;
+TestExtremeDefaultValues.prototype.infDouble = protoDouble.POSITIVE_INFINITY;
+TestExtremeDefaultValues.prototype.negInfDouble = protoDouble.NEGATIVE_INFINITY;
+TestExtremeDefaultValues.prototype.nanDouble = protoDouble.NaN;
+TestExtremeDefaultValues.prototype.infFloat = protoDouble.POSITIVE_INFINITY;
+TestExtremeDefaultValues.prototype.negInfFloat = protoDouble.NEGATIVE_INFINITY;
+TestExtremeDefaultValues.prototype.nanFloat = protoDouble.NaN;
+TestExtremeDefaultValues.prototype.cppTrigraph = "? ? ?? ?? ??? ??/ ??-";
+TestExtremeDefaultValues.prototype.stringWithZero = "hel lo";
+TestExtremeDefaultValues.prototype.bytesWithZero = new Uint8Array([0x77, 0x6F, 0x72, 0x00, 0x6C, 0x64]);
+TestExtremeDefaultValues.prototype.stringPieceWithZero = "ab c";
+TestExtremeDefaultValues.prototype.cordWithZero = "12 3";
+TestExtremeDefaultValues.prototype.replacementString = "${unknown}";
+
 /**
  * @generated from message protobuf_unittest.SparseEnumMessage
  */
@@ -4807,7 +4987,7 @@ export class SparseEnumMessage extends Message<SparseEnumMessage> {
   /**
    * @generated from field: optional protobuf_unittest.TestSparseEnum sparse_enum = 1;
    */
-  sparseEnum?: TestSparseEnum;
+  declare sparseEnum: TestSparseEnum;
 
   constructor(data?: PartialMessage<SparseEnumMessage>) {
     super();
@@ -4837,6 +5017,8 @@ export class SparseEnumMessage extends Message<SparseEnumMessage> {
   }
 }
 
+SparseEnumMessage.prototype.sparseEnum = 123 as TestSparseEnum.SPARSE_A;
+
 /**
  * Test String and Bytes: string is for valid UTF-8 strings
  *
@@ -4846,7 +5028,7 @@ export class OneString extends Message<OneString> {
   /**
    * @generated from field: optional string data = 1;
    */
-  data?: string;
+  declare data: string;
 
   constructor(data?: PartialMessage<OneString>) {
     super();
@@ -4875,6 +5057,8 @@ export class OneString extends Message<OneString> {
     return proto2.util.equals(OneString, a, b);
   }
 }
+
+OneString.prototype.data = "";
 
 /**
  * @generated from message protobuf_unittest.MoreString
@@ -4920,7 +5104,7 @@ export class OneBytes extends Message<OneBytes> {
   /**
    * @generated from field: optional bytes data = 1;
    */
-  data?: Uint8Array;
+  declare data: Uint8Array;
 
   constructor(data?: PartialMessage<OneBytes>) {
     super();
@@ -4949,6 +5133,8 @@ export class OneBytes extends Message<OneBytes> {
     return proto2.util.equals(OneBytes, a, b);
   }
 }
+
+OneBytes.prototype.data = new Uint8Array(0);
 
 /**
  * @generated from message protobuf_unittest.MoreBytes
@@ -4994,162 +5180,162 @@ export class ManyOptionalString extends Message<ManyOptionalString> {
   /**
    * @generated from field: optional string str1 = 1;
    */
-  str1?: string;
+  declare str1: string;
 
   /**
    * @generated from field: optional string str2 = 2;
    */
-  str2?: string;
+  declare str2: string;
 
   /**
    * @generated from field: optional string str3 = 3;
    */
-  str3?: string;
+  declare str3: string;
 
   /**
    * @generated from field: optional string str4 = 4;
    */
-  str4?: string;
+  declare str4: string;
 
   /**
    * @generated from field: optional string str5 = 5;
    */
-  str5?: string;
+  declare str5: string;
 
   /**
    * @generated from field: optional string str6 = 6;
    */
-  str6?: string;
+  declare str6: string;
 
   /**
    * @generated from field: optional string str7 = 7;
    */
-  str7?: string;
+  declare str7: string;
 
   /**
    * @generated from field: optional string str8 = 8;
    */
-  str8?: string;
+  declare str8: string;
 
   /**
    * @generated from field: optional string str9 = 9;
    */
-  str9?: string;
+  declare str9: string;
 
   /**
    * @generated from field: optional string str10 = 10;
    */
-  str10?: string;
+  declare str10: string;
 
   /**
    * @generated from field: optional string str11 = 11;
    */
-  str11?: string;
+  declare str11: string;
 
   /**
    * @generated from field: optional string str12 = 12;
    */
-  str12?: string;
+  declare str12: string;
 
   /**
    * @generated from field: optional string str13 = 13;
    */
-  str13?: string;
+  declare str13: string;
 
   /**
    * @generated from field: optional string str14 = 14;
    */
-  str14?: string;
+  declare str14: string;
 
   /**
    * @generated from field: optional string str15 = 15;
    */
-  str15?: string;
+  declare str15: string;
 
   /**
    * @generated from field: optional string str16 = 16;
    */
-  str16?: string;
+  declare str16: string;
 
   /**
    * @generated from field: optional string str17 = 17;
    */
-  str17?: string;
+  declare str17: string;
 
   /**
    * @generated from field: optional string str18 = 18;
    */
-  str18?: string;
+  declare str18: string;
 
   /**
    * @generated from field: optional string str19 = 19;
    */
-  str19?: string;
+  declare str19: string;
 
   /**
    * @generated from field: optional string str20 = 20;
    */
-  str20?: string;
+  declare str20: string;
 
   /**
    * @generated from field: optional string str21 = 21;
    */
-  str21?: string;
+  declare str21: string;
 
   /**
    * @generated from field: optional string str22 = 22;
    */
-  str22?: string;
+  declare str22: string;
 
   /**
    * @generated from field: optional string str23 = 23;
    */
-  str23?: string;
+  declare str23: string;
 
   /**
    * @generated from field: optional string str24 = 24;
    */
-  str24?: string;
+  declare str24: string;
 
   /**
    * @generated from field: optional string str25 = 25;
    */
-  str25?: string;
+  declare str25: string;
 
   /**
    * @generated from field: optional string str26 = 26;
    */
-  str26?: string;
+  declare str26: string;
 
   /**
    * @generated from field: optional string str27 = 27;
    */
-  str27?: string;
+  declare str27: string;
 
   /**
    * @generated from field: optional string str28 = 28;
    */
-  str28?: string;
+  declare str28: string;
 
   /**
    * @generated from field: optional string str29 = 29;
    */
-  str29?: string;
+  declare str29: string;
 
   /**
    * @generated from field: optional string str30 = 30;
    */
-  str30?: string;
+  declare str30: string;
 
   /**
    * @generated from field: optional string str31 = 31;
    */
-  str31?: string;
+  declare str31: string;
 
   /**
    * @generated from field: optional string str32 = 32;
    */
-  str32?: string;
+  declare str32: string;
 
   constructor(data?: PartialMessage<ManyOptionalString>) {
     super();
@@ -5210,6 +5396,39 @@ export class ManyOptionalString extends Message<ManyOptionalString> {
   }
 }
 
+ManyOptionalString.prototype.str1 = "";
+ManyOptionalString.prototype.str2 = "";
+ManyOptionalString.prototype.str3 = "";
+ManyOptionalString.prototype.str4 = "";
+ManyOptionalString.prototype.str5 = "";
+ManyOptionalString.prototype.str6 = "";
+ManyOptionalString.prototype.str7 = "";
+ManyOptionalString.prototype.str8 = "";
+ManyOptionalString.prototype.str9 = "";
+ManyOptionalString.prototype.str10 = "";
+ManyOptionalString.prototype.str11 = "";
+ManyOptionalString.prototype.str12 = "";
+ManyOptionalString.prototype.str13 = "";
+ManyOptionalString.prototype.str14 = "";
+ManyOptionalString.prototype.str15 = "";
+ManyOptionalString.prototype.str16 = "";
+ManyOptionalString.prototype.str17 = "";
+ManyOptionalString.prototype.str18 = "";
+ManyOptionalString.prototype.str19 = "";
+ManyOptionalString.prototype.str20 = "";
+ManyOptionalString.prototype.str21 = "";
+ManyOptionalString.prototype.str22 = "";
+ManyOptionalString.prototype.str23 = "";
+ManyOptionalString.prototype.str24 = "";
+ManyOptionalString.prototype.str25 = "";
+ManyOptionalString.prototype.str26 = "";
+ManyOptionalString.prototype.str27 = "";
+ManyOptionalString.prototype.str28 = "";
+ManyOptionalString.prototype.str29 = "";
+ManyOptionalString.prototype.str30 = "";
+ManyOptionalString.prototype.str31 = "";
+ManyOptionalString.prototype.str32 = "";
+
 /**
  * Test int32, uint32, int64, uint64, and bool are all compatible
  *
@@ -5219,7 +5438,7 @@ export class Int32Message extends Message<Int32Message> {
   /**
    * @generated from field: optional int32 data = 1;
    */
-  data?: number;
+  declare data: number;
 
   constructor(data?: PartialMessage<Int32Message>) {
     super();
@@ -5249,6 +5468,8 @@ export class Int32Message extends Message<Int32Message> {
   }
 }
 
+Int32Message.prototype.data = 0;
+
 /**
  * @generated from message protobuf_unittest.Uint32Message
  */
@@ -5256,7 +5477,7 @@ export class Uint32Message extends Message<Uint32Message> {
   /**
    * @generated from field: optional uint32 data = 1;
    */
-  data?: number;
+  declare data: number;
 
   constructor(data?: PartialMessage<Uint32Message>) {
     super();
@@ -5286,6 +5507,8 @@ export class Uint32Message extends Message<Uint32Message> {
   }
 }
 
+Uint32Message.prototype.data = 0;
+
 /**
  * @generated from message protobuf_unittest.Int64Message
  */
@@ -5293,7 +5516,7 @@ export class Int64Message extends Message<Int64Message> {
   /**
    * @generated from field: optional int64 data = 1;
    */
-  data?: bigint;
+  declare data: bigint;
 
   constructor(data?: PartialMessage<Int64Message>) {
     super();
@@ -5323,6 +5546,8 @@ export class Int64Message extends Message<Int64Message> {
   }
 }
 
+Int64Message.prototype.data = protoInt64.zero;
+
 /**
  * @generated from message protobuf_unittest.Uint64Message
  */
@@ -5330,7 +5555,7 @@ export class Uint64Message extends Message<Uint64Message> {
   /**
    * @generated from field: optional uint64 data = 1;
    */
-  data?: bigint;
+  declare data: bigint;
 
   constructor(data?: PartialMessage<Uint64Message>) {
     super();
@@ -5360,6 +5585,8 @@ export class Uint64Message extends Message<Uint64Message> {
   }
 }
 
+Uint64Message.prototype.data = protoInt64.zero;
+
 /**
  * @generated from message protobuf_unittest.BoolMessage
  */
@@ -5367,7 +5594,7 @@ export class BoolMessage extends Message<BoolMessage> {
   /**
    * @generated from field: optional bool data = 1;
    */
-  data?: boolean;
+  declare data: boolean;
 
   constructor(data?: PartialMessage<BoolMessage>) {
     super();
@@ -5396,6 +5623,8 @@ export class BoolMessage extends Message<BoolMessage> {
     return proto2.util.equals(BoolMessage, a, b);
   }
 }
+
+BoolMessage.prototype.data = false;
 
 /**
  * Test oneofs.
@@ -5470,12 +5699,12 @@ export class TestOneof_FooGroup extends Message<TestOneof_FooGroup> {
   /**
    * @generated from field: optional int32 a = 5;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional string b = 6;
    */
-  b?: string;
+  declare b: string;
 
   constructor(data?: PartialMessage<TestOneof_FooGroup>) {
     super();
@@ -5506,6 +5735,9 @@ export class TestOneof_FooGroup extends Message<TestOneof_FooGroup> {
   }
 }
 
+TestOneof_FooGroup.prototype.a = 0;
+TestOneof_FooGroup.prototype.b = "";
+
 /**
  * @generated from message protobuf_unittest.TestOneofBackwardsCompatible
  */
@@ -5513,12 +5745,12 @@ export class TestOneofBackwardsCompatible extends Message<TestOneofBackwardsComp
   /**
    * @generated from field: optional int32 foo_int = 1;
    */
-  fooInt?: number;
+  declare fooInt: number;
 
   /**
    * @generated from field: optional string foo_string = 2;
    */
-  fooString?: string;
+  declare fooString: string;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes foo_message = 3;
@@ -5561,6 +5793,9 @@ export class TestOneofBackwardsCompatible extends Message<TestOneofBackwardsComp
   }
 }
 
+TestOneofBackwardsCompatible.prototype.fooInt = 0;
+TestOneofBackwardsCompatible.prototype.fooString = "";
+
 /**
  * @generated from message protobuf_unittest.TestOneofBackwardsCompatible.FooGroup
  */
@@ -5568,12 +5803,12 @@ export class TestOneofBackwardsCompatible_FooGroup extends Message<TestOneofBack
   /**
    * @generated from field: optional int32 a = 5;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional string b = 6;
    */
-  b?: string;
+  declare b: string;
 
   constructor(data?: PartialMessage<TestOneofBackwardsCompatible_FooGroup>) {
     super();
@@ -5603,6 +5838,9 @@ export class TestOneofBackwardsCompatible_FooGroup extends Message<TestOneofBack
     return proto2.util.equals(TestOneofBackwardsCompatible_FooGroup, a, b);
   }
 }
+
+TestOneofBackwardsCompatible_FooGroup.prototype.a = 0;
+TestOneofBackwardsCompatible_FooGroup.prototype.b = "";
 
 /**
  * @generated from message protobuf_unittest.TestOneof2
@@ -5741,12 +5979,12 @@ export class TestOneof2 extends Message<TestOneof2> {
   /**
    * @generated from field: optional int32 baz_int = 18;
    */
-  bazInt?: number;
+  declare bazInt: number;
 
   /**
    * @generated from field: optional string baz_string = 19 [default = "BAZ"];
    */
-  bazString?: string;
+  declare bazString: string;
 
   constructor(data?: PartialMessage<TestOneof2>) {
     super();
@@ -5797,6 +6035,9 @@ export class TestOneof2 extends Message<TestOneof2> {
   }
 }
 
+TestOneof2.prototype.bazInt = 0;
+TestOneof2.prototype.bazString = "BAZ";
+
 /**
  * @generated from enum protobuf_unittest.TestOneof2.NestedEnum
  */
@@ -5830,12 +6071,12 @@ export class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
   /**
    * @generated from field: optional int32 a = 9;
    */
-  a?: number;
+  declare a: number;
 
   /**
    * @generated from field: optional string b = 10;
    */
-  b?: string;
+  declare b: string;
 
   constructor(data?: PartialMessage<TestOneof2_FooGroup>) {
     super();
@@ -5866,6 +6107,9 @@ export class TestOneof2_FooGroup extends Message<TestOneof2_FooGroup> {
   }
 }
 
+TestOneof2_FooGroup.prototype.a = 0;
+TestOneof2_FooGroup.prototype.b = "";
+
 /**
  * @generated from message protobuf_unittest.TestOneof2.NestedMessage
  */
@@ -5873,7 +6117,7 @@ export class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> 
   /**
    * @generated from field: optional int64 moo_int = 1;
    */
-  mooInt?: bigint;
+  declare mooInt: bigint;
 
   /**
    * @generated from field: repeated int32 corge_int = 2;
@@ -5908,6 +6152,8 @@ export class TestOneof2_NestedMessage extends Message<TestOneof2_NestedMessage> 
     return proto2.util.equals(TestOneof2_NestedMessage, a, b);
   }
 }
+
+TestOneof2_NestedMessage.prototype.mooInt = protoInt64.zero;
 
 /**
  * @generated from message protobuf_unittest.TestRequiredOneof
@@ -6318,17 +6564,17 @@ export class TestDynamicExtensions extends Message<TestDynamicExtensions> {
   /**
    * @generated from field: optional fixed32 scalar_extension = 2000;
    */
-  scalarExtension?: number;
+  declare scalarExtension: number;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum enum_extension = 2001;
    */
-  enumExtension?: ForeignEnum;
+  declare enumExtension: ForeignEnum;
 
   /**
    * @generated from field: optional protobuf_unittest.TestDynamicExtensions.DynamicEnumType dynamic_enum_extension = 2002;
    */
-  dynamicEnumExtension?: TestDynamicExtensions_DynamicEnumType;
+  declare dynamicEnumExtension: TestDynamicExtensions_DynamicEnumType;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage message_extension = 2003;
@@ -6384,6 +6630,10 @@ export class TestDynamicExtensions extends Message<TestDynamicExtensions> {
   }
 }
 
+TestDynamicExtensions.prototype.scalarExtension = 0;
+TestDynamicExtensions.prototype.enumExtension = 4 as ForeignEnum.FOREIGN_FOO;
+TestDynamicExtensions.prototype.dynamicEnumExtension = 2200 as TestDynamicExtensions_DynamicEnumType.DYNAMIC_FOO;
+
 /**
  * @generated from enum protobuf_unittest.TestDynamicExtensions.DynamicEnumType
  */
@@ -6417,7 +6667,7 @@ export class TestDynamicExtensions_DynamicMessageType extends Message<TestDynami
   /**
    * @generated from field: optional int32 dynamic_field = 2100;
    */
-  dynamicField?: number;
+  declare dynamicField: number;
 
   constructor(data?: PartialMessage<TestDynamicExtensions_DynamicMessageType>) {
     super();
@@ -6446,6 +6696,8 @@ export class TestDynamicExtensions_DynamicMessageType extends Message<TestDynami
     return proto2.util.equals(TestDynamicExtensions_DynamicMessageType, a, b);
   }
 }
+
+TestDynamicExtensions_DynamicMessageType.prototype.dynamicField = 0;
 
 /**
  * @generated from message protobuf_unittest.TestRepeatedString
@@ -6937,7 +7189,7 @@ export class TestCommentInjectionMessage extends Message<TestCommentInjectionMes
    *
    * @generated from field: optional string a = 1 [default = "*\/ <- Neither should this."];
    */
-  a?: string;
+  declare a: string;
 
   constructor(data?: PartialMessage<TestCommentInjectionMessage>) {
     super();
@@ -6967,6 +7219,8 @@ export class TestCommentInjectionMessage extends Message<TestCommentInjectionMes
   }
 }
 
+TestCommentInjectionMessage.prototype.a = "*/ <- Neither should this.";
+
 /**
  * Used to check that the c++ code generator re-orders messages to reduce
  * padding.
@@ -6977,32 +7231,32 @@ export class TestMessageSize extends Message<TestMessageSize> {
   /**
    * @generated from field: optional bool m1 = 1;
    */
-  m1?: boolean;
+  declare m1: boolean;
 
   /**
    * @generated from field: optional int64 m2 = 2;
    */
-  m2?: bigint;
+  declare m2: bigint;
 
   /**
    * @generated from field: optional bool m3 = 3;
    */
-  m3?: boolean;
+  declare m3: boolean;
 
   /**
    * @generated from field: optional string m4 = 4;
    */
-  m4?: string;
+  declare m4: string;
 
   /**
    * @generated from field: optional int32 m5 = 5;
    */
-  m5?: number;
+  declare m5: number;
 
   /**
    * @generated from field: optional int64 m6 = 6;
    */
-  m6?: bigint;
+  declare m6: bigint;
 
   constructor(data?: PartialMessage<TestMessageSize>) {
     super();
@@ -7036,6 +7290,13 @@ export class TestMessageSize extends Message<TestMessageSize> {
     return proto2.util.equals(TestMessageSize, a, b);
   }
 }
+
+TestMessageSize.prototype.m1 = false;
+TestMessageSize.prototype.m2 = protoInt64.zero;
+TestMessageSize.prototype.m3 = false;
+TestMessageSize.prototype.m4 = "";
+TestMessageSize.prototype.m5 = 0;
+TestMessageSize.prototype.m6 = protoInt64.zero;
 
 /**
  * Test that RPC services work.
@@ -7232,37 +7493,37 @@ export class TestJsonName extends Message<TestJsonName> {
   /**
    * @generated from field: optional int32 field_name1 = 1;
    */
-  fieldName1?: number;
+  declare fieldName1: number;
 
   /**
    * @generated from field: optional int32 fieldName2 = 2;
    */
-  fieldName2?: number;
+  declare fieldName2: number;
 
   /**
    * @generated from field: optional int32 FieldName3 = 3;
    */
-  FieldName3?: number;
+  declare FieldName3: number;
 
   /**
    * @generated from field: optional int32 _field_name4 = 4;
    */
-  FieldName4?: number;
+  declare FieldName4: number;
 
   /**
    * @generated from field: optional int32 FIELD_NAME5 = 5;
    */
-  FIELDNAME5?: number;
+  declare FIELDNAME5: number;
 
   /**
    * @generated from field: optional int32 field_name6 = 6 [json_name = "@type"];
    */
-  fieldName6?: number;
+  declare fieldName6: number;
 
   /**
    * @generated from field: optional int32 fieldname7 = 7;
    */
-  fieldname7?: number;
+  declare fieldname7: number;
 
   constructor(data?: PartialMessage<TestJsonName>) {
     super();
@@ -7298,6 +7559,14 @@ export class TestJsonName extends Message<TestJsonName> {
   }
 }
 
+TestJsonName.prototype.fieldName1 = 0;
+TestJsonName.prototype.fieldName2 = 0;
+TestJsonName.prototype.FieldName3 = 0;
+TestJsonName.prototype.FieldName4 = 0;
+TestJsonName.prototype.FIELDNAME5 = 0;
+TestJsonName.prototype.fieldName6 = 0;
+TestJsonName.prototype.fieldname7 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestHugeFieldNumbers
  */
@@ -7305,12 +7574,12 @@ export class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> {
   /**
    * @generated from field: optional int32 optional_int32 = 536870000;
    */
-  optionalInt32?: number;
+  declare optionalInt32: number;
 
   /**
    * @generated from field: optional int32 fixed_32 = 536870001;
    */
-  fixed32?: number;
+  declare fixed32: number;
 
   /**
    * @generated from field: repeated int32 repeated_int32 = 536870002 [packed = false];
@@ -7325,17 +7594,17 @@ export class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> {
   /**
    * @generated from field: optional protobuf_unittest.ForeignEnum optional_enum = 536870004;
    */
-  optionalEnum?: ForeignEnum;
+  declare optionalEnum: ForeignEnum;
 
   /**
    * @generated from field: optional string optional_string = 536870005;
    */
-  optionalString?: string;
+  declare optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 536870006;
    */
-  optionalBytes?: Uint8Array;
+  declare optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional protobuf_unittest.ForeignMessage optional_message = 536870007;
@@ -7422,6 +7691,12 @@ export class TestHugeFieldNumbers extends Message<TestHugeFieldNumbers> {
   }
 }
 
+TestHugeFieldNumbers.prototype.optionalInt32 = 0;
+TestHugeFieldNumbers.prototype.fixed32 = 0;
+TestHugeFieldNumbers.prototype.optionalEnum = 4 as ForeignEnum.FOREIGN_FOO;
+TestHugeFieldNumbers.prototype.optionalString = "";
+TestHugeFieldNumbers.prototype.optionalBytes = new Uint8Array(0);
+
 /**
  * @generated from message protobuf_unittest.TestHugeFieldNumbers.OptionalGroup
  */
@@ -7429,7 +7704,7 @@ export class TestHugeFieldNumbers_OptionalGroup extends Message<TestHugeFieldNum
   /**
    * @generated from field: optional int32 group_a = 536870009;
    */
-  groupA?: number;
+  declare groupA: number;
 
   constructor(data?: PartialMessage<TestHugeFieldNumbers_OptionalGroup>) {
     super();
@@ -7459,6 +7734,8 @@ export class TestHugeFieldNumbers_OptionalGroup extends Message<TestHugeFieldNum
   }
 }
 
+TestHugeFieldNumbers_OptionalGroup.prototype.groupA = 0;
+
 /**
  * @generated from message protobuf_unittest.TestExtensionInsideTable
  */
@@ -7466,47 +7743,47 @@ export class TestExtensionInsideTable extends Message<TestExtensionInsideTable> 
   /**
    * @generated from field: optional int32 field1 = 1;
    */
-  field1?: number;
+  declare field1: number;
 
   /**
    * @generated from field: optional int32 field2 = 2;
    */
-  field2?: number;
+  declare field2: number;
 
   /**
    * @generated from field: optional int32 field3 = 3;
    */
-  field3?: number;
+  declare field3: number;
 
   /**
    * @generated from field: optional int32 field4 = 4;
    */
-  field4?: number;
+  declare field4: number;
 
   /**
    * @generated from field: optional int32 field6 = 6;
    */
-  field6?: number;
+  declare field6: number;
 
   /**
    * @generated from field: optional int32 field7 = 7;
    */
-  field7?: number;
+  declare field7: number;
 
   /**
    * @generated from field: optional int32 field8 = 8;
    */
-  field8?: number;
+  declare field8: number;
 
   /**
    * @generated from field: optional int32 field9 = 9;
    */
-  field9?: number;
+  declare field9: number;
 
   /**
    * @generated from field: optional int32 field10 = 10;
    */
-  field10?: number;
+  declare field10: number;
 
   constructor(data?: PartialMessage<TestExtensionInsideTable>) {
     super();
@@ -7543,6 +7820,16 @@ export class TestExtensionInsideTable extends Message<TestExtensionInsideTable> 
     return proto2.util.equals(TestExtensionInsideTable, a, b);
   }
 }
+
+TestExtensionInsideTable.prototype.field1 = 0;
+TestExtensionInsideTable.prototype.field2 = 0;
+TestExtensionInsideTable.prototype.field3 = 0;
+TestExtensionInsideTable.prototype.field4 = 0;
+TestExtensionInsideTable.prototype.field6 = 0;
+TestExtensionInsideTable.prototype.field7 = 0;
+TestExtensionInsideTable.prototype.field8 = 0;
+TestExtensionInsideTable.prototype.field9 = 0;
+TestExtensionInsideTable.prototype.field10 = 0;
 
 /**
  * NOTE: Intentionally nested to mirror go/glep.
@@ -7633,7 +7920,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGro
   /**
    * @generated from field: optional string another_field = 6;
    */
-  anotherField?: string;
+  declare anotherField: string;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGroup>) {
     super();
@@ -7663,6 +7950,8 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGro
   }
 }
 
+TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2RepeatedGroup.prototype.anotherField = "";
+
 /**
  * @generated from message protobuf_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup.Layer2AnotherOptionalRepeatedGroup
  */
@@ -7670,7 +7959,7 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOpti
   /**
    * @generated from field: optional string but_why_tho = 5;
    */
-  butWhyTho?: string;
+  declare butWhyTho: string;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOptionalRepeatedGroup>) {
     super();
@@ -7700,6 +7989,8 @@ export class TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOpti
   }
 }
 
+TestNestedGroupExtensionOuter_Layer1OptionalGroup_Layer2AnotherOptionalRepeatedGroup.prototype.butWhyTho = "";
+
 /**
  * @generated from message protobuf_unittest.TestNestedGroupExtensionInnerExtension
  */
@@ -7707,7 +7998,7 @@ export class TestNestedGroupExtensionInnerExtension extends Message<TestNestedGr
   /**
    * @generated from field: optional string inner_name = 1;
    */
-  innerName?: string;
+  declare innerName: string;
 
   constructor(data?: PartialMessage<TestNestedGroupExtensionInnerExtension>) {
     super();
@@ -7737,6 +8028,8 @@ export class TestNestedGroupExtensionInnerExtension extends Message<TestNestedGr
   }
 }
 
+TestNestedGroupExtensionInnerExtension.prototype.innerName = "";
+
 /**
  * @generated from message protobuf_unittest.TestExtensionRangeSerialize
  */
@@ -7744,22 +8037,22 @@ export class TestExtensionRangeSerialize extends Message<TestExtensionRangeSeria
   /**
    * @generated from field: optional int32 foo_one = 1;
    */
-  fooOne?: number;
+  declare fooOne: number;
 
   /**
    * @generated from field: optional int32 foo_two = 6;
    */
-  fooTwo?: number;
+  declare fooTwo: number;
 
   /**
    * @generated from field: optional int32 foo_three = 7;
    */
-  fooThree?: number;
+  declare fooThree: number;
 
   /**
    * @generated from field: optional int32 foo_four = 13;
    */
-  fooFour?: number;
+  declare fooFour: number;
 
   constructor(data?: PartialMessage<TestExtensionRangeSerialize>) {
     super();
@@ -7791,6 +8084,11 @@ export class TestExtensionRangeSerialize extends Message<TestExtensionRangeSeria
     return proto2.util.equals(TestExtensionRangeSerialize, a, b);
   }
 }
+
+TestExtensionRangeSerialize.prototype.fooOne = 0;
+TestExtensionRangeSerialize.prototype.fooTwo = 0;
+TestExtensionRangeSerialize.prototype.fooThree = 0;
+TestExtensionRangeSerialize.prototype.fooFour = 0;
 
 /**
  * @generated from extension: optional int32 bar_one = 2;
@@ -7844,22 +8142,22 @@ export class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple> {
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  declare optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  declare optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  declare optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  declare optionalInt3264: number;
 
   constructor(data?: PartialMessage<TestVerifyInt32Simple>) {
     super();
@@ -7892,6 +8190,11 @@ export class TestVerifyInt32Simple extends Message<TestVerifyInt32Simple> {
   }
 }
 
+TestVerifyInt32Simple.prototype.optionalInt321 = 0;
+TestVerifyInt32Simple.prototype.optionalInt322 = 0;
+TestVerifyInt32Simple.prototype.optionalInt3263 = 0;
+TestVerifyInt32Simple.prototype.optionalInt3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyInt32
  */
@@ -7899,22 +8202,22 @@ export class TestVerifyInt32 extends Message<TestVerifyInt32> {
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  declare optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  declare optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  declare optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  declare optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -7959,6 +8262,11 @@ export class TestVerifyInt32 extends Message<TestVerifyInt32> {
   }
 }
 
+TestVerifyInt32.prototype.optionalInt321 = 0;
+TestVerifyInt32.prototype.optionalInt322 = 0;
+TestVerifyInt32.prototype.optionalInt3263 = 0;
+TestVerifyInt32.prototype.optionalInt3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyMostlyInt32
  */
@@ -7966,37 +8274,37 @@ export class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32> {
   /**
    * @generated from field: optional int64 optional_int64_30 = 30;
    */
-  optionalInt6430?: bigint;
+  declare optionalInt6430: bigint;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  declare optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  declare optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_3 = 3;
    */
-  optionalInt323?: number;
+  declare optionalInt323: number;
 
   /**
    * @generated from field: optional int32 optional_int32_4 = 4;
    */
-  optionalInt324?: number;
+  declare optionalInt324: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  declare optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  declare optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8044,6 +8352,14 @@ export class TestVerifyMostlyInt32 extends Message<TestVerifyMostlyInt32> {
   }
 }
 
+TestVerifyMostlyInt32.prototype.optionalInt6430 = protoInt64.zero;
+TestVerifyMostlyInt32.prototype.optionalInt321 = 0;
+TestVerifyMostlyInt32.prototype.optionalInt322 = 0;
+TestVerifyMostlyInt32.prototype.optionalInt323 = 0;
+TestVerifyMostlyInt32.prototype.optionalInt324 = 0;
+TestVerifyMostlyInt32.prototype.optionalInt3263 = 0;
+TestVerifyMostlyInt32.prototype.optionalInt3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyMostlyInt32BigFieldNumber
  */
@@ -8051,42 +8367,42 @@ export class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVerifyMostl
   /**
    * @generated from field: optional int64 optional_int64_30 = 30;
    */
-  optionalInt6430?: bigint;
+  declare optionalInt6430: bigint;
 
   /**
    * @generated from field: optional int32 optional_int32_300 = 300;
    */
-  optionalInt32300?: number;
+  declare optionalInt32300: number;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  declare optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  declare optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_3 = 3;
    */
-  optionalInt323?: number;
+  declare optionalInt323: number;
 
   /**
    * @generated from field: optional int32 optional_int32_4 = 4;
    */
-  optionalInt324?: number;
+  declare optionalInt324: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  declare optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  declare optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8135,6 +8451,15 @@ export class TestVerifyMostlyInt32BigFieldNumber extends Message<TestVerifyMostl
   }
 }
 
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt6430 = protoInt64.zero;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt32300 = 0;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt321 = 0;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt322 = 0;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt323 = 0;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt324 = 0;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt3263 = 0;
+TestVerifyMostlyInt32BigFieldNumber.prototype.optionalInt3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyUint32Simple
  */
@@ -8142,22 +8467,22 @@ export class TestVerifyUint32Simple extends Message<TestVerifyUint32Simple> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  declare optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  declare optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  declare optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  declare optionalUint3264: number;
 
   constructor(data?: PartialMessage<TestVerifyUint32Simple>) {
     super();
@@ -8190,6 +8515,11 @@ export class TestVerifyUint32Simple extends Message<TestVerifyUint32Simple> {
   }
 }
 
+TestVerifyUint32Simple.prototype.optionalUint321 = 0;
+TestVerifyUint32Simple.prototype.optionalUint322 = 0;
+TestVerifyUint32Simple.prototype.optionalUint3263 = 0;
+TestVerifyUint32Simple.prototype.optionalUint3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyUint32
  */
@@ -8197,22 +8527,22 @@ export class TestVerifyUint32 extends Message<TestVerifyUint32> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  declare optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  declare optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  declare optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  declare optionalUint3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8257,6 +8587,11 @@ export class TestVerifyUint32 extends Message<TestVerifyUint32> {
   }
 }
 
+TestVerifyUint32.prototype.optionalUint321 = 0;
+TestVerifyUint32.prototype.optionalUint322 = 0;
+TestVerifyUint32.prototype.optionalUint3263 = 0;
+TestVerifyUint32.prototype.optionalUint3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyOneUint32
  */
@@ -8264,22 +8599,22 @@ export class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  declare optionalUint321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  declare optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  declare optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  declare optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8324,6 +8659,11 @@ export class TestVerifyOneUint32 extends Message<TestVerifyOneUint32> {
   }
 }
 
+TestVerifyOneUint32.prototype.optionalUint321 = 0;
+TestVerifyOneUint32.prototype.optionalInt322 = 0;
+TestVerifyOneUint32.prototype.optionalInt3263 = 0;
+TestVerifyOneUint32.prototype.optionalInt3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyOneInt32BigFieldNumber
  */
@@ -8331,27 +8671,27 @@ export class TestVerifyOneInt32BigFieldNumber extends Message<TestVerifyOneInt32
   /**
    * @generated from field: optional int32 optional_int32_65 = 65;
    */
-  optionalInt3265?: number;
+  declare optionalInt3265: number;
 
   /**
    * @generated from field: optional int64 optional_int64_1 = 1;
    */
-  optionalInt641?: bigint;
+  declare optionalInt641: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_2 = 2;
    */
-  optionalInt642?: bigint;
+  declare optionalInt642: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_63 = 63;
    */
-  optionalInt6463?: bigint;
+  declare optionalInt6463: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_64 = 64;
    */
-  optionalInt6464?: bigint;
+  declare optionalInt6464: bigint;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8397,6 +8737,12 @@ export class TestVerifyOneInt32BigFieldNumber extends Message<TestVerifyOneInt32
   }
 }
 
+TestVerifyOneInt32BigFieldNumber.prototype.optionalInt3265 = 0;
+TestVerifyOneInt32BigFieldNumber.prototype.optionalInt641 = protoInt64.zero;
+TestVerifyOneInt32BigFieldNumber.prototype.optionalInt642 = protoInt64.zero;
+TestVerifyOneInt32BigFieldNumber.prototype.optionalInt6463 = protoInt64.zero;
+TestVerifyOneInt32BigFieldNumber.prototype.optionalInt6464 = protoInt64.zero;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyInt32BigFieldNumber
  */
@@ -8404,32 +8750,32 @@ export class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt32BigFie
   /**
    * @generated from field: optional int32 optional_int32_1000 = 1000;
    */
-  optionalInt321000?: number;
+  declare optionalInt321000: number;
 
   /**
    * @generated from field: optional int32 optional_int32_65 = 65;
    */
-  optionalInt3265?: number;
+  declare optionalInt3265: number;
 
   /**
    * @generated from field: optional int32 optional_int32_1 = 1;
    */
-  optionalInt321?: number;
+  declare optionalInt321: number;
 
   /**
    * @generated from field: optional int32 optional_int32_2 = 2;
    */
-  optionalInt322?: number;
+  declare optionalInt322: number;
 
   /**
    * @generated from field: optional int32 optional_int32_63 = 63;
    */
-  optionalInt3263?: number;
+  declare optionalInt3263: number;
 
   /**
    * @generated from field: optional int32 optional_int32_64 = 64;
    */
-  optionalInt3264?: number;
+  declare optionalInt3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8476,6 +8822,13 @@ export class TestVerifyInt32BigFieldNumber extends Message<TestVerifyInt32BigFie
   }
 }
 
+TestVerifyInt32BigFieldNumber.prototype.optionalInt321000 = 0;
+TestVerifyInt32BigFieldNumber.prototype.optionalInt3265 = 0;
+TestVerifyInt32BigFieldNumber.prototype.optionalInt321 = 0;
+TestVerifyInt32BigFieldNumber.prototype.optionalInt322 = 0;
+TestVerifyInt32BigFieldNumber.prototype.optionalInt3263 = 0;
+TestVerifyInt32BigFieldNumber.prototype.optionalInt3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyUint32BigFieldNumber
  */
@@ -8483,32 +8836,32 @@ export class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUint32BigF
   /**
    * @generated from field: optional uint32 optional_uint32_1000 = 1000;
    */
-  optionalUint321000?: number;
+  declare optionalUint321000: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_65 = 65;
    */
-  optionalUint3265?: number;
+  declare optionalUint3265: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  declare optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  declare optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  declare optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  declare optionalUint3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestAllTypes optional_all_types = 9;
@@ -8555,6 +8908,13 @@ export class TestVerifyUint32BigFieldNumber extends Message<TestVerifyUint32BigF
   }
 }
 
+TestVerifyUint32BigFieldNumber.prototype.optionalUint321000 = 0;
+TestVerifyUint32BigFieldNumber.prototype.optionalUint3265 = 0;
+TestVerifyUint32BigFieldNumber.prototype.optionalUint321 = 0;
+TestVerifyUint32BigFieldNumber.prototype.optionalUint322 = 0;
+TestVerifyUint32BigFieldNumber.prototype.optionalUint3263 = 0;
+TestVerifyUint32BigFieldNumber.prototype.optionalUint3264 = 0;
+
 /**
  * @generated from message protobuf_unittest.TestVerifyBigFieldNumberUint32
  */
@@ -8599,42 +8959,42 @@ export class TestVerifyBigFieldNumberUint32_Nested extends Message<TestVerifyBig
   /**
    * @generated from field: optional uint32 optional_uint32_5000 = 5000;
    */
-  optionalUint325000?: number;
+  declare optionalUint325000: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1000 = 1000;
    */
-  optionalUint321000?: number;
+  declare optionalUint321000: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_66 = 66;
    */
-  optionalUint3266?: number;
+  declare optionalUint3266: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_65 = 65;
    */
-  optionalUint3265?: number;
+  declare optionalUint3265: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_1 = 1;
    */
-  optionalUint321?: number;
+  declare optionalUint321: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_2 = 2;
    */
-  optionalUint322?: number;
+  declare optionalUint322: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_63 = 63;
    */
-  optionalUint3263?: number;
+  declare optionalUint3263: number;
 
   /**
    * @generated from field: optional uint32 optional_uint32_64 = 64;
    */
-  optionalUint3264?: number;
+  declare optionalUint3264: number;
 
   /**
    * @generated from field: optional protobuf_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
@@ -8683,6 +9043,15 @@ export class TestVerifyBigFieldNumberUint32_Nested extends Message<TestVerifyBig
   }
 }
 
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint325000 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint321000 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint3266 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint3265 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint321 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint322 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint3263 = 0;
+TestVerifyBigFieldNumberUint32_Nested.prototype.optionalUint3264 = 0;
+
 /**
  * This message contains different kind of enums to exercise the different
  * parsers in table-driven.
@@ -8693,17 +9062,17 @@ export class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall0 optional_seq_small_0_lowfield = 1;
    */
-  optionalSeqSmall0Lowfield?: EnumParseTester_SeqSmall0;
+  declare optionalSeqSmall0Lowfield: EnumParseTester_SeqSmall0;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall0 optional_seq_small_0_midfield = 1001;
    */
-  optionalSeqSmall0Midfield?: EnumParseTester_SeqSmall0;
+  declare optionalSeqSmall0Midfield: EnumParseTester_SeqSmall0;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall0 optional_seq_small_0_hifield = 1000001;
    */
-  optionalSeqSmall0Hifield?: EnumParseTester_SeqSmall0;
+  declare optionalSeqSmall0Hifield: EnumParseTester_SeqSmall0;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.SeqSmall0 repeated_seq_small_0_lowfield = 2;
@@ -8738,17 +9107,17 @@ export class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall1 optional_seq_small_1_lowfield = 4;
    */
-  optionalSeqSmall1Lowfield?: EnumParseTester_SeqSmall1;
+  declare optionalSeqSmall1Lowfield: EnumParseTester_SeqSmall1;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall1 optional_seq_small_1_midfield = 1004;
    */
-  optionalSeqSmall1Midfield?: EnumParseTester_SeqSmall1;
+  declare optionalSeqSmall1Midfield: EnumParseTester_SeqSmall1;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqSmall1 optional_seq_small_1_hifield = 1000004;
    */
-  optionalSeqSmall1Hifield?: EnumParseTester_SeqSmall1;
+  declare optionalSeqSmall1Hifield: EnumParseTester_SeqSmall1;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.SeqSmall1 repeated_seq_small_1_lowfield = 5;
@@ -8783,17 +9152,17 @@ export class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqLarge optional_seq_large_lowfield = 7;
    */
-  optionalSeqLargeLowfield?: EnumParseTester_SeqLarge;
+  declare optionalSeqLargeLowfield: EnumParseTester_SeqLarge;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqLarge optional_seq_large_midfield = 1007;
    */
-  optionalSeqLargeMidfield?: EnumParseTester_SeqLarge;
+  declare optionalSeqLargeMidfield: EnumParseTester_SeqLarge;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.SeqLarge optional_seq_large_hifield = 1000007;
    */
-  optionalSeqLargeHifield?: EnumParseTester_SeqLarge;
+  declare optionalSeqLargeHifield: EnumParseTester_SeqLarge;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.SeqLarge repeated_seq_large_lowfield = 8;
@@ -8828,17 +9197,17 @@ export class EnumParseTester extends Message<EnumParseTester> {
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.Arbitrary optional_arbitrary_lowfield = 10;
    */
-  optionalArbitraryLowfield?: EnumParseTester_Arbitrary;
+  declare optionalArbitraryLowfield: EnumParseTester_Arbitrary;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.Arbitrary optional_arbitrary_midfield = 1010;
    */
-  optionalArbitraryMidfield?: EnumParseTester_Arbitrary;
+  declare optionalArbitraryMidfield: EnumParseTester_Arbitrary;
 
   /**
    * @generated from field: optional protobuf_unittest.EnumParseTester.Arbitrary optional_arbitrary_hifield = 1000010;
    */
-  optionalArbitraryHifield?: EnumParseTester_Arbitrary;
+  declare optionalArbitraryHifield: EnumParseTester_Arbitrary;
 
   /**
    * @generated from field: repeated protobuf_unittest.EnumParseTester.Arbitrary repeated_arbitrary_lowfield = 11;
@@ -8875,7 +9244,7 @@ export class EnumParseTester extends Message<EnumParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  declare otherField: number;
 
   constructor(data?: PartialMessage<EnumParseTester>) {
     super();
@@ -8940,6 +9309,20 @@ export class EnumParseTester extends Message<EnumParseTester> {
     return proto2.util.equals(EnumParseTester, a, b);
   }
 }
+
+EnumParseTester.prototype.optionalSeqSmall0Lowfield = 0 as EnumParseTester_SeqSmall0.SEQ_SMALL_0_DEFAULT;
+EnumParseTester.prototype.optionalSeqSmall0Midfield = 0 as EnumParseTester_SeqSmall0.SEQ_SMALL_0_DEFAULT;
+EnumParseTester.prototype.optionalSeqSmall0Hifield = 0 as EnumParseTester_SeqSmall0.SEQ_SMALL_0_DEFAULT;
+EnumParseTester.prototype.optionalSeqSmall1Lowfield = 1 as EnumParseTester_SeqSmall1.SEQ_SMALL_1_DEFAULT;
+EnumParseTester.prototype.optionalSeqSmall1Midfield = 1 as EnumParseTester_SeqSmall1.SEQ_SMALL_1_DEFAULT;
+EnumParseTester.prototype.optionalSeqSmall1Hifield = 1 as EnumParseTester_SeqSmall1.SEQ_SMALL_1_DEFAULT;
+EnumParseTester.prototype.optionalSeqLargeLowfield = -1 as EnumParseTester_SeqLarge.SEQ_LARGE_DEFAULT;
+EnumParseTester.prototype.optionalSeqLargeMidfield = -1 as EnumParseTester_SeqLarge.SEQ_LARGE_DEFAULT;
+EnumParseTester.prototype.optionalSeqLargeHifield = -1 as EnumParseTester_SeqLarge.SEQ_LARGE_DEFAULT;
+EnumParseTester.prototype.optionalArbitraryLowfield = -123123 as EnumParseTester_Arbitrary.ARBITRARY_DEFAULT;
+EnumParseTester.prototype.optionalArbitraryMidfield = -123123 as EnumParseTester_Arbitrary.ARBITRARY_DEFAULT;
+EnumParseTester.prototype.optionalArbitraryHifield = -123123 as EnumParseTester_Arbitrary.ARBITRARY_DEFAULT;
+EnumParseTester.prototype.otherField = 0;
 
 /**
  * @generated from enum protobuf_unittest.EnumParseTester.SeqSmall0
@@ -9292,17 +9675,17 @@ export class BoolParseTester extends Message<BoolParseTester> {
   /**
    * @generated from field: optional bool optional_bool_lowfield = 1;
    */
-  optionalBoolLowfield?: boolean;
+  declare optionalBoolLowfield: boolean;
 
   /**
    * @generated from field: optional bool optional_bool_midfield = 1001;
    */
-  optionalBoolMidfield?: boolean;
+  declare optionalBoolMidfield: boolean;
 
   /**
    * @generated from field: optional bool optional_bool_hifield = 1000001;
    */
-  optionalBoolHifield?: boolean;
+  declare optionalBoolHifield: boolean;
 
   /**
    * @generated from field: repeated bool repeated_bool_lowfield = 2;
@@ -9339,7 +9722,7 @@ export class BoolParseTester extends Message<BoolParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  declare otherField: number;
 
   constructor(data?: PartialMessage<BoolParseTester>) {
     super();
@@ -9378,6 +9761,11 @@ export class BoolParseTester extends Message<BoolParseTester> {
   }
 }
 
+BoolParseTester.prototype.optionalBoolLowfield = false;
+BoolParseTester.prototype.optionalBoolMidfield = false;
+BoolParseTester.prototype.optionalBoolHifield = false;
+BoolParseTester.prototype.otherField = 0;
+
 /**
  * @generated from extension: optional bool optional_bool_ext = 2000000;
  */
@@ -9412,17 +9800,17 @@ export class Int32ParseTester extends Message<Int32ParseTester> {
   /**
    * @generated from field: optional int32 optional_int32_lowfield = 1;
    */
-  optionalInt32Lowfield?: number;
+  declare optionalInt32Lowfield: number;
 
   /**
    * @generated from field: optional int32 optional_int32_midfield = 1001;
    */
-  optionalInt32Midfield?: number;
+  declare optionalInt32Midfield: number;
 
   /**
    * @generated from field: optional int32 optional_int32_hifield = 1000001;
    */
-  optionalInt32Hifield?: number;
+  declare optionalInt32Hifield: number;
 
   /**
    * @generated from field: repeated int32 repeated_int32_lowfield = 2;
@@ -9459,7 +9847,7 @@ export class Int32ParseTester extends Message<Int32ParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  declare otherField: number;
 
   constructor(data?: PartialMessage<Int32ParseTester>) {
     super();
@@ -9498,6 +9886,11 @@ export class Int32ParseTester extends Message<Int32ParseTester> {
   }
 }
 
+Int32ParseTester.prototype.optionalInt32Lowfield = 0;
+Int32ParseTester.prototype.optionalInt32Midfield = 0;
+Int32ParseTester.prototype.optionalInt32Hifield = 0;
+Int32ParseTester.prototype.otherField = 0;
+
 /**
  * @generated from extension: optional int32 optional_int32_ext = 2000000;
  */
@@ -9532,17 +9925,17 @@ export class Int64ParseTester extends Message<Int64ParseTester> {
   /**
    * @generated from field: optional int64 optional_int64_lowfield = 1;
    */
-  optionalInt64Lowfield?: bigint;
+  declare optionalInt64Lowfield: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_midfield = 1001;
    */
-  optionalInt64Midfield?: bigint;
+  declare optionalInt64Midfield: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_hifield = 1000001;
    */
-  optionalInt64Hifield?: bigint;
+  declare optionalInt64Hifield: bigint;
 
   /**
    * @generated from field: repeated int64 repeated_int64_lowfield = 2;
@@ -9579,7 +9972,7 @@ export class Int64ParseTester extends Message<Int64ParseTester> {
    *
    * @generated from field: optional int32 other_field = 99;
    */
-  otherField?: number;
+  declare otherField: number;
 
   constructor(data?: PartialMessage<Int64ParseTester>) {
     super();
@@ -9618,6 +10011,11 @@ export class Int64ParseTester extends Message<Int64ParseTester> {
   }
 }
 
+Int64ParseTester.prototype.optionalInt64Lowfield = protoInt64.zero;
+Int64ParseTester.prototype.optionalInt64Midfield = protoInt64.zero;
+Int64ParseTester.prototype.optionalInt64Hifield = protoInt64.zero;
+Int64ParseTester.prototype.otherField = 0;
+
 /**
  * @generated from extension: optional int64 optional_int64_ext = 2000000;
  */
@@ -9655,7 +10053,7 @@ export class InlinedStringIdxRegressionProto extends Message<InlinedStringIdxReg
    *
    * @generated from field: optional string str1 = 1;
    */
-  str1?: string;
+  declare str1: string;
 
   /**
    * aux_idx == 2
@@ -9669,14 +10067,14 @@ export class InlinedStringIdxRegressionProto extends Message<InlinedStringIdxReg
    *
    * @generated from field: optional string str2 = 3;
    */
-  str2?: string;
+  declare str2: string;
 
   /**
    * aux_idx == 4, inlined_string_idx == 3
    *
    * @generated from field: optional bytes str3 = 4;
    */
-  str3?: Uint8Array;
+  declare str3: Uint8Array;
 
   constructor(data?: PartialMessage<InlinedStringIdxRegressionProto>) {
     super();
@@ -9709,6 +10107,10 @@ export class InlinedStringIdxRegressionProto extends Message<InlinedStringIdxReg
   }
 }
 
+InlinedStringIdxRegressionProto.prototype.str1 = "";
+InlinedStringIdxRegressionProto.prototype.str2 = "";
+InlinedStringIdxRegressionProto.prototype.str3 = new Uint8Array(0);
+
 /**
  * @generated from message protobuf_unittest.StringParseTester
  */
@@ -9716,17 +10118,17 @@ export class StringParseTester extends Message<StringParseTester> {
   /**
    * @generated from field: optional string optional_string_lowfield = 1;
    */
-  optionalStringLowfield?: string;
+  declare optionalStringLowfield: string;
 
   /**
    * @generated from field: optional string optional_string_midfield = 1001;
    */
-  optionalStringMidfield?: string;
+  declare optionalStringMidfield: string;
 
   /**
    * @generated from field: optional string optional_string_hifield = 1000001;
    */
-  optionalStringHifield?: string;
+  declare optionalStringHifield: string;
 
   /**
    * @generated from field: repeated string repeated_string_lowfield = 2;
@@ -9776,6 +10178,10 @@ export class StringParseTester extends Message<StringParseTester> {
   }
 }
 
+StringParseTester.prototype.optionalStringLowfield = "";
+StringParseTester.prototype.optionalStringMidfield = "";
+StringParseTester.prototype.optionalStringHifield = "";
+
 /**
  * @generated from extension: optional string optional_string_ext = 2000000;
  */
@@ -9801,12 +10207,12 @@ export class BadFieldNames extends Message<BadFieldNames> {
   /**
    * @generated from field: optional int32 OptionalInt32 = 1;
    */
-  OptionalInt32?: number;
+  declare OptionalInt32: number;
 
   /**
    * @generated from field: optional int32 for = 2;
    */
-  for?: number;
+  declare for: number;
 
   constructor(data?: PartialMessage<BadFieldNames>) {
     super();
@@ -9837,6 +10243,9 @@ export class BadFieldNames extends Message<BadFieldNames> {
   }
 }
 
+BadFieldNames.prototype.OptionalInt32 = 0;
+BadFieldNames.prototype.for = 0;
+
 /**
  * @generated from message protobuf_unittest.TestNestedMessageRedaction
  */
@@ -9844,12 +10253,12 @@ export class TestNestedMessageRedaction extends Message<TestNestedMessageRedacti
   /**
    * @generated from field: optional string optional_unredacted_nested_string = 1;
    */
-  optionalUnredactedNestedString?: string;
+  declare optionalUnredactedNestedString: string;
 
   /**
    * @generated from field: optional string optional_redacted_nested_string = 2;
    */
-  optionalRedactedNestedString?: string;
+  declare optionalRedactedNestedString: string;
 
   constructor(data?: PartialMessage<TestNestedMessageRedaction>) {
     super();
@@ -9880,6 +10289,9 @@ export class TestNestedMessageRedaction extends Message<TestNestedMessageRedacti
   }
 }
 
+TestNestedMessageRedaction.prototype.optionalUnredactedNestedString = "";
+TestNestedMessageRedaction.prototype.optionalRedactedNestedString = "";
+
 /**
  * @generated from message protobuf_unittest.RedactedFields
  */
@@ -9887,12 +10299,12 @@ export class RedactedFields extends Message<RedactedFields> {
   /**
    * @generated from field: optional string optional_redacted_string = 1;
    */
-  optionalRedactedString?: string;
+  declare optionalRedactedString: string;
 
   /**
    * @generated from field: optional string optional_unredacted_string = 2;
    */
-  optionalUnredactedString?: string;
+  declare optionalUnredactedString: string;
 
   /**
    * @generated from field: repeated string repeated_redacted_string = 3;
@@ -9971,6 +10383,9 @@ export class RedactedFields extends Message<RedactedFields> {
   }
 }
 
+RedactedFields.prototype.optionalRedactedString = "";
+RedactedFields.prototype.optionalUnredactedString = "";
+
 /**
  * @generated from message protobuf_unittest.TestCord
  */
@@ -9978,12 +10393,12 @@ export class TestCord extends Message<TestCord> {
   /**
    * @generated from field: optional bytes optional_bytes_cord = 1;
    */
-  optionalBytesCord?: Uint8Array;
+  declare optionalBytesCord: Uint8Array;
 
   /**
    * @generated from field: optional bytes optional_bytes_cord_default = 2 [default = "hello"];
    */
-  optionalBytesCordDefault?: Uint8Array;
+  declare optionalBytesCordDefault: Uint8Array;
 
   constructor(data?: PartialMessage<TestCord>) {
     super();
@@ -10013,6 +10428,9 @@ export class TestCord extends Message<TestCord> {
     return proto2.util.equals(TestCord, a, b);
   }
 }
+
+TestCord.prototype.optionalBytesCord = new Uint8Array(0);
+TestCord.prototype.optionalBytesCordDefault = new Uint8Array([0x68, 0x65, 0x6C, 0x6C, 0x6F]);
 
 /**
  * @generated from message protobuf_unittest.TestPackedEnumSmallRange

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
@@ -42,17 +42,17 @@ export class OptionsMessage extends Message<OptionsMessage> {
   /**
    * @generated from field: optional int32 plain_field = 1;
    */
-  plainField?: number;
+  declare plainField: number;
 
   /**
    * @generated from field: optional int32 runtime_retention_field = 2;
    */
-  runtimeRetentionField?: number;
+  declare runtimeRetentionField: number;
 
   /**
    * @generated from field: optional int32 source_retention_field = 3;
    */
-  sourceRetentionField?: number;
+  declare sourceRetentionField: number;
 
   constructor(data?: PartialMessage<OptionsMessage>) {
     super();
@@ -83,6 +83,10 @@ export class OptionsMessage extends Message<OptionsMessage> {
     return proto2.util.equals(OptionsMessage, a, b);
   }
 }
+
+OptionsMessage.prototype.plainField = 0;
+OptionsMessage.prototype.runtimeRetentionField = 0;
+OptionsMessage.prototype.sourceRetentionField = 0;
 
 /**
  * @generated from message protobuf_unittest.Extendee
@@ -122,7 +126,7 @@ export class TopLevelMessage extends Message<TopLevelMessage> {
   /**
    * @generated from field: optional float f = 1;
    */
-  f?: number;
+  declare f: number;
 
   /**
    * @generated from oneof protobuf_unittest.TopLevelMessage.o
@@ -163,6 +167,8 @@ export class TopLevelMessage extends Message<TopLevelMessage> {
     return proto2.util.equals(TopLevelMessage, a, b);
   }
 }
+
+TopLevelMessage.prototype.f = 0;
 
 /**
  * @generated from enum protobuf_unittest.TopLevelMessage.NestedEnum

--- a/packages/protobuf-test/src/proto2.test.ts
+++ b/packages/protobuf-test/src/proto2.test.ts
@@ -311,13 +311,14 @@ describe("proto2 optional fields", () => {
       describe("initially", () => {
         test("has expected properties", () => {
           const msg = new messageType();
-          expect(msg.stringField).toBeUndefined();
-          expect(msg.bytesField).toBeUndefined();
-          expect(msg.int32Field).toBeUndefined();
-          expect(msg.int64Field).toBeUndefined();
-          expect(msg.floatField).toBeUndefined();
-          expect(msg.boolField).toBeUndefined();
-          expect(msg.enumField).toBeUndefined();
+          expect(msg.stringField).toBe("");
+          expect(msg.bytesField).toBeInstanceOf(Uint8Array);
+          expect(msg.bytesField.length).toBe(0);
+          expect(msg.int32Field).toBe(0);
+          expect(msg.int64Field).toBe(protoInt64.zero);
+          expect(msg.floatField).toBe(0);
+          expect(msg.boolField).toBe(false);
+          expect(msg.enumField).toBe(1);
           expect(msg.messageField).toBeUndefined();
         });
         test.each(messageType.fields.byNumber())(
@@ -397,13 +398,14 @@ describe("proto2 optional fields", () => {
         describe("initially", () => {
           test("has expected properties", () => {
             const msg = new messageType();
-            expect(msg.stringField).toBeUndefined();
-            expect(msg.bytesField).toBeUndefined();
-            expect(msg.int32Field).toBeUndefined();
-            expect(msg.int64Field).toBeUndefined();
-            expect(msg.floatField).toBeUndefined();
-            expect(msg.boolField).toBeUndefined();
-            expect(msg.enumField).toBeUndefined();
+            expect(msg.stringField).toBe('hello " */ ');
+            expect(msg.bytesField).toBeInstanceOf(Uint8Array);
+            expect(msg.bytesField.length).toBe(17);
+            expect(msg.int32Field).toBe(128);
+            expect(msg.int64Field).toBe(protoInt64.parse(-256));
+            expect(msg.floatField).toBe(-512.13);
+            expect(msg.boolField).toBe(true);
+            expect(msg.enumField).toBe(TS.Proto2Enum.YES);
             expect(msg.messageField).toBeUndefined();
           });
           test.each(messageType.fields.byNumber())(

--- a/packages/protobuf-test/src/proto2.test.ts
+++ b/packages/protobuf-test/src/proto2.test.ts
@@ -129,9 +129,7 @@ describe("proto2 required fields", () => {
             "field $name is an own property",
             (field) => {
               const msg = new messageType();
-              expect(
-                Object.prototype.hasOwnProperty.call(msg, field.localName),
-              ).toBeFalsy();
+              expect(isFieldSet(msg, field)).toBeFalsy();
             },
           );
         });
@@ -143,9 +141,6 @@ describe("proto2 required fields", () => {
               expect(spread[field.localName as keyof typeof spread]).toBe(
                 undefined,
               );
-              expect(
-                Object.prototype.hasOwnProperty.call(spread, field.localName),
-              ).toBeFalsy();
               expect(field.localName in spread).toBe(false);
             },
           );

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -55,6 +55,8 @@ import type { BinaryReadOptions, BinaryWriteOptions } from "./binary-format.js";
 import type { FeatureResolverFn } from "./private/feature-set.js";
 import { createFeatureResolver } from "./private/feature-set.js";
 import { LongType, ScalarType } from "./scalar.js";
+import { isFieldSet } from "./field-accessor.js";
+import type { Message } from "./message.js";
 
 /**
  * Create a DescriptorSet, a convenient interface for working with a set of
@@ -83,8 +85,9 @@ export function createDescriptorSet(
         : input;
   const resolverByEdition = new Map<Edition, FeatureResolverFn>();
   const files = fileDescriptors.map((proto) => {
-    const edition =
-      proto.edition ?? parseFileSyntax(proto.syntax, proto.edition).edition;
+    const edition = isFieldSet(proto, "edition")
+      ? proto.edition
+      : parseFileSyntax(proto.syntax, proto.edition).edition;
     let resolveFeatures = resolverByEdition.get(edition);
     if (resolveFeatures === undefined) {
       resolveFeatures = createFeatureResolver(
@@ -144,7 +147,7 @@ function newFile(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): DescFile {
-  assert(proto.name, `invalid FileDescriptorProto: missing name`);
+  assertFieldSet(proto, "name");
   const file: DescFile = {
     kind: "file",
     proto,
@@ -279,7 +282,7 @@ function addEnum(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): void {
-  assert(proto.name, `invalid EnumDescriptorProto: missing name`);
+  assertFieldSet(proto, "name");
   const desc: DescEnum = {
     kind: "enum",
     proto,
@@ -291,7 +294,7 @@ function addEnum(
     values: [],
     sharedPrefix: findEnumSharedPrefix(
       proto.name,
-      proto.value.map((v) => v.name ?? ""),
+      proto.value.map((v) => v.name),
     ),
     toString(): string {
       return `enum ${this.typeName}`;
@@ -318,11 +321,8 @@ function addEnum(
   };
   cart.enums.set(desc.typeName, desc);
   proto.value.forEach((proto) => {
-    assert(proto.name, `invalid EnumValueDescriptorProto: missing name`);
-    assert(
-      proto.number !== undefined,
-      `invalid EnumValueDescriptorProto: missing number`,
-    );
+    assertFieldSet(proto, "name");
+    assertFieldSet(proto, "number");
     desc.values.push({
       kind: "enum_value",
       proto,
@@ -367,7 +367,6 @@ function addMessage(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): void {
-  assert(proto.name, `invalid DescriptorProto: missing name`);
   const desc: DescMessage = {
     kind: "message",
     proto,
@@ -429,7 +428,7 @@ function addService(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): void {
-  assert(proto.name, `invalid ServiceDescriptorProto: missing name`);
+  assertFieldSet(proto, "name");
   const desc: DescService = {
     kind: "service",
     proto,
@@ -468,18 +467,15 @@ function newMethod(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): DescMethod {
-  assert(proto.name, `invalid MethodDescriptorProto: missing name`);
-  assert(proto.inputType, `invalid MethodDescriptorProto: missing input_type`);
-  assert(
-    proto.outputType,
-    `invalid MethodDescriptorProto: missing output_type`,
-  );
+  assertFieldSet(proto, "name");
+  assertFieldSet(proto, "inputType");
+  assertFieldSet(proto, "outputType");
   let methodKind: MethodKind;
-  if (proto.clientStreaming === true && proto.serverStreaming === true) {
+  if (proto.clientStreaming && proto.serverStreaming) {
     methodKind = MethodKind.BiDiStreaming;
-  } else if (proto.clientStreaming === true) {
+  } else if (proto.clientStreaming) {
     methodKind = MethodKind.ClientStreaming;
-  } else if (proto.serverStreaming === true) {
+  } else if (proto.serverStreaming) {
     methodKind = MethodKind.ServerStreaming;
   } else {
     methodKind = MethodKind.Unary;
@@ -543,7 +539,7 @@ function newOneof(
   parent: DescMessage,
   resolveFeatures: FeatureResolverFn,
 ): DescOneof {
-  assert(proto.name, `invalid OneofDescriptorProto: missing name`);
+  assertFieldSet(proto, "name");
   return {
     kind: "oneof",
     proto,
@@ -579,9 +575,9 @@ function newField(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): DescField {
-  assert(proto.name, `invalid FieldDescriptorProto: missing name`);
-  assert(proto.number, `invalid FieldDescriptorProto: missing number`);
-  assert(proto.type, `invalid FieldDescriptorProto: missing type`);
+  assertFieldSet(proto, "name");
+  assertFieldSet(proto, "number");
+  assertFieldSet(proto, "type");
   const common = {
     proto,
     deprecated: proto.options?.deprecated ?? false,
@@ -621,7 +617,7 @@ function newField(
   switch (proto.type) {
     case FieldDescriptorProto_Type.MESSAGE:
     case FieldDescriptorProto_Type.GROUP: {
-      assert(proto.typeName, `invalid FieldDescriptorProto: missing type_name`);
+      assertFieldSet(proto, "typeName");
       const mapEntry = cart.mapEntries.get(trimLeadingDot(proto.typeName));
       if (mapEntry !== undefined) {
         assert(
@@ -650,7 +646,7 @@ function newField(
       };
     }
     case FieldDescriptorProto_Type.ENUM: {
-      assert(proto.typeName, `invalid FieldDescriptorProto: missing type_name`);
+      assertFieldSet(proto, "typeName");
       const e = cart.enums.get(trimLeadingDot(proto.typeName));
       assert(
         e !== undefined,
@@ -697,7 +693,7 @@ function newExtension(
   cart: Cart,
   resolveFeatures: FeatureResolverFn,
 ): DescExtension {
-  assert(proto.extendee, `invalid FieldDescriptorProto: missing extendee`);
+  assertFieldSet(proto, "extendee");
   const field = newField(
     proto,
     file,
@@ -748,10 +744,7 @@ function newExtension(
 /**
  * Parse the "syntax" and "edition" fields, stripping test editions.
  */
-function parseFileSyntax(
-  syntax: string | undefined,
-  edition: Edition | undefined,
-) {
+function parseFileSyntax(syntax: string, edition: Edition) {
   let e: Exclude<
     Edition,
     | Edition.EDITION_1_TEST_ONLY
@@ -762,7 +755,7 @@ function parseFileSyntax(
   >;
   let s: "proto2" | "proto3" | "editions";
   switch (syntax) {
-    case undefined:
+    case "":
     case "proto2":
       s = "proto2";
       e = Edition.EDITION_PROTO2;
@@ -774,7 +767,6 @@ function parseFileSyntax(
     case "editions":
       s = "editions";
       switch (edition) {
-        case undefined:
         case Edition.EDITION_1_TEST_ONLY:
         case Edition.EDITION_2_TEST_ONLY:
         case Edition.EDITION_99997_TEST_ONLY:
@@ -835,7 +827,7 @@ function makeTypeName(
   let typeName: string;
   if (parent) {
     typeName = `${parent.typeName}.${proto.name}`;
-  } else if (file.proto.package !== undefined) {
+  } else if (file.proto.package.length > 0) {
     typeName = `${file.proto.package}.${proto.name}`;
   } else {
     typeName = `${proto.name}`;
@@ -875,7 +867,7 @@ function getMapFieldTypes(
       mapKey !== ScalarType.FLOAT &&
       mapKey !== ScalarType.DOUBLE,
     `invalid DescriptorProto: map entry ${mapEntry.toString()} has unexpected key type ${
-      keyField.proto.type ?? -1
+      keyField.proto.type
     }`,
   );
   const valueField = mapEntry.fields.find((f) => f.proto.number === 2);
@@ -923,20 +915,17 @@ function findOneof(
   proto: FieldDescriptorProto,
   allOneofs: DescOneof[],
 ): DescOneof | undefined {
-  const oneofIndex = proto.oneofIndex;
-  if (oneofIndex === undefined) {
+  if (!isFieldSet(proto, "oneofIndex")) {
     return undefined;
   }
-  let oneof: DescOneof | undefined;
-  if (proto.proto3Optional !== true) {
-    oneof = allOneofs[oneofIndex];
-    assert(
-      oneof,
-      `invalid FieldDescriptorProto: oneof #${oneofIndex} for field #${
-        proto.number ?? -1
-      } not found`,
-    );
+  if (proto.proto3Optional) {
+    return undefined;
   }
+  const oneof = allOneofs[proto.oneofIndex];
+  assert(
+    oneof,
+    `invalid FieldDescriptorProto: oneof #${proto.oneofIndex} for field #${proto.number} not found`,
+  );
   return oneof;
 }
 
@@ -951,11 +940,11 @@ function isOptionalField(
   switch (syntax) {
     case "proto2":
       return (
-        proto.oneofIndex === undefined &&
+        !isFieldSet(proto, "oneofIndex") &&
         proto.label === FieldDescriptorProto_Label.OPTIONAL
       );
     case "proto3":
-      return proto.proto3Optional === true;
+      return proto.proto3Optional;
     case "editions":
       return false;
   }
@@ -1013,15 +1002,22 @@ function isPackedField(
       // length-delimited types cannot be packed
       return false;
     default:
+      const protoOptions = proto.options; // eslint-disable-line no-case-declarations
       switch (file.edition) {
         case Edition.EDITION_PROTO2:
-          return proto.options?.packed ?? false;
+          return protoOptions !== undefined &&
+            isFieldSet(protoOptions, "packed")
+            ? protoOptions.packed
+            : false;
         case Edition.EDITION_PROTO3:
-          return proto.options?.packed ?? true;
+          return protoOptions !== undefined &&
+            isFieldSet(protoOptions, "packed")
+            ? protoOptions.packed
+            : true;
         default: {
           const { repeatedFieldEncoding } = resolveFeatures(
             parent?.getFeatures() ?? file.getFeatures(),
-            proto.options?.features,
+            protoOptions?.features,
           );
           return (
             repeatedFieldEncoding == FeatureSet_RepeatedFieldEncoding.PACKED
@@ -1081,8 +1077,12 @@ function findComments(
     }
     return {
       leadingDetached: location.leadingDetachedComments,
-      leading: location.leadingComments,
-      trailing: location.trailingComments,
+      leading: isFieldSet(location, "leadingComments")
+        ? location.leadingComments
+        : undefined,
+      trailing: isFieldSet(location, "trailingComments")
+        ? location.trailingComments
+        : undefined,
       sourcePath,
     };
   }
@@ -1162,11 +1162,12 @@ function declarationString(this: DescField | DescExtension): string {
   }
   parts.push(`${type} ${this.name} = ${this.number}`);
   const options: string[] = [];
-  if (this.proto.options?.packed !== undefined) {
-    options.push(`packed = ${this.proto.options.packed.toString()}`);
+  const protoOptions = this.proto.options;
+  if (protoOptions !== undefined && isFieldSet(protoOptions, "packed")) {
+    options.push(`packed = ${protoOptions.packed.toString()}`);
   }
-  let defaultValue = this.proto.defaultValue;
-  if (defaultValue !== undefined) {
+  if (isFieldSet(this.proto, "defaultValue")) {
+    let defaultValue = this.proto.defaultValue;
     if (
       this.proto.type == FieldDescriptorProto_Type.BYTES ||
       this.proto.type == FieldDescriptorProto_Type.STRING
@@ -1178,10 +1179,10 @@ function declarationString(this: DescField | DescExtension): string {
   if (this.jsonName !== undefined) {
     options.push(`json_name = "${this.jsonName}"`);
   }
-  if (this.proto.options?.jstype !== undefined) {
-    options.push(`jstype = ${FieldOptions_JSType[this.proto.options.jstype]}`);
+  if (protoOptions !== undefined && isFieldSet(protoOptions, "jstype")) {
+    options.push(`jstype = ${FieldOptions_JSType[protoOptions.jstype]}`);
   }
-  if (this.proto.options?.deprecated === true) {
+  if (protoOptions !== undefined && isFieldSet(protoOptions, "deprecated")) {
     options.push(`deprecated = true`);
   }
   if (options.length > 0) {
@@ -1196,10 +1197,10 @@ function declarationString(this: DescField | DescExtension): string {
 function getDefaultValue(
   this: DescField | DescExtension,
 ): number | boolean | string | bigint | Uint8Array | undefined {
-  const d = this.proto.defaultValue;
-  if (d === undefined) {
+  if (!isFieldSet(this.proto, "defaultValue")) {
     return undefined;
   }
+  const d = this.proto.defaultValue;
   switch (this.fieldKind) {
     case "enum":
       return parseTextFormatEnumValue(this.enum, d);
@@ -1207,5 +1208,20 @@ function getDefaultValue(
       return parseTextFormatScalarValue(this.scalar, d);
     default:
       return undefined;
+  }
+}
+
+// TODO consider to remove to save bundle size.
+// Before proto2 fields were switched to use the prototype chain, we used
+// assertions to narrow down optional types. This function is used to make the
+// same assertions, but they are no longer necessary for the type system, and
+// the value they provide is questionable.
+function assertFieldSet<T extends Message<T>>(
+  target: T,
+  field: Parameters<typeof isFieldSet<T>>[1],
+) {
+  if (!isFieldSet(target, field)) {
+    const type = target.getType().typeName.split(".").pop();
+    throw new Error(`invalid ${type}: missing ${field}`);
   }
 }

--- a/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/google/protobuf/compiler/plugin_pb.ts
@@ -36,6 +36,7 @@ import type { FieldList } from "../../../field-list.js";
 import type { BinaryReadOptions } from "../../../binary-format.js";
 import type { JsonReadOptions, JsonValue } from "../../../json-format.js";
 import { FileDescriptorProto, GeneratedCodeInfo } from "../descriptor_pb.js";
+import { protoInt64 } from "../../../proto-int64.js";
 
 /**
  * The version number of protocol compiler.
@@ -46,17 +47,17 @@ export class Version extends Message<Version> {
   /**
    * @generated from field: optional int32 major = 1;
    */
-  major?: number;
+  declare major: number;
 
   /**
    * @generated from field: optional int32 minor = 2;
    */
-  minor?: number;
+  declare minor: number;
 
   /**
    * @generated from field: optional int32 patch = 3;
    */
-  patch?: number;
+  declare patch: number;
 
   /**
    * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
@@ -64,7 +65,7 @@ export class Version extends Message<Version> {
    *
    * @generated from field: optional string suffix = 4;
    */
-  suffix?: string;
+  declare suffix: string;
 
   constructor(data?: PartialMessage<Version>) {
     super();
@@ -97,6 +98,11 @@ export class Version extends Message<Version> {
   }
 }
 
+Version.prototype.major = 0;
+Version.prototype.minor = 0;
+Version.prototype.patch = 0;
+Version.prototype.suffix = "";
+
 /**
  * An encoded CodeGeneratorRequest is written to the plugin's stdin.
  *
@@ -117,7 +123,7 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
    *
    * @generated from field: optional string parameter = 2;
    */
-  parameter?: string;
+  declare parameter: string;
 
   /**
    * FileDescriptorProtos for all files in files_to_generate and everything
@@ -192,6 +198,8 @@ export class CodeGeneratorRequest extends Message<CodeGeneratorRequest> {
   }
 }
 
+CodeGeneratorRequest.prototype.parameter = "";
+
 /**
  * The plugin writes an encoded CodeGeneratorResponse to stdout.
  *
@@ -210,7 +218,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional string error = 1;
    */
-  error?: string;
+  declare error: string;
 
   /**
    * A bitmask of supported features that the code generator supports.
@@ -218,7 +226,7 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
    *
    * @generated from field: optional uint64 supported_features = 2;
    */
-  supportedFeatures?: bigint;
+  declare supportedFeatures: bigint;
 
   /**
    * @generated from field: repeated google.protobuf.compiler.CodeGeneratorResponse.File file = 15;
@@ -254,6 +262,9 @@ export class CodeGeneratorResponse extends Message<CodeGeneratorResponse> {
     return proto2.util.equals(CodeGeneratorResponse, a, b);
   }
 }
+
+CodeGeneratorResponse.prototype.error = "";
+CodeGeneratorResponse.prototype.supportedFeatures = protoInt64.zero;
 
 /**
  * Sync with code_generator.h.
@@ -304,7 +315,7 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * If non-empty, indicates that the named file should already exist, and the
@@ -347,14 +358,14 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
    *
    * @generated from field: optional string insertion_point = 2;
    */
-  insertionPoint?: string;
+  declare insertionPoint: string;
 
   /**
    * The file contents.
    *
    * @generated from field: optional string content = 15;
    */
-  content?: string;
+  declare content: string;
 
   /**
    * Information describing the file content being inserted. If an insertion
@@ -395,4 +406,8 @@ export class CodeGeneratorResponse_File extends Message<CodeGeneratorResponse_Fi
     return proto2.util.equals(CodeGeneratorResponse_File, a, b);
   }
 }
+
+CodeGeneratorResponse_File.prototype.name = "";
+CodeGeneratorResponse_File.prototype.insertionPoint = "";
+CodeGeneratorResponse_File.prototype.content = "";
 

--- a/packages/protobuf/src/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/google/protobuf/descriptor_pb.ts
@@ -30,6 +30,7 @@ import { Message } from "../../message.js";
 import type { FieldList } from "../../field-list.js";
 import type { BinaryReadOptions } from "../../binary-format.js";
 import type { JsonReadOptions, JsonValue } from "../../json-format.js";
+import { protoInt64 } from "../../proto-int64.js";
 
 /**
  * The full set of known editions.
@@ -160,14 +161,14 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    *
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  declare package: string;
 
   /**
    * Names of files imported by this file.
@@ -236,14 +237,14 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
    *
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  declare syntax: string;
 
   /**
    * The edition of the proto file.
    *
    * @generated from field: optional google.protobuf.Edition edition = 14;
    */
-  edition?: Edition;
+  declare edition: Edition;
 
   constructor(data?: PartialMessage<FileDescriptorProto>) {
     super();
@@ -285,6 +286,11 @@ export class FileDescriptorProto extends Message<FileDescriptorProto> {
   }
 }
 
+FileDescriptorProto.prototype.name = "";
+FileDescriptorProto.prototype.package = "";
+FileDescriptorProto.prototype.syntax = "";
+FileDescriptorProto.prototype.edition = 0 as Edition.EDITION_UNKNOWN;
+
 /**
  * Describes a message type.
  *
@@ -294,7 +300,7 @@ export class DescriptorProto extends Message<DescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto field = 2;
@@ -381,6 +387,8 @@ export class DescriptorProto extends Message<DescriptorProto> {
   }
 }
 
+DescriptorProto.prototype.name = "";
+
 /**
  * @generated from message google.protobuf.DescriptorProto.ExtensionRange
  */
@@ -390,14 +398,14 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  declare start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  declare end: number;
 
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
@@ -434,6 +442,9 @@ export class DescriptorProto_ExtensionRange extends Message<DescriptorProto_Exte
   }
 }
 
+DescriptorProto_ExtensionRange.prototype.start = 0;
+DescriptorProto_ExtensionRange.prototype.end = 0;
+
 /**
  * Range of reserved tag numbers. Reserved tag numbers may not be used by
  * fields or extension ranges in the same message. Reserved ranges may
@@ -447,14 +458,14 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  declare start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  declare end: number;
 
   constructor(data?: PartialMessage<DescriptorProto_ReservedRange>) {
     super();
@@ -484,6 +495,9 @@ export class DescriptorProto_ReservedRange extends Message<DescriptorProto_Reser
     return proto2.util.equals(DescriptorProto_ReservedRange, a, b);
   }
 }
+
+DescriptorProto_ReservedRange.prototype.start = 0;
+DescriptorProto_ReservedRange.prototype.end = 0;
 
 /**
  * @generated from message google.protobuf.ExtensionRangeOptions
@@ -519,7 +533,7 @@ export class ExtensionRangeOptions extends Message<ExtensionRangeOptions> {
    *
    * @generated from field: optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3 [default = UNVERIFIED];
    */
-  verification?: ExtensionRangeOptions_VerificationState;
+  declare verification: ExtensionRangeOptions_VerificationState;
 
   constructor(data?: PartialMessage<ExtensionRangeOptions>) {
     super();
@@ -551,6 +565,8 @@ export class ExtensionRangeOptions extends Message<ExtensionRangeOptions> {
     return proto2.util.equals(ExtensionRangeOptions, a, b);
   }
 }
+
+ExtensionRangeOptions.prototype.verification = 1 as ExtensionRangeOptions_VerificationState.UNVERIFIED;
 
 /**
  * The verification state of the extension range.
@@ -585,7 +601,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional int32 number = 1;
    */
-  number?: number;
+  declare number: number;
 
   /**
    * The fully-qualified name of the extension field. There must be a leading
@@ -593,7 +609,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional string full_name = 2;
    */
-  fullName?: string;
+  declare fullName: string;
 
   /**
    * The fully-qualified type name of the extension field. Unlike
@@ -602,7 +618,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional string type = 3;
    */
-  type?: string;
+  declare type: string;
 
   /**
    * If true, indicates that the number is reserved in the extension range,
@@ -611,7 +627,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional bool reserved = 5;
    */
-  reserved?: boolean;
+  declare reserved: boolean;
 
   /**
    * If true, indicates that the extension must be defined as repeated.
@@ -619,7 +635,7 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
    *
    * @generated from field: optional bool repeated = 6;
    */
-  repeated?: boolean;
+  declare repeated: boolean;
 
   constructor(data?: PartialMessage<ExtensionRangeOptions_Declaration>) {
     super();
@@ -653,6 +669,12 @@ export class ExtensionRangeOptions_Declaration extends Message<ExtensionRangeOpt
   }
 }
 
+ExtensionRangeOptions_Declaration.prototype.number = 0;
+ExtensionRangeOptions_Declaration.prototype.fullName = "";
+ExtensionRangeOptions_Declaration.prototype.type = "";
+ExtensionRangeOptions_Declaration.prototype.reserved = false;
+ExtensionRangeOptions_Declaration.prototype.repeated = false;
+
 /**
  * Describes a field within a message.
  *
@@ -662,17 +684,17 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional int32 number = 3;
    */
-  number?: number;
+  declare number: number;
 
   /**
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Label label = 4;
    */
-  label?: FieldDescriptorProto_Label;
+  declare label: FieldDescriptorProto_Label;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
@@ -680,7 +702,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Type type = 5;
    */
-  type?: FieldDescriptorProto_Type;
+  declare type: FieldDescriptorProto_Type;
 
   /**
    * For message and enum types, this is the name of the type.  If the name
@@ -691,7 +713,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string type_name = 6;
    */
-  typeName?: string;
+  declare typeName: string;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
@@ -699,7 +721,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string extendee = 2;
    */
-  extendee?: string;
+  declare extendee: string;
 
   /**
    * For numeric types, contains the original text representation of the value.
@@ -709,7 +731,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string default_value = 7;
    */
-  defaultValue?: string;
+  declare defaultValue: string;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
@@ -717,7 +739,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional int32 oneof_index = 9;
    */
-  oneofIndex?: number;
+  declare oneofIndex: number;
 
   /**
    * JSON name of this field. The value is set by protocol compiler. If the
@@ -727,7 +749,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional string json_name = 10;
    */
-  jsonName?: string;
+  declare jsonName: string;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
@@ -759,7 +781,7 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    *
    * @generated from field: optional bool proto3_optional = 17;
    */
-  proto3Optional?: boolean;
+  declare proto3Optional: boolean;
 
   constructor(data?: PartialMessage<FieldDescriptorProto>) {
     super();
@@ -798,6 +820,17 @@ export class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     return proto2.util.equals(FieldDescriptorProto, a, b);
   }
 }
+
+FieldDescriptorProto.prototype.name = "";
+FieldDescriptorProto.prototype.number = 0;
+FieldDescriptorProto.prototype.label = 1 as FieldDescriptorProto_Label.OPTIONAL;
+FieldDescriptorProto.prototype.type = 1 as FieldDescriptorProto_Type.DOUBLE;
+FieldDescriptorProto.prototype.typeName = "";
+FieldDescriptorProto.prototype.extendee = "";
+FieldDescriptorProto.prototype.defaultValue = "";
+FieldDescriptorProto.prototype.oneofIndex = 0;
+FieldDescriptorProto.prototype.jsonName = "";
+FieldDescriptorProto.prototype.proto3Optional = false;
 
 /**
  * @generated from enum google.protobuf.FieldDescriptorProto.Type
@@ -979,7 +1012,7 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
@@ -1015,6 +1048,8 @@ export class OneofDescriptorProto extends Message<OneofDescriptorProto> {
   }
 }
 
+OneofDescriptorProto.prototype.name = "";
+
 /**
  * Describes an enum type.
  *
@@ -1024,7 +1059,7 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: repeated google.protobuf.EnumValueDescriptorProto value = 2;
@@ -1085,6 +1120,8 @@ export class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   }
 }
 
+EnumDescriptorProto.prototype.name = "";
+
 /**
  * Range of reserved numeric values. Reserved values may not be used by
  * entries in the same enum. Reserved ranges may not overlap.
@@ -1101,14 +1138,14 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  declare start: number;
 
   /**
    * Inclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  declare end: number;
 
   constructor(data?: PartialMessage<EnumDescriptorProto_EnumReservedRange>) {
     super();
@@ -1139,6 +1176,9 @@ export class EnumDescriptorProto_EnumReservedRange extends Message<EnumDescripto
   }
 }
 
+EnumDescriptorProto_EnumReservedRange.prototype.start = 0;
+EnumDescriptorProto_EnumReservedRange.prototype.end = 0;
+
 /**
  * Describes a value within an enum.
  *
@@ -1148,12 +1188,12 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: optional int32 number = 2;
    */
-  number?: number;
+  declare number: number;
 
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
@@ -1190,6 +1230,9 @@ export class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto> 
   }
 }
 
+EnumValueDescriptorProto.prototype.name = "";
+EnumValueDescriptorProto.prototype.number = 0;
+
 /**
  * Describes a service.
  *
@@ -1199,7 +1242,7 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * @generated from field: repeated google.protobuf.MethodDescriptorProto method = 2;
@@ -1241,6 +1284,8 @@ export class ServiceDescriptorProto extends Message<ServiceDescriptorProto> {
   }
 }
 
+ServiceDescriptorProto.prototype.name = "";
+
 /**
  * Describes a method of a service.
  *
@@ -1250,7 +1295,7 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  declare name: string;
 
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -1258,12 +1303,12 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
    *
    * @generated from field: optional string input_type = 2;
    */
-  inputType?: string;
+  declare inputType: string;
 
   /**
    * @generated from field: optional string output_type = 3;
    */
-  outputType?: string;
+  declare outputType: string;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
@@ -1275,14 +1320,14 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
    *
    * @generated from field: optional bool client_streaming = 5 [default = false];
    */
-  clientStreaming?: boolean;
+  declare clientStreaming: boolean;
 
   /**
    * Identifies if server streams multiple server messages
    *
    * @generated from field: optional bool server_streaming = 6 [default = false];
    */
-  serverStreaming?: boolean;
+  declare serverStreaming: boolean;
 
   constructor(data?: PartialMessage<MethodDescriptorProto>) {
     super();
@@ -1317,6 +1362,12 @@ export class MethodDescriptorProto extends Message<MethodDescriptorProto> {
   }
 }
 
+MethodDescriptorProto.prototype.name = "";
+MethodDescriptorProto.prototype.inputType = "";
+MethodDescriptorProto.prototype.outputType = "";
+MethodDescriptorProto.prototype.clientStreaming = false;
+MethodDescriptorProto.prototype.serverStreaming = false;
+
 /**
  * @generated from message google.protobuf.FileOptions
  */
@@ -1329,7 +1380,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_package = 1;
    */
-  javaPackage?: string;
+  declare javaPackage: string;
 
   /**
    * Controls the name of the wrapper Java class generated for the .proto file.
@@ -1340,7 +1391,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string java_outer_classname = 8;
    */
-  javaOuterClassname?: string;
+  declare javaOuterClassname: string;
 
   /**
    * If enabled, then the Java code generator will generate a separate .java
@@ -1352,7 +1403,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_multiple_files = 10 [default = false];
    */
-  javaMultipleFiles?: boolean;
+  declare javaMultipleFiles: boolean;
 
   /**
    * This option does nothing.
@@ -1360,7 +1411,7 @@ export class FileOptions extends Message<FileOptions> {
    * @generated from field: optional bool java_generate_equals_and_hash = 20 [deprecated = true];
    * @deprecated
    */
-  javaGenerateEqualsAndHash?: boolean;
+  declare javaGenerateEqualsAndHash: boolean;
 
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -1372,12 +1423,12 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool java_string_check_utf8 = 27 [default = false];
    */
-  javaStringCheckUtf8?: boolean;
+  declare javaStringCheckUtf8: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9 [default = SPEED];
    */
-  optimizeFor?: FileOptions_OptimizeMode;
+  declare optimizeFor: FileOptions_OptimizeMode;
 
   /**
    * Sets the Go package where structs generated from this .proto will be
@@ -1388,7 +1439,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string go_package = 11;
    */
-  goPackage?: string;
+  declare goPackage: string;
 
   /**
    * Should generic services be generated in each language?  "Generic" services
@@ -1404,22 +1455,22 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_generic_services = 16 [default = false];
    */
-  ccGenericServices?: boolean;
+  declare ccGenericServices: boolean;
 
   /**
    * @generated from field: optional bool java_generic_services = 17 [default = false];
    */
-  javaGenericServices?: boolean;
+  declare javaGenericServices: boolean;
 
   /**
    * @generated from field: optional bool py_generic_services = 18 [default = false];
    */
-  pyGenericServices?: boolean;
+  declare pyGenericServices: boolean;
 
   /**
    * @generated from field: optional bool php_generic_services = 42 [default = false];
    */
-  phpGenericServices?: boolean;
+  declare phpGenericServices: boolean;
 
   /**
    * Is this file deprecated?
@@ -1429,7 +1480,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool deprecated = 23 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
@@ -1437,7 +1488,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional bool cc_enable_arenas = 31 [default = true];
    */
-  ccEnableArenas?: boolean;
+  declare ccEnableArenas: boolean;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
@@ -1445,14 +1496,14 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string objc_class_prefix = 36;
    */
-  objcClassPrefix?: string;
+  declare objcClassPrefix: string;
 
   /**
    * Namespace for generated classes; defaults to the package.
    *
    * @generated from field: optional string csharp_namespace = 37;
    */
-  csharpNamespace?: string;
+  declare csharpNamespace: string;
 
   /**
    * By default Swift generators will take the proto package and CamelCase it
@@ -1462,7 +1513,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string swift_prefix = 39;
    */
-  swiftPrefix?: string;
+  declare swiftPrefix: string;
 
   /**
    * Sets the php class prefix which is prepended to all php generated classes
@@ -1470,7 +1521,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_class_prefix = 40;
    */
-  phpClassPrefix?: string;
+  declare phpClassPrefix: string;
 
   /**
    * Use this option to change the namespace of php generated classes. Default
@@ -1479,7 +1530,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_namespace = 41;
    */
-  phpNamespace?: string;
+  declare phpNamespace: string;
 
   /**
    * Use this option to change the namespace of php generated metadata classes.
@@ -1488,7 +1539,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string php_metadata_namespace = 44;
    */
-  phpMetadataNamespace?: string;
+  declare phpMetadataNamespace: string;
 
   /**
    * Use this option to change the package of ruby generated classes. Default
@@ -1497,7 +1548,7 @@ export class FileOptions extends Message<FileOptions> {
    *
    * @generated from field: optional string ruby_package = 45;
    */
-  rubyPackage?: string;
+  declare rubyPackage: string;
 
   /**
    * Any features defined in the specific edition.
@@ -1563,6 +1614,27 @@ export class FileOptions extends Message<FileOptions> {
   }
 }
 
+FileOptions.prototype.javaPackage = "";
+FileOptions.prototype.javaOuterClassname = "";
+FileOptions.prototype.javaMultipleFiles = false;
+FileOptions.prototype.javaGenerateEqualsAndHash = false;
+FileOptions.prototype.javaStringCheckUtf8 = false;
+FileOptions.prototype.optimizeFor = 1 as FileOptions_OptimizeMode.SPEED;
+FileOptions.prototype.goPackage = "";
+FileOptions.prototype.ccGenericServices = false;
+FileOptions.prototype.javaGenericServices = false;
+FileOptions.prototype.pyGenericServices = false;
+FileOptions.prototype.phpGenericServices = false;
+FileOptions.prototype.deprecated = false;
+FileOptions.prototype.ccEnableArenas = true;
+FileOptions.prototype.objcClassPrefix = "";
+FileOptions.prototype.csharpNamespace = "";
+FileOptions.prototype.swiftPrefix = "";
+FileOptions.prototype.phpClassPrefix = "";
+FileOptions.prototype.phpNamespace = "";
+FileOptions.prototype.phpMetadataNamespace = "";
+FileOptions.prototype.rubyPackage = "";
+
 /**
  * Generated classes can be optimized for speed or code size.
  *
@@ -1625,7 +1697,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool message_set_wire_format = 1 [default = false];
    */
-  messageSetWireFormat?: boolean;
+  declare messageSetWireFormat: boolean;
 
   /**
    * Disables the generation of the standard "descriptor()" accessor, which can
@@ -1634,7 +1706,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool no_standard_descriptor_accessor = 2 [default = false];
    */
-  noStandardDescriptorAccessor?: boolean;
+  declare noStandardDescriptorAccessor: boolean;
 
   /**
    * Is this message deprecated?
@@ -1644,7 +1716,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * NOTE: Do not set the option in .proto files. Always use the maps syntax
@@ -1671,7 +1743,7 @@ export class MessageOptions extends Message<MessageOptions> {
    *
    * @generated from field: optional bool map_entry = 7;
    */
-  mapEntry?: boolean;
+  declare mapEntry: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -1688,7 +1760,7 @@ export class MessageOptions extends Message<MessageOptions> {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  declare deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -1738,6 +1810,12 @@ export class MessageOptions extends Message<MessageOptions> {
   }
 }
 
+MessageOptions.prototype.messageSetWireFormat = false;
+MessageOptions.prototype.noStandardDescriptorAccessor = false;
+MessageOptions.prototype.deprecated = false;
+MessageOptions.prototype.mapEntry = false;
+MessageOptions.prototype.deprecatedLegacyJsonFieldConflicts = false;
+
 /**
  * @generated from message google.protobuf.FieldOptions
  */
@@ -1752,7 +1830,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.CType ctype = 1 [default = STRING];
    */
-  ctype?: FieldOptions_CType;
+  declare ctype: FieldOptions_CType;
 
   /**
    * The packed option can be enabled for repeated primitive fields to enable
@@ -1765,7 +1843,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool packed = 2;
    */
-  packed?: boolean;
+  declare packed: boolean;
 
   /**
    * The jstype option determines the JavaScript type used for values of the
@@ -1782,7 +1860,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL];
    */
-  jstype?: FieldOptions_JSType;
+  declare jstype: FieldOptions_JSType;
 
   /**
    * Should this field be parsed lazily?  Lazy applies only to message-type
@@ -1818,7 +1896,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool lazy = 5 [default = false];
    */
-  lazy?: boolean;
+  declare lazy: boolean;
 
   /**
    * unverified_lazy does no correctness checks on the byte stream. This should
@@ -1827,7 +1905,7 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool unverified_lazy = 15 [default = false];
    */
-  unverifiedLazy?: boolean;
+  declare unverifiedLazy: boolean;
 
   /**
    * Is this field deprecated?
@@ -1837,14 +1915,14 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * For Google-internal migration only. Do not use.
    *
    * @generated from field: optional bool weak = 10 [default = false];
    */
-  weak?: boolean;
+  declare weak: boolean;
 
   /**
    * Indicate that the field value should not be printed out when using debug
@@ -1852,12 +1930,12 @@ export class FieldOptions extends Message<FieldOptions> {
    *
    * @generated from field: optional bool debug_redact = 16 [default = false];
    */
-  debugRedact?: boolean;
+  declare debugRedact: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.OptionRetention retention = 17;
    */
-  retention?: FieldOptions_OptionRetention;
+  declare retention: FieldOptions_OptionRetention;
 
   /**
    * @generated from field: repeated google.protobuf.FieldOptions.OptionTargetType targets = 19;
@@ -1922,6 +2000,16 @@ export class FieldOptions extends Message<FieldOptions> {
     return proto2.util.equals(FieldOptions, a, b);
   }
 }
+
+FieldOptions.prototype.ctype = 0 as FieldOptions_CType.STRING;
+FieldOptions.prototype.packed = false;
+FieldOptions.prototype.jstype = 0 as FieldOptions_JSType.JS_NORMAL;
+FieldOptions.prototype.lazy = false;
+FieldOptions.prototype.unverifiedLazy = false;
+FieldOptions.prototype.deprecated = false;
+FieldOptions.prototype.weak = false;
+FieldOptions.prototype.debugRedact = false;
+FieldOptions.prototype.retention = 0 as FieldOptions_OptionRetention.RETENTION_UNKNOWN;
 
 /**
  * @generated from enum google.protobuf.FieldOptions.CType
@@ -2100,14 +2188,14 @@ export class FieldOptions_EditionDefault extends Message<FieldOptions_EditionDef
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: Edition;
+  declare edition: Edition;
 
   /**
    * Textproto value.
    *
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  declare value: string;
 
   constructor(data?: PartialMessage<FieldOptions_EditionDefault>) {
     super();
@@ -2137,6 +2225,9 @@ export class FieldOptions_EditionDefault extends Message<FieldOptions_EditionDef
     return proto2.util.equals(FieldOptions_EditionDefault, a, b);
   }
 }
+
+FieldOptions_EditionDefault.prototype.edition = 0 as Edition.EDITION_UNKNOWN;
+FieldOptions_EditionDefault.prototype.value = "";
 
 /**
  * @generated from message google.protobuf.OneofOptions
@@ -2195,7 +2286,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool allow_alias = 2;
    */
-  allowAlias?: boolean;
+  declare allowAlias: boolean;
 
   /**
    * Is this enum deprecated?
@@ -2205,7 +2296,7 @@ export class EnumOptions extends Message<EnumOptions> {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -2218,7 +2309,7 @@ export class EnumOptions extends Message<EnumOptions> {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  declare deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -2266,6 +2357,10 @@ export class EnumOptions extends Message<EnumOptions> {
   }
 }
 
+EnumOptions.prototype.allowAlias = false;
+EnumOptions.prototype.deprecated = false;
+EnumOptions.prototype.deprecatedLegacyJsonFieldConflicts = false;
+
 /**
  * @generated from message google.protobuf.EnumValueOptions
  */
@@ -2278,7 +2373,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool deprecated = 1 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -2294,7 +2389,7 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
    *
    * @generated from field: optional bool debug_redact = 3 [default = false];
    */
-  debugRedact?: boolean;
+  declare debugRedact: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2334,6 +2429,9 @@ export class EnumValueOptions extends Message<EnumValueOptions> {
   }
 }
 
+EnumValueOptions.prototype.deprecated = false;
+EnumValueOptions.prototype.debugRedact = false;
+
 /**
  * @generated from message google.protobuf.ServiceOptions
  */
@@ -2353,7 +2451,7 @@ export class ServiceOptions extends Message<ServiceOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2392,6 +2490,8 @@ export class ServiceOptions extends Message<ServiceOptions> {
   }
 }
 
+ServiceOptions.prototype.deprecated = false;
+
 /**
  * @generated from message google.protobuf.MethodOptions
  */
@@ -2404,12 +2504,12 @@ export class MethodOptions extends Message<MethodOptions> {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  declare deprecated: boolean;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
    */
-  idempotencyLevel?: MethodOptions_IdempotencyLevel;
+  declare idempotencyLevel: MethodOptions_IdempotencyLevel;
 
   /**
    * Any features defined in the specific edition.
@@ -2455,6 +2555,9 @@ export class MethodOptions extends Message<MethodOptions> {
     return proto2.util.equals(MethodOptions, a, b);
   }
 }
+
+MethodOptions.prototype.deprecated = false;
+MethodOptions.prototype.idempotencyLevel = 0 as MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN;
 
 /**
  * Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
@@ -2512,32 +2615,32 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
    *
    * @generated from field: optional string identifier_value = 3;
    */
-  identifierValue?: string;
+  declare identifierValue: string;
 
   /**
    * @generated from field: optional uint64 positive_int_value = 4;
    */
-  positiveIntValue?: bigint;
+  declare positiveIntValue: bigint;
 
   /**
    * @generated from field: optional int64 negative_int_value = 5;
    */
-  negativeIntValue?: bigint;
+  declare negativeIntValue: bigint;
 
   /**
    * @generated from field: optional double double_value = 6;
    */
-  doubleValue?: number;
+  declare doubleValue: number;
 
   /**
    * @generated from field: optional bytes string_value = 7;
    */
-  stringValue?: Uint8Array;
+  declare stringValue: Uint8Array;
 
   /**
    * @generated from field: optional string aggregate_value = 8;
    */
-  aggregateValue?: string;
+  declare aggregateValue: string;
 
   constructor(data?: PartialMessage<UninterpretedOption>) {
     super();
@@ -2572,6 +2675,13 @@ export class UninterpretedOption extends Message<UninterpretedOption> {
     return proto2.util.equals(UninterpretedOption, a, b);
   }
 }
+
+UninterpretedOption.prototype.identifierValue = "";
+UninterpretedOption.prototype.positiveIntValue = protoInt64.zero;
+UninterpretedOption.prototype.negativeIntValue = protoInt64.zero;
+UninterpretedOption.prototype.doubleValue = 0;
+UninterpretedOption.prototype.stringValue = new Uint8Array(0);
+UninterpretedOption.prototype.aggregateValue = "";
 
 /**
  * The name of the uninterpreted option.  Each string represents a segment in
@@ -2639,32 +2749,32 @@ export class FeatureSet extends Message<FeatureSet> {
   /**
    * @generated from field: optional google.protobuf.FeatureSet.FieldPresence field_presence = 1;
    */
-  fieldPresence?: FeatureSet_FieldPresence;
+  declare fieldPresence: FeatureSet_FieldPresence;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.EnumType enum_type = 2;
    */
-  enumType?: FeatureSet_EnumType;
+  declare enumType: FeatureSet_EnumType;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding = 3;
    */
-  repeatedFieldEncoding?: FeatureSet_RepeatedFieldEncoding;
+  declare repeatedFieldEncoding: FeatureSet_RepeatedFieldEncoding;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.Utf8Validation utf8_validation = 4;
    */
-  utf8Validation?: FeatureSet_Utf8Validation;
+  declare utf8Validation: FeatureSet_Utf8Validation;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.MessageEncoding message_encoding = 5;
    */
-  messageEncoding?: FeatureSet_MessageEncoding;
+  declare messageEncoding: FeatureSet_MessageEncoding;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.JsonFormat json_format = 6;
    */
-  jsonFormat?: FeatureSet_JsonFormat;
+  declare jsonFormat: FeatureSet_JsonFormat;
 
   constructor(data?: PartialMessage<FeatureSet>) {
     super();
@@ -2698,6 +2808,13 @@ export class FeatureSet extends Message<FeatureSet> {
     return proto2.util.equals(FeatureSet, a, b);
   }
 }
+
+FeatureSet.prototype.fieldPresence = 0 as FeatureSet_FieldPresence.FIELD_PRESENCE_UNKNOWN;
+FeatureSet.prototype.enumType = 0 as FeatureSet_EnumType.ENUM_TYPE_UNKNOWN;
+FeatureSet.prototype.repeatedFieldEncoding = 0 as FeatureSet_RepeatedFieldEncoding.REPEATED_FIELD_ENCODING_UNKNOWN;
+FeatureSet.prototype.utf8Validation = 0 as FeatureSet_Utf8Validation.UTF8_VALIDATION_UNKNOWN;
+FeatureSet.prototype.messageEncoding = 0 as FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN;
+FeatureSet.prototype.jsonFormat = 0 as FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN;
 
 /**
  * @generated from enum google.protobuf.FeatureSet.FieldPresence
@@ -2881,7 +2998,7 @@ export class FeatureSetDefaults extends Message<FeatureSetDefaults> {
    *
    * @generated from field: optional google.protobuf.Edition minimum_edition = 4;
    */
-  minimumEdition?: Edition;
+  declare minimumEdition: Edition;
 
   /**
    * The maximum known edition (inclusive) when this was constructed. Editions
@@ -2889,7 +3006,7 @@ export class FeatureSetDefaults extends Message<FeatureSetDefaults> {
    *
    * @generated from field: optional google.protobuf.Edition maximum_edition = 5;
    */
-  maximumEdition?: Edition;
+  declare maximumEdition: Edition;
 
   constructor(data?: PartialMessage<FeatureSetDefaults>) {
     super();
@@ -2921,6 +3038,9 @@ export class FeatureSetDefaults extends Message<FeatureSetDefaults> {
   }
 }
 
+FeatureSetDefaults.prototype.minimumEdition = 0 as Edition.EDITION_UNKNOWN;
+FeatureSetDefaults.prototype.maximumEdition = 0 as Edition.EDITION_UNKNOWN;
+
 /**
  * A map from every known edition with a unique set of defaults to its
  * defaults. Not all editions may be contained here.  For a given edition,
@@ -2933,7 +3053,7 @@ export class FeatureSetDefaults_FeatureSetEditionDefault extends Message<Feature
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: Edition;
+  declare edition: Edition;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet features = 2;
@@ -2968,6 +3088,8 @@ export class FeatureSetDefaults_FeatureSetEditionDefault extends Message<Feature
     return proto2.util.equals(FeatureSetDefaults_FeatureSetEditionDefault, a, b);
   }
 }
+
+FeatureSetDefaults_FeatureSetEditionDefault.prototype.edition = 0 as Edition.EDITION_UNKNOWN;
 
 /**
  * Encapsulates information about the original source file from which a
@@ -3148,12 +3270,12 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
    *
    * @generated from field: optional string leading_comments = 3;
    */
-  leadingComments?: string;
+  declare leadingComments: string;
 
   /**
    * @generated from field: optional string trailing_comments = 4;
    */
-  trailingComments?: string;
+  declare trailingComments: string;
 
   /**
    * @generated from field: repeated string leading_detached_comments = 6;
@@ -3191,6 +3313,9 @@ export class SourceCodeInfo_Location extends Message<SourceCodeInfo_Location> {
     return proto2.util.equals(SourceCodeInfo_Location, a, b);
   }
 }
+
+SourceCodeInfo_Location.prototype.leadingComments = "";
+SourceCodeInfo_Location.prototype.trailingComments = "";
 
 /**
  * Describes the relationship between generated code and its original source
@@ -3253,7 +3378,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional string source_file = 2;
    */
-  sourceFile?: string;
+  declare sourceFile: string;
 
   /**
    * Identifies the starting offset in bytes in the generated code
@@ -3261,7 +3386,7 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 begin = 3;
    */
-  begin?: number;
+  declare begin: number;
 
   /**
    * Identifies the ending offset in bytes in the generated code that
@@ -3270,12 +3395,12 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
    *
    * @generated from field: optional int32 end = 4;
    */
-  end?: number;
+  declare end: number;
 
   /**
    * @generated from field: optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic = 5;
    */
-  semantic?: GeneratedCodeInfo_Annotation_Semantic;
+  declare semantic: GeneratedCodeInfo_Annotation_Semantic;
 
   constructor(data?: PartialMessage<GeneratedCodeInfo_Annotation>) {
     super();
@@ -3308,6 +3433,11 @@ export class GeneratedCodeInfo_Annotation extends Message<GeneratedCodeInfo_Anno
     return proto2.util.equals(GeneratedCodeInfo_Annotation, a, b);
   }
 }
+
+GeneratedCodeInfo_Annotation.prototype.sourceFile = "";
+GeneratedCodeInfo_Annotation.prototype.begin = 0;
+GeneratedCodeInfo_Annotation.prototype.end = 0;
+GeneratedCodeInfo_Annotation.prototype.semantic = 0 as GeneratedCodeInfo_Annotation_Semantic.NONE;
 
 /**
  * Represents the identified object's effect on the element in the original

--- a/packages/protobuf/src/private/feature-set.ts
+++ b/packages/protobuf/src/private/feature-set.ts
@@ -68,9 +68,9 @@ export function createFeatureResolver(
   const min = fds.minimumEdition;
   const max = fds.maximumEdition;
   if (
-    min === undefined ||
-    max === undefined ||
-    fds.defaults.some((d) => d.edition === undefined)
+    min == Edition.EDITION_UNKNOWN ||
+    max == Edition.EDITION_UNKNOWN ||
+    fds.defaults.some((d) => d.edition == Edition.EDITION_UNKNOWN)
   ) {
     throw new Error("Invalid FeatureSetDefaults");
   }
@@ -86,7 +86,7 @@ export function createFeatureResolver(
   }
   let highestMatch: { e: Edition; f: FeatureSet } | undefined = undefined;
   for (const c of fds.defaults) {
-    const e = c.edition ?? 0;
+    const e = c.edition;
     if (e > edition) {
       continue;
     }
@@ -138,9 +138,6 @@ function validateMergedFeatures(
 ): featureSet is MergedFeatureSet {
   for (const fi of FeatureSet.fields.list()) {
     const v = featureSet[fi.localName as keyof FeatureSet] as unknown;
-    if (v === undefined) {
-      return false;
-    }
     if (fi.kind == "enum" && v === 0) {
       return false;
     }

--- a/packages/protobuf/src/private/message-type.ts
+++ b/packages/protobuf/src/private/message-type.ts
@@ -19,8 +19,8 @@ import type { JsonReadOptions, JsonValue } from "../json-format.js";
 import type { MessageType } from "../message-type.js";
 import type { BinaryReadOptions } from "../binary-format.js";
 import type { ProtoRuntime } from "./proto-runtime.js";
-import { fieldUsesPrototype } from "./reflect.js";
 import { scalarZeroValue } from "./scalars.js";
+import type { FieldInfo } from "../field";
 
 /**
  * Create a new message type using the given runtime.
@@ -44,12 +44,12 @@ export function makeMessageType<T extends Message<T> = AnyMessage>(
 ): MessageType<T> {
   const localName =
     opt?.localName ?? typeName.substring(typeName.lastIndexOf(".") + 1);
-  let prototypeFieldsAdded = false;
+  let prototypeFieldsNeeded = runtime.syntax == "proto2";
   const type = {
     [localName]: function (this: T, data?: PartialMessage<T>) {
-      if (!prototypeFieldsAdded) {
+      if (prototypeFieldsNeeded) {
         addPrototypeFields(type);
-        prototypeFieldsAdded = true;
+        prototypeFieldsNeeded = false;
       }
       runtime.util.initFields(this);
       runtime.util.initPartial(data, this);
@@ -95,4 +95,16 @@ function addPrototypeFields(ctor: MessageType) {
     }
     (ctor.prototype as Record<string, unknown>)[field.localName] = value;
   }
+}
+
+// Behavior must match with the counterpart in @bufbuild/protoc-gen-es
+function fieldUsesPrototype(field: FieldInfo): boolean {
+  if (field.repeated || field.oneof) {
+    return false;
+  }
+  if (field.kind != "scalar" && field.kind != "enum") {
+    return false;
+  }
+  // proto2 singular scalar and enum fields use an initial value on the prototype chain
+  return true;
 }

--- a/packages/protobuf/src/private/names.ts
+++ b/packages/protobuf/src/private/names.ts
@@ -51,7 +51,7 @@ export function localName(
     case "service":
     case "extension": {
       const pkg = desc.file.proto.package;
-      const offset = pkg === undefined ? 0 : pkg.length + 1;
+      const offset = pkg.length > 0 ? pkg.length + 1 : 0;
       const name = desc.typeName.substring(offset).replace(/\./g, "_");
       // For services, we only care about safe identifiers, not safe object properties,
       // but we have shipped v1 with a bug that respected object properties, and we

--- a/packages/protobuf/src/private/reflect.ts
+++ b/packages/protobuf/src/private/reflect.ts
@@ -78,11 +78,7 @@ export function clearField(
         if (implicitPresence) {
           target[localName] = field.T.values[0].no;
         } else {
-          if (fieldUsesPrototype(field)) {
-            delete target[localName];
-          } else {
-            target[localName] = undefined;
-          }
+          delete target[localName];
         }
         break;
       case "scalar":
@@ -90,11 +86,7 @@ export function clearField(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           target[localName] = scalarZeroValue(field.T, field.L);
         } else {
-          if (fieldUsesPrototype(field)) {
-            delete target[localName];
-          } else {
-            target[localName] = undefined;
-          }
+          delete target[localName];
         }
         break;
       case "message":
@@ -102,18 +94,4 @@ export function clearField(
         break;
     }
   }
-}
-
-/**
- * Tells whether a field uses the prototype chain for field presence.
- * Behavior must match with the counterpart in @bufbuild/protoc-gen-es.
- */
-export function fieldUsesPrototype(field: FieldInfo): boolean {
-  if (field.repeated || field.oneof) {
-    return false;
-  }
-  if (field.kind != "scalar" && field.kind != "enum") {
-    return false;
-  }
-  return field.req;
 }

--- a/packages/protoc-gen-es/src/editions.ts
+++ b/packages/protoc-gen-es/src/editions.ts
@@ -31,7 +31,7 @@ export function getNonEditionRuntime(
   if (file.syntax === "editions") {
     // TODO support editions
     throw new Error(
-      `${file.proto.name ?? ""}: syntax "editions" is not supported yet`,
+      `${file.proto.name}: syntax "editions" is not supported yet`,
     );
   }
   return schema.runtime[file.syntax];

--- a/packages/protoc-gen-es/src/util.ts
+++ b/packages/protoc-gen-es/src/util.ts
@@ -18,12 +18,7 @@ import type {
   DescEnumValue,
   ScalarValue,
 } from "@bufbuild/protobuf";
-import {
-  codegenInfo,
-  FieldDescriptorProto_Label,
-  ScalarType,
-  LongType,
-} from "@bufbuild/protobuf";
+import { codegenInfo, Edition, ScalarType, LongType } from "@bufbuild/protobuf";
 import type { Printable } from "@bufbuild/protoplugin/ecmascript";
 import { localName } from "@bufbuild/protoplugin/ecmascript";
 
@@ -36,13 +31,17 @@ export function fieldUsesPrototype(field: DescField): field is DescField & {
   oneof: undefined;
   repeated: false;
 } {
+  if (field.parent.file.edition != Edition.EDITION_PROTO2) {
+    return false;
+  }
   if (field.repeated || field.oneof) {
     return false;
   }
   if (field.fieldKind != "scalar" && field.fieldKind != "enum") {
     return false;
   }
-  return field.proto.label === FieldDescriptorProto_Label.REQUIRED;
+  // proto2 singular scalar and enum fields use an initial value on the prototype chain
+  return true;
 }
 
 export function getFieldTypeInfo(field: DescField | DescExtension): {

--- a/packages/protoplugin-test/src/plugin-edition-support.test.ts
+++ b/packages/protoplugin-test/src/plugin-edition-support.test.ts
@@ -117,9 +117,9 @@ describe("editions support in plugins", () => {
   });
 
   function supportsEditions(res: CodeGeneratorResponse): boolean {
-    const f = res.supportedFeatures ?? 0n;
     return (
-      (f & BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS)) ===
+      (res.supportedFeatures &
+        BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS)) ===
       BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS)
     );
   }

--- a/packages/protoplugin-test/src/target.test.ts
+++ b/packages/protoplugin-test/src/target.test.ts
@@ -76,7 +76,7 @@ describe("target", () => {
         generateDts,
         transpile,
       });
-      const gotFiles = res.file.map((f) => f.name ?? "").sort();
+      const gotFiles = res.file.map((f) => f.name).sort();
       expect(gotFiles).toStrictEqual(["test.js", "test.d.ts"].sort());
     });
     test("should call generateJs and generateDts", async () => {
@@ -115,7 +115,7 @@ describe("target", () => {
         generateDts,
         transpile,
       });
-      const gotFiles = res.file.map((f) => f.name ?? "").sort();
+      const gotFiles = res.file.map((f) => f.name).sort();
       const wantFiles = targets
         .map((t) => (t == "dts" ? "test.d.ts" : `test.${t}`))
         .sort();
@@ -226,7 +226,7 @@ describe("target", () => {
       });
 
       test("should generate expected files", () => {
-        const gotFiles = res.file.map((f) => f.name ?? "").sort();
+        const gotFiles = res.file.map((f) => f.name).sort();
         expect(gotFiles).toStrictEqual(expectedFiles);
       });
     },

--- a/packages/protoplugin/src/ecmascript/file-preamble.ts
+++ b/packages/protoplugin/src/ecmascript/file-preamble.ts
@@ -48,7 +48,7 @@ export function makeFilePreamble(
   }
   builder.push("\n");
   builder.push(`// @generated from file ${file.name}.proto (`);
-  if (file.proto.package !== undefined) {
+  if (file.proto.package.length > 0) {
     builder.push(`package ${file.proto.package}, `);
   }
   switch (file.edition) {

--- a/packages/protoplugin/src/ecmascript/jsdoc.ts
+++ b/packages/protoplugin/src/ecmascript/jsdoc.ts
@@ -93,7 +93,7 @@ function createTextForDesc(desc: Exclude<AnyDesc, DescFile>) {
     case "enum":
     case "message":
     case "service":
-      deprecated = deprecated || (desc.file.proto.options?.deprecated ?? false);
+      deprecated = deprecated || desc.file.deprecated;
       break;
     default:
       break;

--- a/packages/protoplugin/src/ecmascript/parameter.ts
+++ b/packages/protoplugin/src/ecmascript/parameter.ts
@@ -28,7 +28,7 @@ export interface ParsedParameter {
 }
 
 export function parseParameter(
-  parameter: string | undefined,
+  parameter: string,
   parseExtraOption: ((key: string, value: string) => void) | undefined,
 ): ParsedParameter {
   let targets: Target[] = ["js", "dts"];
@@ -166,9 +166,9 @@ export function parseParameter(
 }
 
 function splitParameter(
-  parameter: string | undefined,
+  parameter: string,
 ): { key: string; value: string; raw: string }[] {
-  if (parameter == undefined) {
+  if (parameter.length == 0) {
     return [];
   }
   return parameter.split(",").map((raw) => {


### PR DESCRIPTION
This widens https://github.com/bufbuild/protobuf-es/pull/716 to support default values for proto2 optional fields as well, and applies the same technique to support field presence as for proto2 required fields.

Since the well-known types in `google/protobuf/descriptor.proto` and `google/protobuf/plugin.proto` use proto2, call sites in our descriptor wrappers and plugin-framework that distinguish between set/unset fields need to be updated to use the functions for field presence added in https://github.com/bufbuild/protobuf-es/pull/717.