### PR TITLE
Add `google.protobuf.Any` helpers

### DIFF
--- a/packages/protobuf-test/src/next/wkt/any.test.ts
+++ b/packages/protobuf-test/src/next/wkt/any.test.ts
@@ -1,0 +1,99 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "@jest/globals";
+import {
+  AnyDesc,
+  anyIs,
+  anyPack,
+  anyUnpack,
+  ValueDesc,
+  type Value,
+} from "@bufbuild/protobuf/next/wkt";
+import { create } from "@bufbuild/protobuf/next";
+import { createDescSet } from "@bufbuild/protobuf/next/reflect";
+
+describe("google.protobuf.Any", () => {
+  test(`is correctly identifies by message and type name`, () => {
+    const val = create(ValueDesc, {
+      kind: { case: "numberValue", value: 1 },
+    });
+    const any = anyPack(val);
+
+    expect(anyIs(any, ValueDesc)).toBe(true);
+    expect(anyIs(any, ValueDesc.typeName)).toBe(true);
+
+    // The typeUrl set in the Any doesn't have to start with a URL prefix
+    expect(anyIs(any, "type.googleapis.com/google.protobuf.Value")).toBe(false);
+  });
+
+  test(`matches type name with leading slash`, () => {
+    const any = create(AnyDesc, { typeUrl: "/google.protobuf.Value" });
+    expect(anyIs(any, ValueDesc)).toBe(true);
+  });
+
+  test(`is returns false for an empty Any`, () => {
+    const any = create(AnyDesc);
+
+    expect(anyIs(any, ValueDesc)).toBe(false);
+    expect(anyIs(any, "google.protobuf.Value")).toBe(false);
+    expect(anyIs(any, "")).toBe(false);
+  });
+
+  test(`unpack correctly unpacks a message in the registry`, () => {
+    const typeRegistry = createDescSet(ValueDesc);
+    const val = create(ValueDesc, {
+      kind: { case: "numberValue", value: 1 },
+    });
+    const any = anyPack(val);
+
+    const unpacked = anyUnpack(any, typeRegistry) as Value;
+
+    expect(unpacked).toBeDefined();
+    expect(unpacked.kind.case).toBe("numberValue");
+    expect(unpacked.kind.value).toBe(1);
+  });
+
+  test(`unpack correctly unpacks a message with a leading slash type url in the registry`, () => {
+    const typeRegistry = createDescSet(ValueDesc);
+    const val = create(ValueDesc, {
+      kind: { case: "numberValue", value: 1 },
+    });
+    const { value } = anyPack(val);
+    const any = create(AnyDesc, { typeUrl: "/google.protobuf.Value", value });
+
+    const unpacked = anyUnpack(any, typeRegistry) as Value;
+
+    expect(unpacked).toBeDefined();
+    expect(unpacked.kind.case).toBe("numberValue");
+    expect(unpacked.kind.value).toBe(1);
+  });
+
+  test(`unpack returns undefined if message not in the registry`, () => {
+    const typeRegistry = createDescSet();
+    const val = create(ValueDesc, {
+      kind: { case: "numberValue", value: 1 },
+    });
+    const any = anyPack(val);
+    const unpacked = anyUnpack(any, typeRegistry);
+    expect(unpacked).toBeUndefined();
+  });
+
+  test(`unpack returns undefined with an empty Any`, () => {
+    const typeRegistry = createDescSet(ValueDesc);
+    const any = create(AnyDesc);
+    const unpacked = anyUnpack(any, typeRegistry);
+    expect(unpacked).toBeUndefined();
+  });
+});

--- a/packages/protobuf-test/src/next/wkt/any.test.ts
+++ b/packages/protobuf-test/src/next/wkt/any.test.ts
@@ -19,8 +19,8 @@ import {
   anyPack,
   anyUnpack,
   ValueDesc,
-  type Value,
 } from "@bufbuild/protobuf/next/wkt";
+import type { Value } from "@bufbuild/protobuf/next/wkt";
 import { create } from "@bufbuild/protobuf/next";
 import { createDescSet } from "@bufbuild/protobuf/next/reflect";
 

