### PR TITLE
Add support for parsing into an existing message

### DIFF
--- a/packages/protobuf-test/src/next/binary.test.ts
+++ b/packages/protobuf-test/src/next/binary.test.ts
@@ -89,4 +89,9 @@ function testV1Compat<T extends Message<T>, Desc extends DescMessage>(
   const v2Bytes = toBinary(v2Msg);
   expect(type.fromBinary(v2Bytes)).toEqual(v1Msg);
   expect(equals(fromBinary(desc, v1Bytes), v2Msg)).toBe(true);
+  v1Msg.fromBinary(v2Bytes);
+  fromBinary(v2Msg, v1Bytes);
+  console.log(v2Msg);
+  expect(type.fromBinary(toBinary(v2Msg))).toEqual(v1Msg);
+  expect(equals(fromBinary(desc, v1Msg.toBinary()), v2Msg)).toBe(true);
 }

--- a/packages/protobuf-test/src/next/binary.test.ts
+++ b/packages/protobuf-test/src/next/binary.test.ts
@@ -91,7 +91,6 @@ function testV1Compat<T extends Message<T>, Desc extends DescMessage>(
   expect(equals(fromBinary(desc, v1Bytes), v2Msg)).toBe(true);
   v1Msg.fromBinary(v2Bytes);
   fromBinary(v2Msg, v1Bytes);
-  console.log(v2Msg);
   expect(type.fromBinary(toBinary(v2Msg))).toEqual(v1Msg);
   expect(equals(fromBinary(desc, v1Msg.toBinary()), v2Msg)).toBe(true);
 }

--- a/packages/protobuf/src/next/from-binary.ts
+++ b/packages/protobuf/src/next/from-binary.ts
@@ -14,7 +14,7 @@
 
 import type { BinaryReadOptions } from "../binary-format.js";
 import type { DescField, DescMessage } from "../descriptor-set.js";
-import type { MessageShape, Message } from "./types.js";
+import type { MessageShape } from "./types.js";
 import type { ReflectMessage } from "./reflect/reflect.js";
 import type { IBinaryReader } from "../binary-encoding.js";
 import {
@@ -94,7 +94,7 @@ function readMessage(
     ? reader.len
     : reader.pos + lengthOrEndTagFieldNo;
   let fieldNo: number | undefined, wireType: WireType | undefined;
-  const unknownFields: Message["$unknown"] = [];
+  const unknownFields = message.getUnknown() ?? [];
   while (reader.pos < end) {
     [fieldNo, wireType] = reader.tag();
     if (wireType == WireType.EndGroup) {

--- a/packages/protobuf/src/next/from-binary.ts
+++ b/packages/protobuf/src/next/from-binary.ts
@@ -44,6 +44,14 @@ function makeReadOptions(
 }
 
 /**
+ * Parse serialized binary data.
+ */
+export function fromBinary<Desc extends DescMessage>(
+  desc: Desc,
+  bytes: Uint8Array,
+  options?: Partial<BinaryReadOptions>,
+): MessageShape<Desc>;
+/**
  * Parse from binary data, merging fields.
  *
  * Repeated fields are appended. Map entries are added, overwriting
@@ -54,14 +62,6 @@ function makeReadOptions(
  */
 export function fromBinary<Desc extends DescMessage>(
   msg: MessageShape<Desc>,
-  bytes: Uint8Array,
-  options?: Partial<BinaryReadOptions>,
-): MessageShape<Desc>;
-/**
- * Parse serialized binary data.
- */
-export function fromBinary<Desc extends DescMessage>(
-  desc: Desc,
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
 ): MessageShape<Desc>;


### PR DESCRIPTION
Add support parsing into an existing message. Behavior is the same as v1:
- Repeated fields are appended.
- Map entries are added, overwriting existing keys.
- If a message field is already present, it will be merged with the new data.