### PR TITLE
Generate type imports when possible for .d.ts

### DIFF
--- a/packages/protobuf-test/src/gen/js/extra/enum_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/enum_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file extra/enum.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { EnumOptions, EnumValueOptions, Message, proto3 } from "@bufbuild/protobuf";
+import type { BinaryReadOptions, EnumOptions, EnumValueOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum spec.AnnotatedEnum

--- a/packages/protobuf-test/src/gen/js/extra/extensions-proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/extensions-proto3_pb.d.ts
@@ -16,8 +16,7 @@
 // @generated from file extra/extensions-proto3.proto (package proto3ext, syntax proto3)
 /* eslint-disable */
 
-import type { Extension } from "@bufbuild/protobuf";
-import { FileOptions } from "@bufbuild/protobuf";
+import type { Extension, FileOptions } from "@bufbuild/protobuf";
 
 /**
  * @generated from extension: uint32 uint32_ext = 1001;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/map_lite_unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/map_lite_unittest_pb.d.ts
@@ -18,8 +18,7 @@
 
 import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto2 } from "@bufbuild/protobuf";
-import type { ForeignMessageLite, TestAllTypesLite } from "./unittest_lite_pb.js";
-import { TestAllExtensionsLite } from "./unittest_lite_pb.js";
+import type { ForeignMessageLite, TestAllExtensionsLite, TestAllTypesLite } from "./unittest_lite_pb.js";
 
 /**
  * @generated from enum protobuf_unittest.Proto2MapEnumLite

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -25,8 +25,8 @@
 // We don't put this in a package within proto2 because we need to make sure
 // that the generated code doesn't depend on being in the proto2 namespace.
 
-import type { Any, BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { EnumOptions, EnumValueOptions, FieldOptions, FileOptions, Message, MessageOptions, MethodOptions, OneofOptions, proto2, ServiceOptions } from "@bufbuild/protobuf";
+import type { Any, BinaryReadOptions, EnumOptions, EnumValueOptions, Extension, FieldList, FieldOptions, FileOptions, JsonReadOptions, JsonValue, MessageOptions, MethodOptions, OneofOptions, PartialMessage, PlainMessage, ServiceOptions } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.MethodOpt1

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_features_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_features_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/unittest_features.proto (package pb, syntax proto2)
 /* eslint-disable */
 
-import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { FeatureSet, Message, proto2 } from "@bufbuild/protobuf";
+import type { BinaryReadOptions, Extension, FeatureSet, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message pb.TestMessage

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_invalid_features_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_invalid_features_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/unittest_invalid_features.proto (package pb, syntax proto2)
 /* eslint-disable */
 
-import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { FeatureSet, Message, proto2 } from "@bufbuild/protobuf";
+import type { BinaryReadOptions, Extension, FeatureSet, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message pb.TestInvalidFeatures

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
@@ -25,7 +25,7 @@
 
 import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto2 } from "@bufbuild/protobuf";
-import { TestMessageSet } from "./unittest_mset_wire_format_pb.js";
+import type { TestMessageSet } from "./unittest_mset_wire_format_pb.js";
 
 /**
  * @generated from message protobuf_unittest.TestMessageSetContainer

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/unittest_proto3_optional.proto (package protobuf_unittest, syntax proto3)
 /* eslint-disable */
 
-import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, MessageOptions, proto3 } from "@bufbuild/protobuf";
+import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, MessageOptions, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
+import { Message, proto3 } from "@bufbuild/protobuf";
 
 /**
  * @generated from message protobuf_unittest.TestProto3Optional

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
@@ -16,8 +16,8 @@
 // @generated from file google/protobuf/unittest_retention.proto (package protobuf_unittest, syntax proto2)
 /* eslint-disable */
 
-import type { BinaryReadOptions, Extension, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { EnumOptions, EnumValueOptions, ExtensionRangeOptions, FieldOptions, FileOptions, Message, MessageOptions, MethodOptions, OneofOptions, proto2, ServiceOptions } from "@bufbuild/protobuf";
+import type { BinaryReadOptions, EnumOptions, EnumValueOptions, Extension, ExtensionRangeOptions, FieldList, FieldOptions, FileOptions, JsonReadOptions, JsonValue, MessageOptions, MethodOptions, OneofOptions, PartialMessage, PlainMessage, ServiceOptions } from "@bufbuild/protobuf";
+import { Message, proto2 } from "@bufbuild/protobuf";
 
 /**
  * @generated from enum protobuf_unittest.TopLevelEnum

--- a/packages/protoc-gen-es/src/declaration.ts
+++ b/packages/protoc-gen-es/src/declaration.ts
@@ -48,7 +48,7 @@ export function generateDts(schema: Schema) {
 // prettier-ignore
 function generateEnum(schema: Schema, f: GeneratedFile, enumeration: DescEnum) {
   f.print(f.jsDoc(enumeration));
-  f.print("export declare enum ", enumeration, " {");
+  f.print(f.exportDecl("declare enum", localName(enumeration)), " {");
   for (const value of enumeration.values) {
     if (enumeration.values.indexOf(value) > 0) {
       f.print();
@@ -72,8 +72,9 @@ function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage)
     JsonReadOptions,
     JsonValue
   } = schema.runtime;
+  const m = localName(message);
   f.print(f.jsDoc(message));
-  f.print("export declare class ", message, " extends ", Message, "<", message, "> {");
+  f.print(f.exportDecl("declare class", m), " extends ", Message, "<", m, "> {");
   for (const member of message.members) {
     switch (member.kind) {
       case "oneof":
@@ -85,7 +86,7 @@ function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage)
     }
     f.print();
   }
-  f.print("  constructor(data?: ", PartialMessage, "<", message, ">);");
+  f.print("  constructor(data?: ", PartialMessage, "<", m, ">);");
   f.print();
   generateWktMethods(schema, f, message);
   f.print("  static readonly runtime: typeof ", protoN, ";");
@@ -95,13 +96,13 @@ function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage)
   //f.print("  static readonly options: { readonly [extensionName: string]: ", rt.JsonValue, " } = {};")
   f.print();
   generateWktStaticMethods(schema, f, message);
-  f.print("  static fromBinary(bytes: Uint8Array, options?: Partial<", BinaryReadOptions, ">): ", message, ";")
+  f.print("  static fromBinary(bytes: Uint8Array, options?: Partial<", BinaryReadOptions, ">): ", m, ";")
   f.print()
-  f.print("  static fromJson(jsonValue: ", JsonValue, ", options?: Partial<", JsonReadOptions, ">): ", message, ";")
+  f.print("  static fromJson(jsonValue: ", JsonValue, ", options?: Partial<", JsonReadOptions, ">): ", m, ";")
   f.print()
-  f.print("  static fromJsonString(jsonString: string, options?: Partial<", JsonReadOptions, ">): ", message, ";")
+  f.print("  static fromJsonString(jsonString: string, options?: Partial<", JsonReadOptions, ">): ", m, ";")
   f.print()
-  f.print("  static equals(a: ", message, " | ", PlainMessage, "<", message, "> | undefined, b: ", message, " | ", PlainMessage, "<", message, "> | undefined): boolean;")
+  f.print("  static equals(a: ", m, " | ", PlainMessage, "<", m, "> | undefined, b: ", m, " | ", PlainMessage, "<", m, "> | undefined): boolean;")
   f.print("}")
   f.print()
   for (const nestedEnum of message.nestedEnums) {
@@ -151,8 +152,9 @@ function generateExtension(
   ext: DescExtension,
 ) {
   const { typing } = getFieldTypeInfo(ext);
+  const e = f.import(ext.extendee).toTypeOnly();
   f.print(f.jsDoc(ext));
-  f.print(f.exportDecl("declare const", ext), ": ", schema.runtime.Extension, "<", ext.extendee, ", ", typing, ">;");
+  f.print(f.exportDecl("declare const", localName(ext)), ": ", schema.runtime.Extension, "<", e, ", ", typing, ">;");
   f.print();
 }
 


### PR DESCRIPTION
When generating with target "dts", the resulting .d.ts files sometimes import message classes or enumerations as values, even though they are only used as types.

This PR makes sure we generate type imports when possible.