### PR TITLE
Support unknown fields in clone

### DIFF
--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -40,6 +40,7 @@ export interface AnyMessage extends Message<AnyMessage> {
 export class Message<T extends Message<T> = AnyMessage> {
   /**
    * Compare with a message of the same type.
+   * Note that this function disregards extensions and unknown fields.
    */
   equals(other: T | PlainMessage<T> | undefined | null): boolean {
     return this.getType().runtime.util.equals(

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -230,6 +230,9 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
         }
         any[member.localName] = copy;
       }
+      for (const uf of type.runtime.bin.listUnknownFields(message)) {
+        type.runtime.bin.onUnknownField(any, uf.no, uf.wireType, uf.data);
+      }
       return target;
     },
   };


### PR DESCRIPTION
Support unknown fields in clone. This also documents equal's behavior of ignoring the unknown fields and extensions.