### PR TITLE
Build ESM artifacts with Node16 moduleResolution

### DIFF
--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/types/*",
     "build": "npm run build:esm+types",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "pregenerate": "rm -rf src/gen/*",
     "generate": "protoc --es_out=src/gen --es_opt=ts_nocheck=false,target=ts --proto_path=$(upstream-include conformance) $(upstream-files conformance)",
     "postgenerate": "license-header src/gen",

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types && npm run build:copy-gen-js",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "build:copy-gen-js": "rsync -a --exclude '*.js' src/gen/js dist/types/gen && rsync -a --exclude '*.d.ts' src/gen/js dist/esm/gen",
     "pregenerate": "rm -rf src/gen/*/* descriptorset.*",
     "generate": "npm run generate:ts && npm run generate:js && npm run generate:wkt:ts && npm run generate:wkt:js && npm run generate:desc",

--- a/packages/protobuf-test/src/create-registry.test.ts
+++ b/packages/protobuf-test/src/create-registry.test.ts
@@ -31,7 +31,7 @@ import {
   Proto2ExtEnum,
   Proto2ExtMessage,
   uint32_ext,
-} from "./gen/ts/extra/extensions-proto2_pb";
+} from "./gen/ts/extra/extensions-proto2_pb.js";
 import {
   TestAllTypes,
   TestAllTypes_NestedEnum,

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/*",
     "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
+    "build:cjs": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "../../node_modules/typescript/bin/tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
     "bootstrap:featureset-defaults": "upstream-inject-feature-defaults src/private/feature-set.ts",
     "prebootstrap:wkt": "rm -rf .tmp && mkdir -p .tmp/google/protobuf && cp -rp src/google/protobuf/* .tmp/google/protobuf",
     "bootstrap:wkt": "protoc --es_out=src --es_opt=bootstrap_wkt=true,ts_nocheck=false,target=ts --proto_path $(upstream-include wkt) $(upstream-files wkt) && license-header src/google/protobuf",

--- a/packages/protoc-gen-es/package.json
+++ b/packages/protoc-gen-es/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/cjs/*",
-    "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs"
+    "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs"
   },
   "preferUnplugged": true,
   "dependencies": {

--- a/packages/protoplugin-test/package.json
+++ b/packages/protoplugin-test/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "build": "npm run build:esm+types",
-    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types",
+    "build:esm+types": "../../node_modules/typescript/bin/tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationDir ./dist/types",
     "pregenerate": "rm -rf src/gen/*/*",
     "generate": "protoc --es_out=src/gen --es_opt=ts_nocheck=false,target=ts --proto_path=proto option-enum.proto option-message.proto file-option.proto",
     "postgenerate": "license-header src/gen",

--- a/packages/protoplugin-test/src/file-es_proto_int64.test.ts
+++ b/packages/protoplugin-test/src/file-es_proto_int64.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 import { LongType, ScalarType } from "@bufbuild/protobuf";
 

--- a/packages/protoplugin-test/src/file-es_ref_enum.test.ts
+++ b/packages/protoplugin-test/src/file-es_ref_enum.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 
 describe("file print", () => {

--- a/packages/protoplugin-test/src/file-es_ref_message.test.ts
+++ b/packages/protoplugin-test/src/file-es_ref_message.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 
 describe("file print", () => {

--- a/packages/protoplugin-test/src/file-es_string.test.ts
+++ b/packages/protoplugin-test/src/file-es_string.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { createTestPluginAndRun } from "./helpers";
+import { createTestPluginAndRun } from "./helpers.js";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 
 describe("file print", () => {

--- a/packages/protoplugin/ecmascript/index.js
+++ b/packages/protoplugin/ecmascript/index.js
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { Schema as SchemaInternal } from "./ecmascript/schema.js";
-export type { Plugin } from "./plugin.js";
-export { runNodeJs } from "./run-node.js";
-export { createEcmaScriptPlugin } from "./create-es-plugin.js";
-
-/**
- * @deprecated Please use Schema from @bufbuild/protoplugin/ecmascript instead
- */
-export type Schema = SchemaInternal;
+// Workaround for bundlers that do not support subpath exports.
+// eslint-disable-next-line no-undef
+module.exports = require("../dist/cjs/ecmascript/index.js");

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "clean": "rm -rf ./dist/*",
     "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
+    "build:cjs": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "../../node_modules/typescript/bin/tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
     "attw": "attw --pack"
   },
   "type": "module",

--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createSchema, Schema } from "./ecmascript/schema.js";
+import type { Schema } from "./ecmascript/schema.js";
+import { createSchema } from "./ecmascript/schema.js";
 import type { FileInfo } from "./ecmascript/generated-file.js";
 import type { Plugin } from "./plugin.js";
 import { transpile } from "./ecmascript/transpile.js";

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
+import type {
   AnyDesc,
   DescEnum,
   DescExtension,
   DescFile,
   DescMessage,
-  LongType,
-  protoInt64,
-  ScalarType,
 } from "@bufbuild/protobuf";
+import { LongType, protoInt64, ScalarType } from "@bufbuild/protobuf";
 import type { ImportSymbol } from "./import-symbol.js";
 import { createImportSymbol } from "./import-symbol.js";
 import type { RuntimeImports } from "./runtime-imports.js";
 import { makeImportPathRelative } from "./import-path.js";
 import type { JSDocBlock } from "./jsdoc.js";
 import { createJsDocBlock } from "./jsdoc.js";
-import {
+import type {
   ExportDeclaration,
   LiteralProtoInt64,
   LiteralString,

--- a/packages/protoplugin/src/ecmascript/import-path.ts
+++ b/packages/protoplugin/src/ecmascript/import-path.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { codegenInfo, DescFile } from "@bufbuild/protobuf";
+import type { DescFile } from "@bufbuild/protobuf";
+import { codegenInfo } from "@bufbuild/protobuf";
 
 /**
  * A configuration for rewriting import paths, a feature mainly used for

--- a/packages/protoplugin/src/ecmascript/index.ts
+++ b/packages/protoplugin/src/ecmascript/index.ts
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  AnyDesc,
-  codegenInfo,
-  DescExtension,
-  DescFile,
-} from "@bufbuild/protobuf";
-import { Printable } from "./generated-file.js";
+import type { AnyDesc, DescExtension, DescFile } from "@bufbuild/protobuf";
+import { codegenInfo } from "@bufbuild/protobuf";
+import type { Printable } from "./generated-file.js";
 import { createJsDocBlock as createJsDocBlockInternal } from "./jsdoc.js";
 
 export { reifyWkt } from "./reify-wkt.js";

--- a/packages/protoplugin/src/ecmascript/legacy-custom-options.ts
+++ b/packages/protoplugin/src/ecmascript/legacy-custom-options.ts
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { AnyDesc } from "@bufbuild/protobuf";
-import {
-  proto3,
-  BinaryReader,
-  Message,
-  MessageType,
-  ScalarType,
-} from "@bufbuild/protobuf";
+import type { AnyDesc, MessageType } from "@bufbuild/protobuf";
+import { proto3, BinaryReader, Message, ScalarType } from "@bufbuild/protobuf";
 
 /**
  * @deprecated Please use extensions instead.

--- a/packages/protoplugin/src/ecmascript/legacy-gencommon.ts
+++ b/packages/protoplugin/src/ecmascript/legacy-gencommon.ts
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescExtension } from "@bufbuild/protobuf";
-import {
-  codegenInfo,
-  DescField,
-  LongType,
-  ScalarType,
-} from "@bufbuild/protobuf";
+import type { DescExtension, DescField } from "@bufbuild/protobuf";
+import { codegenInfo, LongType, ScalarType } from "@bufbuild/protobuf";
 import type { GeneratedFile, Printable } from "./generated-file.js";
 import type { ImportSymbol } from "./import-symbol.js";
 

--- a/packages/protoplugin/src/ecmascript/opaque-printables.ts
+++ b/packages/protoplugin/src/ecmascript/opaque-printables.ts
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  DescEnum,
-  DescExtension,
-  DescMessage,
-  LongType,
-  ScalarType,
-} from "@bufbuild/protobuf";
+import type { DescEnum, DescExtension, DescMessage } from "@bufbuild/protobuf";
+import { LongType, ScalarType } from "@bufbuild/protobuf";
 
 export type LiteralProtoInt64 = {
   readonly kind: "es_proto_int64";

--- a/packages/protoplugin/src/ecmascript/parameter.ts
+++ b/packages/protoplugin/src/ecmascript/parameter.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Target } from "./target.js";
-import { RewriteImports } from "./import-path.js";
+import type { Target } from "./target.js";
+import type { RewriteImports } from "./import-path.js";
 import { PluginOptionError } from "../error.js";
 
 export interface ParsedParameter {

--- a/packages/protoplugin/src/ecmascript/schema.ts
+++ b/packages/protoplugin/src/ecmascript/schema.ts
@@ -31,15 +31,17 @@ import type {
   GeneratedFileController,
 } from "./generated-file.js";
 import { createGeneratedFile } from "./generated-file.js";
-import { createRuntimeImports, RuntimeImports } from "./runtime-imports.js";
-import { createImportSymbol, ImportSymbol } from "./import-symbol.js";
+import type { RuntimeImports } from "./runtime-imports.js";
+import { createRuntimeImports } from "./runtime-imports.js";
+import type { ImportSymbol } from "./import-symbol.js";
+import { createImportSymbol } from "./import-symbol.js";
 import type { Target } from "./target.js";
 import {
   deriveImportPath,
   makeImportPath,
   rewriteImportPath,
 } from "./import-path.js";
-import { ParsedParameter } from "./parameter.js";
+import type { ParsedParameter } from "./parameter.js";
 import { makeFilePreamble } from "./file-preamble.js";
 
 /**

--- a/packages/upstream-protobuf/package.json
+++ b/packages/upstream-protobuf/package.json
@@ -16,7 +16,8 @@
   },
   "exports": {
     ".": {
-      "import": "./index.mjs"
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
     }
   },
   "dependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,9 +15,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-
     // We need node's module resolution, so we do not have to skip lib checks
-    "moduleResolution": "Node",
+    "moduleResolution": "Node16",
+    "module": "Node16",
+    "verbatimModuleSyntax": true,
     "skipLibCheck": false
   }
 }


### PR DESCRIPTION
Fixes #599 

This switches all packages to build ESM artifacts with Node16 module resolution. In doing so, it turns on Node16 for both `moduleResolution` and `module` by default throughout the repo. It also turns on `verbatimModuleSyntax` by default (which is why the need for all the `import type {...}` changes).

For CJS artifacts, the exceptions for `moduleResolution node10` and `verbatimModuleSyntax false` are now specified in the command script.