### PR TITLE
Avoid reserved object property names in generated enumerations

### DIFF
--- a/packages/protobuf-test/extra/name-clash.proto
+++ b/packages/protobuf-test/extra/name-clash.proto
@@ -43,19 +43,25 @@ message ReservedPropertyNames {
     enum EnumBuiltIn {
         constructor = 0;
         toString = 1;
-        to_JSON = 2;
-        value_of = 3;
+        toJSON = 2;
+        valueOf = 3;
+    }
+    enum EnumBuiltInPrefixed {
+        ENUM_BUILT_IN_PREFIXED_constructor = 0;
+        ENUM_BUILT_IN_PREFIXED_toString = 1;
+        ENUM_BUILT_IN_PREFIXED_toJSON = 2;
+        ENUM_BUILT_IN_PREFIXED_valueOf = 3;
     }
     enum EnumRuntime {
-        to_json = 0;
+        toJson = 0;
         type = 6;
         clone = 7;
         equals = 8;
-        from_binary = 9;
-        from_json = 10;
-        from_json_string = 11;
-        to_binary = 12;
-        to_json_string = 14;
+        fromBinary = 9;
+        fromJson = 10;
+        fromJsonString = 11;
+        toBinary = 12;
+        toJsonString = 14;
     }
     message OneofBultIn {
         oneof built_in {

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -74,22 +74,47 @@ export declare enum ReservedPropertyNames_EnumBuiltIn {
   /**
    * @generated from enum value: constructor = 0;
    */
-  constructor = 0,
+  constructor$ = 0,
 
   /**
    * @generated from enum value: toString = 1;
    */
-  toString = 1,
+  toString$ = 1,
 
   /**
-   * @generated from enum value: to_JSON = 2;
+   * @generated from enum value: toJSON = 2;
    */
-  to_JSON = 2,
+  toJSON$ = 2,
 
   /**
-   * @generated from enum value: value_of = 3;
+   * @generated from enum value: valueOf = 3;
    */
-  value_of = 3,
+  valueOf$ = 3,
+}
+
+/**
+ * @generated from enum spec.ReservedPropertyNames.EnumBuiltInPrefixed
+ */
+export declare enum ReservedPropertyNames_EnumBuiltInPrefixed {
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_constructor = 0;
+   */
+  constructor$ = 0,
+
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_toString = 1;
+   */
+  toString$ = 1,
+
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_toJSON = 2;
+   */
+  toJSON$ = 2,
+
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_valueOf = 3;
+   */
+  valueOf$ = 3,
 }
 
 /**
@@ -97,9 +122,9 @@ export declare enum ReservedPropertyNames_EnumBuiltIn {
  */
 export declare enum ReservedPropertyNames_EnumRuntime {
   /**
-   * @generated from enum value: to_json = 0;
+   * @generated from enum value: toJson = 0;
    */
-  to_json = 0,
+  toJson = 0,
 
   /**
    * @generated from enum value: type = 6;
@@ -117,29 +142,29 @@ export declare enum ReservedPropertyNames_EnumRuntime {
   equals = 8,
 
   /**
-   * @generated from enum value: from_binary = 9;
+   * @generated from enum value: fromBinary = 9;
    */
-  from_binary = 9,
+  fromBinary = 9,
 
   /**
-   * @generated from enum value: from_json = 10;
+   * @generated from enum value: fromJson = 10;
    */
-  from_json = 10,
+  fromJson = 10,
 
   /**
-   * @generated from enum value: from_json_string = 11;
+   * @generated from enum value: fromJsonString = 11;
    */
-  from_json_string = 11,
+  fromJsonString = 11,
 
   /**
-   * @generated from enum value: to_binary = 12;
+   * @generated from enum value: toBinary = 12;
    */
-  to_binary = 12,
+  toBinary = 12,
 
   /**
-   * @generated from enum value: to_json_string = 14;
+   * @generated from enum value: toJsonString = 14;
    */
-  to_json_string = 14,
+  toJsonString = 14,
 }
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.js
@@ -45,10 +45,23 @@ export const ReservedPropertyNames = /*@__PURE__*/ proto3.makeMessageType(
 export const ReservedPropertyNames_EnumBuiltIn = /*@__PURE__*/ proto3.makeEnum(
   "spec.ReservedPropertyNames.EnumBuiltIn",
   [
-    {no: 0, name: "constructor"},
-    {no: 1, name: "toString"},
-    {no: 2, name: "to_JSON"},
-    {no: 3, name: "value_of"},
+    {no: 0, name: "constructor", localName: "constructor$"},
+    {no: 1, name: "toString", localName: "toString$"},
+    {no: 2, name: "toJSON", localName: "toJSON$"},
+    {no: 3, name: "valueOf", localName: "valueOf$"},
+  ],
+);
+
+/**
+ * @generated from enum spec.ReservedPropertyNames.EnumBuiltInPrefixed
+ */
+export const ReservedPropertyNames_EnumBuiltInPrefixed = /*@__PURE__*/ proto3.makeEnum(
+  "spec.ReservedPropertyNames.EnumBuiltInPrefixed",
+  [
+    {no: 0, name: "ENUM_BUILT_IN_PREFIXED_constructor", localName: "constructor$"},
+    {no: 1, name: "ENUM_BUILT_IN_PREFIXED_toString", localName: "toString$"},
+    {no: 2, name: "ENUM_BUILT_IN_PREFIXED_toJSON", localName: "toJSON$"},
+    {no: 3, name: "ENUM_BUILT_IN_PREFIXED_valueOf", localName: "valueOf$"},
   ],
 );
 
@@ -58,15 +71,15 @@ export const ReservedPropertyNames_EnumBuiltIn = /*@__PURE__*/ proto3.makeEnum(
 export const ReservedPropertyNames_EnumRuntime = /*@__PURE__*/ proto3.makeEnum(
   "spec.ReservedPropertyNames.EnumRuntime",
   [
-    {no: 0, name: "to_json"},
+    {no: 0, name: "toJson"},
     {no: 6, name: "type"},
     {no: 7, name: "clone"},
     {no: 8, name: "equals"},
-    {no: 9, name: "from_binary"},
-    {no: 10, name: "from_json"},
-    {no: 11, name: "from_json_string"},
-    {no: 12, name: "to_binary"},
-    {no: 14, name: "to_json_string"},
+    {no: 9, name: "fromBinary"},
+    {no: 10, name: "fromJson"},
+    {no: 11, name: "fromJsonString"},
+    {no: 12, name: "toBinary"},
+    {no: 14, name: "toJsonString"},
   ],
 );
 

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -99,29 +99,61 @@ export enum ReservedPropertyNames_EnumBuiltIn {
   /**
    * @generated from enum value: constructor = 0;
    */
-  constructor = 0,
+  constructor$ = 0,
 
   /**
    * @generated from enum value: toString = 1;
    */
-  toString = 1,
+  toString$ = 1,
 
   /**
-   * @generated from enum value: to_JSON = 2;
+   * @generated from enum value: toJSON = 2;
    */
-  to_JSON = 2,
+  toJSON$ = 2,
 
   /**
-   * @generated from enum value: value_of = 3;
+   * @generated from enum value: valueOf = 3;
    */
-  value_of = 3,
+  valueOf$ = 3,
 }
 // Retrieve enum metadata with: proto3.getEnumType(ReservedPropertyNames_EnumBuiltIn)
 proto3.util.setEnumType(ReservedPropertyNames_EnumBuiltIn, "spec.ReservedPropertyNames.EnumBuiltIn", [
   { no: 0, name: "constructor" },
   { no: 1, name: "toString" },
-  { no: 2, name: "to_JSON" },
-  { no: 3, name: "value_of" },
+  { no: 2, name: "toJSON" },
+  { no: 3, name: "valueOf" },
+]);
+
+/**
+ * @generated from enum spec.ReservedPropertyNames.EnumBuiltInPrefixed
+ */
+export enum ReservedPropertyNames_EnumBuiltInPrefixed {
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_constructor = 0;
+   */
+  constructor$ = 0,
+
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_toString = 1;
+   */
+  toString$ = 1,
+
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_toJSON = 2;
+   */
+  toJSON$ = 2,
+
+  /**
+   * @generated from enum value: ENUM_BUILT_IN_PREFIXED_valueOf = 3;
+   */
+  valueOf$ = 3,
+}
+// Retrieve enum metadata with: proto3.getEnumType(ReservedPropertyNames_EnumBuiltInPrefixed)
+proto3.util.setEnumType(ReservedPropertyNames_EnumBuiltInPrefixed, "spec.ReservedPropertyNames.EnumBuiltInPrefixed", [
+  { no: 0, name: "ENUM_BUILT_IN_PREFIXED_constructor" },
+  { no: 1, name: "ENUM_BUILT_IN_PREFIXED_toString" },
+  { no: 2, name: "ENUM_BUILT_IN_PREFIXED_toJSON" },
+  { no: 3, name: "ENUM_BUILT_IN_PREFIXED_valueOf" },
 ]);
 
 /**
@@ -129,9 +161,9 @@ proto3.util.setEnumType(ReservedPropertyNames_EnumBuiltIn, "spec.ReservedPropert
  */
 export enum ReservedPropertyNames_EnumRuntime {
   /**
-   * @generated from enum value: to_json = 0;
+   * @generated from enum value: toJson = 0;
    */
-  to_json = 0,
+  toJson = 0,
 
   /**
    * @generated from enum value: type = 6;
@@ -149,41 +181,41 @@ export enum ReservedPropertyNames_EnumRuntime {
   equals = 8,
 
   /**
-   * @generated from enum value: from_binary = 9;
+   * @generated from enum value: fromBinary = 9;
    */
-  from_binary = 9,
+  fromBinary = 9,
 
   /**
-   * @generated from enum value: from_json = 10;
+   * @generated from enum value: fromJson = 10;
    */
-  from_json = 10,
+  fromJson = 10,
 
   /**
-   * @generated from enum value: from_json_string = 11;
+   * @generated from enum value: fromJsonString = 11;
    */
-  from_json_string = 11,
+  fromJsonString = 11,
 
   /**
-   * @generated from enum value: to_binary = 12;
+   * @generated from enum value: toBinary = 12;
    */
-  to_binary = 12,
+  toBinary = 12,
 
   /**
-   * @generated from enum value: to_json_string = 14;
+   * @generated from enum value: toJsonString = 14;
    */
-  to_json_string = 14,
+  toJsonString = 14,
 }
 // Retrieve enum metadata with: proto3.getEnumType(ReservedPropertyNames_EnumRuntime)
 proto3.util.setEnumType(ReservedPropertyNames_EnumRuntime, "spec.ReservedPropertyNames.EnumRuntime", [
-  { no: 0, name: "to_json" },
+  { no: 0, name: "toJson" },
   { no: 6, name: "type" },
   { no: 7, name: "clone" },
   { no: 8, name: "equals" },
-  { no: 9, name: "from_binary" },
-  { no: 10, name: "from_json" },
-  { no: 11, name: "from_json_string" },
-  { no: 12, name: "to_binary" },
-  { no: 14, name: "to_json_string" },
+  { no: 9, name: "fromBinary" },
+  { no: 10, name: "fromJson" },
+  { no: 11, name: "fromJsonString" },
+  { no: 12, name: "toBinary" },
+  { no: 14, name: "toJsonString" },
 ]);
 
 /**

--- a/packages/protobuf-test/src/name-clash.test.ts
+++ b/packages/protobuf-test/src/name-clash.test.ts
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { NoClashOneofADT as TS_NoClashOneofADT } from "./gen/ts/extra/name-clash_pb.js";
+import * as ts_name_clash from "./gen/ts/extra/name-clash_pb.js";
+import * as js_name_clash from "./gen/js/extra/name-clash_pb.js";
+import { proto3 } from "@bufbuild/protobuf";
 
 describe("message looking like a oneof ADT", () => {
   test("takes all fields in constructor", () => {
-    const m = new TS_NoClashOneofADT({
+    const m = new ts_name_clash.NoClashOneofADT({
       m: {
         case: "value",
         value: "xxx",
@@ -26,11 +28,70 @@ describe("message looking like a oneof ADT", () => {
     expect(m).toBeDefined();
   });
   test("takes partial input in constructor", () => {
-    const m = new TS_NoClashOneofADT({
+    const m = new ts_name_clash.NoClashOneofADT({
       m: {
         case: "value",
       },
     });
     expect(m).toBeDefined();
+  });
+});
+
+describe("enum values", () => {
+  test("reserved property names (generated ts)", () => {
+    const e = ts_name_clash.ReservedPropertyNames_EnumBuiltIn;
+    expect(e.constructor$).toBe(0);
+    expect(e.toString$).toBe(1);
+    expect(e.toJSON$).toBe(2);
+    expect(e.valueOf$).toBe(3);
+    const localNames = proto3.getEnumType(e).values.map((v) => v.localName);
+    expect(localNames).toStrictEqual([
+      "constructor$",
+      "toString$",
+      "toJSON$",
+      "valueOf$",
+    ]);
+  });
+  test("reserved property names with prefix (generated ts)", () => {
+    const e = ts_name_clash.ReservedPropertyNames_EnumBuiltInPrefixed;
+    expect(e.constructor$).toBe(0);
+    expect(e.toString$).toBe(1);
+    expect(e.toJSON$).toBe(2);
+    expect(e.valueOf$).toBe(3);
+    const localNames = proto3.getEnumType(e).values.map((v) => v.localName);
+    expect(localNames).toStrictEqual([
+      "constructor$",
+      "toString$",
+      "toJSON$",
+      "valueOf$",
+    ]);
+  });
+  test("reserved property names (generated js)", () => {
+    const e = js_name_clash.ReservedPropertyNames_EnumBuiltIn;
+    expect(e.constructor$).toBe(0);
+    expect(e.toString$).toBe(1);
+    expect(e.toJSON$).toBe(2);
+    expect(e.valueOf$).toBe(3);
+    const localNames = proto3.getEnumType(e).values.map((v) => v.localName);
+    expect(localNames).toStrictEqual([
+      "constructor$",
+      "toString$",
+      "toJSON$",
+      "valueOf$",
+    ]);
+  });
+  test("reserved property names with prefix (generated js)", () => {
+    const e = js_name_clash.ReservedPropertyNames_EnumBuiltInPrefixed;
+    expect(e.constructor$).toBe(0);
+    expect(e.toString$).toBe(1);
+    expect(e.toJSON$).toBe(2);
+    expect(e.valueOf$).toBe(3);
+    const localNames = proto3.getEnumType(e).values.map((v) => v.localName);
+    expect(localNames).toStrictEqual([
+      "constructor$",
+      "toString$",
+      "toJSON$",
+      "valueOf$",
+    ]);
   });
 });

--- a/packages/protobuf/src/private/names.ts
+++ b/packages/protobuf/src/private/names.ts
@@ -61,11 +61,11 @@ export function localName(
       return safeObjectProperty(safeIdentifier(name));
     }
     case "enum_value": {
+      let name = desc.name;
       const sharedPrefix = desc.parent.sharedPrefix;
-      if (sharedPrefix === undefined) {
-        return desc.name;
+      if (sharedPrefix !== undefined) {
+        name = name.substring(sharedPrefix.length);
       }
-      const name = desc.name.substring(sharedPrefix.length);
       return safeObjectProperty(name);
     }
     case "rpc": {

--- a/packages/protoc-gen-es/src/javascript.ts
+++ b/packages/protoc-gen-es/src/javascript.ts
@@ -59,14 +59,11 @@ function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
   f.print(f.exportDecl("const", enumeration), " = /*@__PURE__*/ ", protoN, ".makeEnum(")
   f.print(`  "`, enumeration.typeName, `",`)
   f.print(`  [`)
-  if (enumeration.sharedPrefix === undefined) {
-    for (const value of enumeration.values) {
+  for (const value of enumeration.values) {
+    if (localName(value) === value.name) {
       f.print("    {no: ", value.number, ", name: ", f.string(value.name), "},")
-    }
-  } else {
-    for (const value of enumeration.values) {
-      const localName = value.name.substring(enumeration.sharedPrefix.length);
-      f.print("    {no: ", value.number, ", name: ", f.string(value.name), ", localName: ", f.string(localName), "},")
+    } else {
+      f.print("    {no: ", value.number, ", name: ", f.string(value.name), ", localName: ", f.string(localName(value)), "},")
     }
   }
   f.print(`  ],`)


### PR DESCRIPTION
A protobuf enum can have values named "constructor", or "toString". When we generate a TypeScript / JavaScript enumeration for, we append an "$" to the name. These property names are valid in TypeScript, but they can potentially cause issues , depending on how the generated objects are used.

The logic to escape reserved names has a flaw: It is not applied in case the enumeration uses a shared prefix (values each start with the enum name).

This PR fixes the issue and adds test coverage.