### PR TITLE
Fix assertion for FIXED32 scalar type when parsing JSON

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 97,734 b      | 41,763 b | 10,857 b |
+| protobuf-es         | 97,764 b      | 41,777 b | 10,850 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf/src/binary-encoding.ts
+++ b/packages/protobuf/src/binary-encoding.ts
@@ -95,12 +95,12 @@ export interface IBinaryReader {
   skip(wireType: WireType): Uint8Array;
 
   /**
-   * Read a `int32` field, a signed 32 bit varint.
+   * Read a `uint32` field, an unsigned 32 bit varint.
    */
   uint32(): number;
 
   /**
-   * Read a `sint32` field, a signed, zigzag-encoded 32-bit varint.
+   * Read a `int32` field, a signed 32 bit varint.
    */
   int32(): number;
 

--- a/packages/protobuf/src/private/json-format.ts
+++ b/packages/protobuf/src/private/json-format.ts
@@ -526,7 +526,8 @@ function readScalar(
         if (json.trim().length === json.length) int32 = Number(json);
       }
       if (int32 === undefined) break;
-      if (type == ScalarType.UINT32) assertUInt32(int32);
+      if (type == ScalarType.UINT32 || type == ScalarType.FIXED32)
+        assertUInt32(int32);
       else assertInt32(int32);
       return int32;
 


### PR DESCRIPTION
FIXED32 is an _unsigned_, fixed-length 32-bit integer. When we parse it from JSON, we assert that it is in bounds for a _signed_ integer. This fixes the assertion to expect an unsigned integer.