### PR TITLE
Automatically publish with the proper dist-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ setversion: ## Set a new version in for the project, i.e. make setversion SET_VE
 release: all ## Release @bufbuild/protobuf
 	@[ -z "$(shell git status --short)" ] || (echo "Uncommitted changes found." && exit 1);
 	npm publish \
+		--tag $(shell node scripts/get-workspace-publish-tag.js) \
 		--workspace packages/protobuf \
 		--workspace packages/protoplugin \
 		--workspace packages/protoc-gen-es

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ setversion: ## Set a new version in for the project, i.e. make setversion SET_VE
 release: all ## Release @bufbuild/protobuf
 	@[ -z "$(shell git status --short)" ] || (echo "Uncommitted changes found." && exit 1);
 	npm publish \
-		--tag $(shell node scripts/get-workspace-publish-tag.js) \
+		--tag $(shell node scripts/get-workspace-publish-tag.js || kill $$PPID;) \
 		--workspace packages/protobuf \
 		--workspace packages/protoplugin \
 		--workspace packages/protoc-gen-es

--- a/scripts/get-workspace-publish-tag.js
+++ b/scripts/get-workspace-publish-tag.js
@@ -1,0 +1,75 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { existsSync } from "node:fs";
+
+/*
+
+USAGE: node get-workspace-publish-tag.js
+
+Looks at the version used in the workspace, and returns one of:
+ - latest - for versions such as 3.1.4, 2.0.0, but also 0.1.2
+ - alpha - for versions such as 1.0.0-alpha.8
+ - beta - for versions such as 1.0.0-beta.8
+ - rc - for versions such as 1.0.0-rc.8
+
+*/
+
+const version = findWorkspaceVersion("packages");
+
+if (/^\d\.\d\.\d$/.test(version)) {
+  process.stdout.write("latest");
+} else if (/^\d\.\d\.\d-alpha.*$/.test(version)) {
+  process.stdout.write("alpha");
+} else if (/^\d\.\d\.\d-beta.*$/.test(version)) {
+  process.stdout.write("beta");
+} else if (/^\d\.\d\.\d-rc.*$/.test(version)) {
+  process.stdout.write("rc");
+} else {
+  throw new Error(`Unable to determine publish tag from version ${version}`);
+}
+
+/**
+ * @param {string} packagesDir
+ * @returns {string}
+ */
+function findWorkspaceVersion(packagesDir) {
+  let version = undefined;
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const path = join(packagesDir, entry.name, "package.json");
+    if (existsSync(path)) {
+      const pkg = JSON.parse(readFileSync(path, "utf-8"));
+      if (pkg.private === true) {
+        continue;
+      }
+      if (!pkg.version) {
+        throw new Error(`${path} is missing "version"`);
+      }
+      if (version === undefined) {
+        version = pkg.version;
+      } else if (version !== pkg.version) {
+        throw new Error(`${path} has unexpected version ${pkg.version}`);
+      }
+    }
+  }
+  if (version === undefined) {
+    throw new Error(`unable to find workspace version`);
+  }
+  return version;
+}


### PR DESCRIPTION
npm uses dist-tags to distinguish between the "latest" version, and other distributions. When publishing a package, the tag can be given with the flag `--tag`. When installing a package, the version tagged "latest" will be installed by default. When a tag is specified (for example `npm install foo@alpha`), the tagged version is installed.

Since we follow semver, we can trivially deduce the proper dist-tag from our workspace version: When running the target `release`, we call `npm publish --tag latest` for stable versions such as 3.1.4. For alpha versions such as 2.0.0-alpha.8, we call `npm publish --tag alpha`. Similar for beta versions and release candidates.