### PR TITLE
Run CI processes against v2 branch also

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: ci
 on:
   push:
-    branches: [main]
+    branches: [main, v2]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, v2]
   workflow_dispatch:
 jobs:
   ci:

--- a/.github/workflows/notify-approval-bypass.yaml
+++ b/.github/workflows/notify-approval-bypass.yaml
@@ -3,8 +3,7 @@ on:
   pull_request:
     types:
       - closed
-    branches:
-      - main
+    branches: [main, v2]
 permissions:
   pull-requests: read
 jobs:


### PR DESCRIPTION
This adds the `v2` branch to our CI workflows so that the CI processes (and the approval bypass) Github actions are run when pull requests and merges happen with that branch. 