### PR TITLE
Fix tsconfig for protoc-gen-es

### DIFF
--- a/packages/protoc-gen-es/package.json
+++ b/packages/protoc-gen-es/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/cjs/*",
-    "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs"
+    "build": "../../node_modules/typescript/bin/tsc --project tsconfig.json --outDir ./dist/cjs"
   },
   "preferUnplugged": true,
   "dependencies": {

--- a/packages/protoc-gen-es/tsconfig.json
+++ b/packages/protoc-gen-es/tsconfig.json
@@ -2,6 +2,11 @@
   "files": ["src/protoc-gen-es-plugin.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "resolveJsonModule": true
+    // We import the plugin's version number from package.json
+    "resolveJsonModule": true,
+    // This package is only built for CJS
+    "module": "commonjs",
+    "verbatimModuleSyntax": false,
+    "moduleResolution": "node10",
   }
 }

--- a/packages/protoc-gen-es/tsconfig.json
+++ b/packages/protoc-gen-es/tsconfig.json
@@ -4,9 +4,9 @@
   "compilerOptions": {
     // We import the plugin's version number from package.json
     "resolveJsonModule": true,
-    // This package is only built for CJS
-    "module": "commonjs",
+    // This package is CommonJS
     "verbatimModuleSyntax": false,
-    "moduleResolution": "node10",
+    "module": "CommonJS",
+    "moduleResolution": "Node10"
   }
 }

--- a/packages/protoplugin-example/tsconfig.json
+++ b/packages/protoplugin-example/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src/**/*.ts", "test/*.ts"],
   "compilerOptions": {
     "target": "es2017",
-    "moduleResolution": "Node",
+    "moduleResolution": "Node10",
     "esModuleInterop": false,
     "resolveJsonModule": true,
     "strict": true,


### PR DESCRIPTION
In https://github.com/bufbuild/protobuf-es/pull/754, we switched our builds to use Node16 module resolution.

protoc-gen-es remained CommonJS (no `"type": "module"` in package.json). Because the TypeScript language service used in the the picked up the new tsconfig base settings with `"moduleResolution": "Node16"`, this causes errors in the IDE. The build is not affected, so this passed CI.

To fix the issue, this adds the same module and resolution settings to the package's tsconfig that are using during build.