### PR TITLE
V2: Revise map field serialization with file option message_encoding = DELIMITED

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,229 b      | 64,861 b | 15,866 b |
+| protobuf-es         | 126,925 b      | 65,122 b | 15,890 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/extra/edition2023-map-encoding.proto
+++ b/packages/protobuf-test/extra/edition2023-map-encoding.proto
@@ -14,13 +14,14 @@
 
 edition = "2023";
 package spec;
-import "google/protobuf/wrappers.proto";
 
 option features.message_encoding = DELIMITED;
 
 // Map fields are syntactic sugar for a repeated message field with field 1 for
-// key and field 2 for value. Despite that, the file feature message_encoding =
-// DELIMITED should NOT apply to this "synthetic" message.
+// key and field 2 for value.
+// The file feature message_encoding = DELIMITED should apply to this "synthetic"
+// message, following the logic of other message fields.
 message Edition2023MapEncodingMessage {
-  map<int32, bool> map_field = 77;
+  map<int32, Child> map_field = 77;
+  message Child {}
 }

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.d.ts
@@ -23,18 +23,28 @@ export declare const fileDesc_extra_edition2023_map_encoding: GenDescFile;
 
 /**
  * Map fields are syntactic sugar for a repeated message field with field 1 for
- * key and field 2 for value. Despite that, the file feature message_encoding =
- * DELIMITED should NOT apply to this "synthetic" message.
+ * key and field 2 for value.
+ * The file feature message_encoding = DELIMITED should apply to this "synthetic"
+ * message, following the logic of other message fields.
  *
  * @generated from message spec.Edition2023MapEncodingMessage
  */
 export declare type Edition2023MapEncodingMessage = Message<"spec.Edition2023MapEncodingMessage"> & {
   /**
-   * @generated from field: map<int32, bool> map_field = 77;
+   * @generated from field: map<int32, spec.Edition2023MapEncodingMessage.Child> map_field = 77;
    */
-  mapField: { [key: number]: boolean };
+  mapField: { [key: number]: Edition2023MapEncodingMessage_Child };
 };
 
 // Describes the message spec.Edition2023MapEncodingMessage. Use `create(Edition2023MapEncodingMessageDesc)` to create a new Edition2023MapEncodingMessage.
 export declare const Edition2023MapEncodingMessageDesc: GenDescMessage<Edition2023MapEncodingMessage>;
+
+/**
+ * @generated from message spec.Edition2023MapEncodingMessage.Child
+ */
+export declare type Edition2023MapEncodingMessage_Child = Message<"spec.Edition2023MapEncodingMessage.Child"> & {
+};
+
+// Describes the message spec.Edition2023MapEncodingMessage.Child. Use `create(Edition2023MapEncodingMessage_ChildDesc)` to create a new Edition2023MapEncodingMessage_Child.
+export declare const Edition2023MapEncodingMessage_ChildDesc: GenDescMessage<Edition2023MapEncodingMessage_Child>;
 

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.js
@@ -17,12 +17,15 @@
 /* eslint-disable */
 
 import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
-import { fileDesc_google_protobuf_wrappers } from "@bufbuild/protobuf/wkt";
 
 export const fileDesc_extra_edition2023_map_encoding = /*@__PURE__*/
-  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMilgEKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkQKCW1hcF9maWVsZBhNIAMoCzIxLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuTWFwRmllbGRFbnRyeRovCg1NYXBGaWVsZEVudHJ5EgsKA2tleRgBIAEoBRINCgV2YWx1ZRgCIAEoCDoCOAFCBZIDAigCYghlZGl0aW9uc3DoBw", [fileDesc_google_protobuf_wrappers]);
+  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMiygEKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkQKCW1hcF9maWVsZBhNIAMoCzIxLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuTWFwRmllbGRFbnRyeRpaCg1NYXBGaWVsZEVudHJ5EgsKA2tleRgBIAEoBRI4CgV2YWx1ZRgCIAEoCzIpLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuQ2hpbGQ6AjgBGgcKBUNoaWxkQgWSAwIoAmIIZWRpdGlvbnNw6Ac");
 
 // Describes the message spec.Edition2023MapEncodingMessage. Use `create(Edition2023MapEncodingMessageDesc)` to create a new Edition2023MapEncodingMessage.
 export const Edition2023MapEncodingMessageDesc = /*@__PURE__*/
   messageDesc(fileDesc_extra_edition2023_map_encoding, 0);
+
+// Describes the message spec.Edition2023MapEncodingMessage.Child. Use `create(Edition2023MapEncodingMessage_ChildDesc)` to create a new Edition2023MapEncodingMessage_Child.
+export const Edition2023MapEncodingMessage_ChildDesc = /*@__PURE__*/
+  messageDesc(fileDesc_extra_edition2023_map_encoding, 0, 0);
 

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023-map-encoding_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023-map-encoding_pb.ts
@@ -18,28 +18,39 @@
 
 import type { GenDescFile, GenDescMessage } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
-import { fileDesc_google_protobuf_wrappers } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
 export const fileDesc_extra_edition2023_map_encoding: GenDescFile = /*@__PURE__*/
