### PR TITLE
Update script to bump workspace version to include package-lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,7 @@ bootstrap: $(BUILD)/upstream-protobuf $(BUILD)/protoc-gen-es node_modules ## Boo
 .PHONY: setversion
 setversion: ## Set a new version in for the project, i.e. make setversion SET_VERSION=1.2.3
 	node scripts/set-workspace-version.js $(SET_VERSION)
-	rm package-lock.json
-	npm i
+	npm ci
 	$(MAKE) all
 
 # Recommended procedure:

--- a/scripts/set-workspace-version.js
+++ b/scripts/set-workspace-version.js
@@ -17,6 +17,7 @@
 import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { existsSync } from "node:fs";
+import assert from "node:assert";
 
 if (process.argv.length < 3) {
   process.stderr.write(
@@ -36,11 +37,15 @@ if (process.argv.length < 3) {
 try {
   const newVersion = process.argv[2];
   const packagesDir = "packages";
+  const lockFile = "package-lock.json";
   const packages = readPackages(packagesDir);
-  const updates = setVersion(packages, newVersion);
-  updates.push(...syncDeps(packages));
+  const lock = tryReadLock(lockFile);
+  const updates = setVersion(packages, lock, newVersion);
   if (updates.length > 0) {
     writePackages(packagesDir, packages);
+    if (lock) {
+      writeLock(lockFile, lock);
+    }
     process.stdout.write(formatUpdates(updates) + "\n");
   }
 } catch (e) {
@@ -48,25 +53,35 @@ try {
   process.exit(1);
 }
 
-function setVersion(packages, newVersion) {
+function setVersion(packages, lock, newVersion) {
   const updates = [];
   for (const pkg of packages) {
     if (typeof pkg.version !== "string") {
       continue;
     }
+    assert(pkg.name);
     if (pkg.version === newVersion) {
       continue;
+    }
+    pkg.version = newVersion;
+    if (lock) {
+      const l = Array.from(Object.values(lock.packages)).find(l => l.name === pkg.name);
+      assert(l);
+      l.version = newVersion;
     }
     updates.push({
       package: pkg,
       message: `updated version from ${pkg.version} to ${newVersion}`,
     });
-    pkg.version = newVersion;
+  }
+  updates.push(...syncDeps(packages, packages));
+  if (lock) {
+    syncDeps(Object.values(lock.packages), packages);
   }
   return updates;
 }
 
-function syncDeps(packages) {
+function syncDeps(packages, deps) {
   const updates = [];
   for (const pkg of packages) {
     for (const key of [
@@ -79,7 +94,7 @@ function syncDeps(packages) {
         continue;
       }
       for (const [name, version] of Object.entries(pkg[key])) {
-        const dep = packages.find((x) => x.name === name);
+        const dep = deps.find((x) => x.name === name);
         if (!dep) {
           continue;
         }
@@ -99,7 +114,7 @@ function syncDeps(packages) {
         pkg[key][name] = wantVersion;
         updates.push({
           package: pkg,
-          message: `updated ${key}["${name}"] from ${version} to ${dep.version}`,
+          message: `updated ${key}["${name}"] from ${version} to ${wantVersion}`,
         });
       }
     }
@@ -154,4 +169,19 @@ function formatUpdates(updates) {
     }
   }
   return lines.join("\n");
+}
+
+function tryReadLock(lockFile) {
+  if (!existsSync(lockFile)) {
+    return null;
+  }
+  const lock = JSON.parse(readFileSync(lockFile, "utf-8"));
+  assert(lock.lockfileVersion === 3);
+  assert(typeof lock.packages == "object");
+  assert(lock.packages !== null);
+  return lock;
+}
+
+function writeLock(lockFile, lock) {
+  writeFileSync(lockFile, JSON.stringify(lock, null, 2) + "\n");
 }

--- a/scripts/set-workspace-version.js
+++ b/scripts/set-workspace-version.js
@@ -65,7 +65,9 @@ function setVersion(packages, lock, newVersion) {
     }
     pkg.version = newVersion;
     if (lock) {
-      const l = Array.from(Object.values(lock.packages)).find(l => l.name === pkg.name);
+      const l = Array.from(Object.values(lock.packages)).find(
+        (l) => l.name === pkg.name,
+      );
       assert(l);
       l.version = newVersion;
     }


### PR DESCRIPTION
To cut a release, we run `scripts/set-workspace-version.js`, which modifies all package versions in the workspace, delete `package-lock.json`, and run `npm install` to re-generate it.

This process is not ideal, because npm gathers version information from `node_modules`, but does not populate the hash fields in the lock file. 

This PR updates the script to modify the `package-lock.json` along with the workspace packages, so that we don't have to re-generate it.