### PR TITLE
Fix JSON serialization docs

### DIFF
--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -949,7 +949,7 @@ Options for `Message.fromBinary`:
 
 ### JSON serialization options
 
-Options for `Message.fromJson` and `Message.fromJsonString`:
+Options for `Message.toJson` and `Message.toJsonString`:
 
 - `emitDefaultValues?: boolean`<br/>
   Fields with default values are omitted by default in JSON output.
@@ -969,7 +969,7 @@ Options for `Message.fromJson` and `Message.fromJsonString`:
   option to `JSON.stringify`, which controls indentation for prettier output.
   See the [`JSON.stringify` docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#parameters).
 
-Options for `Message.toJson` and `Message.toJsonString`:
+Options for `Message.fromJson` and `Message.fromJsonString`:
 
 - `ignoreUnknownFields?: boolean`<br/>
   By default, unknown properties are rejected.

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -949,6 +949,16 @@ Options for `Message.fromBinary`:
 
 ### JSON serialization options
 
+Options for `Message.fromJson` and `Message.fromJsonString`:
+
+- `ignoreUnknownFields?: boolean`<br/>
+  By default, unknown properties are rejected.
+  This option overrides this behavior and ignores properties, as
+  well as unrecognized enum string representations.
+- `typeRegistry?: IMessageTypeRegistry & Partial<IExtensionRegistry>`<br/>
+  A registry to parse [extensions](#extensions-and-json) and 
+  [google.protobuf.Any](#any) from JSON.
+
 Options for `Message.toJson` and `Message.toJsonString`:
 
 - `emitDefaultValues?: boolean`<br/>
@@ -968,16 +978,6 @@ Options for `Message.toJson` and `Message.toJsonString`:
   Only available with `toJsonString`. A convenience property for the `space` 
   option to `JSON.stringify`, which controls indentation for prettier output.
   See the [`JSON.stringify` docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#parameters).
-
-Options for `Message.fromJson` and `Message.fromJsonString`:
-
-- `ignoreUnknownFields?: boolean`<br/>
-  By default, unknown properties are rejected.
-  This option overrides this behavior and ignores properties, as
-  well as unrecognized enum string representations.
-- `typeRegistry?: IMessageTypeRegistry & Partial<IExtensionRegistry>`<br/>
-  A registry to parse [extensions](#extensions-and-json) and 
-  [google.protobuf.Any](#any) from JSON.
 
 
 ### JSON.stringify


### PR DESCRIPTION
Fixes #737 

This fixes the JSON serialization docs to list options for the correct methods.