### PR TITLE
Sayers/remove node export

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -10,10 +10,9 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm && npm run build:proxy",
+    "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
-    "build:proxy": "node ../../scripts/gen-esm-proxy.mjs .",
     "bootstrap:featureset-defaults": "upstream-inject-feature-defaults src/private/feature-set.ts",
     "prebootstrap:wkt": "rm -rf .tmp && mkdir -p .tmp/google/protobuf && cp -rp src/google/protobuf/* .tmp/google/protobuf",
     "bootstrap:wkt": "protoc --es_out=src --es_opt=bootstrap_wkt=true,ts_nocheck=false,target=ts --proto_path $(upstream-include wkt) $(upstream-files wkt) && license-header src/google/protobuf",
@@ -25,11 +24,6 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
-      "node": {
-        "import": "./dist/proxy/index.js",
-        "require": "./dist/cjs/index.js"
-      },
-      "module": "./dist/esm/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -55,7 +55,7 @@ import type { BinaryReadOptions, BinaryWriteOptions } from "./binary-format.js";
 import type { FeatureResolverFn } from "./private/feature-set.js";
 import { createFeatureResolver } from "./private/feature-set.js";
 import { LongType, ScalarType } from "./scalar.js";
-import { isMessage } from "./is-message";
+import { isMessage } from "./is-message.js";
 
 /**
  * Create a DescriptorSet, a convenient interface for working with a set of

--- a/packages/protobuf/src/create-registry-from-desc.ts
+++ b/packages/protobuf/src/create-registry-from-desc.ts
@@ -66,7 +66,7 @@ import type {
 import { createDescriptorSet } from "./create-descriptor-set.js";
 import type { Extension } from "./extension.js";
 import type { ExtensionFieldSource } from "./private/extensions.js";
-import { isMessage } from "./is-message";
+import { isMessage } from "./is-message.js";
 
 // well-known message types with specialized JSON representation
 const wkMessages = [

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -27,7 +27,7 @@ import { assert } from "./assert.js";
 import { isFieldSet } from "./reflect.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable prefer-const,no-case-declarations,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return */
 

--- a/packages/protobuf/src/private/field-wrapper.ts
+++ b/packages/protobuf/src/private/field-wrapper.ts
@@ -16,7 +16,7 @@ import { Message } from "../message.js";
 import type { MessageType } from "../message-type.js";
 import type { DescExtension, DescField } from "../descriptor-set.js";
 import { ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- unknown fields are represented with any */
 

--- a/packages/protobuf/src/private/json-format.ts
+++ b/packages/protobuf/src/private/json-format.ts
@@ -45,7 +45,7 @@ import { scalarZeroValue } from "./scalars.js";
 import { isScalarZeroValue } from "./scalars.js";
 import type { ScalarValue } from "../scalar.js";
 import { LongType, ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable no-case-declarations,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
 

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -19,7 +19,7 @@ import type { MessageType } from "../message-type.js";
 import type { Util } from "./util.js";
 import { scalarEquals } from "./scalars.js";
 import { ScalarType } from "../scalar.js";
-import { isMessage } from "../is-message";
+import { isMessage } from "../is-message.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-argument,no-case-declarations */
 

--- a/packages/protobuf/src/to-plain-message.ts
+++ b/packages/protobuf/src/to-plain-message.ts
@@ -16,7 +16,7 @@
 
 import { Message } from "./message.js";
 import type { AnyMessage, PlainMessage } from "./message.js";
-import { isMessage } from "./is-message";
+import { isMessage } from "./is-message.js";
 
 /**
  * toPlainMessage returns a new object by stripping

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -21,19 +21,11 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
-      "node": {
-        "import": "./dist/proxy/index.js",
-        "require": "./dist/cjs/index.js"
-      },
       "module": "./dist/esm/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./ecmascript": {
-      "node": {
-        "import": "./dist/proxy/ecmascript/index.js",
-        "require": "./dist/cjs/ecmascript/index.js"
-      },
       "module": "./dist/esm/ecmascript/index.js",
       "import": "./dist/esm/ecmascript/index.js",
       "require": "./dist/cjs/ecmascript/index.js"

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -34,7 +34,7 @@ import {
   LiteralString,
   RefDescEnum,
   RefDescMessage,
-} from "./opaque-printables";
+} from "./opaque-printables.js";
 
 /**
  * All types that can be passed to GeneratedFile.print()


### PR DESCRIPTION
Fixes #713

In #728, #729, and #742, we made changes that remove a common failure point for the dual package hazard -- usage of `instanceof` with custom types . As a result, the `node` exports condition for our packages should not be necessary and is actually problematic for some bundlers.