### PR TITLE
V2: Remove DescField.optional

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 127,054 b      | 65,501 b | 15,983 b |
+| protobuf-es         | 126,666 b      | 65,334 b | 15,946 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/reflect/registry.test.ts
+++ b/packages/protobuf-test/src/reflect/registry.test.ts
@@ -802,73 +802,6 @@ describe("DescField", () => {
       ).toBe(false);
     });
   });
-  describe("optional", () => {
-    test("false for proto2 required scalar", async () => {
-      const field = await compileField(`
-        syntax="proto2";
-        message M { required int32 f1 = 1; }
-      `);
-      expect(
-        field.fieldKind == "scalar" ||
-          field.fieldKind == "message" ||
-          field.fieldKind == "enum"
-          ? field.optional
-          : undefined,
-      ).toBe(false);
-    });
-    test("true for proto2 optional scalar", async () => {
-      const field = await compileField(`
-        syntax="proto2";
-        message M { required int32 f1 = 1; }
-      `);
-      expect(
-        field.fieldKind == "scalar" ||
-          field.fieldKind == "message" ||
-          field.fieldKind == "enum"
-          ? field.optional
-          : undefined,
-      ).toBe(false);
-    });
-    test("true for proto3 optional scalar", async () => {
-      const field = await compileField(`
-        syntax="proto3";
-        message M { optional int32 f1 = 1; }
-      `);
-      expect(
-        field.fieldKind == "scalar" ||
-          field.fieldKind == "message" ||
-          field.fieldKind == "enum"
-          ? field.optional
-          : undefined,
-      ).toBe(true);
-    });
-    test("false for features.field_presence = EXPLICIT", async () => {
-      const field = await compileField(`
-        edition="2023";
-        message M { int32 f1 = 1 [features.field_presence = EXPLICIT]; }
-      `);
-      expect(
-        field.fieldKind == "scalar" ||
-          field.fieldKind == "message" ||
-          field.fieldKind == "enum"
-          ? field.optional
-          : undefined,
-      ).toBe(false);
-    });
-    test("false for features.field_presence = IMPLICIT", async () => {
-      const field = await compileField(`
-        edition="2023";
-        message M { int32 f1 = 1 [features.field_presence = IMPLICIT]; }
-      `);
-      expect(
-        field.fieldKind == "scalar" ||
-          field.fieldKind == "message" ||
-          field.fieldKind == "enum"
-          ? field.optional
-          : undefined,
-      ).toBe(false);
-    });
-  });
   describe("longType", () => {
     test("returns default LongType.BIGINT for option omitted", async () => {
       const { fields } = await compileMessage(`
@@ -1171,7 +1104,6 @@ describe("DescField", () => {
         field.packed;
 
         // exclusive to singular
-        field.optional;
         const def: undefined = field.getDefaultValue();
 
         // exclusive to map
@@ -1194,7 +1126,6 @@ describe("DescField", () => {
         field.packed;
 
         // exclusive to singular
-        field.optional;
         const def: string | number | bigint | boolean | Uint8Array | undefined =
           field.getDefaultValue();
 
@@ -1229,7 +1160,6 @@ describe("DescField", () => {
         field.packed;
 
         // exclusive to singular
-        field.optional;
         const def: number | undefined = field.getDefaultValue();
 
         // exclusive to map

--- a/packages/protobuf/src/desc-types.ts
+++ b/packages/protobuf/src/desc-types.ts
@@ -326,10 +326,6 @@ type descFieldSingularCommon = {
    */
   readonly oneof: DescOneof | undefined;
   /**
-   * Whether this field was declared with `optional` in the protobuf source.
-   */
-  readonly optional: boolean;
-  /**
    * Presence of the field.
    * See https://protobuf.dev/programming-guides/field_presence/
    */

--- a/packages/protobuf/src/reflect/registry.ts
+++ b/packages/protobuf/src/reflect/registry.ts
@@ -375,8 +375,6 @@ const TYPE_ENUM: FieldDescriptorProto_Type.ENUM = 14;
 
 // bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_REPEATED: const $name: FieldDescriptorProto_Label.$localName = $number;
 const LABEL_REPEATED: FieldDescriptorProto_Label.REPEATED = 3;
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_OPTIONAL: const $name: FieldDescriptorProto_Label.$localName = $number;
-const LABEL_OPTIONAL: FieldDescriptorProto_Label.OPTIONAL = 1;
 // bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_REQUIRED: const $name: FieldDescriptorProto_Label.$localName = $number;
 const LABEL_REQUIRED: FieldDescriptorProto_Label.REQUIRED = 2;
 
@@ -909,7 +907,6 @@ function newField(
     }
   }
   field.presence = getFieldPresence(proto, oneof, parentOrFile);
-  field.optional = isOptionalField(field as DescField | DescExtension);
   return field as DescField | DescExtension;
 }
 
@@ -1078,21 +1075,6 @@ function getFieldPresence(
   }
   // also resolves proto2/proto3 defaults
   return resolveFeature("fieldPresence", { proto, parent });
-}
-
-/**
- * Did the user use the `optional` keyword?
- */
-function isOptionalField(field: DescField | DescExtension): boolean {
-  const edition = (field.kind == "extension" ? field.file : field.parent.file)
-    .edition;
-  if (edition == EDITION_PROTO2) {
-    return !field.oneof && field.proto.label == LABEL_OPTIONAL;
-  }
-  if (edition == EDITION_PROTO3) {
-    return field.proto.proto3Optional;
-  }
-  return false;
 }
 
 /**

--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -313,7 +313,7 @@ function generateMessageShape(f: GeneratedFile, message: DescMessage, target: Ex
         break;
       default: {
         f.print(f.jsDoc(member, "  "));
-        const {typing, optional} = fieldTypeScriptType(member);
+        const { typing, optional } = fieldTypeScriptType(member);
         if (optional) {
           f.print("  ", localName(member), "?: ", typing, ";");
         } else {

--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -27,12 +27,7 @@ import type {
   Printable,
   Target,
 } from "@bufbuild/protoplugin/ecmascript";
-import {
-  arrayLiteral,
-  fieldUsesPrototype,
-  functionCall,
-  getFieldTypeInfo,
-} from "./util";
+import { arrayLiteral, functionCall, fieldTypeScriptType } from "./util";
 import { version } from "../package.json";
 
 export const protocGenEs = createEcmaScriptPlugin({
@@ -92,7 +87,7 @@ function generateTs(schema: Schema) {
           const { GenDescExtension, extDesc } = f.runtime.codegen;
           const name = f.importDesc(desc).name;
           const E = f.importShape(desc.extendee);
-          const V = getFieldTypeInfo(desc).typing;
+          const V = fieldTypeScriptType(desc).typing;
           const call = functionCall(extDesc, [f.importDesc(file), ...pathInFileDesc(desc)]);
           f.print(f.jsDoc(desc));
           f.print(f.exportDecl("const", name), ": ", GenDescExtension, "<", E, ", ", V, ">", " = ", pure);
@@ -219,7 +214,7 @@ function generateDts(schema: Schema) {
           const { GenDescExtension } = f.runtime.codegen;
           const name = f.importDesc(desc).name;
           const E = f.importShape(desc.extendee);
-          const V = getFieldTypeInfo(desc).typing;
+          const V = fieldTypeScriptType(desc).typing;
           f.print(f.jsDoc(desc));
           f.print(f.exportDecl("declare const", name), ": ", GenDescExtension, "<", E, ", ", V, ">;");
           f.print();
@@ -310,7 +305,7 @@ function generateMessageShape(f: GeneratedFile, message: DescMessage, target: Ex
             f.print(`  } | {`);
           }
           f.print(f.jsDoc(field, "    "));
-          const { typing } = getFieldTypeInfo(field);
+          const { typing } = fieldTypeScriptType(field);
           f.print(`    value: `, typing, `;`);
           f.print(`    case: "`, localName(field), `";`);
         }
@@ -318,11 +313,11 @@ function generateMessageShape(f: GeneratedFile, message: DescMessage, target: Ex
         break;
       default: {
         f.print(f.jsDoc(member, "  "));
-        const {typing, optional} = getFieldTypeInfo(member);
-        if (fieldUsesPrototype(member) || !optional) {
-          f.print("  ", localName(member), ": ", typing, ";");
-        } else {
+        const {typing, optional} = fieldTypeScriptType(member);
+        if (optional) {
           f.print("  ", localName(member), "?: ", typing, ";");
+        } else {
+          f.print("  ", localName(member), ": ", typing, ";");
         }
         break;
       }

--- a/packages/protoplugin-test/src/source-code-info.test.ts
+++ b/packages/protoplugin-test/src/source-code-info.test.ts
@@ -127,7 +127,7 @@ describe("getComments()", () => {
 });
 
 describe("getDeclarationString()", () => {
-  test("for field built-in option", async () => {
+  test("for field with json_name option", async () => {
     const field = await compileField(`
       syntax="proto3";
       message M {
@@ -138,7 +138,18 @@ describe("getDeclarationString()", () => {
       'string scalar_field = 1 [json_name = "scalarFieldJsonName"]',
     );
   });
-  test("for field with labels", async () => {
+  test("for field with jstype option", async () => {
+    const field = await compileField(`
+      syntax="proto3";
+      message M {
+        string scalar_field = 1 [jstype = JS_NORMAL];
+      }
+    `);
+    expect(getDeclarationString(field)).toBe(
+      "string scalar_field = 1 [jstype = JS_NORMAL]",
+    );
+  });
+  test("for repeated field", async () => {
     const field = await compileField(`
       syntax="proto3";
       message M {
@@ -147,6 +158,28 @@ describe("getDeclarationString()", () => {
     `);
     expect(getDeclarationString(field)).toBe(
       "repeated double double_field = 1",
+    );
+  });
+  test("for proto2 optional field", async () => {
+    const field = await compileField(`
+      syntax="proto3";
+      message M {
+        optional double double_field = 1;
+      }
+    `);
+    expect(getDeclarationString(field)).toBe(
+      "optional double double_field = 1",
+    );
+  });
+  test("for proto2 required field", async () => {
+    const field = await compileField(`
+      syntax="proto2";
+      message M {
+        required double double_field = 1;
+      }
+    `);
+    expect(getDeclarationString(field)).toBe(
+      "required double double_field = 1",
     );
   });
   test("for map field", async () => {


### PR DESCRIPTION
With [field presence](https://protobuf.dev/programming-guides/field_presence/) available as a back-filled feature, there is no important use case left for `DescField.optional`.