### PR TITLE
Fix overeager escaping of message, enum, service, and extension names

### DIFF
--- a/packages/protobuf-test/extra/name-clash.proto
+++ b/packages/protobuf-test/extra/name-clash.proto
@@ -107,6 +107,16 @@ message case {
 message return {
 }
 
+// reserved object property
+message constructor {
+}
+message toString {
+}
+message toJSON {
+}
+message valueOf {
+}
+
 // used by runtime
 message Message {
 }

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -528,77 +528,77 @@ export declare class return$ extends Message$1<return$> {
  *
  * @generated from message spec.constructor
  */
-export declare class constructor$ extends Message$1<constructor$> {
-  constructor(data?: PartialMessage$1<constructor$>);
+export declare class constructor extends Message$1<constructor> {
+  constructor(data?: PartialMessage$1<constructor>);
 
   static readonly runtime: typeof proto3;
   static readonly typeName = "spec.constructor";
   static readonly fields: FieldList;
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): constructor$;
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): constructor;
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): constructor$;
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): constructor;
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): constructor$;
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): constructor;
 
-  static equals(a: constructor$ | PlainMessage$1<constructor$> | undefined, b: constructor$ | PlainMessage$1<constructor$> | undefined): boolean;
+  static equals(a: constructor | PlainMessage$1<constructor> | undefined, b: constructor | PlainMessage$1<constructor> | undefined): boolean;
 }
 
 /**
  * @generated from message spec.toString
  */
-export declare class toString$ extends Message$1<toString$> {
-  constructor(data?: PartialMessage$1<toString$>);
+export declare class toString extends Message$1<toString> {
+  constructor(data?: PartialMessage$1<toString>);
 
   static readonly runtime: typeof proto3;
   static readonly typeName = "spec.toString";
   static readonly fields: FieldList;
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toString$;
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toString;
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toString$;
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toString;
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toString$;
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toString;
 
-  static equals(a: toString$ | PlainMessage$1<toString$> | undefined, b: toString$ | PlainMessage$1<toString$> | undefined): boolean;
+  static equals(a: toString | PlainMessage$1<toString> | undefined, b: toString | PlainMessage$1<toString> | undefined): boolean;
 }
 
 /**
  * @generated from message spec.toJSON
  */
-export declare class toJSON$ extends Message$1<toJSON$> {
-  constructor(data?: PartialMessage$1<toJSON$>);
+export declare class toJSON extends Message$1<toJSON> {
+  constructor(data?: PartialMessage$1<toJSON>);
 
   static readonly runtime: typeof proto3;
   static readonly typeName = "spec.toJSON";
   static readonly fields: FieldList;
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toJSON$;
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toJSON;
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toJSON$;
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toJSON;
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toJSON$;
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toJSON;
 
-  static equals(a: toJSON$ | PlainMessage$1<toJSON$> | undefined, b: toJSON$ | PlainMessage$1<toJSON$> | undefined): boolean;
+  static equals(a: toJSON | PlainMessage$1<toJSON> | undefined, b: toJSON | PlainMessage$1<toJSON> | undefined): boolean;
 }
 
 /**
  * @generated from message spec.valueOf
  */
-export declare class valueOf$ extends Message$1<valueOf$> {
-  constructor(data?: PartialMessage$1<valueOf$>);
+export declare class valueOf extends Message$1<valueOf> {
+  constructor(data?: PartialMessage$1<valueOf>);
 
   static readonly runtime: typeof proto3;
   static readonly typeName = "spec.valueOf";
   static readonly fields: FieldList;
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): valueOf$;
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): valueOf;
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): valueOf$;
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): valueOf;
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): valueOf$;
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): valueOf;
 
