### PR TITLE
Replace instanceof Message usages 

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -37,7 +37,6 @@ to Protobuf-ES.
 |------------------------|-------------|---------------------|-------------|
 | Initializers           | ✅           | ❌                   | ✅           |
 | Plain properties       | ✅           | ❌                   | ✅           |
-| `instanceof`           | ✅           | ✅                   | ❌           |
 | JSON format            | ✅           | ❌                   | ✅           |
 | Binary format          | ✅           | ✅                   | ✅           |
 | TypeScript             | ✅           | ❌                   | ✅           |
@@ -423,11 +422,8 @@ declare var message: Example;
 
 ```diff
 - Example.is(message);
-+ message instanceof Example;
++ isMessage(message, Example);
 ```
-
-Note that `instanceof` has much better performance characteristics than `is()`.
-For that reason, we do not provide an equivalent to `isAssignable()`.
 
 
 ### Reflection

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -13,6 +13,7 @@ provided by the library.
   - [Cloning messages](#cloning-messages)
   - [Comparing messages](#comparing-messages)
   - [Serializing messages](#serializing-messages)
+  - [Identifying messages](#identifying-messages)
 - [Enumerations](#enumerations)
 - [Extensions](#extensions)
   - [Extensions and JSON](#extensions-and-json)
@@ -314,6 +315,34 @@ JSON.
 To learn about serialization options and other details related to serialization, 
 see the section about [advanced serialization](#advanced-serialization).
 
+### Identifying messages
+
+To check whether a given object is any subtype of `Message` or is a specific
+type of `Message`, we recommend using the exported function `isMessage`.
+
+`isMessage` is _mostly_ equivalent to the `instanceof` operator. For
+example, `isMessage(foo, MyMessage)` is the same as `foo instanceof MyMessage`,
+and `isMessage(foo)` is the same as `foo instanceof Message`. 
+
+The advantage of `isMessage` is that it compares identity by the message type 
+name, not by class identity. This makes it robust against the dual package 
+hazard and similar situations, where the same message is duplicated.
+
+To determine if an object is any subtype of `Message`, pass that object to the
+function. To determine if an object is a specific type of `Message`, pass the 
+object as well as the type.
+
+```typescript
+import { isMessage } from "@bufbuild/protobuf";
+
+const user = new User({
+    firstName: "Homer",
+});
+
+isMessage(user);                    // true
+isMessage(user, User);              // true
+isMessage(user, OtherMessageType);  // false
+```
 
 ## Enumerations
 

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -317,8 +317,7 @@ see the section about [advanced serialization](#advanced-serialization).
 
 ### Identifying messages
 
-To check whether a given object is any subtype of `Message` or is a specific
-type of `Message`, we recommend using the exported function `isMessage`.
+To check whether a given object is a message, use the function `isMessage`.
 
 `isMessage` is _mostly_ equivalent to the `instanceof` operator. For
 example, `isMessage(foo, MyMessage)` is the same as `foo instanceof MyMessage`,

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -1100,7 +1100,7 @@ function to your users that processes this message:
 ```ts
 export function sendUser(user: PartialMessage<User>) {
   // convert partial messages into their full representation if necessary
-  const u = user instanceof User ? user : new User(user);
+  const u = isMessage(user, User) ? user : new User(user);
   // process further...
   const bytes = u.toBinary();
 }

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -317,7 +317,7 @@ see the section about [advanced serialization](#advanced-serialization).
 
 ### Identifying messages
 
-To check whether a given object is a message, use the function `isMessage`.
+To check whether a given object is a message, use the function [`isMessage`][src-isMessage].
 
 `isMessage` is _mostly_ equivalent to the `instanceof` operator. For
 example, `isMessage(foo, MyMessage)` is the same as `foo instanceof MyMessage`,
@@ -1206,6 +1206,7 @@ Note that any message is assignable to `AnyMessage`.
 [src-PlainMessage]: https://github.com/bufbuild/protobuf-es/blob/9b8efb4f4eb8ff8ce9f56798e769914ee2069cd1/packages/protobuf/src/message.ts#L137
 [src-AnyMessage]: https://github.com/bufbuild/protobuf-es/blob/9b8efb4f4eb8ff8ce9f56798e769914ee2069cd1/packages/protobuf/src/message.ts#L25
 [src-toPlainMessage]: https://github.com/bufbuild/protobuf-es/blob/51573c39ff38a9b43b6f7c22ba6b5ba40fa3ec3a/packages/protobuf/src/to-plain-message.ts#L29
+[src-isMessage]: https://github.com/bufbuild/protobuf-es/blob/3864c00709c444d5cf2cef694345b9beea7b3ed9/packages/protobuf/src/is-message.ts#L31
 [@bufbuild/protobuf]: https://www.npmjs.com/package/@bufbuild/protobuf
 [@bufbuild/protoplugin]: https://www.npmjs.com/package/@bufbuild/protoplugin
 [pkg-protoplugin]: https://www.npmjs.com/package/@bufbuild/protoplugin

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 96,999 b      | 41,438 b | 10,763 b |
+| protobuf-es         | 97,509 b      | 41,686 b | 10,827 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 97,509 b      | 41,686 b | 10,827 b |
+| protobuf-es         | 97,510 b      | 41,660 b | 10,845 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/create-registry-from-desc.test.ts
+++ b/packages/protobuf-test/src/create-registry-from-desc.test.ts
@@ -55,9 +55,11 @@ describe("createRegistryFromDescriptors()", () => {
     expect(dr.findExtensionFor("foo.Bar", 123)).toBeUndefined();
   });
   test("from google.protobuf.FileDescriptorSet", () => {
+    console.log("START===================================");
     const dr = createRegistryFromDescriptors(
       FileDescriptorSet.fromBinary(getTestFileDescriptorSetBytes()),
     );
+    console.log("END===================================");
     expectMessageTypes(dr);
     expectEnumTypes(dr);
     expectServiceTypes(dr);

--- a/packages/protobuf-test/src/create-registry-from-desc.test.ts
+++ b/packages/protobuf-test/src/create-registry-from-desc.test.ts
@@ -55,11 +55,9 @@ describe("createRegistryFromDescriptors()", () => {
     expect(dr.findExtensionFor("foo.Bar", 123)).toBeUndefined();
   });
   test("from google.protobuf.FileDescriptorSet", () => {
-    console.log("START===================================");
     const dr = createRegistryFromDescriptors(
       FileDescriptorSet.fromBinary(getTestFileDescriptorSetBytes()),
     );
-    console.log("END===================================");
     expectMessageTypes(dr);
     expectEnumTypes(dr);
     expectServiceTypes(dr);

--- a/packages/protobuf-test/src/edition-feature-resolver.test.ts
+++ b/packages/protobuf-test/src/edition-feature-resolver.test.ts
@@ -33,6 +33,7 @@ import {
   FeatureSet_Utf8Validation,
   FeatureSetDefaults,
   FeatureSetDefaults_FeatureSetEditionDefault,
+  isMessage,
   protoInt64,
   ScalarType,
 } from "@bufbuild/protobuf";
@@ -633,7 +634,7 @@ describe("FeatureResolver", function () {
       ...descExtensions: DescExtension[]
     ): FeatureSet;
     function getDefaults(edition: Edition, ...rest: unknown[]) {
-      if (rest[0] instanceof FeatureSetDefaults) {
+      if (isMessage(rest[0], FeatureSetDefaults)) {
         const compiledFeatureSetDefaults = rest[0];
         const resolver = FeatureResolver.create(
           edition,

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -53,9 +53,4 @@ describe("isMessage", () => {
 
     expect(isMessage(user, JS_User)).toBeTruthy();
   });
-  // test("Message is a message", () => {
-  //   const msg = new Message();
-  //   expect(isMessage(msg)).toBeFalsy();
-  //   expect(isMessage(msg)).toBeFalsy();
-  // });
 });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -1,0 +1,33 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "@jest/globals";
+import { User } from "./gen/ts/extra/example_pb.js";
+import { isMessage, Message } from "@bufbuild/protobuf";
+
+describe("isMessage", () => {
+  test("Message", () => {
+    const msg = new Message();
+
+    expect(isMessage(msg)).toBeTruthy();
+  });
+  test("subclass of Message", () => {
+    const user = new User({
+      firstName: "Homer",
+      lastName: "Simpson",
+    });
+
+    expect(isMessage(user, User)).toBeTruthy();
+  });
+});

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -13,17 +13,49 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { User } from "./gen/ts/extra/example_pb.js";
-import { isMessage } from "@bufbuild/protobuf";
+import { User as TS_User } from "./gen/ts/extra/example_pb.js";
+import { User as JS_User } from "./gen/js/extra/example_pb.js";
+import { isMessage, Message } from "@bufbuild/protobuf";
 
 describe("isMessage", () => {
   test("subclass of Message", () => {
-    const user = new User({
+    const user = new TS_User({
       firstName: "Homer",
       lastName: "Simpson",
     });
 
     expect(isMessage(user)).toBeTruthy();
-    expect(isMessage(user, User)).toBeTruthy();
+    expect(isMessage(user, TS_User)).toBeTruthy();
   });
+  test("returns false if expected Message property is not a function", () => {
+    const user = new TS_User({
+      firstName: "Homer",
+      lastName: "Simpson",
+    });
+    // @ts-ignore - Setting to a boolean to force a failure
+    user.toJson = false;
+
+    expect(isMessage(user, TS_User)).toBeFalsy();
+  });
+  test("null returns false", () => {
+    expect(isMessage(null)).toBeFalsy();
+    expect(isMessage(null, TS_User)).toBeFalsy();
+  });
+  test("non-object returns false", () => {
+    expect(isMessage("test")).toBeFalsy();
+    expect(isMessage("test", TS_User)).toBeFalsy();
+  });
+  test("mixed instances", () => {
+    const user = new TS_User({
+      firstName: "Homer",
+      lastName: "Simpson",
+    });
+
+    expect(isMessage(user, JS_User)).toBeTruthy();
+  });
+  // test("Message is a message", () => {
+  //   const msg = new Message();
+  //   expect(isMessage(msg)).toBeFalsy();
+  //   expect(isMessage(msg)).toBeFalsy();
+  // });
 });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -56,9 +56,11 @@ describe("isMessage", () => {
   test("type guard works as expected", () => {
     const user: unknown = new TS_User();
     if (isMessage(user)) {
+      // @ts-ignore
       expect(user.toJsonString).toBeDefined();
     }
     if (isMessage(user, TS_User)) {
+      // @ts-ignore
       expect(user.firstName).toBeDefined();
     }
   });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, test } from "@jest/globals";
 import { User as TS_User } from "./gen/ts/extra/example_pb.js";
 import { User as JS_User } from "./gen/js/extra/example_pb.js";
-import { isMessage, Message } from "@bufbuild/protobuf";
+import { isMessage } from "@bufbuild/protobuf";
 
 describe("isMessage", () => {
   test("subclass of Message", () => {

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -56,11 +56,9 @@ describe("isMessage", () => {
   test("type guard works as expected", () => {
     const user: unknown = new TS_User();
     if (isMessage(user)) {
-      // @ts-ignore
       expect(user.toJsonString).toBeDefined();
     }
     if (isMessage(user, TS_User)) {
-      // @ts-ignore
       expect(user.firstName).toBeDefined();
     }
   });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -53,4 +53,13 @@ describe("isMessage", () => {
 
     expect(isMessage(user, JS_User)).toBeTruthy();
   });
+  test("type guard works as expected", () => {
+    const user: unknown = new TS_User();
+    if (isMessage(user)) {
+      expect(user.toJsonString).toBeDefined();
+    }
+    if (isMessage(user, TS_User)) {
+      expect(user.firstName).toBeDefined();
+    }
+  });
 });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -56,9 +56,11 @@ describe("isMessage", () => {
   test("type guard works as expected", () => {
     const user: unknown = new TS_User();
     if (isMessage(user)) {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(user.toJsonString).toBeDefined();
     }
     if (isMessage(user, TS_User)) {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(user.firstName).toBeDefined();
     }
   });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -32,7 +32,7 @@ describe("isMessage", () => {
       firstName: "Homer",
       lastName: "Simpson",
     });
-    // @ts-ignore - Setting to a boolean to force a failure
+    // @ts-expect-error: Setting to a boolean to force a failure
     user.toJson = false;
 
     expect(isMessage(user, TS_User)).toBeFalsy();

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -20,14 +20,22 @@ describe("isMessage", () => {
   test("Message", () => {
     const msg = new Message();
 
-    expect(isMessage(msg)).toBeTruthy();
-  });
-  test("subclass of Message", () => {
     const user = new User({
       firstName: "Homer",
       lastName: "Simpson",
     });
+    console.log(user.getType());
 
-    expect(isMessage(user, User)).toBeTruthy();
+    console.log(msg.getType().typeName);
+
+    expect(isMessage(msg)).toBeTruthy();
   });
+  // test("subclass of Message", () => {
+  //   const user = new User({
+  //     firstName: "Homer",
+  //     lastName: "Simpson",
+  //   });
+
+  //   expect(isMessage(user, User)).toBeTruthy();
+  // });
 });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -14,28 +14,16 @@
 
 import { describe, expect, test } from "@jest/globals";
 import { User } from "./gen/ts/extra/example_pb.js";
-import { isMessage, Message } from "@bufbuild/protobuf";
+import { isMessage } from "@bufbuild/protobuf";
 
 describe("isMessage", () => {
-  test("Message", () => {
-    const msg = new Message();
-
+  test("subclass of Message", () => {
     const user = new User({
       firstName: "Homer",
       lastName: "Simpson",
     });
-    console.log(user.getType());
 
-    console.log(msg.getType().typeName);
-
-    expect(isMessage(msg)).toBeTruthy();
+    expect(isMessage(user)).toBeTruthy();
+    expect(isMessage(user, User)).toBeTruthy();
   });
-  // test("subclass of Message", () => {
-  //   const user = new User({
-  //     firstName: "Homer",
-  //     lastName: "Simpson",
-  //   });
-
-  //   expect(isMessage(user, User)).toBeTruthy();
-  // });
 });

--- a/packages/protobuf-test/src/is-message.test.ts
+++ b/packages/protobuf-test/src/is-message.test.ts
@@ -56,11 +56,9 @@ describe("isMessage", () => {
   test("type guard works as expected", () => {
     const user: unknown = new TS_User();
     if (isMessage(user)) {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(user.toJsonString).toBeDefined();
+      expect(user.toJsonString()).toBeDefined();
     }
     if (isMessage(user, TS_User)) {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(user.firstName).toBeDefined();
     }
   });

--- a/packages/protobuf-test/src/mixing-instances.test.ts
+++ b/packages/protobuf-test/src/mixing-instances.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, test } from "@jest/globals";
 import {
   MessageFieldMessage as TS_MessageFieldMessage,
-  MessageFieldMessage_TestMessage as TS_MessageFieldMessage_TestMessage,
+  // MessageFieldMessage_TestMessage as TS_MessageFieldMessage_TestMessage,
 } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage_TestMessage as JS_MessageFieldMessage_TestMessage } from "./gen/js/extra/msg-message_pb.js";
 
@@ -43,8 +43,9 @@ describe("mixing message instances in the constructor", () => {
       messageField: test,
     });
     expect(message.messageField?.name).toBe("foo");
-    expect(message.messageField).toBeInstanceOf(
-      TS_MessageFieldMessage_TestMessage,
-    );
+    // TODO - Need to figure out how to handle this
+    // expect(message.messageField).toBeInstanceOf(
+    //   TS_MessageFieldMessage_TestMessage,
+    // );
   });
 });

--- a/packages/protobuf-test/src/mixing-instances.test.ts
+++ b/packages/protobuf-test/src/mixing-instances.test.ts
@@ -41,6 +41,6 @@ describe("mixing message instances in the constructor", () => {
       messageField: test,
     });
     expect(message.messageField?.name).toBe("foo");
-    expect(isMessage(message.messageField, JS_MessageFieldMessage_TestMessage));
+    expect(message.messageField).toBe(test);
   });
 });

--- a/packages/protobuf-test/src/mixing-instances.test.ts
+++ b/packages/protobuf-test/src/mixing-instances.test.ts
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import {
-  MessageFieldMessage as TS_MessageFieldMessage,
-  // MessageFieldMessage_TestMessage as TS_MessageFieldMessage_TestMessage,
-} from "./gen/ts/extra/msg-message_pb.js";
+import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage_TestMessage as JS_MessageFieldMessage_TestMessage } from "./gen/js/extra/msg-message_pb.js";
+import { isMessage } from "@bufbuild/protobuf";
 
 describe("mixing message instances", () => {
   const message = new TS_MessageFieldMessage();
@@ -37,15 +35,12 @@ describe("mixing message instances", () => {
 });
 
 describe("mixing message instances in the constructor", () => {
-  test("normalizes by creating a new instance", () => {
+  test("matches expected message", () => {
     const test = new JS_MessageFieldMessage_TestMessage({ name: "foo" });
     const message = new TS_MessageFieldMessage({
       messageField: test,
     });
     expect(message.messageField?.name).toBe("foo");
-    // TODO - Need to figure out how to handle this
-    // expect(message.messageField).toBeInstanceOf(
-    //   TS_MessageFieldMessage_TestMessage,
-    // );
+    expect(isMessage(message.messageField, JS_MessageFieldMessage_TestMessage));
   });
 });

--- a/packages/protobuf-test/src/mixing-instances.test.ts
+++ b/packages/protobuf-test/src/mixing-instances.test.ts
@@ -15,7 +15,6 @@
 import { describe, expect, test } from "@jest/globals";
 import { MessageFieldMessage as TS_MessageFieldMessage } from "./gen/ts/extra/msg-message_pb.js";
 import { MessageFieldMessage_TestMessage as JS_MessageFieldMessage_TestMessage } from "./gen/js/extra/msg-message_pb.js";
-import { isMessage } from "@bufbuild/protobuf";
 
 describe("mixing message instances", () => {
   const message = new TS_MessageFieldMessage();

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -55,7 +55,6 @@ import type { BinaryReadOptions, BinaryWriteOptions } from "./binary-format.js";
 import type { FeatureResolverFn } from "./private/feature-set.js";
 import { createFeatureResolver } from "./private/feature-set.js";
 import { LongType, ScalarType } from "./scalar.js";
-import { isMessage } from "./is-message.js";
 
 /**
  * Create a DescriptorSet, a convenient interface for working with a set of
@@ -77,11 +76,12 @@ export function createDescriptorSet(
     extensions: new Map<string, DescExtension>(),
     mapEntries: new Map<string, DescMessage>(),
   };
-  const fileDescriptors = isMessage(input, FileDescriptorSet)
-    ? input.file
-    : input instanceof Uint8Array
-      ? FileDescriptorSet.fromBinary(input).file
-      : input;
+  const fileDescriptors =
+    input instanceof FileDescriptorSet
+      ? input.file
+      : input instanceof Uint8Array
+        ? FileDescriptorSet.fromBinary(input).file
+        : input;
   const resolverByEdition = new Map<Edition, FeatureResolverFn>();
   for (const proto of fileDescriptors) {
     const edition =

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -55,6 +55,7 @@ import type { BinaryReadOptions, BinaryWriteOptions } from "./binary-format.js";
 import type { FeatureResolverFn } from "./private/feature-set.js";
 import { createFeatureResolver } from "./private/feature-set.js";
 import { LongType, ScalarType } from "./scalar.js";
+import { isMessage } from "./is-message.js";
 
 /**
  * Create a DescriptorSet, a convenient interface for working with a set of
@@ -76,12 +77,11 @@ export function createDescriptorSet(
     extensions: new Map<string, DescExtension>(),
     mapEntries: new Map<string, DescMessage>(),
   };
-  const fileDescriptors =
-    input instanceof FileDescriptorSet
-      ? input.file
-      : input instanceof Uint8Array
-        ? FileDescriptorSet.fromBinary(input).file
-        : input;
+  const fileDescriptors = isMessage(input, FileDescriptorSet)
+    ? input.file
+    : input instanceof Uint8Array
+      ? FileDescriptorSet.fromBinary(input).file
+      : input;
   const resolverByEdition = new Map<Edition, FeatureResolverFn>();
   for (const proto of fileDescriptors) {
     const edition =

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -55,6 +55,7 @@ import type { BinaryReadOptions, BinaryWriteOptions } from "./binary-format.js";
 import type { FeatureResolverFn } from "./private/feature-set.js";
 import { createFeatureResolver } from "./private/feature-set.js";
 import { LongType, ScalarType } from "./scalar.js";
+import { isMessage } from "./is-message";
 
 /**
  * Create a DescriptorSet, a convenient interface for working with a set of
@@ -76,12 +77,11 @@ export function createDescriptorSet(
     extensions: new Map<string, DescExtension>(),
     mapEntries: new Map<string, DescMessage>(),
   };
-  const fileDescriptors =
-    input instanceof FileDescriptorSet
-      ? input.file
-      : input instanceof Uint8Array
-        ? FileDescriptorSet.fromBinary(input).file
-        : input;
+  const fileDescriptors = isMessage(input, FileDescriptorSet)
+    ? input.file
+    : input instanceof Uint8Array
+      ? FileDescriptorSet.fromBinary(input).file
+      : input;
   const resolverByEdition = new Map<Edition, FeatureResolverFn>();
   for (const proto of fileDescriptors) {
     const edition =

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -66,7 +66,6 @@ import type {
 import { createDescriptorSet } from "./create-descriptor-set.js";
 import type { Extension } from "./extension.js";
 import type { ExtensionFieldSource } from "./private/extensions.js";
-import { isMessage } from "./is-message.js";
 
 // well-known message types with specialized JSON representation
 const wkMessages = [
@@ -112,7 +111,7 @@ export function createRegistryFromDescriptors(
   IExtensionRegistry &
   IServiceTypeRegistry {
   const set: DescriptorSet =
-    input instanceof Uint8Array || isMessage(input, FileDescriptorSet)
+    input instanceof Uint8Array || input instanceof FileDescriptorSet
       ? createDescriptorSet(input)
       : input;
   const enums = new Map<string, EnumType>();

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -66,6 +66,7 @@ import type {
 import { createDescriptorSet } from "./create-descriptor-set.js";
 import type { Extension } from "./extension.js";
 import type { ExtensionFieldSource } from "./private/extensions.js";
+import { isMessage } from "./is-message.js";
 
 // well-known message types with specialized JSON representation
 const wkMessages = [
@@ -111,7 +112,7 @@ export function createRegistryFromDescriptors(
   IExtensionRegistry &
   IServiceTypeRegistry {
   const set: DescriptorSet =
-    input instanceof Uint8Array || input instanceof FileDescriptorSet
+    input instanceof Uint8Array || isMessage(input, FileDescriptorSet)
       ? createDescriptorSet(input)
       : input;
   const enums = new Map<string, EnumType>();

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -66,6 +66,7 @@ import type {
 import { createDescriptorSet } from "./create-descriptor-set.js";
 import type { Extension } from "./extension.js";
 import type { ExtensionFieldSource } from "./private/extensions.js";
+import { isMessage } from "./is-message";
 
 // well-known message types with specialized JSON representation
 const wkMessages = [
@@ -111,7 +112,7 @@ export function createRegistryFromDescriptors(
   IExtensionRegistry &
   IServiceTypeRegistry {
   const set: DescriptorSet =
-    input instanceof Uint8Array || input instanceof FileDescriptorSet
+    input instanceof Uint8Array || isMessage(input, FileDescriptorSet)
       ? createDescriptorSet(input)
       : input;
   const enums = new Map<string, EnumType>();

--- a/packages/protobuf/src/is-message.ts
+++ b/packages/protobuf/src/is-message.ts
@@ -25,11 +25,14 @@ import { Message } from "./message.js";
  * class identity. This makes it robust against the dual package hazard and
  * similar situations, where the same message is duplicated.
  *
- * In most cases, `isMessage` should be preferred over `instanceof`. However, due
- * to the fact that `isMessage` does not use class identity, there are subtle
- * differences between this function and `instanceof`.
- * Notably, calling `isMessage` on an explicit type of Message will return
- * false.
+ * This function is _mostly_ equivalent to the `instanceof` operator. For
+ * example, `isMessage(foo, MyMessage)` is the same as `foo instanceof MyMessage`,
+ * and `isMessage(foo)` is the same as `foo instanceof Message`. In most cases,
+ * `isMessage` should be preferred over `instanceof`.
+ *
+ * However, due to the fact that `isMessage` does not use class identity, there
+ * are subtle differences between this function and `instanceof`. Notably,
+ * calling `isMessage` on an explicit type of Message will return false.
  */
 export function isMessage<T extends Message<T> = AnyMessage>(
   arg: unknown,

--- a/packages/protobuf/src/is-message.ts
+++ b/packages/protobuf/src/is-message.ts
@@ -17,16 +17,19 @@ import type { AnyMessage } from "./message.js";
 import { Message } from "./message.js";
 
 /**
- * Check whether the given object is an instance of the given message type.
- *
- * This function is equivalent to the `instanceof` operator. For example,
- * `isMessage(foo, MyMessage)` is the same as `foo instanceof MyMessage`, and
- * `isMessage(foo)` is the same as `foo instanceof Message`.
+ * Check whether the given object is any subtype of Message or is a specific
+ * Message by passing the type.
  *
  * Just like `instanceof`, `isMessage` narrows the type. The advantage of
  * `isMessage` is that it compares identity by the message type name, not by
  * class identity. This makes it robust against the dual package hazard and
  * similar situations, where the same message is duplicated.
+ *
+ * In most cases, `isMessage` should be preferred over `instanceof`. However, due
+ * to the fact that `isMessage` does not use class identity, there are subtle
+ * differences between this function and `instanceof`.
+ * Notably, calling `isMessage` on an explicit type of Message will return
+ * false.
  */
 export function isMessage<T extends Message<T> = AnyMessage>(
   arg: unknown,

--- a/packages/protobuf/src/is-message.ts
+++ b/packages/protobuf/src/is-message.ts
@@ -32,7 +32,6 @@ export function isMessage<T extends Message<T> = AnyMessage>(
   arg: unknown,
   type?: MessageType<T>,
 ): arg is T {
-  console.log("Type of arg " + typeof arg);
   if (arg === null || typeof arg != "object") {
     return false;
   }
@@ -45,36 +44,12 @@ export function isMessage<T extends Message<T> = AnyMessage>(
     return false;
   }
   const actualType = (arg as { getType(): unknown }).getType();
-<<<<<<< Updated upstream
-  if (actualType === null || typeof actualType != "function") {
-    return false;
-  }
-
-  console.log(actualType.constructor);
-  console.log(Message);
-
-  const blah = Object.getPrototypeOf(actualType);
-  console.log(Message.prototype);
-  console.log(Object.getOwnPropertyNames(Message.prototype));
-  console.log(Object.getOwnPropertyNames(blah));
-
-  console.log(Object.getPrototypeOf(actualType) === Message.prototype);
-
-  if (actualType.constructor === Message) {
-    console.log("its a message!");
-    return true;
-  }
-
-  if (!("typeName" in actualType) || typeof actualType.typeName != "string") {
-    console.log("failed the last IF");
-=======
   if (
     actualType === null ||
     typeof actualType != "function" ||
     !("typeName" in actualType) ||
     typeof actualType.typeName != "string"
   ) {
->>>>>>> Stashed changes
     return false;
   }
   return type === undefined ? true : actualType.typeName == type.typeName;

--- a/packages/protobuf/src/is-message.ts
+++ b/packages/protobuf/src/is-message.ts
@@ -45,6 +45,7 @@ export function isMessage<T extends Message<T> = AnyMessage>(
     return false;
   }
   const actualType = (arg as { getType(): unknown }).getType();
+<<<<<<< Updated upstream
   if (actualType === null || typeof actualType != "function") {
     return false;
   }
@@ -66,6 +67,14 @@ export function isMessage<T extends Message<T> = AnyMessage>(
 
   if (!("typeName" in actualType) || typeof actualType.typeName != "string") {
     console.log("failed the last IF");
+=======
+  if (
+    actualType === null ||
+    typeof actualType != "function" ||
+    !("typeName" in actualType) ||
+    typeof actualType.typeName != "string"
+  ) {
+>>>>>>> Stashed changes
     return false;
   }
   return type === undefined ? true : actualType.typeName == type.typeName;

--- a/packages/protobuf/src/is-message.ts
+++ b/packages/protobuf/src/is-message.ts
@@ -32,6 +32,7 @@ export function isMessage<T extends Message<T> = AnyMessage>(
   arg: unknown,
   type?: MessageType<T>,
 ): arg is T {
+  console.log("Type of arg " + typeof arg);
   if (arg === null || typeof arg != "object") {
     return false;
   }
@@ -44,12 +45,27 @@ export function isMessage<T extends Message<T> = AnyMessage>(
     return false;
   }
   const actualType = (arg as { getType(): unknown }).getType();
-  if (
-    actualType === null ||
-    typeof actualType != "object" ||
-    !("typeName" in actualType) ||
-    typeof actualType.typeName != "string"
-  ) {
+  if (actualType === null || typeof actualType != "function") {
+    return false;
+  }
+
+  console.log(actualType.constructor);
+  console.log(Message);
+
+  const blah = Object.getPrototypeOf(actualType);
+  console.log(Message.prototype);
+  console.log(Object.getOwnPropertyNames(Message.prototype));
+  console.log(Object.getOwnPropertyNames(blah));
+
+  console.log(Object.getPrototypeOf(actualType) === Message.prototype);
+
+  if (actualType.constructor === Message) {
+    console.log("its a message!");
+    return true;
+  }
+
+  if (!("typeName" in actualType) || typeof actualType.typeName != "string") {
+    console.log("failed the last IF");
     return false;
   }
   return type === undefined ? true : actualType.typeName == type.typeName;

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -27,7 +27,6 @@ import { assert } from "./assert.js";
 import { isFieldSet } from "./reflect.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message.js";
 
 /* eslint-disable prefer-const,no-case-declarations,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return */
 
@@ -211,7 +210,7 @@ function readField(
           readMessageField(reader, new messageType(), options, field),
         );
       } else {
-        if (isMessage(target[localName])) {
+        if (target[localName] instanceof Message) {
           readMessageField(reader, target[localName], options, field);
         } else {
           target[localName] = readMessageField(

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -27,6 +27,7 @@ import { assert } from "./assert.js";
 import { isFieldSet } from "./reflect.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message";
 
 /* eslint-disable prefer-const,no-case-declarations,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return */
 
@@ -210,7 +211,7 @@ function readField(
           readMessageField(reader, new messageType(), options, field),
         );
       } else {
-        if (target[localName] instanceof Message) {
+        if (isMessage(target[localName])) {
           readMessageField(reader, target[localName], options, field);
         } else {
           target[localName] = readMessageField(

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -27,6 +27,7 @@ import { assert } from "./assert.js";
 import { isFieldSet } from "./reflect.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable prefer-const,no-case-declarations,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return */
 
@@ -210,7 +211,7 @@ function readField(
           readMessageField(reader, new messageType(), options, field),
         );
       } else {
-        if (target[localName] instanceof Message) {
+        if (isMessage(target[localName])) {
           readMessageField(reader, target[localName], options, field);
         } else {
           target[localName] = readMessageField(

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -16,6 +16,7 @@ import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { DescExtension, DescField } from "../descriptor-set.js";
 import { ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- unknown fields are represented with any */
 
@@ -40,7 +41,7 @@ export function wrapField<T extends Message<T>>(
   type: MessageType<T>,
   value: any,
 ): T {
-  if (value instanceof Message || !type.fieldWrapper) {
+  if (isMessage(value) || !type.fieldWrapper) {
     return value as T;
   }
   return type.fieldWrapper.wrapField(value);

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -16,7 +16,6 @@ import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { DescExtension, DescField } from "../descriptor-set.js";
 import { ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- unknown fields are represented with any */
 
@@ -41,7 +40,7 @@ export function wrapField<T extends Message<T>>(
   type: MessageType<T>,
   value: any,
 ): T {
-  if (isMessage(value) || !type.fieldWrapper) {
+  if (value instanceof Message || !type.fieldWrapper) {
     return value as T;
   }
   return type.fieldWrapper.wrapField(value);

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -16,6 +16,7 @@ import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { DescExtension, DescField } from "../descriptor-set.js";
 import { ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- unknown fields are represented with any */
 
@@ -40,7 +41,7 @@ export function wrapField<T extends Message<T>>(
   type: MessageType<T>,
   value: any,
 ): T {
-  if (value instanceof Message || !type.fieldWrapper) {
+  if (isMessage(value) || !type.fieldWrapper) {
     return value as T;
   }
   return type.fieldWrapper.wrapField(value);

--- a/packages/protobuf/src/private/json-format.ts
+++ b/packages/protobuf/src/private/json-format.ts
@@ -45,6 +45,7 @@ import { scalarZeroValue } from "./scalars.js";
 import { isScalarZeroValue } from "./scalars.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable no-case-declarations,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
 
@@ -385,7 +386,7 @@ function readField(
           return;
         }
         let currentValue = target[localName] as Message | undefined;
-        if (currentValue instanceof Message) {
+        if (isMessage(currentValue)) {
           currentValue.fromJson(jsonValue, options);
         } else {
           target[localName] = currentValue = messageType.fromJson(

--- a/packages/protobuf/src/private/json-format.ts
+++ b/packages/protobuf/src/private/json-format.ts
@@ -45,7 +45,6 @@ import { scalarZeroValue } from "./scalars.js";
 import { isScalarZeroValue } from "./scalars.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message.js";
 
 /* eslint-disable no-case-declarations,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
 
@@ -386,7 +385,7 @@ function readField(
           return;
         }
         let currentValue = target[localName] as Message | undefined;
-        if (isMessage(currentValue)) {
+        if (currentValue instanceof Message) {
           currentValue.fromJson(jsonValue, options);
         } else {
           target[localName] = currentValue = messageType.fromJson(

--- a/packages/protobuf/src/private/json-format.ts
+++ b/packages/protobuf/src/private/json-format.ts
@@ -45,6 +45,7 @@ import { scalarZeroValue } from "./scalars.js";
 import { isScalarZeroValue } from "./scalars.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message";
 
 /* eslint-disable no-case-declarations,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
 
@@ -385,7 +386,7 @@ function readField(
           return;
         }
         let currentValue = target[localName] as Message | undefined;
-        if (currentValue instanceof Message) {
+        if (isMessage(currentValue)) {
           currentValue.fromJson(jsonValue, options);
         } else {
           target[localName] = currentValue = messageType.fromJson(

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -19,7 +19,6 @@ import type { MessageType } from "../message-type.js";
 import type { Util } from "./util.js";
 import { scalarEquals } from "./scalars.js";
 import { ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-argument,no-case-declarations */
 
@@ -53,7 +52,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             if (
               sourceField &&
               sourceField.kind == "message" &&
-              !isMessage(val, sourceField.T)
+              !(val instanceof sourceField.T)
             ) {
               val = new sourceField.T(val);
             } else if (
@@ -105,7 +104,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             const mt = member.T;
             if (member.repeated) {
               t[localName] = (s[localName] as any[]).map((val) =>
-                isMessage(val, mt) ? val : new mt(val),
+                val instanceof mt ? val : new mt(val),
               );
             } else {
               const val = s[localName];
@@ -119,7 +118,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
                   t[localName] = val;
                 }
               } else {
-                t[localName] = isMessage(val, mt) ? val : new mt(val);
+                t[localName] = val instanceof mt ? val : new mt(val);
               }
             }
             break;
@@ -240,7 +239,7 @@ function cloneSingularField(value: any): any {
   if (value === undefined) {
     return value;
   }
-  if (isMessage(value)) {
+  if (value instanceof Message) {
     return value.clone();
   }
   if (value instanceof Uint8Array) {

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -53,7 +53,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             if (
               sourceField &&
               sourceField.kind == "message" &&
-              !(val instanceof sourceField.T)
+              !isMessage(val, sourceField.T)
             ) {
               val = new sourceField.T(val);
             } else if (
@@ -105,7 +105,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             const mt = member.T;
             if (member.repeated) {
               t[localName] = (s[localName] as any[]).map((val) =>
-                val instanceof mt ? val : new mt(val),
+                isMessage(val, mt) ? val : new mt(val),
               );
             } else {
               const val = s[localName];
@@ -119,7 +119,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
                   t[localName] = val;
                 }
               } else {
-                t[localName] = val instanceof mt ? val : new mt(val);
+                t[localName] = isMessage(val, mt) ? val : new mt(val);
               }
             }
             break;

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -19,6 +19,7 @@ import type { MessageType } from "../message-type.js";
 import type { Util } from "./util.js";
 import { scalarEquals } from "./scalars.js";
 import { ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message";
 
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-argument,no-case-declarations */
 
@@ -239,7 +240,7 @@ function cloneSingularField(value: any): any {
   if (value === undefined) {
     return value;
   }
-  if (value instanceof Message) {
+  if (isMessage(value)) {
     return value.clone();
   }
   if (value instanceof Uint8Array) {

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -19,6 +19,7 @@ import type { MessageType } from "../message-type.js";
 import type { Util } from "./util.js";
 import { scalarEquals } from "./scalars.js";
 import { ScalarType } from "../scalar.js";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-argument,no-case-declarations */
 
@@ -52,7 +53,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             if (
               sourceField &&
               sourceField.kind == "message" &&
-              !(val instanceof sourceField.T)
+              !isMessage(val, sourceField.T)
             ) {
               val = new sourceField.T(val);
             } else if (
@@ -104,7 +105,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
             const mt = member.T;
             if (member.repeated) {
               t[localName] = (s[localName] as any[]).map((val) =>
-                val instanceof mt ? val : new mt(val),
+                isMessage(val, mt) ? val : new mt(val),
               );
             } else {
               const val = s[localName];
@@ -118,7 +119,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
                   t[localName] = val;
                 }
               } else {
-                t[localName] = val instanceof mt ? val : new mt(val);
+                t[localName] = isMessage(val, mt) ? val : new mt(val);
               }
             }
             break;
@@ -239,7 +240,7 @@ function cloneSingularField(value: any): any {
   if (value === undefined) {
     return value;
   }
-  if (value instanceof Message) {
+  if (isMessage(value)) {
     return value.clone();
   }
   if (value instanceof Uint8Array) {

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -16,7 +16,6 @@
 
 import { Message } from "./message.js";
 import type { AnyMessage, PlainMessage } from "./message.js";
-import { isMessage } from "./is-message.js";
 
 /**
  * toPlainMessage returns a new object by stripping
@@ -30,8 +29,8 @@ import { isMessage } from "./is-message.js";
 export function toPlainMessage<T extends Message<T>>(
   message: T | PlainMessage<T>,
 ): PlainMessage<T> {
-  if (!isMessage(message)) {
-    return message as PlainMessage<T>;
+  if (!(message instanceof Message)) {
+    return message;
   }
 
   const type = message.getType();
@@ -63,7 +62,7 @@ function toPlainValue(value: any) {
   if (value === undefined) {
     return value;
   }
-  if (isMessage(value)) {
+  if (value instanceof Message) {
     return toPlainMessage(value);
   }
   if (value instanceof Uint8Array) {

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -16,6 +16,7 @@
 
 import { Message } from "./message.js";
 import type { AnyMessage, PlainMessage } from "./message.js";
+import { isMessage } from "./is-message";
 
 /**
  * toPlainMessage returns a new object by stripping
@@ -29,8 +30,8 @@ import type { AnyMessage, PlainMessage } from "./message.js";
 export function toPlainMessage<T extends Message<T>>(
   message: T | PlainMessage<T>,
 ): PlainMessage<T> {
-  if (!(message instanceof Message)) {
-    return message;
+  if (!isMessage(message)) {
+    return message as PlainMessage<T>;
   }
 
   const type = message.getType();
@@ -62,7 +63,7 @@ function toPlainValue(value: any) {
   if (value === undefined) {
     return value;
   }
-  if (value instanceof Message) {
+  if (isMessage(value)) {
     return toPlainMessage(value);
   }
   if (value instanceof Uint8Array) {

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -16,6 +16,7 @@
 
 import { Message } from "./message.js";
 import type { AnyMessage, PlainMessage } from "./message.js";
+import { isMessage } from "./is-message.js";
 
 /**
  * toPlainMessage returns a new object by stripping
@@ -29,8 +30,8 @@ import type { AnyMessage, PlainMessage } from "./message.js";
 export function toPlainMessage<T extends Message<T>>(
   message: T | PlainMessage<T>,
 ): PlainMessage<T> {
-  if (!(message instanceof Message)) {
-    return message;
+  if (!isMessage(message)) {
+    return message as PlainMessage<T>;
   }
 
   const type = message.getType();
@@ -62,7 +63,7 @@ function toPlainValue(value: any) {
   if (value === undefined) {
     return value;
   }
-  if (value instanceof Message) {
+  if (isMessage(value)) {
     return toPlainMessage(value);
   }
   if (value instanceof Uint8Array) {


### PR DESCRIPTION
This replaces the usage of `instanceof Message` (and `Message` subclasses) with the new `isMessage` function. In addition, it adds some tests to verify behavior.

`isMessage` can be used to determine whether a given object is any subtype of `Message` or is a specific
`Message` by passing the type. It is recommended to use this instead of `instanceof Message`.

**Example usage**
```typescript
import { isMessage } from "@bufbuild/protobuf";

const user = new User({
    firstName: "Homer",
});

isMessage(user);                    // true
isMessage(user, User);              // true
isMessage(user, OtherMessageType);  // false
```

View the docs [here](./docs/runtime-api.md#identifying-messages).

**Perf benchmarks:**
```
// isMessage
large google.protobuf.FileDescriptorSet (1061190 bytes) x 60.52 ops/sec ±1.13% (63 runs sampled)
tiny docs.User (4 bytes) x 3,386,238 ops/sec ±0.19% (100 runs sampled)
scalar values (102 bytes) x 630,178 ops/sec ±0.19% (96 runs sampled)
repeated scalar fields (195 bytes) x 401,749 ops/sec ±0.19% (98 runs sampled)
map with scalar keys and values (186 bytes) x 225,122 ops/sec ±0.21% (100 runs sampled)
repeated field with 1000 messages (2000 bytes) x 7,154 ops/sec ±0.42% (96 runs sampled)
map field with 1000 messages (8890 bytes) x 3,594 ops/sec ±0.21% (98 runs sampled)
```

```
// main
large google.protobuf.FileDescriptorSet (1061190 bytes) x 60.74 ops/sec ±1.27% (64 runs sampled)
tiny docs.User (4 bytes) x 3,416,634 ops/sec ±0.24% (97 runs sampled)
scalar values (102 bytes) x 627,019 ops/sec ±0.23% (99 runs sampled)
repeated scalar fields (195 bytes) x 397,073 ops/sec ±1.53% (97 runs sampled)
map with scalar keys and values (186 bytes) x 224,147 ops/sec ±0.42% (98 runs sampled)
repeated field with 1000 messages (2000 bytes) x 7,162 ops/sec ±0.39% (95 runs sampled)
map field with 1000 messages (8890 bytes) x 3,307 ops/sec ±0.20% (97 runs sampled)
```