-  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMilgEKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkQKCW1hcF9maWVsZBhNIAMoCzIxLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuTWFwRmllbGRFbnRyeRovCg1NYXBGaWVsZEVudHJ5EgsKA2tleRgBIAEoBRINCgV2YWx1ZRgCIAEoCDoCOAFCBZIDAigCYghlZGl0aW9uc3DoBw", [fileDesc_google_protobuf_wrappers]);
+  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMiygEKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkQKCW1hcF9maWVsZBhNIAMoCzIxLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuTWFwRmllbGRFbnRyeRpaCg1NYXBGaWVsZEVudHJ5EgsKA2tleRgBIAEoBRI4CgV2YWx1ZRgCIAEoCzIpLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuQ2hpbGQ6AjgBGgcKBUNoaWxkQgWSAwIoAmIIZWRpdGlvbnNw6Ac");
 
 /**
  * Map fields are syntactic sugar for a repeated message field with field 1 for
- * key and field 2 for value. Despite that, the file feature message_encoding =
- * DELIMITED should NOT apply to this "synthetic" message.
+ * key and field 2 for value.
+ * The file feature message_encoding = DELIMITED should apply to this "synthetic"
+ * message, following the logic of other message fields.
  *
  * @generated from message spec.Edition2023MapEncodingMessage
  */
 export type Edition2023MapEncodingMessage = Message<"spec.Edition2023MapEncodingMessage"> & {
   /**
-   * @generated from field: map<int32, bool> map_field = 77;
+   * @generated from field: map<int32, spec.Edition2023MapEncodingMessage.Child> map_field = 77;
    */
-  mapField: { [key: number]: boolean };
+  mapField: { [key: number]: Edition2023MapEncodingMessage_Child };
 };
 
 // Describes the message spec.Edition2023MapEncodingMessage.
 // Use `create(Edition2023MapEncodingMessageDesc)` to create a new Edition2023MapEncodingMessage.
 export const Edition2023MapEncodingMessageDesc: GenDescMessage<Edition2023MapEncodingMessage> = /*@__PURE__*/
   messageDesc(fileDesc_extra_edition2023_map_encoding, 0);
+
+/**
+ * @generated from message spec.Edition2023MapEncodingMessage.Child
+ */
+export type Edition2023MapEncodingMessage_Child = Message<"spec.Edition2023MapEncodingMessage.Child"> & {
+};
+
+// Describes the message spec.Edition2023MapEncodingMessage.Child.
+// Use `create(Edition2023MapEncodingMessage_ChildDesc)` to create a new Edition2023MapEncodingMessage_Child.
+export const Edition2023MapEncodingMessage_ChildDesc: GenDescMessage<Edition2023MapEncodingMessage_Child> = /*@__PURE__*/
+  messageDesc(fileDesc_extra_edition2023_map_encoding, 0, 0);
 

--- a/packages/protobuf-test/src/reflect/registry.test.ts
+++ b/packages/protobuf-test/src/reflect/registry.test.ts
@@ -790,7 +790,7 @@ describe("DescField", () => {
         field.fieldKind == "message" ? field.delimitedEncoding : undefined,
       ).toBe(true);
     });
-    test("false for map field with inherited features.message_encoding = DELIMITED", async () => {
+    test("true for map field with inherited features.message_encoding = DELIMITED", async () => {
       const field = await compileField(`
         edition="2023";
         option features.message_encoding = DELIMITED;
@@ -800,7 +800,7 @@ describe("DescField", () => {
       `);
       expect(
         field.fieldKind == "map" ? field.delimitedEncoding : undefined,
-      ).toBe(false);
+      ).toBe(true);
     });
   });
   describe("optional", () => {

--- a/packages/protobuf/src/desc-types.ts
+++ b/packages/protobuf/src/desc-types.ts
@@ -504,9 +504,9 @@ type descFieldMapCommon<T extends ScalarType = ScalarType> = T extends Exclude<S
   readonly oneof: undefined;
   /**
    * Encode the map entry message delimited (a.k.a. proto2 group encoding),
-   * or length-prefixed? This is always false for map fields.
+   * or length-prefixed? This also applies to map values, if they are messages.
    */
-  readonly delimitedEncoding: false;
+  readonly delimitedEncoding: boolean;
 } : never;
 
 type descFieldMapScalar<T extends ScalarType = ScalarType> = T extends T

--- a/packages/protobuf/src/reflect/registry.ts
+++ b/packages/protobuf/src/reflect/registry.ts
@@ -835,7 +835,7 @@ function newField(
       field.mapKey = keyField.scalar;
       field.mapKind = valueField.fieldKind;
       field.message = valueField.message;
-      field.delimitedEncoding = false; // map fields are always LENGTH_PREFIXED
+      field.delimitedEncoding = isDelimitedEncoding(proto, parentOrFile);
       field.enum = valueField.enum;
       field.scalar = valueField.scalar;
       return field as DescField;


### PR DESCRIPTION
With this change, delimited encoding applies to the map entry message, and - if the map uses a message type for values - to map values.

Whether this is the "correct" behavior is unclear as of now.