### PR TITLE
V2: Mark all exports from codegenv1 private

### DIFF
--- a/packages/protobuf/src/codegenv1/restore-json-names.ts
+++ b/packages/protobuf/src/codegenv1/restore-json-names.ts
@@ -16,6 +16,9 @@ import type { DescriptorProto } from "../wkt/gen/google/protobuf/descriptor_pb.j
 import { protoCamelCase } from "../reflect/names.js";
 import { unsafeIsSetExplicit } from "../reflect/unsafe.js";
 
+/**
+ * @private
+ */
 export function restoreJsonNames(message: DescriptorProto) {
   for (const f of message.field) {
     if (!unsafeIsSetExplicit(f, "jsonName")) {

--- a/packages/protobuf/src/codegenv1/symbols.ts
+++ b/packages/protobuf/src/codegenv1/symbols.ts
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @private
+ */
 export const packageName = "@bufbuild/protobuf";
 
+/**
+ * @private
+ */
 export const wktPublicImportPaths: Readonly<Record<string, string>> = {
   "google/protobuf/compiler/plugin.proto": packageName + "/wkt",
   "google/protobuf/any.proto": packageName + "/wkt",
@@ -29,6 +35,9 @@ export const wktPublicImportPaths: Readonly<Record<string, string>> = {
   "google/protobuf/wrappers.proto": packageName + "/wkt",
 };
 
+/**
+ * @private
+ */
 // prettier-ignore
 export const symbols = {
   isMessage:               {typeOnly: false, bootstrapWktFrom: "../../is-message.js",           from: packageName },

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -21,21 +21,61 @@ import type {
   DescService,
 } from "../desc-types.js";
 
+/**
+ * Describes a protobuf source file.
+ *
+ * @private
+ */
 export type GenDescFile = DescFile;
 
+/**
+ * Describes a message declaration in a protobuf source file.
+ *
+ * This type is identical to DescMessage, but carries additional type
+ * information.
+ *
+ * @private
+ */
 export type GenDescMessage<RuntimeShape extends Message> = DescMessage &
   brand<RuntimeShape>;
 
+/**
+ * Describes an enumeration in a protobuf source file.
+ *
+ * This type is identical to DescEnum, but carries additional type
+ * information.
+ *
+ * @private
+ */
 export type GenDescEnum<RuntimeShape> = DescEnum & brand<RuntimeShape>;
 
+/**
+ * Describes an extension in a protobuf source file.
+ *
+ * This type is identical to DescExtension, but carries additional type
+ * information.
+ *
+ * @private
+ */
 export type GenDescExtension<
   Extendee extends Message = Message,
   RuntimeShape = unknown,
 > = DescExtension & brand<Extendee, RuntimeShape>;
 
+/**
+ * Describes a service declaration in a protobuf source file.
+ *
+ * This type is identical to DescService, but carries additional type
+ * information.
+ *
+ * @private
+ */
 export type GenDescService<RuntimeShape extends GenDescServiceShape> =
   DescService & brand<RuntimeShape>;
 
+/**
+ * @private
+ */
 export type GenDescServiceShape = {
   [localName: string]: {
     kind: "unary" | "server_streaming" | "client_streaming" | "bidi_streaming";


### PR DESCRIPTION
`@bufbuild/protobuf/codegenv1` should only be used from generated code. 

It uses the `v1` suffix so that breaking changes in generated code can result in a build-time error, and to potentially support old generated code with a new version of the runtime.