--- a/packages/protobuf/src/next/wkt/any.ts
+++ b/packages/protobuf/src/next/wkt/any.ts
@@ -1,0 +1,105 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Message, MessageShape } from "../types.js";
+import { type Any, AnyDesc } from "./gen/google/protobuf/any_pbv2.js";
+import type { DescMessage } from "../../descriptor-set.js";
+import type { DescSet } from "../reflect/index.js";
+import { create } from "../create.js";
+import { toBinary } from "../to-binary.js";
+import { fromBinary } from "../from-binary.js";
+
+/**
+ * Creates a `google.protobuf.Any` from a message.
+ */
+export function anyPack(message: Message): Any;
+/**
+ * Packs the message into the given any.
+ */
+export function anyPack(message: Message, into: Any): void;
+export function anyPack(message: Message, into?: Any) {
+  let ret = false;
+  if (!into) {
+    into = create(AnyDesc);
+    ret = true;
+  }
+  into.value = toBinary(message);
+  into.typeUrl = typeNameToUrl(message.$typeName);
+  return ret ? into : undefined;
+}
+
+export function anyIs(any: Any, desc: DescMessage): boolean;
+export function anyIs(any: Any, typeName: string): boolean;
+export function anyIs(any: Any, descOrTypeName: DescMessage | string): boolean {
+  if (any.typeUrl === "") {
+    return false;
+  }
+  const want =
+    typeof descOrTypeName == "string"
+      ? descOrTypeName
+      : descOrTypeName.typeName;
+  const got = typeUrlToName(any.typeUrl);
+  return want === got;
+}
+
+/**
+ * Upacks the message the Any represents.
+ *
+ * To lookup the type information it either needs a DescSet
+ * or the DescMessage.
+ */
+export function anyUnpack(any: Any, set: DescSet): Message | undefined;
+export function anyUnpack<Desc extends DescMessage>(
+  any: Any,
+  messageDesc: Desc,
+): MessageShape<Desc> | undefined;
+export function anyUnpack(
+  any: Any,
+  descSetOrMessage: DescSet | DescMessage,
+): Message | undefined {
+  if (any.typeUrl === "") {
+    return undefined;
+  }
+  const desc =
+    descSetOrMessage.kind == "message"
+      ? descSetOrMessage
+      : descSetOrMessage.getMessage(typeUrlToName(any.typeUrl));
+  if (!desc) {
+    return undefined;
+  }
+  return fromBinary(desc, any.value);
+}
+
+/**
+ * Same as anyUnpack but unpacks into the target message.
+ */
+export function anyUnpackTo(any: Any, target: Message) {
+  if (any.typeUrl === "") {
+    return undefined;
+  }
+  return fromBinary(target, any.value);
+}
+
+function typeNameToUrl(name: string): string {
+  return `type.googleapis.com/${name}`;
+}
+
+function typeUrlToName(url: string): string {
+  const slash = url.lastIndexOf("/");
+  const name = slash >= 0 ? url.substring(slash + 1) : url;
+  if (!name.length) {
+    throw new Error(`invalid type url: ${url}`);
+  }
+  return name;
+}

--- a/packages/protobuf/src/next/wkt/any.ts
+++ b/packages/protobuf/src/next/wkt/any.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import type { Message, MessageShape } from "../types.js";
-import { type Any, AnyDesc } from "./gen/google/protobuf/any_pbv2.js";
+import type { Any } from "./gen/google/protobuf/any_pbv2.js";
+import { AnyDesc } from "./gen/google/protobuf/any_pbv2.js";
 import type { DescMessage } from "../../descriptor-set.js";
 import type { DescSet } from "../reflect/index.js";
 import { create } from "../create.js";
@@ -39,7 +40,13 @@ export function anyPack(message: Message, into?: Any) {
   return ret ? into : undefined;
 }
 
-export function anyIs(any: Any, desc: DescMessage): boolean;
+/**
+ * Returns true if the Any contains the type given by messageDesc.
+ */
+export function anyIs(any: Any, messageDesc: DescMessage): boolean;
+/**
+ * Returns true if the Any contains a message with the given typeName.
+ */
 export function anyIs(any: Any, typeName: string): boolean;
 export function anyIs(any: Any, descOrTypeName: DescMessage | string): boolean {
   if (any.typeUrl === "") {
@@ -54,12 +61,18 @@ export function anyIs(any: Any, descOrTypeName: DescMessage | string): boolean {
 }
 
 /**
- * Upacks the message the Any represents.
+ * Unpacks the message the Any represents.
  *
- * To lookup the type information it either needs a DescSet
- * or the DescMessage.
+ * Returns undefined if the Any is empty, or if packed type is not included
+ * in the given set.
  */
 export function anyUnpack(any: Any, set: DescSet): Message | undefined;
+/**
+ * Unpacks the message the Any represents.
+ *
+ * Returns undefined if the Any is empty, or if it does not contain the type
+ * given by messageDesc.
+ */
 export function anyUnpack<Desc extends DescMessage>(
   any: Any,
   messageDesc: Desc,

--- a/packages/protobuf/src/next/wkt/index.ts
+++ b/packages/protobuf/src/next/wkt/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 export * from "./timestamp.js";
+export * from "./any.js";
 export * from "./gen/google/protobuf/api_pbv2.js";
 export * from "./gen/google/protobuf/any_pbv2.js";
 export * from "./gen/google/protobuf/descriptor_pbv2.js";


### PR DESCRIPTION
Add `google.protobuf.Any` helpers. Ported the non-json tests from v1, will add the json ones once we add json support