-  static equals(a: valueOf$ | PlainMessage$1<valueOf$> | undefined, b: valueOf$ | PlainMessage$1<valueOf$> | undefined): boolean;
+  static equals(a: valueOf | PlainMessage$1<valueOf> | undefined, b: valueOf | PlainMessage$1<valueOf> | undefined): boolean;
 }
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -524,6 +524,84 @@ export declare class return$ extends Message$1<return$> {
 }
 
 /**
+ * reserved object property
+ *
+ * @generated from message spec.constructor
+ */
+export declare class constructor$ extends Message$1<constructor$> {
+  constructor(data?: PartialMessage$1<constructor$>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.constructor";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): constructor$;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): constructor$;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): constructor$;
+
+  static equals(a: constructor$ | PlainMessage$1<constructor$> | undefined, b: constructor$ | PlainMessage$1<constructor$> | undefined): boolean;
+}
+
+/**
+ * @generated from message spec.toString
+ */
+export declare class toString$ extends Message$1<toString$> {
+  constructor(data?: PartialMessage$1<toString$>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.toString";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toString$;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toString$;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toString$;
+
+  static equals(a: toString$ | PlainMessage$1<toString$> | undefined, b: toString$ | PlainMessage$1<toString$> | undefined): boolean;
+}
+
+/**
+ * @generated from message spec.toJSON
+ */
+export declare class toJSON$ extends Message$1<toJSON$> {
+  constructor(data?: PartialMessage$1<toJSON$>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.toJSON";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toJSON$;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toJSON$;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toJSON$;
+
+  static equals(a: toJSON$ | PlainMessage$1<toJSON$> | undefined, b: toJSON$ | PlainMessage$1<toJSON$> | undefined): boolean;
+}
+
+/**
+ * @generated from message spec.valueOf
+ */
+export declare class valueOf$ extends Message$1<valueOf$> {
+  constructor(data?: PartialMessage$1<valueOf$>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.valueOf";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): valueOf$;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): valueOf$;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): valueOf$;
+
+  static equals(a: valueOf$ | PlainMessage$1<valueOf$> | undefined, b: valueOf$ | PlainMessage$1<valueOf$> | undefined): boolean;
+}
+
+/**
  * used by runtime
  *
  * @generated from message spec.Message

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
@@ -207,37 +207,33 @@ export const return$ = proto3.makeMessageType(
  *
  * @generated from message spec.constructor
  */
-export const constructor$ = proto3.makeMessageType(
+export const constructor = proto3.makeMessageType(
   "spec.constructor",
   [],
-  {localName: "constructor$"},
 );
 
 /**
  * @generated from message spec.toString
  */
-export const toString$ = proto3.makeMessageType(
+export const toString = proto3.makeMessageType(
   "spec.toString",
   [],
-  {localName: "toString$"},
 );
 
 /**
  * @generated from message spec.toJSON
  */
-export const toJSON$ = proto3.makeMessageType(
+export const toJSON = proto3.makeMessageType(
   "spec.toJSON",
   [],
-  {localName: "toJSON$"},
 );
 
 /**
  * @generated from message spec.valueOf
  */
-export const valueOf$ = proto3.makeMessageType(
+export const valueOf = proto3.makeMessageType(
   "spec.valueOf",
   [],
-  {localName: "valueOf$"},
 );
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
@@ -203,6 +203,44 @@ export const return$ = proto3.makeMessageType(
 );
 
 /**
+ * reserved object property
+ *
+ * @generated from message spec.constructor
+ */
+export const constructor$ = proto3.makeMessageType(
+  "spec.constructor",
+  [],
+  {localName: "constructor$"},
+);
+
+/**
+ * @generated from message spec.toString
+ */
+export const toString$ = proto3.makeMessageType(
+  "spec.toString",
+  [],
+  {localName: "toString$"},
+);
+
+/**
+ * @generated from message spec.toJSON
+ */
+export const toJSON$ = proto3.makeMessageType(
+  "spec.toJSON",
+  [],
+  {localName: "toJSON$"},
+);
+
+/**
+ * @generated from message spec.valueOf
+ */
+export const valueOf$ = proto3.makeMessageType(
+  "spec.valueOf",
+  [],
+  {localName: "valueOf$"},
+);
+
+/**
  * used by runtime
  *
  * @generated from message spec.Message

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -714,6 +714,132 @@ export class return$ extends Message$1<return$> {
 }
 
 /**
+ * reserved object property
+ *
+ * @generated from message spec.constructor
+ */
+export class constructor$ extends Message$1<constructor$> {
+  constructor(data?: PartialMessage$1<constructor$>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "spec.constructor";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): constructor$ {
+    return new constructor$().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): constructor$ {
+    return new constructor$().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): constructor$ {
+    return new constructor$().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: constructor$ | PlainMessage$1<constructor$> | undefined, b: constructor$ | PlainMessage$1<constructor$> | undefined): boolean {
+    return proto3.util.equals(constructor$, a, b);
+  }
+}
+
+/**
+ * @generated from message spec.toString
+ */
+export class toString$ extends Message$1<toString$> {
+  constructor(data?: PartialMessage$1<toString$>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "spec.toString";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toString$ {
+    return new toString$().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toString$ {
+    return new toString$().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toString$ {
+    return new toString$().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: toString$ | PlainMessage$1<toString$> | undefined, b: toString$ | PlainMessage$1<toString$> | undefined): boolean {
+    return proto3.util.equals(toString$, a, b);
+  }
+}
+
+/**
+ * @generated from message spec.toJSON
+ */
+export class toJSON$ extends Message$1<toJSON$> {
+  constructor(data?: PartialMessage$1<toJSON$>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "spec.toJSON";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toJSON$ {
+    return new toJSON$().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toJSON$ {
+    return new toJSON$().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toJSON$ {
+    return new toJSON$().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: toJSON$ | PlainMessage$1<toJSON$> | undefined, b: toJSON$ | PlainMessage$1<toJSON$> | undefined): boolean {
+    return proto3.util.equals(toJSON$, a, b);
+  }
+}
+
+/**
+ * @generated from message spec.valueOf
+ */
+export class valueOf$ extends Message$1<valueOf$> {
+  constructor(data?: PartialMessage$1<valueOf$>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "spec.valueOf";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): valueOf$ {
+    return new valueOf$().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): valueOf$ {
+    return new valueOf$().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): valueOf$ {
+    return new valueOf$().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: valueOf$ | PlainMessage$1<valueOf$> | undefined, b: valueOf$ | PlainMessage$1<valueOf$> | undefined): boolean {
+    return proto3.util.equals(valueOf$, a, b);
+  }
+}
+
+/**
  * used by runtime
  *
  * @generated from message spec.Message

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -718,8 +718,8 @@ export class return$ extends Message$1<return$> {
  *
  * @generated from message spec.constructor
  */
-export class constructor$ extends Message$1<constructor$> {
-  constructor(data?: PartialMessage$1<constructor$>) {
+export class constructor extends Message$1<constructor> {
+  constructor(data?: PartialMessage$1<constructor>) {
     super();
     proto3.util.initPartial(data, this);
   }
@@ -729,28 +729,28 @@ export class constructor$ extends Message$1<constructor$> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): constructor$ {
-    return new constructor$().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): constructor {
+    return new constructor().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): constructor$ {
-    return new constructor$().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): constructor {
+    return new constructor().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): constructor$ {
-    return new constructor$().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): constructor {
+    return new constructor().fromJsonString(jsonString, options);
   }
 
-  static equals(a: constructor$ | PlainMessage$1<constructor$> | undefined, b: constructor$ | PlainMessage$1<constructor$> | undefined): boolean {
-    return proto3.util.equals(constructor$, a, b);
+  static equals(a: constructor | PlainMessage$1<constructor> | undefined, b: constructor | PlainMessage$1<constructor> | undefined): boolean {
+    return proto3.util.equals(constructor, a, b);
   }
 }
 
 /**
  * @generated from message spec.toString
  */
-export class toString$ extends Message$1<toString$> {
-  constructor(data?: PartialMessage$1<toString$>) {
+export class toString extends Message$1<toString> {
+  constructor(data?: PartialMessage$1<toString>) {
     super();
     proto3.util.initPartial(data, this);
   }
@@ -760,28 +760,28 @@ export class toString$ extends Message$1<toString$> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toString$ {
-    return new toString$().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toString {
+    return new toString().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toString$ {
-    return new toString$().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toString {
+    return new toString().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toString$ {
-    return new toString$().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toString {
+    return new toString().fromJsonString(jsonString, options);
   }
 
-  static equals(a: toString$ | PlainMessage$1<toString$> | undefined, b: toString$ | PlainMessage$1<toString$> | undefined): boolean {
-    return proto3.util.equals(toString$, a, b);
+  static equals(a: toString | PlainMessage$1<toString> | undefined, b: toString | PlainMessage$1<toString> | undefined): boolean {
+    return proto3.util.equals(toString, a, b);
   }
 }
 
 /**
  * @generated from message spec.toJSON
  */
-export class toJSON$ extends Message$1<toJSON$> {
-  constructor(data?: PartialMessage$1<toJSON$>) {
+export class toJSON extends Message$1<toJSON> {
+  constructor(data?: PartialMessage$1<toJSON>) {
     super();
     proto3.util.initPartial(data, this);
   }
@@ -791,28 +791,28 @@ export class toJSON$ extends Message$1<toJSON$> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toJSON$ {
-    return new toJSON$().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): toJSON {
+    return new toJSON().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toJSON$ {
-    return new toJSON$().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): toJSON {
+    return new toJSON().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toJSON$ {
-    return new toJSON$().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): toJSON {
+    return new toJSON().fromJsonString(jsonString, options);
   }
 
-  static equals(a: toJSON$ | PlainMessage$1<toJSON$> | undefined, b: toJSON$ | PlainMessage$1<toJSON$> | undefined): boolean {
-    return proto3.util.equals(toJSON$, a, b);
+  static equals(a: toJSON | PlainMessage$1<toJSON> | undefined, b: toJSON | PlainMessage$1<toJSON> | undefined): boolean {
+    return proto3.util.equals(toJSON, a, b);
   }
 }
 
 /**
  * @generated from message spec.valueOf
  */
-export class valueOf$ extends Message$1<valueOf$> {
-  constructor(data?: PartialMessage$1<valueOf$>) {
+export class valueOf extends Message$1<valueOf> {
+  constructor(data?: PartialMessage$1<valueOf>) {
     super();
     proto3.util.initPartial(data, this);
   }
@@ -822,20 +822,20 @@ export class valueOf$ extends Message$1<valueOf$> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): valueOf$ {
-    return new valueOf$().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): valueOf {
+    return new valueOf().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): valueOf$ {
-    return new valueOf$().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): valueOf {
+    return new valueOf().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): valueOf$ {
-    return new valueOf$().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): valueOf {
+    return new valueOf().fromJsonString(jsonString, options);
   }
 
-  static equals(a: valueOf$ | PlainMessage$1<valueOf$> | undefined, b: valueOf$ | PlainMessage$1<valueOf$> | undefined): boolean {
-    return proto3.util.equals(valueOf$, a, b);
+  static equals(a: valueOf | PlainMessage$1<valueOf> | undefined, b: valueOf | PlainMessage$1<valueOf> | undefined): boolean {
+    return proto3.util.equals(valueOf, a, b);
   }
 }
 

--- a/packages/protobuf/src/private/names.ts
+++ b/packages/protobuf/src/private/names.ts
@@ -53,12 +53,7 @@ export function localName(
       const pkg = desc.file.proto.package;
       const offset = pkg.length > 0 ? pkg.length + 1 : 0;
       const name = desc.typeName.substring(offset).replace(/\./g, "_");
-      // For services, we only care about safe identifiers, not safe object properties,
-      // but we have shipped v1 with a bug that respected object properties, and we
-      // do not want to introduce a breaking change, so we continue to escape for
-      // safe object properties.
-      // See https://github.com/bufbuild/protobuf-es/pull/391
-      return safeObjectProperty(safeIdentifier(name));
+      return safeIdentifier(name);
     }
     case "enum_value": {
       const sharedPrefix = desc.parent.sharedPrefix;


### PR DESCRIPTION
It is possible to define messages, fields, and other elements in Protobuf that would be illegal in ECMAScript. For example, a field named "constructor", or a message named "throw" would lead to syntax errors in generated code.

Such names are automatically escaped by Protobuf-ES. But the escaping was overly eager, and escaped message, enum, service, and extension names if they collided with a reserved object property. Since these types generate identifiers, not object properties, this is unnecessary.

This PR changes the logic to only escape reserved identifiers for message, enum, service, and extension names. This is a breaking change:

- If you have a Protobuf message, enum, service, or extension with one of the names "constructor", "toString", "toJSON", or "valueOf", the generated code will no longer escape the name by appending a `$`.
- If you have been using `localName` from `@bufbuild/protoplugin/ecmascript` (or from `codegenInfo` from `@bufbuild/protobuf`), _and_ rely on the name being safe for an object property, please add additional escaping via `safeObjectProperty` from `codegenInfo` from `@bufbuild/protobuf`.
