### PR TITLE
Update DescField structure

### DIFF
--- a/packages/protobuf-test/src/jstype.test.ts
+++ b/packages/protobuf-test/src/jstype.test.ts
@@ -204,7 +204,14 @@ describe("createRegistryFromDescriptors with jstype", () => {
     assert(mt);
     for (const field of mt.fields) {
       test(`${messageTypeName} field #${field.number}`, () => {
-        expect(field.longType).toBe(longType);
+        if (
+          field.fieldKind == "scalar" ||
+          (field.fieldKind == "list" && field.listKind == "scalar")
+        ) {
+          expect(field.longType).toBe(longType);
+        } else {
+          expect(false).toBe(true);
+        }
       });
     }
   }

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -56,9 +56,6 @@ export function getUnwrappedFieldType(
   if (field.fieldKind !== "message") {
     return undefined;
   }
-  if (field.repeated) {
-    return undefined;
-  }
   if (field.oneof != undefined) {
     return undefined;
   }

--- a/packages/protoc-gen-es/src/typescript.ts
+++ b/packages/protoc-gen-es/src/typescript.ts
@@ -199,7 +199,7 @@ function generateExtension(
   f.print(f.exportDecl("const", ext), " = ", protoN, ".makeExtension<", ext.extendee, ", ", typing, ">(");
   f.print("  ", f.string(ext.typeName), ", ");
   f.print("  ", ext.extendee, ", ");
-  if (ext.fieldKind == "scalar") {
+  if (ext.fieldKind == "scalar" || (ext.fieldKind == "list" && ext.listKind == "scalar")) {
     f.print("  ", getFieldInfoLiteral(schema, ext), ",");
   } else {
     f.print("  () => (", getFieldInfoLiteral(schema, ext), "),");
@@ -470,7 +470,7 @@ function generateWktMethods(schema: Schema, f: GeneratedFile, message: DescMessa
       f.print(`      throw new Error("cannot decode `, message.typeName, ` from JSON " + `, protoN, `.json.debug(json));`)
       f.print("    }")
       f.print("    for (const [k, v] of Object.entries(json)) {")
-      f.print("      this.", localName(ref.fields), "[k] = ", ref.fields.mapValue.message ?? "", ".fromJson(v);")
+      f.print("      this.", localName(ref.fields), "[k] = ", ref.fields.message ?? "", ".fromJson(v);")
       f.print("    }")
       f.print("    return this;")
       f.print("  }")


### PR DESCRIPTION
This PR changes the `DescField` type, our wrapper for the Protobuf message `FieldDescriptorProto`. 

Before, fields could be of four different kinds, discriminated by `fieldKind: "scalar" | "enum" | "message" | "map"`. This PR adds a fifth case `"list"`, and removes the property `repeated`. List fields receive an additional discriminator `listKind: "scalar" | "enum" | "message"`, and re-uses the existing properties "scalar", "enum", and "message" for the element type.

The same pattern was applied to map fields: For `fieldKind: "map"`, the property `mapValue` is replaced by `mapKind: "scalar" | "enum" | "message"`. 

As a result, the following switch statements exhaustively cover all major field types:

```ts
function f(field: DescField) {
  switch (field.fieldKind) {
    case "message":
      break;
    case "scalar":
      break;
    case "enum":
      break;
    case "list":
      switch (field.listKind) {
        case "scalar":
          break;
        case "message":
          break;
        case "enum":
          break;
      }
      break;
    case "map":
      switch (field.mapKind) {
        case "scalar":
          break;
        case "message":
          break;
        case "enum":
          break;
      }
      break;
  }
}
```

We also limit the visibility of properties that are specific to certain field types. For example, the property `longType` is only available for scalar fields (singular, or in a list).
