### PR TITLE
Deprecate properties toString and text of JSDocBlock

### DIFF
--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -29,7 +29,6 @@ import { makeImportPathRelative } from "./import-path.js";
 import type { JSDocBlock } from "./jsdoc.js";
 import { createJsDocBlock } from "./jsdoc.js";
 import {
-  createExportDeclaration,
   ExportDeclaration,
   LiteralProtoInt64,
   LiteralString,
@@ -227,7 +226,11 @@ export function createGeneratedFile(
       return createImportSymbol(name, importPath);
     },
     exportDecl(declaration, name) {
-      return createExportDeclaration(declaration, name);
+      return {
+        kind: "es_export_decl",
+        declaration,
+        name,
+      };
     },
     string(string) {
       // We do not use LiteralString, which was added later, to maintain backwards compatibility

--- a/packages/protoplugin/src/ecmascript/jsdoc.ts
+++ b/packages/protoplugin/src/ecmascript/jsdoc.ts
@@ -16,11 +16,18 @@ import type { AnyDesc, DescFile } from "@bufbuild/protobuf";
 
 export type JSDocBlock = {
   readonly kind: "es_jsdoc";
+  /**
+   * @deprecated In a future release, we will make this property optional.
+   */
   text: string;
   indentation?: string;
+  /**
+   * @deprecated In a future release, we will remove this method.
+   */
   toString(): string;
 };
 
+// TODO simplify type JSDocBlock to bring it in line with others in opaque-printables.ts
 export function createJsDocBlock(
   textOrDesc: string | Exclude<AnyDesc, DescFile>,
   indentation?: string,

--- a/packages/protoplugin/src/ecmascript/opaque-printables.ts
+++ b/packages/protoplugin/src/ecmascript/opaque-printables.ts
@@ -54,14 +54,3 @@ export type ExportDeclaration = {
   declaration: string;
   name: string | DescMessage | DescEnum | DescExtension;
 };
-
-export function createExportDeclaration(
-  declaration: string,
-  name: ExportDeclaration["name"],
-): ExportDeclaration {
-  return {
-    kind: "es_export_decl",
-    declaration,
-    name,
-  };
-}


### PR DESCRIPTION
Currently, the method `GeneratedFile.jsDoc` returns a `JSDocBlock` that leaks implementation details through the properties "toString" and "text".

This PR marks the properties as deprecated, so that we can remove them in the future. This will allow us to accept JSDoc blocks as object literals in `GeneratedFile.print`, in line with similar objects.