### PR TITLE
Rename DescSet to Registry

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,313 b      | 64,853 b | 15,924 b |
+| protobuf-es         | 126,360 b      | 64,858 b | 15,905 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-conformance/src/conformance.ts
+++ b/packages/protobuf-conformance/src/conformance.ts
@@ -23,7 +23,7 @@ import {
   toBinary,
   toJsonString,
 } from "@bufbuild/protobuf/next";
-import { createDescSet } from "@bufbuild/protobuf/next/reflect";
+import { createRegistry } from "@bufbuild/protobuf/next/reflect";
 import type {
   ConformanceRequest,
   ConformanceResponse,
@@ -46,7 +46,7 @@ import {
   fileDesc_google_protobuf_wrappers,
 } from "@bufbuild/protobuf/next/wkt";
 
-const registry = createDescSet(
+const registry = createRegistry(
   fileDesc_google_protobuf_test_messages_proto2,
   fileDesc_google_protobuf_test_messages_proto3,
   fileDesc_google_protobuf_any,
@@ -114,7 +114,7 @@ function test(request: ConformanceRequest): ConformanceResponse["result"] {
           ignoreUnknownFields:
             request.testCategory ===
             TestCategory.JSON_IGNORE_UNKNOWN_PARSING_TEST,
-          descSet: registry,
+          registry,
         });
         break;
 
@@ -146,7 +146,7 @@ function test(request: ConformanceRequest): ConformanceResponse["result"] {
         return {
           case: "jsonPayload",
           value: toJsonString(payloadType, payload, {
-            descSet: registry,
+            registry,
           }),
         };
 

--- a/packages/protobuf-test/src/jstype.test.ts
+++ b/packages/protobuf-test/src/jstype.test.ts
@@ -18,7 +18,7 @@ import {
   protoInt64,
 } from "@bufbuild/protobuf";
 import { fromBinary } from "@bufbuild/protobuf/next";
-import { createDescFileSet } from "@bufbuild/protobuf/next/reflect";
+import { createFileRegistry } from "@bufbuild/protobuf/next/reflect";
 import { FileDescriptorSetDesc } from "@bufbuild/protobuf/next/wkt";
 import { readFileSync } from "fs";
 import { describe, expect, test } from "@jest/globals";
@@ -189,7 +189,7 @@ describe("createDescriptorSet with jstype", () => {
 });
 
 describe("createRegistryFromDescriptors with jstype", () => {
-  const set = createDescFileSet(
+  const reg = createFileRegistry(
     fromBinary(FileDescriptorSetDesc, readFileSync("./descriptorset.binpb")),
   );
   testAllFieldsLongType("spec.JSTypeOmittedMessage", LongType.BIGINT);
@@ -202,7 +202,7 @@ describe("createRegistryFromDescriptors with jstype", () => {
   testAllFieldsLongType("spec.JSTypeProto2NumberMessage", LongType.BIGINT);
 
   function testAllFieldsLongType(messageTypeName: string, longType: LongType) {
-    const mt = set.getMessage(messageTypeName);
+    const mt = reg.getMessage(messageTypeName);
     assert(mt);
     for (const field of mt.fields) {
       test(`${messageTypeName} field #${field.number}`, () => {

--- a/packages/protobuf-test/src/next/codegenv1/boot.test.ts
+++ b/packages/protobuf-test/src/next/codegenv1/boot.test.ts
@@ -39,13 +39,13 @@ import {
   createFileDescriptorProtoBoot,
   embedFileDesc,
 } from "@bufbuild/protobuf/next/codegenv1";
-import { createDescFileSet } from "@bufbuild/protobuf/next/reflect";
+import { createFileRegistry } from "@bufbuild/protobuf/next/reflect";
 import { boot } from "@bufbuild/protobuf/next/codegenv1";
 
 describe("boot()", () => {
   test("hydrates google/protobuf/descriptor.proto", async () => {
     const fileDescriptorProto = await compileGoogleProtobufDescriptorProto();
-    const fileDesc = createDescFileSet(
+    const fileDesc = createFileRegistry(
       fileDescriptorProto,
       () => undefined,
     ).getFile(fileDescriptorProto.name);

--- a/packages/protobuf-test/src/next/codegenv1/embed.test.ts
+++ b/packages/protobuf-test/src/next/codegenv1/embed.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, test } from "@jest/globals";
 import { compileFile, compileFileDescriptorSet } from "../helpers.js";
 import { embedFileDesc } from "@bufbuild/protobuf/next/codegenv1";
 import assert from "node:assert";
-import { createDescFileSet } from "@bufbuild/protobuf/next/reflect";
+import { createFileRegistry } from "@bufbuild/protobuf/next/reflect";
 
 describe("embedFileDesc()", () => {
   test("embeds file descriptor", async () => {
@@ -31,7 +31,7 @@ describe("embedFileDesc()", () => {
     expect(typeof embedded.base64()).toBe("string");
   });
   test("embeds google/protobuf.descriptor.proto", async () => {
-    const file = createDescFileSet(
+    const file = createFileRegistry(
       await compileFileDescriptorSet({
         "google/protobuf/descriptor.proto": `
         syntax="proto2"; 

--- a/packages/protobuf-test/src/next/helpers.ts
+++ b/packages/protobuf-test/src/next/helpers.ts
@@ -14,7 +14,7 @@
 
 import type { DescMessage } from "@bufbuild/protobuf";
 import { UpstreamProtobuf } from "upstream-protobuf";
-import { createDescFileSet, localName } from "@bufbuild/protobuf/next/reflect";
+import { createFileRegistry, localName } from "@bufbuild/protobuf/next/reflect";
 import * as proto3_ts from "../gen/ts/extra/proto3_pbv2.js";
 import type { DescField } from "@bufbuild/protobuf";
 import { fromBinary } from "@bufbuild/protobuf/next";
@@ -48,8 +48,8 @@ export async function compileFile(proto: string) {
     },
   );
   const fds = fromBinary(FileDescriptorSetDesc, bytes);
-  const set = createDescFileSet(fds);
-  const file = set.getFile("input.proto");
+  const reg = createFileRegistry(fds);
+  const file = reg.getFile("input.proto");
   assert(file);
   return file;
 }

--- a/packages/protobuf-test/src/next/json.test.ts
+++ b/packages/protobuf-test/src/next/json.test.ts
@@ -40,7 +40,7 @@ import {
   anyUnpack,
 } from "@bufbuild/protobuf/next/wkt";
 import type { DescMessage, JsonValue } from "@bufbuild/protobuf";
-import { createDescSet } from "@bufbuild/protobuf/next/reflect";
+import { createRegistry } from "@bufbuild/protobuf/next/reflect";
 
 import {
   Proto2ExtendeeDesc,
@@ -317,7 +317,7 @@ describe(`json serialization`, () => {
         );
         expect(
           toJson(AnyDesc, any, {
-            descSet: createDescSet(ValueDesc, StructDesc),
+            registry: createRegistry(ValueDesc, StructDesc),
           }),
         ).toStrictEqual({
           "@type": "type.googleapis.com/google.protobuf.Value",
@@ -338,7 +338,7 @@ describe(`json serialization`, () => {
           }),
         );
         const got = toJson(AnyDesc, str, {
-          descSet: createDescSet(StructDesc, ValueDesc),
+          registry: createRegistry(StructDesc, ValueDesc),
         });
         expect(got).toStrictEqual({
           "@type": "type.googleapis.com/google.protobuf.Struct",
@@ -353,7 +353,7 @@ describe(`json serialization`, () => {
           }),
         );
         const got = toJson(AnyDesc, str, {
-          descSet: createDescSet(StructDesc, ValueDesc),
+          registry: createRegistry(StructDesc, ValueDesc),
         });
         expect(got).toStrictEqual({
           "@type": "type.googleapis.com/google.protobuf.Value",
@@ -370,7 +370,7 @@ describe(`json serialization`, () => {
             "@type": "type.googleapis.com/google.protobuf.Value",
             value: 1,
           },
-          { descSet: createDescSet(StructDesc, ValueDesc) },
+          { registry: createRegistry(StructDesc, ValueDesc) },
         );
         expect(anyUnpack(any, ValueDesc)).toStrictEqual(want);
       });
@@ -380,7 +380,7 @@ describe(`json serialization`, () => {
           create(JsonNamesMessageDesc, { a: "a", b: "b", c: "c" }),
         );
         const got = toJson(AnyDesc, any, {
-          descSet: createDescSet(JsonNamesMessageDesc),
+          registry: createRegistry(JsonNamesMessageDesc),
         });
         expect(got).toStrictEqual({
           "@type": "type.googleapis.com/spec.JsonNamesMessage",
@@ -564,7 +564,7 @@ describe(`json serialization`, () => {
     test("encode and decode an extension", () => {
       const extendee = create(Proto2ExtendeeDesc);
       setExtension(extendee, string_ext, "foo");
-      const jsonOpts = { descSet: createDescSet(string_ext) };
+      const jsonOpts = { registry: createRegistry(string_ext) };
       expect(
         getExtension(
           fromJson(

--- a/packages/protobuf-test/src/next/reflect/registry.test.ts
+++ b/packages/protobuf-test/src/next/reflect/registry.test.ts
@@ -14,10 +14,10 @@
 
 import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
 import assert from "node:assert";
-import type { DescFileSet } from "@bufbuild/protobuf/next/reflect";
+import type { FileRegistry } from "@bufbuild/protobuf/next/reflect";
 import {
-  createDescFileSet,
-  createDescSet,
+  createFileRegistry,
+  createRegistry,
   LongType,
   protoCamelCase,
   ScalarType,
@@ -46,8 +46,8 @@ import {
   compileService,
 } from "../helpers.js";
 
-describe("createDescSet()", function () {
-  let testSet: DescFileSet;
+describe("createRegistry()", function () {
+  let testReg: FileRegistry;
   let testDescs: {
     message: DescMessage;
     enum: DescEnum;
@@ -64,17 +64,17 @@ describe("createDescSet()", function () {
         extend Msg { optional int32 ext = 1; }
       `,
     });
-    testSet = createDescFileSet(fileDescriptorSet);
-    const descMsg = testSet.get("Msg");
+    testReg = createFileRegistry(fileDescriptorSet);
+    const descMsg = testReg.get("Msg");
     assert(descMsg);
     assert(descMsg.kind == "message");
-    const descEnu = testSet.get("Enu");
+    const descEnu = testReg.get("Enu");
     assert(descEnu);
     assert(descEnu.kind == "enum");
-    const descSrv = testSet.get("Srv");
+    const descSrv = testReg.get("Srv");
     assert(descSrv);
     assert(descSrv.kind == "service");
-    const descExt = testSet.get("ext");
+    const descExt = testReg.get("ext");
     assert(descExt);
     assert(descExt.kind == "extension");
     testDescs = {
@@ -86,62 +86,62 @@ describe("createDescSet()", function () {
   });
   describe("get()", () => {
     test("gets message", () => {
-      const set = createDescSet(testDescs.message);
-      expect(set.get("Msg")).toBe(testDescs.message);
+      const reg = createRegistry(testDescs.message);
+      expect(reg.get("Msg")).toBe(testDescs.message);
     });
     test("gets enum", () => {
-      const set = createDescSet(testDescs.enum);
-      expect(set.get("Enu")).toBe(testDescs.enum);
+      const reg = createRegistry(testDescs.enum);
+      expect(reg.get("Enu")).toBe(testDescs.enum);
     });
     test("gets service", () => {
-      const set = createDescSet(testDescs.service);
-      expect(set.get("Srv")).toBe(testDescs.service);
+      const reg = createRegistry(testDescs.service);
+      expect(reg.get("Srv")).toBe(testDescs.service);
     });
     test("gets extension", () => {
-      const set = createDescSet(testDescs.extension);
-      expect(set.get("ext")).toBe(testDescs.extension);
+      const reg = createRegistry(testDescs.extension);
+      expect(reg.get("ext")).toBe(testDescs.extension);
     });
   });
   describe("getMessage()", () => {
     test("gets message", () => {
-      const set = createDescSet(testDescs.message);
-      const msg: DescMessage | undefined = set.getMessage("Msg");
+      const reg = createRegistry(testDescs.message);
+      const msg: DescMessage | undefined = reg.getMessage("Msg");
       expect(msg).toBe(testDescs.message);
     });
   });
   describe("getEnum()", () => {
     test("gets enum", () => {
-      const set = createDescSet(testDescs.enum);
-      const msg: DescEnum | undefined = set.getEnum("Enu");
+      const reg = createRegistry(testDescs.enum);
+      const msg: DescEnum | undefined = reg.getEnum("Enu");
       expect(msg).toBe(testDescs.enum);
     });
   });
   describe("getService()", () => {
     test("gets service", () => {
-      const set = createDescSet(testDescs.service);
-      const msg: DescService | undefined = set.getService("Srv");
+      const reg = createRegistry(testDescs.service);
+      const msg: DescService | undefined = reg.getService("Srv");
       expect(msg).toBe(testDescs.service);
     });
   });
   describe("getExtension()", () => {
     test("gets extension", () => {
-      const set = createDescSet(testDescs.extension);
-      const ext: DescExtension | undefined = set.getExtension("ext");
+      const reg = createRegistry(testDescs.extension);
+      const ext: DescExtension | undefined = reg.getExtension("ext");
       expect(ext).toBe(testDescs.extension);
     });
   });
   describe("getExtensionFor()", () => {
     test("gets extension", () => {
-      const set = createDescSet(testDescs.extension);
-      const ext: DescExtension | undefined = set.getExtensionFor(
+      const reg = createRegistry(testDescs.extension);
+      const ext: DescExtension | undefined = reg.getExtensionFor(
         testDescs.message,
         1,
       );
       expect(ext).toBe(testDescs.extension);
     });
     test("returns undefined on unknown extension field number", () => {
-      const set = createDescSet(testDescs.extension);
-      const msg: DescExtension | undefined = set.getExtensionFor(
+      const reg = createRegistry(testDescs.extension);
+      const msg: DescExtension | undefined = reg.getExtensionFor(
         testDescs.message,
         2,
       );
@@ -155,10 +155,10 @@ describe("createDescSet()", function () {
       `,
       });
       const otherMessageDesc =
-        createDescFileSet(fileDescriptorSet).getMessage("OtherMsg");
+        createFileRegistry(fileDescriptorSet).getMessage("OtherMsg");
       assert(otherMessageDesc);
-      const set = createDescSet(testDescs.extension);
-      const msg: DescExtension | undefined = set.getExtensionFor(
+      const reg = createRegistry(testDescs.extension);
+      const msg: DescExtension | undefined = reg.getExtensionFor(
         otherMessageDesc,
         2,
       );
@@ -167,13 +167,13 @@ describe("createDescSet()", function () {
   });
   describe("iterator", () => {
     test("gets registered types", () => {
-      const set = createDescSet(
+      const reg = createRegistry(
         testDescs.message,
         testDescs.enum,
         testDescs.service,
         testDescs.extension,
       );
-      const actual = Array.from(set)
+      const actual = Array.from(reg)
         .map((t) => t.typeName)
         .sort();
       const want = ["Msg", "Enu", "Srv", "ext"].sort();
@@ -192,11 +192,11 @@ describe("createDescSet()", function () {
       `,
       });
       const testMessage =
-        createDescFileSet(fileDescriptorSet).getMessage("Msg");
+        createFileRegistry(fileDescriptorSet).getMessage("Msg");
       assert(testMessage);
-      const set = createDescSet(testMessage);
-      expect(set.get("Msg")).toBeDefined();
-      expect(set.get("FieldMsg")).toBeUndefined();
+      const reg = createRegistry(testMessage);
+      expect(reg.get("Msg")).toBeDefined();
+      expect(reg.get("FieldMsg")).toBeUndefined();
     });
     test("does not make nested messages available", async () => {
       const fileDescriptorSet = await compileFileDescriptorSet({
@@ -207,15 +207,15 @@ describe("createDescSet()", function () {
         }
       `,
       });
-      const testSet = createDescFileSet(fileDescriptorSet);
-      const testMessage = testSet.getMessage("Msg");
+      const testReg = createFileRegistry(fileDescriptorSet);
+      const testMessage = testReg.getMessage("Msg");
       assert(testMessage);
-      const nestedTestMessage = testSet.getMessage("Msg.Nested");
+      const nestedTestMessage = testReg.getMessage("Msg.Nested");
       assert(nestedTestMessage);
-      const set = createDescSet(testMessage);
-      expect(set.get("Msg")).toBeDefined();
-      expect(set.get("Msg.Nested")).toBeUndefined();
-      expect(Array.from(set).length).toBe(1);
+      const reg = createRegistry(testMessage);
+      expect(reg.get("Msg")).toBeDefined();
+      expect(reg.get("Msg.Nested")).toBeUndefined();
+      expect(Array.from(reg).length).toBe(1);
     });
     test("later duplicate type overwrites former type", async () => {
       const fileDescriptorSet = await compileFileDescriptorSet({
@@ -225,38 +225,38 @@ describe("createDescSet()", function () {
       `,
       });
       const duplicateMessage =
-        createDescFileSet(fileDescriptorSet).getMessage("Msg");
+        createFileRegistry(fileDescriptorSet).getMessage("Msg");
       assert(duplicateMessage);
       assert(duplicateMessage.typeName === testDescs.message.typeName);
-      const set = createDescSet(duplicateMessage, testDescs.message);
-      expect(set.getMessage("Msg")).toBe(testDescs.message);
+      const reg = createRegistry(duplicateMessage, testDescs.message);
+      expect(reg.getMessage("Msg")).toBe(testDescs.message);
     });
   });
   describe("from DescFile", () => {
     test("provides all types from the file", () => {
-      const testFile = testSet.getFile("a.proto");
+      const testFile = testReg.getFile("a.proto");
       assert(testFile);
-      const set = createDescSet(testFile);
-      const setTypeNames = Array.from(set)
+      const reg = createRegistry(testFile);
+      const regTypeNames = Array.from(reg)
         .map((t) => t.typeName)
         .sort();
-      expect(setTypeNames).toStrictEqual(["Msg", "Enu", "Srv", "ext"].sort());
+      expect(regTypeNames).toStrictEqual(["Msg", "Enu", "Srv", "ext"].sort());
     });
   });
-  describe("from DescSet", () => {
-    test("creates a copy of the given DescSet", () => {
-      const testSetTypeNames = Array.from(testSet)
+  describe("from Registry", () => {
+    test("creates a copy of the given Registry", () => {
+      const testSetTypeNames = Array.from(testReg)
         .map((t) => t.typeName)
         .sort();
       assert(testSetTypeNames.length > 0);
-      const set = createDescSet(testSet);
-      const setTypeNames = Array.from(set)
+      const reg = createRegistry(testReg);
+      const regTypeNames = Array.from(reg)
         .map((t) => t.typeName)
         .sort();
-      expect(setTypeNames).toStrictEqual(testSetTypeNames);
+      expect(regTypeNames).toStrictEqual(testSetTypeNames);
     });
-    test("merges two DescSets", async () => {
-      const secondSet = createDescFileSet(
+    test("merges two Registries", async () => {
+      const secondReg = createFileRegistry(
         await compileFileDescriptorSet({
           "a.proto": `
         syntax="proto2";
@@ -267,16 +267,16 @@ describe("createDescSet()", function () {
       `,
         }),
       );
-      const set = createDescSet(testSet, secondSet);
-      const setTypeNames = Array.from(set)
+      const reg = createRegistry(testReg, secondReg);
+      const regTypeNames = Array.from(reg)
         .map((t) => t.typeName)
         .sort();
-      expect(setTypeNames).toStrictEqual(
+      expect(regTypeNames).toStrictEqual(
         ["Msg", "Enu", "Srv", "ext", "Msg2", "Enu2", "Srv2", "ext2"].sort(),
       );
     });
     test("later duplicate type overwrites former type", async () => {
-      const secondSet = createDescFileSet(
+      const secondReg = createFileRegistry(
         await compileFileDescriptorSet({
           "a.proto": `
         syntax="proto2";
@@ -285,20 +285,20 @@ describe("createDescSet()", function () {
       `,
         }),
       );
-      const set = createDescSet(testSet, secondSet);
-      const setTypeNames = Array.from(set)
+      const reg = createRegistry(testReg, secondReg);
+      const regTypeNames = Array.from(reg)
         .map((t) => t.typeName)
         .sort();
-      expect(setTypeNames).toStrictEqual(
+      expect(regTypeNames).toStrictEqual(
         ["Msg", "Enu", "Srv", "ext", "Msg3"].sort(),
       );
-      expect(set.get("Msg")).toBe(secondSet.get("Msg"));
-      expect(set.get("Msg")).not.toBe(testSet.get("Msg"));
+      expect(reg.get("Msg")).toBe(secondReg.get("Msg"));
+      expect(reg.get("Msg")).not.toBe(testReg.get("Msg"));
     });
   });
 });
 
-describe("createDescFileSet()", function () {
+describe("createFileRegistry()", function () {
   let testFileDescriptorSet: FileDescriptorSet;
   beforeEach(async () => {
     testFileDescriptorSet = await compileFileDescriptorSet({
@@ -326,11 +326,11 @@ describe("createDescFileSet()", function () {
   });
   describe("from FileDescriptorSet", function () {
     test("provides files through getFile()", () => {
-      const fileSet = createDescFileSet(testFileDescriptorSet);
-      const a = fileSet.getFile("a.proto");
-      const b = fileSet.getFile("b.proto");
-      const c = fileSet.getFile("c.proto");
-      const d = fileSet.getFile("d.proto");
+      const fileReg = createFileRegistry(testFileDescriptorSet);
+      const a = fileReg.getFile("a.proto");
+      const b = fileReg.getFile("b.proto");
+      const c = fileReg.getFile("c.proto");
+      const d = fileReg.getFile("d.proto");
       expect(a).toBeDefined();
       expect(b).toBeDefined();
       expect(c).toBeDefined();
@@ -341,8 +341,8 @@ describe("createDescFileSet()", function () {
       expect(d?.dependencies).toStrictEqual([]);
     });
     test("provides files through file iterable", () => {
-      const fileSet = createDescFileSet(testFileDescriptorSet);
-      expect(Array.from(fileSet.files).map((f) => f.name)).toStrictEqual([
+      const fileReg = createFileRegistry(testFileDescriptorSet);
+      expect(Array.from(fileReg.files).map((f) => f.name)).toStrictEqual([
         "d",
         "b",
         "c",
@@ -352,47 +352,47 @@ describe("createDescFileSet()", function () {
   });
   describe("from FileDescriptorProto", function () {
     let descFileA: DescFile;
-    let testFileSet: DescFileSet;
+    let testFileReg: FileRegistry;
     beforeAll(() => {
-      testFileSet = createDescFileSet(testFileDescriptorSet);
-      const a = testFileSet.getFile("a.proto");
+      testFileReg = createFileRegistry(testFileDescriptorSet);
+      const a = testFileReg.getFile("a.proto");
       assert(a);
       assert(a.proto);
       descFileA = a;
     });
     test("resolves all dependencies as FileDescriptorProto", function () {
-      const set = createDescFileSet(descFileA.proto, (protoFileName) =>
-        testFileSet.getFile(protoFileName),
+      const reg = createFileRegistry(descFileA.proto, (protoFileName) =>
+        testFileReg.getFile(protoFileName),
       );
-      expect(set.getFile("a.proto")).toBeDefined();
-      expect(set.getFile("b.proto")).toBeDefined();
-      expect(set.getFile("c.proto")).toBeDefined();
-      expect(set.getFile("d.proto")).toBeDefined();
-      expect(set.getMessage("A")).toBeDefined();
-      expect(set.getMessage("B")).toBeDefined();
-      expect(set.getMessage("C")).toBeDefined();
-      expect(set.getMessage("D")).toBeDefined();
+      expect(reg.getFile("a.proto")).toBeDefined();
+      expect(reg.getFile("b.proto")).toBeDefined();
+      expect(reg.getFile("c.proto")).toBeDefined();
+      expect(reg.getFile("d.proto")).toBeDefined();
+      expect(reg.getMessage("A")).toBeDefined();
+      expect(reg.getMessage("B")).toBeDefined();
+      expect(reg.getMessage("C")).toBeDefined();
+      expect(reg.getMessage("D")).toBeDefined();
     });
     test("resolves all dependencies as DescFile", function () {
-      const set = createDescFileSet(descFileA.proto, (protoFileName) =>
-        testFileSet.getFile(protoFileName),
+      const reg = createFileRegistry(descFileA.proto, (protoFileName) =>
+        testFileReg.getFile(protoFileName),
       );
-      expect(set.getFile("a.proto")).toBeDefined();
-      expect(set.getFile("b.proto")).toBeDefined();
-      expect(set.getFile("c.proto")).toBeDefined();
-      expect(set.getFile("d.proto")).toBeDefined();
-      expect(set.getMessage("A")).toBeDefined();
-      expect(set.getMessage("B")).toBeDefined();
-      expect(set.getMessage("C")).toBeDefined();
-      expect(set.getMessage("D")).toBeDefined();
+      expect(reg.getFile("a.proto")).toBeDefined();
+      expect(reg.getFile("b.proto")).toBeDefined();
+      expect(reg.getFile("c.proto")).toBeDefined();
+      expect(reg.getFile("d.proto")).toBeDefined();
+      expect(reg.getMessage("A")).toBeDefined();
+      expect(reg.getMessage("B")).toBeDefined();
+      expect(reg.getMessage("C")).toBeDefined();
+      expect(reg.getMessage("D")).toBeDefined();
     });
     test("raises error on unresolvable dependency", function () {
       function t() {
-        createDescFileSet(descFileA.proto, (protoFileName) => {
+        createFileRegistry(descFileA.proto, (protoFileName) => {
           if (protoFileName === "c.proto") {
             return undefined;
           }
-          return testFileSet.getFile(protoFileName);
+          return testFileReg.getFile(protoFileName);
         });
       }
       expect(t).toThrow(/^Unable to resolve c.proto, imported by a.proto$/);
@@ -402,7 +402,7 @@ describe("createDescFileSet()", function () {
     testFileDescriptorSet.file[0].syntax = "editions";
     testFileDescriptorSet.file[0].edition = Edition.EDITION_1_TEST_ONLY;
     function t() {
-      createDescFileSet(testFileDescriptorSet);
+      createFileRegistry(testFileDescriptorSet);
     }
     expect(t).toThrow(/^d.proto: unsupported edition$/);
   });
@@ -410,33 +410,33 @@ describe("createDescFileSet()", function () {
     testFileDescriptorSet.file[0].syntax = "editions";
     testFileDescriptorSet.file[0].edition = Edition.EDITION_99999_TEST_ONLY;
     function t() {
-      createDescFileSet(testFileDescriptorSet);
+      createFileRegistry(testFileDescriptorSet);
     }
     expect(t).toThrow(/^d.proto: unsupported edition$/);
   });
-  describe("from DescFileSet", function () {
-    test("creates a copy of the given DescFileSet", () => {
-      const testSet = createDescFileSet(testFileDescriptorSet);
-      const testSetFileNames = Array.from(testSet.files)
+  describe("from FileRegistry", function () {
+    test("creates a copy of the given FileRegistry", () => {
+      const testReg = createFileRegistry(testFileDescriptorSet);
+      const testRegFileNames = Array.from(testReg.files)
         .map((f) => f.name)
         .sort();
-      const testSetTypeNames = Array.from(testSet)
+      const testRegTypeNames = Array.from(testReg)
         .map((t) => t.typeName)
         .sort();
-      assert(testSetTypeNames.length > 0);
+      assert(testRegTypeNames.length > 0);
 
-      const set = createDescFileSet(testSet);
-      const setFileNames = Array.from(set.files)
+      const reg = createFileRegistry(testReg);
+      const regFileNames = Array.from(reg.files)
         .map((f) => f.name)
         .sort();
-      expect(setFileNames).toStrictEqual(testSetFileNames);
-      const setTypeNames = Array.from(set)
+      expect(regFileNames).toStrictEqual(testRegFileNames);
+      const regTypeNames = Array.from(reg)
         .map((t) => t.typeName)
         .sort();
-      expect(setTypeNames).toStrictEqual(testSetTypeNames);
+      expect(regTypeNames).toStrictEqual(testRegTypeNames);
     });
-    test("merges two DescFileSets", async () => {
-      const setA = createDescFileSet(
+    test("merges two FileRegistries", async () => {
+      const regA = createFileRegistry(
         await compileFileDescriptorSet({
           "a.proto": `
           syntax="proto2";
@@ -447,7 +447,7 @@ describe("createDescFileSet()", function () {
         `,
         }),
       );
-      const setB = createDescFileSet(
+      const regB = createFileRegistry(
         await compileFileDescriptorSet({
           "b.proto": `
           syntax="proto2";
@@ -458,22 +458,22 @@ describe("createDescFileSet()", function () {
         `,
         }),
       );
-      const set = createDescFileSet(setA, setB);
+      const reg = createFileRegistry(regA, regB);
       expect(
-        Array.from(set)
+        Array.from(reg)
           .map((t) => t.typeName)
           .sort(),
       ).toStrictEqual(
         ["Msg", "Enu", "Srv", "ext", "Msg2", "Enu2", "Srv2", "ext2"].sort(),
       );
       expect(
-        Array.from(set.files)
+        Array.from(reg.files)
           .map((f) => f.name)
           .sort(),
       ).toStrictEqual(["a", "b"].sort());
     });
     test("later duplicate file overwrites former file", async () => {
-      const setA = createDescFileSet(
+      const regA = createFileRegistry(
         await compileFileDescriptorSet({
           "a.proto": `
           syntax="proto2";
@@ -481,7 +481,7 @@ describe("createDescFileSet()", function () {
         `,
         }),
       );
-      const setB = createDescFileSet(
+      const regB = createFileRegistry(
         await compileFileDescriptorSet({
           "a.proto": `
           syntax="proto2";
@@ -489,10 +489,10 @@ describe("createDescFileSet()", function () {
         `,
         }),
       );
-      const set = createDescFileSet(setA, setB);
-      expect(Array.from(set.files).map((f) => f.name)).toStrictEqual(["a"]);
+      const reg = createFileRegistry(regA, regB);
+      expect(Array.from(reg.files).map((f) => f.name)).toStrictEqual(["a"]);
       expect(
-        Array.from(set)
+        Array.from(reg)
           .map((t) => t.typeName)
           .sort(),
       ).toStrictEqual(["MsgA", "MsgB"].sort());
@@ -505,8 +505,8 @@ describe("DescFile", () => {
     const fileDescriptorSet = await compileFileDescriptorSet({
       "a.proto": `syntax="proto2";`,
     });
-    const set = createDescFileSet(fileDescriptorSet);
-    const descFile = set.getFile("a.proto");
+    const reg = createFileRegistry(fileDescriptorSet);
+    const descFile = reg.getFile("a.proto");
     expect(descFile).toBeDefined();
     expect(descFile?.edition).toBe(Edition.EDITION_PROTO2);
   });
@@ -514,8 +514,8 @@ describe("DescFile", () => {
     const fileDescriptorSet = await compileFileDescriptorSet({
       "a.proto": `syntax="proto3";`,
     });
-    const set = createDescFileSet(fileDescriptorSet);
-    const descFile = set.getFile("a.proto");
+    const reg = createFileRegistry(fileDescriptorSet);
+    const descFile = reg.getFile("a.proto");
     expect(descFile).toBeDefined();
     expect(descFile?.edition).toBe(Edition.EDITION_PROTO3);
   });
@@ -523,8 +523,8 @@ describe("DescFile", () => {
     const fileDescriptorSet = await compileFileDescriptorSet({
       "a.proto": `edition = "2023";`,
     });
-    const set = createDescFileSet(fileDescriptorSet);
-    const descFile = set.getFile("a.proto");
+    const reg = createFileRegistry(fileDescriptorSet);
+    const descFile = reg.getFile("a.proto");
     expect(descFile).toBeDefined();
     expect(descFile?.edition).toBe(Edition.EDITION_2023);
   });
@@ -536,8 +536,8 @@ describe("DescFile", () => {
       "b.proto": `syntax="proto3";`,
       "c.proto": `syntax="proto3";`,
     });
-    const set = createDescFileSet(fileDescriptorSet);
-    const a = set.getFile("a.proto");
+    const reg = createFileRegistry(fileDescriptorSet);
+    const a = reg.getFile("a.proto");
     expect(a?.name).toBe("a");
     expect(a?.dependencies.length).toBe(2);
     expect(a?.dependencies.map((f) => f.name)).toStrictEqual(["b", "c"]);
@@ -979,7 +979,7 @@ describe("DescField", () => {
         `,
       });
       const fields =
-        createDescFileSet(fileDescriptorSet).getMessage("M")?.fields;
+        createFileRegistry(fileDescriptorSet).getMessage("M")?.fields;
       assert(fields);
       {
         const f = fields.shift();
@@ -1018,7 +1018,7 @@ describe("DescField", () => {
         `,
       });
       const fields =
-        createDescFileSet(fileDescriptorSet).getMessage("M")?.fields;
+        createFileRegistry(fileDescriptorSet).getMessage("M")?.fields;
       assert(fields);
       {
         const f = fields.shift();
@@ -1057,7 +1057,7 @@ describe("DescField", () => {
         `,
       });
       const fields =
-        createDescFileSet(fileDescriptorSet).getMessage("M")?.fields;
+        createFileRegistry(fileDescriptorSet).getMessage("M")?.fields;
       assert(fields);
       {
         const f = fields.shift();
@@ -1096,7 +1096,7 @@ describe("DescField", () => {
         `,
       });
       const fields =
-        createDescFileSet(fileDescriptorSet).getMessage("M")?.fields;
+        createFileRegistry(fileDescriptorSet).getMessage("M")?.fields;
       assert(fields);
       {
         const f = fields.shift();
@@ -1126,7 +1126,7 @@ describe("DescField", () => {
         `,
     });
     const field =
-      createDescFileSet(fileDescriptorSet).getMessage("M")?.fields[0];
+      createFileRegistry(fileDescriptorSet).getMessage("M")?.fields[0];
     assert(field);
 
     // always available

--- a/packages/protobuf-test/src/next/wkt/any.test.ts
+++ b/packages/protobuf-test/src/next/wkt/any.test.ts
@@ -22,7 +22,7 @@ import {
 } from "@bufbuild/protobuf/next/wkt";
 import type { Value } from "@bufbuild/protobuf/next/wkt";
 import { create } from "@bufbuild/protobuf/next";
-import { createDescSet } from "@bufbuild/protobuf/next/reflect";
+import { createRegistry } from "@bufbuild/protobuf/next/reflect";
 
 describe("google.protobuf.Any", () => {
   test(`is correctly identifies by message and type name`, () => {
@@ -52,7 +52,7 @@ describe("google.protobuf.Any", () => {
   });
 
   test(`unpack correctly unpacks a message in the registry`, () => {
-    const typeRegistry = createDescSet(ValueDesc);
+    const typeRegistry = createRegistry(ValueDesc);
     const val = create(ValueDesc, {
       kind: { case: "numberValue", value: 1 },
     });
@@ -66,7 +66,7 @@ describe("google.protobuf.Any", () => {
   });
 
   test(`unpack correctly unpacks a message with a leading slash type url in the registry`, () => {
-    const typeRegistry = createDescSet(ValueDesc);
+    const typeRegistry = createRegistry(ValueDesc);
     const val = create(ValueDesc, {
       kind: { case: "numberValue", value: 1 },
     });
@@ -81,7 +81,7 @@ describe("google.protobuf.Any", () => {
   });
 
   test(`unpack returns undefined if message not in the registry`, () => {
-    const typeRegistry = createDescSet();
+    const typeRegistry = createRegistry();
     const val = create(ValueDesc, {
       kind: { case: "numberValue", value: 1 },
     });
@@ -91,7 +91,7 @@ describe("google.protobuf.Any", () => {
   });
 
   test(`unpack returns undefined with an empty Any`, () => {
-    const typeRegistry = createDescSet(ValueDesc);
+    const typeRegistry = createRegistry(ValueDesc);
     const any = create(AnyDesc);
     const unpacked = anyUnpack(any, typeRegistry);
     expect(unpacked).toBeUndefined();

--- a/packages/protobuf/scripts/bootstrap-inject.mjs
+++ b/packages/protobuf/scripts/bootstrap-inject.mjs
@@ -18,7 +18,7 @@ import assert from "node:assert";
 import { stdout, stderr, argv } from "node:process";
 import { UpstreamProtobuf } from "upstream-protobuf";
 import {
-  createDescFileSet,
+  createFileRegistry,
   localName,
   reflect,
 } from "@bufbuild/protobuf/next/reflect";
@@ -84,7 +84,7 @@ async function main(args) {
 /**
  * @param {string} filePath
  * @param {string} content
- * @param {DescFileSet} descriptorProto
+ * @param {FileRegistry} descriptorProto
  * @param {UpstreamProtobuf} upstream
  */
 async function processFile(filePath, content, descriptorProto, upstream) {
@@ -258,7 +258,7 @@ async function compileDefaults(upstream, minimumEdition, maximumEdition) {
 
 /**
  * @param {UpstreamProtobuf} upstream
- * @return {Promise<DescFileSet>}
+ * @return {Promise<FileRegistry>}
  */
 async function compileDescriptorProto(upstream) {
   const path = "google/protobuf/descriptor.proto";
@@ -274,7 +274,7 @@ async function compileDescriptorProto(upstream) {
     },
   );
   const fds = fromBinary(FileDescriptorSetDesc, fdsBytes);
-  const set = createDescFileSet(fds);
+  const set = createFileRegistry(fds);
   const file = set.getFile(path);
   assert(file);
   return set;

--- a/packages/protobuf/src/create-descriptor-set.ts
+++ b/packages/protobuf/src/create-descriptor-set.ts
@@ -23,7 +23,7 @@ import type {
   DescService,
 } from "./desc-types.js";
 import type { DescriptorSet } from "./descriptor-set.js";
-import { createDescFileSet } from "./next/reflect/desc-set.js";
+import { createFileRegistry } from "./next/reflect/registry.js";
 import { createV2FileDescriptorSetFromV1Input } from "./create-descriptor-set-compat.js";
 
 /**
@@ -37,12 +37,12 @@ import { createV2FileDescriptorSetFromV1Input } from "./create-descriptor-set-co
 export function createDescriptorSet(
   input: FileDescriptorProto[] | FileDescriptorSet | Uint8Array,
 ): DescriptorSet {
-  const set = createDescFileSet(createV2FileDescriptorSetFromV1Input(input));
+  const reg = createFileRegistry(createV2FileDescriptorSetFromV1Input(input));
   const enums = new Map<string, DescEnum>();
   const messages = new Map<string, DescMessage>();
   const services = new Map<string, DescService>();
   const extensions = new Map<string, DescExtension>();
-  for (const type of set) {
+  for (const type of reg) {
     switch (type.kind) {
       case "service":
         services.set(type.typeName, type);
@@ -59,7 +59,7 @@ export function createDescriptorSet(
     }
   }
   return {
-    files: Array.from(set.files),
+    files: Array.from(reg.files),
     enums,
     messages,
     services,

--- a/packages/protobuf/src/next/codegenv1/boot.ts
+++ b/packages/protobuf/src/next/codegenv1/boot.ts
@@ -28,7 +28,7 @@ import type {
 } from "../wkt/gen/google/protobuf/descriptor_pbv2.js";
 import type { DescFile } from "../../desc-types.js";
 import { restoreJsonNames } from "./restore-json-names.js";
-import { createDescFileSet } from "../reflect/desc-set.js";
+import { createFileRegistry } from "../reflect/registry.js";
 import { assert } from "../reflect/assert.js";
 
 /**
@@ -42,8 +42,8 @@ import { assert } from "../reflect/assert.js";
 export function boot(boot: FileDescriptorProtoBoot): DescFile {
   const root = bootFileDescriptorProto(boot);
   root.messageType.forEach(restoreJsonNames);
-  const set = createDescFileSet(root, () => undefined);
-  const file = set.getFile(root.name);
+  const reg = createFileRegistry(root, () => undefined);
+  const file = reg.getFile(root.name);
   assert(file);
   return file;
 }

--- a/packages/protobuf/src/next/codegenv1/file.ts
+++ b/packages/protobuf/src/next/codegenv1/file.ts
@@ -15,7 +15,7 @@
 import { base64Decode } from "../wire/index.js";
 import { FileDescriptorProtoDesc } from "../wkt/gen/google/protobuf/descriptor_pbv2.js";
 import type { DescFile } from "../../desc-types.js";
-import { createDescFileSet } from "../reflect/desc-set.js";
+import { createFileRegistry } from "../reflect/registry.js";
 import { assert } from "../reflect/assert.js";
 import { restoreJsonNames } from "./restore-json-names.js";
 import { fromBinary } from "../from-binary.js";
@@ -29,10 +29,10 @@ export function fileDesc(b64: string, imports?: DescFile[]): DescFile {
   const root = fromBinary(FileDescriptorProtoDesc, base64Decode(b64));
   root.messageType.forEach(restoreJsonNames);
   root.dependency = imports?.map((f) => f.proto.name) ?? [];
-  const set = createDescFileSet(root, (protoFileName) =>
+  const reg = createFileRegistry(root, (protoFileName) =>
     imports?.find((f) => f.proto.name === protoFileName),
   );
-  const file = set.getFile(root.name);
+  const file = reg.getFile(root.name);
   assert(file);
   return file;
 }

--- a/packages/protobuf/src/next/from-json.ts
+++ b/packages/protobuf/src/next/from-json.ts
@@ -25,7 +25,7 @@ import type { JsonValue } from "./json-value.js";
 import { assertFloat32, assertInt32, assertUInt32 } from "./reflect/assert.js";
 import { protoInt64 } from "./proto-int64.js";
 import { create } from "./create.js";
-import type { DescSet } from "./reflect/desc-set.js";
+import type { Registry } from "./reflect/registry.js";
 import type { ReflectMessage, MapEntryKey } from "./reflect/reflect-types.js";
 import { reflect } from "./reflect/reflect.js";
 import { formatVal } from "./reflect/reflect-check.js";
@@ -72,7 +72,7 @@ export interface JsonReadOptions {
    * This option is required to read `google.protobuf.Any` and extensions
    * from JSON format.
    */
-  descSet?: DescSet;
+  registry?: Registry;
 }
 
 // Default options for parsing JSON.
@@ -198,7 +198,7 @@ function readMessage(
       if (
         jsonKey.startsWith("[") &&
         jsonKey.endsWith("]") &&
-        (extension = opts.descSet?.getExtension(
+        (extension = opts.registry?.getExtension(
           jsonKey.substring(1, jsonKey.length - 1),
         )) &&
         extension.extendee.typeName === msg.desc.typeName
@@ -669,7 +669,7 @@ function anyFromJson(any: Any, json: JsonValue, opts: JsonReadOptions) {
     );
   }
   const typeName = typeUrlToName(typeUrl),
-    desc = opts.descSet?.getMessage(typeName);
+    desc = opts.registry?.getMessage(typeName);
   if (!desc) {
     throw new Error(
       `cannot decode message ${any.$typeName} from JSON: ${typeUrl} is not in the type registry`,

--- a/packages/protobuf/src/next/reflect/index.ts
+++ b/packages/protobuf/src/next/reflect/index.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 export * from "./error.js";
-export * from "./desc-set.js";
 export * from "./names.js";
 export * from "./nested-types.js";
 export * from "./reflect.js";
-export * from "./scalar.js";
 export * from "./reflect-types.js";
+export * from "./registry.js";
+export * from "./scalar.js";
 export { isReflectList, isReflectMap, isReflectMessage } from "./guard.js";

--- a/packages/protobuf/src/next/to-json.ts
+++ b/packages/protobuf/src/next/to-json.ts
@@ -18,7 +18,7 @@ import { assert } from "./reflect/assert.js";
 import { protoCamelCase } from "./reflect/names.js";
 import { reflect } from "./reflect/reflect.js";
 import { ScalarType } from "./reflect/scalar.js";
-import type { DescSet } from "./reflect/desc-set.js";
+import type { Registry } from "./reflect/registry.js";
 import type {
   ReflectList,
   ReflectMap,
@@ -79,7 +79,7 @@ export interface JsonWriteOptions {
    * This option is required to write `google.protobuf.Any` and extensions
    * to JSON format.
    */
-  descSet?: DescSet;
+  registry?: Registry;
 }
 
 /**
@@ -156,7 +156,7 @@ function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
       json[jsonName(f, opts)] = jsonValue;
     }
   }
-  if (opts.descSet) {
+  if (opts.registry) {
     const tagSeen = new Set<number>();
     for (const uf of msg.getUnknown() ?? []) {
       // Same tag can appear multiple times, so we
@@ -164,7 +164,7 @@ function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
       if (tagSeen.has(uf.no)) {
         continue;
       }
-      const extension = opts.descSet.getExtensionFor(msg.desc, uf.no);
+      const extension = opts.registry.getExtensionFor(msg.desc, uf.no);
       if (!extension) {
         continue;
       }
@@ -378,13 +378,13 @@ function anyToJson(val: Any, opts: JsonWriteOptions): JsonValue {
   if (val.typeUrl === "") {
     return {};
   }
-  const { descSet } = opts;
+  const { registry } = opts;
   let message: Message | undefined;
   let desc: DescMessage | undefined;
-  if (descSet) {
-    message = anyUnpack(val, descSet);
+  if (registry) {
+    message = anyUnpack(val, registry);
     if (message) {
-      desc = descSet.getMessage(message.$typeName);
+      desc = registry.getMessage(message.$typeName);
     }
   }
   if (!desc || !message) {

--- a/packages/protobuf/src/next/wkt/any.ts
+++ b/packages/protobuf/src/next/wkt/any.ts
@@ -16,7 +16,7 @@ import type { Message, MessageShape } from "../types.js";
 import type { Any } from "./gen/google/protobuf/any_pbv2.js";
 import { AnyDesc } from "./gen/google/protobuf/any_pbv2.js";
 import type { DescMessage } from "../../desc-types.js";
-import type { DescSet } from "../reflect/index.js";
+import type { Registry } from "../reflect/index.js";
 import { create } from "../create.js";
 import { toBinary } from "../to-binary.js";
 import { fromBinary, mergeFromBinary } from "../from-binary.js";
@@ -79,9 +79,9 @@ export function anyIs(any: Any, descOrTypeName: DescMessage | string): boolean {
  * Unpacks the message the Any represents.
  *
  * Returns undefined if the Any is empty, or if packed type is not included
- * in the given set.
+ * in the given registry.
  */
-export function anyUnpack(any: Any, set: DescSet): Message | undefined;
+export function anyUnpack(any: Any, registry: Registry): Message | undefined;
 
 /**
  * Unpacks the message the Any represents.
@@ -96,15 +96,15 @@ export function anyUnpack<Desc extends DescMessage>(
 
 export function anyUnpack(
   any: Any,
-  descSetOrMessage: DescSet | DescMessage,
+  registryOrMessageDesc: Registry | DescMessage,
 ): Message | undefined {
   if (any.typeUrl === "") {
     return undefined;
   }
   const desc =
-    descSetOrMessage.kind == "message"
-      ? descSetOrMessage
-      : descSetOrMessage.getMessage(typeUrlToName(any.typeUrl));
+    registryOrMessageDesc.kind == "message"
+      ? registryOrMessageDesc
+      : registryOrMessageDesc.getMessage(typeUrlToName(any.typeUrl));
   if (!desc) {
     return undefined;
   }

--- a/packages/protoplugin-test/src/helpers.ts
+++ b/packages/protoplugin-test/src/helpers.ts
@@ -18,7 +18,7 @@ import {
   FileDescriptorSetDesc,
 } from "@bufbuild/protobuf/next/wkt";
 import { fromBinary } from "@bufbuild/protobuf/next";
-import { createDescFileSet } from "@bufbuild/protobuf/next/reflect";
+import { createFileRegistry } from "@bufbuild/protobuf/next/reflect";
 import type { Plugin } from "@bufbuild/protoplugin";
 import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
 import type {
@@ -132,8 +132,8 @@ export async function compileFile(proto: string) {
     },
   );
   const fds = fromBinary(FileDescriptorSetDesc, bytes);
-  const set = createDescFileSet(fds);
-  const file = set.getFile("input.proto");
+  const reg = createFileRegistry(fds);
+  const file = reg.getFile("input.proto");
   assert(file);
   return file;
 }

--- a/packages/protoplugin/src/ecmascript/schema.ts
+++ b/packages/protoplugin/src/ecmascript/schema.ts
@@ -24,7 +24,7 @@ import type { CodeGeneratorRequest } from "@bufbuild/protobuf/next/wkt";
 import { Edition } from "@bufbuild/protobuf/next/wkt";
 import { FileDescriptorSetDesc } from "@bufbuild/protobuf/next/wkt";
 import {
-  createDescFileSet,
+  createFileRegistry,
   nestedTypes,
 } from "@bufbuild/protobuf/next/reflect";
 import type {
@@ -220,14 +220,14 @@ function getFilesToGenerate(
       }
     }
   }
-  const descriptorSet = createDescFileSet(
+  const registry = createFileRegistry(
     create(FileDescriptorSetDesc, {
       file: request.protoFile,
     }),
   );
   const allFiles: DescFile[] = [];
   const filesToGenerate: DescFile[] = [];
-  for (const file of descriptorSet.files) {
+  for (const file of registry.files) {
     allFiles.push(file);
     if (request.fileToGenerate.includes(file.proto.name)) {
       filesToGenerate.push(file);


### PR DESCRIPTION
`DescSet` and `DescFileSet` are not self-explanatory names. I suggest to rename them to `Registry` and `FileRegistry`. 

Related changes:
- `createDescSet` -> `createRegistry`
- `createDescFileSet` -> `createFileRegistry`
- `JsonReadOptions.descSet` -> `JsonReadOptions.registry`
- `JsonWriteOptions.descSet` -> `JsonWriteOptions.registry`

This should also provide for a better migration for users from v1 who have been using `createRegistry()`.

