### PR TITLE
Add type guard for PluginOptionError

### DIFF
--- a/packages/protoplugin/src/error.ts
+++ b/packages/protoplugin/src/error.ts
@@ -39,8 +39,5 @@ export function isPluginOptionError(arg: unknown): arg is PluginOptionError {
   if (!(arg instanceof Error)) {
     return false;
   }
-  if (Object.getPrototypeOf(arg) === PluginOptionError.prototype) {
-    return true;
-  }
   return arg.name === "PluginOptionError";
 }

--- a/packages/protoplugin/src/error.ts
+++ b/packages/protoplugin/src/error.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 export class PluginOptionError extends Error {
+  override name = "PluginOptionError";
+
   constructor(option: string, reason?: unknown) {
     const detail = reason !== undefined ? reasonToString(reason) : "";
     super(
@@ -31,4 +33,14 @@ export function reasonToString(reason: unknown): string {
     return reason;
   }
   return String(reason);
+}
+
+export function isPluginOptionError(arg: unknown): arg is PluginOptionError {
+  if (!(arg instanceof Error)) {
+    return false;
+  }
+  if (Object.getPrototypeOf(arg) === PluginOptionError.prototype) {
+    return true;
+  }
+  return arg.name === "PluginOptionError";
 }

--- a/packages/protoplugin/src/run-node.ts
+++ b/packages/protoplugin/src/run-node.ts
@@ -15,7 +15,7 @@
 import type { Plugin } from "./plugin.js";
 import type { ReadStream, WriteStream } from "tty";
 import { CodeGeneratorRequest } from "@bufbuild/protobuf";
-import { PluginOptionError, reasonToString } from "./error.js";
+import { isPluginOptionError, reasonToString } from "./error.js";
 
 /**
  * Run a plugin with Node.js.
@@ -49,10 +49,9 @@ export function runNodeJs(plugin: Plugin): void {
     })
     .then(() => process.exit(0))
     .catch((reason) => {
-      const message =
-        reason instanceof PluginOptionError
-          ? reason.message
-          : reasonToString(reason);
+      const message = isPluginOptionError(reason)
+        ? reason.message
+        : reasonToString(reason);
       process.stderr.write(`${plugin.name}: ${message}\n`);
       process.exit(1);
       return;


### PR DESCRIPTION
This adds a type guard function for `PluginOptionError` so that `instanceof` is no longer used. For additional details, see #713 