### PR TITLE
Remove overload and move to `mergeFromBinary`

### DIFF
--- a/packages/protobuf-test/src/next/binary.test.ts
+++ b/packages/protobuf-test/src/next/binary.test.ts
@@ -13,7 +13,13 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { toBinary, create, fromBinary, equals } from "@bufbuild/protobuf/next";
+import {
+  toBinary,
+  create,
+  fromBinary,
+  mergeFromBinary,
+  equals,
+} from "@bufbuild/protobuf/next";
 import type { MessageInitShape } from "@bufbuild/protobuf/next";
 import {
   ScalarValuesMessage,
@@ -89,7 +95,7 @@ function testV1Compat<T extends Message<T>, Desc extends DescMessage>(
   expect(type.fromBinary(v2Bytes)).toEqual(v1Msg);
   expect(equals(desc, fromBinary(desc, v1Bytes), v2Msg)).toBe(true);
   v1Msg.fromBinary(v2Bytes);
-  fromBinary(desc, v2Msg, v1Bytes);
+  mergeFromBinary(desc, v2Msg, v1Bytes);
   expect(type.fromBinary(toBinary(desc, v2Msg))).toEqual(v1Msg);
   expect(equals(desc, fromBinary(desc, v1Msg.toBinary()), v2Msg)).toBe(true);
 }

--- a/packages/protobuf/src/next/from-binary.ts
+++ b/packages/protobuf/src/next/from-binary.ts
@@ -59,7 +59,16 @@ export function fromBinary<Desc extends DescMessage>(
   messageDesc: Desc,
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
-): MessageShape<Desc>;
+): MessageShape<Desc> {
+  const msg = reflect(messageDesc);
+  readMessage(
+    msg,
+    new BinaryReader(bytes),
+    bytes.byteLength,
+    makeReadOptions(options),
+  );
+  return msg.message as MessageShape<Desc>;
+}
 
 /**
  * Parse from binary data, merging fields.
@@ -70,32 +79,19 @@ export function fromBinary<Desc extends DescMessage>(
  * If a message field is already present, it will be merged with the
  * new data.
  */
-export function fromBinary<Desc extends DescMessage>(
+export function mergeFromBinary<Desc extends DescMessage>(
   messageDesc: Desc,
   target: MessageShape<Desc>,
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
-): MessageShape<Desc>;
-
-export function fromBinary<Desc extends DescMessage>(
-  desc: Desc,
-  targetOrBytes: MessageShape<Desc> | Uint8Array,
-  bytesOrOptions?: Uint8Array | Partial<BinaryReadOptions>,
-  options?: Partial<BinaryReadOptions>,
 ): MessageShape<Desc> {
-  let msg: ReflectMessage;
-  let bytes: Uint8Array;
-  if (targetOrBytes instanceof Uint8Array) {
-    bytes = targetOrBytes;
-    msg = reflect(desc);
-    options = bytesOrOptions as Partial<BinaryReadOptions> | undefined;
-  } else {
-    msg = reflect(desc, targetOrBytes);
-    bytes = bytesOrOptions as Uint8Array;
-  }
-  const opt = makeReadOptions(options);
-  readMessage(msg, new BinaryReader(bytes), bytes.byteLength, opt);
-  return msg.message as MessageShape<Desc>;
+  readMessage(
+    reflect(messageDesc, target),
+    new BinaryReader(bytes),
+    bytes.byteLength,
+    makeReadOptions(options),
+  );
+  return target;
 }
 
 // TODO: Improve the function signature, we got most it from v1.

--- a/packages/protobuf/src/next/index.ts
+++ b/packages/protobuf/src/next/index.ts
@@ -20,7 +20,7 @@ export * from "./equals.js";
 export * from "./fields.js";
 export { toBinary } from "./to-binary.js";
 export type { BinaryWriteOptions } from "./to-binary.js";
-export { fromBinary } from "./from-binary.js";
+export { fromBinary, mergeFromBinary } from "./from-binary.js";
 export type { BinaryReadOptions } from "./from-binary.js";
 export * from "./to-json.js";
 export * from "./extension-accessor.js";

--- a/packages/protobuf/src/next/wkt/any.ts
+++ b/packages/protobuf/src/next/wkt/any.ts
@@ -19,7 +19,7 @@ import type { DescMessage } from "../../descriptor-set.js";
 import type { DescSet } from "../reflect/index.js";
 import { create } from "../create.js";
 import { toBinary } from "../to-binary.js";
-import { fromBinary } from "../from-binary.js";
+import { fromBinary, mergeFromBinary } from "../from-binary.js";
 
 /**
  * Creates a `google.protobuf.Any` from a message.
@@ -122,7 +122,7 @@ export function anyUnpackTo<Desc extends DescMessage>(
   if (any.typeUrl === "") {
     return undefined;
   }
-  return fromBinary(messageDesc, message, any.value);
+  return mergeFromBinary(messageDesc, message, any.value);
 }
 
 function typeNameToUrl(name: string): string {


### PR DESCRIPTION
Remove overload and move to `mergeFromBinary`. This is more clear both within an IDE and to quickly grok what the function is doing. Earlier users had to (at least) count the parameters to tell the difference.