### PR TITLE
Remove redundant type MergedFeatureSet

### DIFF
--- a/packages/protobuf/src/descriptor-set.ts
+++ b/packages/protobuf/src/descriptor-set.ts
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {
+import {
   DescriptorProto,
   Edition,
   EnumDescriptorProto,
   EnumValueDescriptorProto,
+  FeatureSet,
   FieldDescriptorProto,
   FileDescriptorProto,
   MethodDescriptorProto,
@@ -25,7 +26,6 @@ import type {
 } from "./google/protobuf/descriptor_pb.js";
 import { LongType, ScalarType } from "./scalar.js";
 import type { MethodIdempotency, MethodKind } from "./service-type.js";
-import type { MergedFeatureSet } from "./private/feature-set.js";
 
 /**
  * DescriptorSet provides a convenient interface for working with a set
@@ -150,7 +150,7 @@ export interface DescFile {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -202,7 +202,7 @@ export interface DescEnum {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -247,7 +247,7 @@ export interface DescEnumValue {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -318,7 +318,7 @@ export interface DescMessage {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -421,7 +421,7 @@ interface DescFieldCommon {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -673,7 +673,7 @@ export interface DescOneof {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -716,7 +716,7 @@ export interface DescService {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }
@@ -767,7 +767,7 @@ export interface DescMethod {
   /**
    * Get the edition features for this protobuf element.
    */
-  getFeatures(): MergedFeatureSet;
+  getFeatures(): FeatureSet;
 
   toString(): string;
 }

--- a/packages/protobuf/src/private/feature-set.ts
+++ b/packages/protobuf/src/private/feature-set.ts
@@ -38,21 +38,13 @@ function getFeatureSetDefaults(
 }
 
 /**
- * A merged google.protobuf.FeaturesSet, with all fields guaranteed to be set.
- */
-export type MergedFeatureSet = FeatureSet & Required<FeatureSet>;
-
-/**
  * A function that resolves features.
  *
  * If no feature set is provided, the default feature set for the edition is
  * returned. If features are provided, they are merged into the edition default
  * features.
  */
-export type FeatureResolverFn = (
-  a?: FeatureSet,
-  b?: FeatureSet,
-) => MergedFeatureSet;
+export type FeatureResolverFn = (a?: FeatureSet, b?: FeatureSet) => FeatureSet;
 
 /**
  * Create an edition feature resolver with the given feature set defaults, or
@@ -102,7 +94,7 @@ export function createFeatureResolver(
     throw new Error(`No valid default found for edition ${Edition[edition]}`);
   }
   const featureSetBin = highestMatch.f.toBinary(serializationOptions);
-  return (...rest): MergedFeatureSet => {
+  return (...rest): FeatureSet => {
     const f = FeatureSet.fromBinary(featureSetBin, serializationOptions);
     for (const c of rest) {
       if (c !== undefined) {
@@ -135,7 +127,7 @@ export function createFeatureResolver(
 // FeatureSet are set.
 function validateMergedFeatures(
   featureSet: FeatureSet,
-): featureSet is MergedFeatureSet {
+): featureSet is FeatureSet {
   for (const fi of FeatureSet.fields.list()) {
     const v = featureSet[fi.localName as keyof FeatureSet] as unknown;
     if (fi.kind == "enum" && v === 0) {


### PR DESCRIPTION
With https://github.com/bufbuild/protobuf-es/pull/716, the typings for `FeatureSet` have changes, and the type `MergedFeatureSet` is no longer useful. 