### PR TITLE
Support extensions in json encoding

### DIFF
--- a/packages/protobuf-test/src/next/json.test.ts
+++ b/packages/protobuf-test/src/next/json.test.ts
@@ -18,6 +18,8 @@ import {
   toJson,
   fromJson,
   mergeFromJson,
+  setExtension,
+  getExtension,
 } from "@bufbuild/protobuf/next";
 import type {
   MessageInitShape,
@@ -55,6 +57,10 @@ import type {
 } from "@bufbuild/protobuf";
 import { createDescSet } from "@bufbuild/protobuf/next/reflect";
 import { equals } from "@bufbuild/protobuf/next";
+import {
+  Proto2ExtendeeDesc,
+  string_ext,
+} from "../gen/ts/extra/extensions-proto2_pbv2.js";
 
 describe("json serialization", () => {
   describe("should be identical to v1", () => {
@@ -128,6 +134,23 @@ describe("json serialization", () => {
           descSet: createDescSet(StructDesc, ValueDesc),
         });
       });
+    });
+  });
+  describe.only("extensions", () => {
+    test("encode and decode an extension", () => {
+      const extendee = create(Proto2ExtendeeDesc);
+      setExtension(extendee, string_ext, "foo");
+      const jsonOpts = { descSet: createDescSet(string_ext) };
+      expect(
+        getExtension(
+          fromJson(
+            Proto2ExtendeeDesc,
+            toJson(Proto2ExtendeeDesc, extendee, jsonOpts),
+            jsonOpts,
+          ),
+          string_ext,
+        ),
+      ).toEqual("foo");
     });
   });
 });

--- a/packages/protobuf/src/next/extension-accessor.ts
+++ b/packages/protobuf/src/next/extension-accessor.ts
@@ -134,7 +134,10 @@ function filterUnknownFields(
   return unknownFields.filter((uf) => uf.no === extension.number);
 }
 
-function createExtensionContainer<Desc extends DescExtension>(
+/**
+ * @private
+ */
+export function createExtensionContainer<Desc extends DescExtension>(
   extension: Desc,
   value?: ExtensionValueShape<Desc>,
 ): [ReflectMessage, DescField, () => ExtensionValueShape<Desc>] {

--- a/packages/protobuf/src/next/from-json.ts
+++ b/packages/protobuf/src/next/from-json.ts
@@ -16,6 +16,7 @@
 
 import type {
   DescEnum,
+  DescExtension,
   DescField,
   DescMessage,
   DescOneof,
@@ -55,6 +56,10 @@ import type {
   ListValue,
 } from "./wkt/index.js";
 import { isWrapperDesc } from "./wkt/wrappers.js";
+import {
+  createExtensionContainer,
+  setExtension,
+} from "./extension-accessor.js";
 
 /**
  * Options for parsing JSON data.
@@ -202,15 +207,20 @@ function readMessage(
       }
       readField(msg, field, jsonValue, opts);
     } else {
+      let extension: DescExtension | undefined = undefined;
       if (
         jsonKey.startsWith("[") &&
         jsonKey.endsWith("]") &&
-        opts.descSet?.getExtension(jsonKey.substring(1, jsonKey.length - 1))
+        (extension = opts.descSet?.getExtension(
+          jsonKey.substring(1, jsonKey.length - 1),
+        )) &&
+        extension.extendee.typeName === msg.desc.typeName
       ) {
-        // TODO: Support Extension.
-        throw new Error("extension support not implemented");
+        const [container, field, get] = createExtensionContainer(extension);
+        readField(container, field, jsonValue, opts);
+        setExtension(msg.message, extension, get());
       }
-      if (!opts.ignoreUnknownFields) {
+      if (!extension && !opts.ignoreUnknownFields) {
         throw new Error(
           `cannot decode message ${msg.desc.typeName} from JSON: key "${jsonKey}" is unknown`,
         );

--- a/packages/protobuf/src/next/index.ts
+++ b/packages/protobuf/src/next/index.ts
@@ -24,4 +24,9 @@ export { fromBinary, mergeFromBinary } from "./from-binary.js";
 export type { BinaryReadOptions } from "./from-binary.js";
 export * from "./to-json.js";
 export * from "./from-json.js";
-export * from "./extension-accessor.js";
+export {
+  hasExtension,
+  getExtension,
+  setExtension,
+  clearExtension,
+} from "./extension-accessor.js";


### PR DESCRIPTION
Support extensions in json encoding. Uses the extension container, if we refactor the fromJson, fromBinary and toBinary we might be able to get rid of it.