### PR TITLE
V2: Update the test file for deprecation

### DIFF
--- a/packages/protobuf-test/extra/deprecation-explicit.proto
+++ b/packages/protobuf-test/extra/deprecation-explicit.proto
@@ -15,32 +15,46 @@
 syntax = "proto3";
 package spec;
 
+import "google/protobuf/empty.proto";
+
 // The entire message is deprecated
 message DeprecatedMessage {
-    option deprecated = true;
-    string field = 1;
+  option deprecated = true;
+  string field = 1;
 }
 
 // A single field of this message is deprecated
 message DeprecatedFieldMessage {
+  // This field is deprecated
+  string deprecated_field = 1 [deprecated = true];
 
-    // This field is deprecated
-    string deprecated_field = 1 [deprecated = true];
-
-    // This field is not deprecated
-    string current_field = 2;
-
+  // This field is not deprecated
+  string current_field = 2;
 }
 
 // The entire enum is deprecated
 enum DeprecatedEnum {
-    option deprecated = true;
-    DEPRECATED_ENUM_A = 0;
-    DEPRECATED_ENUM_B = 1;
+  option deprecated = true;
+  DEPRECATED_ENUM_A = 0;
+  DEPRECATED_ENUM_B = 1;
 }
 
 // Only a single enum value is deprecated
 enum DeprecatedValueEnum {
-    DEPRECATED_VALUE_ENUM_UNSPECIFIED = 0;
-    DEPRECATED_VALUE_ENUM_DEPRECATED_VALUE = 1 [deprecated = true];
+  DEPRECATED_VALUE_ENUM_UNSPECIFIED = 0;
+  DEPRECATED_VALUE_ENUM_DEPRECATED_VALUE = 1 [deprecated = true];
+}
+
+// The entire service is deprecated
+service DeprecatedService {
+  option deprecated = true;
+  rpc Deprecated(google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+// A single RPC of this service is deprecated
+service DeprecatedRpcService {
+  rpc Deprecated(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+  rpc NotDeprecated(google.protobuf.Empty) returns (google.protobuf.Empty);
 }

--- a/packages/protobuf-test/extra/deprecation-explicit.proto
+++ b/packages/protobuf-test/extra/deprecation-explicit.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 package spec;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
 
 // The entire message is deprecated
 message DeprecatedMessage {
@@ -57,4 +58,9 @@ service DeprecatedRpcService {
     option deprecated = true;
   }
   rpc NotDeprecated(google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+extend google.protobuf.FieldOptions {
+  // This extension is deprecated
+  int32 explicitly_deprecated_option = 2001 [deprecated = true];
 }

--- a/packages/protobuf-test/extra/deprecation-implicit.proto
+++ b/packages/protobuf-test/extra/deprecation-implicit.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 package spec;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/descriptor.proto";
 
 option deprecated = true;
 
@@ -29,4 +30,8 @@ enum ImplicitlyDeprecatedEnum {
 
 service ImplicitlyDeprecatedService {
   rpc ImplicitlyDeprecatedRpc(google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+extend google.protobuf.FieldOptions {
+  int32 implicitly_deprecated_option = 2001;
 }

--- a/packages/protobuf-test/extra/deprecation-implicit.proto
+++ b/packages/protobuf-test/extra/deprecation-implicit.proto
@@ -13,12 +13,20 @@
 // limitations under the License.
 
 syntax = "proto3";
-
 package spec;
+
+import "google/protobuf/empty.proto";
 
 option deprecated = true;
 
-
 message ImplicitlyDeprecatedMessage {
+  string implicitly_deprecated_field = 1;
+}
 
+enum ImplicitlyDeprecatedEnum {
+  IMPLICITLY_DEPRECATED_ENUM_UNSPECIFIED = 0;
+}
+
+service ImplicitlyDeprecatedService {
+  rpc ImplicitlyDeprecatedRpc(google.protobuf.Empty) returns (google.protobuf.Empty);
 }

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
@@ -16,9 +16,9 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
-import type { Empty } from "@bufbuild/protobuf/wkt";
+import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
 
 export declare const fileDesc_extra_deprecation_explicit: GenDescFile;
 
@@ -148,4 +148,12 @@ export declare const DeprecatedRpcService: GenDescService<{
   },
 }
 >;
+
+/**
+ * This extension is deprecated
+ *
+ * @generated from extension: int32 explicitly_deprecated_option = 2001 [deprecated = true];
+ * @deprecated
+ */
+export declare const explicitly_deprecated_option: GenDescExtension<FieldOptions, number>;
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
@@ -16,8 +16,9 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescEnum, GenDescFile, GenDescMessage } from "@bufbuild/protobuf/codegenv1";
+import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
+import type { Empty } from "@bufbuild/protobuf/wkt";
 
 export declare const fileDesc_extra_deprecation_explicit: GenDescFile;
 
@@ -103,4 +104,48 @@ export enum DeprecatedValueEnum {
 
 // Describes the enum spec.DeprecatedValueEnum.
 export declare const DeprecatedValueEnumDesc: GenDescEnum<DeprecatedValueEnum>;
+
+/**
+ * The entire service is deprecated
+ *
+ * @generated from service spec.DeprecatedService
+ * @deprecated
+ */
+export declare const DeprecatedService: GenDescService<{
+  /**
+   * @generated from rpc spec.DeprecatedService.Deprecated
+   */
+  deprecated: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+}
+>;
+
+/**
+ * A single RPC of this service is deprecated
+ *
+ * @generated from service spec.DeprecatedRpcService
+ */
+export declare const DeprecatedRpcService: GenDescService<{
+  /**
+   * @generated from rpc spec.DeprecatedRpcService.Deprecated
+   * @deprecated
+   */
+  deprecated: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+  /**
+   * @generated from rpc spec.DeprecatedRpcService.NotDeprecated
+   */
+  notDeprecated: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+}
+>;
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.js
@@ -16,11 +16,11 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import { enumDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
-import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
+import { enumDesc, extDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
+import { fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 
 export const fileDesc_extra_deprecation_explicit = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIATJWChFEZXByZWNhdGVkU2VydmljZRI8CgpEZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GgOIAgEymgEKFERlcHJlY2F0ZWRScGNTZXJ2aWNlEkEKCkRlcHJlY2F0ZWQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkiA4gCARI/Cg1Ob3REZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5YgZwcm90bzM", [fileDesc_google_protobuf_empty]);
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIATJWChFEZXByZWNhdGVkU2VydmljZRI8CgpEZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GgOIAgEymgEKFERlcHJlY2F0ZWRScGNTZXJ2aWNlEkEKCkRlcHJlY2F0ZWQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkiA4gCARI/Cg1Ob3REZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5OmQKHGV4cGxpY2l0bHlfZGVwcmVjYXRlZF9vcHRpb24SHS5nb29nbGUucHJvdG9idWYuRmllbGRPcHRpb25zGNEPIAEoBUICGAFSGmV4cGxpY2l0bHlEZXByZWNhdGVkT3B0aW9uYgZwcm90bzM", [fileDesc_google_protobuf_empty, fileDesc_google_protobuf_descriptor]);
 
 // Describes the message spec.DeprecatedMessage. Use `create(DeprecatedMessageDesc)` to create a new DeprecatedMessage.
 export const DeprecatedMessageDesc = /*@__PURE__*/
@@ -71,4 +71,13 @@ export const DeprecatedService = /*@__PURE__*/
  */
 export const DeprecatedRpcService = /*@__PURE__*/
   serviceDesc(fileDesc_extra_deprecation_explicit, 1);
+
+/**
+ * This extension is deprecated
+ *
+ * @generated from extension: int32 explicitly_deprecated_option = 2001 [deprecated = true];
+ * @deprecated
+ */
+export const explicitly_deprecated_option = /*@__PURE__*/
+  extDesc(fileDesc_extra_deprecation_explicit, 0);
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.js
@@ -16,10 +16,11 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import { enumDesc, fileDesc, messageDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
+import { enumDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
+import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 
 export const fileDesc_extra_deprecation_explicit = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIAWIGcHJvdG8z");
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIATJWChFEZXByZWNhdGVkU2VydmljZRI8CgpEZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GgOIAgEymgEKFERlcHJlY2F0ZWRScGNTZXJ2aWNlEkEKCkRlcHJlY2F0ZWQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkiA4gCARI/Cg1Ob3REZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5YgZwcm90bzM", [fileDesc_google_protobuf_empty]);
 
 // Describes the message spec.DeprecatedMessage. Use `create(DeprecatedMessageDesc)` to create a new DeprecatedMessage.
 export const DeprecatedMessageDesc = /*@__PURE__*/
@@ -53,4 +54,21 @@ export const DeprecatedValueEnumDesc = /*@__PURE__*/
  */
 export const DeprecatedValueEnum = /*@__PURE__*/
   tsEnum(DeprecatedValueEnumDesc);
+
+/**
+ * The entire service is deprecated
+ *
+ * @generated from service spec.DeprecatedService
+ * @deprecated
+ */
+export const DeprecatedService = /*@__PURE__*/
+  serviceDesc(fileDesc_extra_deprecation_explicit, 0);
+
+/**
+ * A single RPC of this service is deprecated
+ *
+ * @generated from service spec.DeprecatedRpcService
+ */
+export const DeprecatedRpcService = /*@__PURE__*/
+  serviceDesc(fileDesc_extra_deprecation_explicit, 1);
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
@@ -16,9 +16,9 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
-import type { Empty } from "@bufbuild/protobuf/wkt";
+import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
 
 export declare const fileDesc_extra_deprecation_implicit: GenDescFile;
 
@@ -65,4 +65,9 @@ export declare const ImplicitlyDeprecatedService: GenDescService<{
   },
 }
 >;
+
+/**
+ * @generated from extension: int32 implicitly_deprecated_option = 2001;
+ */
+export declare const implicitly_deprecated_option: GenDescExtension<FieldOptions, number>;
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
@@ -16,8 +16,9 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescFile, GenDescMessage } from "@bufbuild/protobuf/codegenv1";
+import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
+import type { Empty } from "@bufbuild/protobuf/wkt";
 
 export declare const fileDesc_extra_deprecation_implicit: GenDescFile;
 
@@ -26,8 +27,42 @@ export declare const fileDesc_extra_deprecation_implicit: GenDescFile;
  * @deprecated
  */
 export declare type ImplicitlyDeprecatedMessage = Message<"spec.ImplicitlyDeprecatedMessage"> & {
+  /**
+   * @generated from field: string implicitly_deprecated_field = 1;
+   */
+  implicitlyDeprecatedField: string;
 };
 
 // Describes the message spec.ImplicitlyDeprecatedMessage. Use `create(ImplicitlyDeprecatedMessageDesc)` to create a new ImplicitlyDeprecatedMessage.
 export declare const ImplicitlyDeprecatedMessageDesc: GenDescMessage<ImplicitlyDeprecatedMessage>;
+
+/**
+ * @generated from enum spec.ImplicitlyDeprecatedEnum
+ * @deprecated
+ */
+export enum ImplicitlyDeprecatedEnum {
+  /**
+   * @generated from enum value: IMPLICITLY_DEPRECATED_ENUM_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+}
+
+// Describes the enum spec.ImplicitlyDeprecatedEnum.
+export declare const ImplicitlyDeprecatedEnumDesc: GenDescEnum<ImplicitlyDeprecatedEnum>;
+
+/**
+ * @generated from service spec.ImplicitlyDeprecatedService
+ * @deprecated
+ */
+export declare const ImplicitlyDeprecatedService: GenDescService<{
+  /**
+   * @generated from rpc spec.ImplicitlyDeprecatedService.ImplicitlyDeprecatedRpc
+   */
+  implicitlyDeprecatedRpc: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+}
+>;
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.js
@@ -16,12 +16,31 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
+import { enumDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
+import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 
 export const fileDesc_extra_deprecation_implicit = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyIdChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2VCA7gBAWIGcHJvdG8z");
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyJCChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2USIwobaW1wbGljaXRseV9kZXByZWNhdGVkX2ZpZWxkGAEgASgJKkYKGEltcGxpY2l0bHlEZXByZWNhdGVkRW51bRIqCiZJTVBMSUNJVExZX0RFUFJFQ0FURURfRU5VTV9VTlNQRUNJRklFRBAAMmgKG0ltcGxpY2l0bHlEZXByZWNhdGVkU2VydmljZRJJChdJbXBsaWNpdGx5RGVwcmVjYXRlZFJwYxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eUIDuAEBYgZwcm90bzM", [fileDesc_google_protobuf_empty]);
 
 // Describes the message spec.ImplicitlyDeprecatedMessage. Use `create(ImplicitlyDeprecatedMessageDesc)` to create a new ImplicitlyDeprecatedMessage.
 export const ImplicitlyDeprecatedMessageDesc = /*@__PURE__*/
   messageDesc(fileDesc_extra_deprecation_implicit, 0);
+
+// Describes the enum spec.ImplicitlyDeprecatedEnum.
+export const ImplicitlyDeprecatedEnumDesc = /*@__PURE__*/
+  enumDesc(fileDesc_extra_deprecation_implicit, 0);
+
+/**
+ * @generated from enum spec.ImplicitlyDeprecatedEnum
+ * @deprecated
+ */
+export const ImplicitlyDeprecatedEnum = /*@__PURE__*/
+  tsEnum(ImplicitlyDeprecatedEnumDesc);
+
+/**
+ * @generated from service spec.ImplicitlyDeprecatedService
+ * @deprecated
+ */
+export const ImplicitlyDeprecatedService = /*@__PURE__*/
+  serviceDesc(fileDesc_extra_deprecation_implicit, 0);
 

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.js
@@ -16,11 +16,11 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import { enumDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
-import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
+import { enumDesc, extDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
+import { fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 
 export const fileDesc_extra_deprecation_implicit = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyJCChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2USIwobaW1wbGljaXRseV9kZXByZWNhdGVkX2ZpZWxkGAEgASgJKkYKGEltcGxpY2l0bHlEZXByZWNhdGVkRW51bRIqCiZJTVBMSUNJVExZX0RFUFJFQ0FURURfRU5VTV9VTlNQRUNJRklFRBAAMmgKG0ltcGxpY2l0bHlEZXByZWNhdGVkU2VydmljZRJJChdJbXBsaWNpdGx5RGVwcmVjYXRlZFJwYxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eUIDuAEBYgZwcm90bzM", [fileDesc_google_protobuf_empty]);
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyJCChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2USIwobaW1wbGljaXRseV9kZXByZWNhdGVkX2ZpZWxkGAEgASgJKkYKGEltcGxpY2l0bHlEZXByZWNhdGVkRW51bRIqCiZJTVBMSUNJVExZX0RFUFJFQ0FURURfRU5VTV9VTlNQRUNJRklFRBAAMmgKG0ltcGxpY2l0bHlEZXByZWNhdGVkU2VydmljZRJJChdJbXBsaWNpdGx5RGVwcmVjYXRlZFJwYxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eTpgChxpbXBsaWNpdGx5X2RlcHJlY2F0ZWRfb3B0aW9uEh0uZ29vZ2xlLnByb3RvYnVmLkZpZWxkT3B0aW9ucxjRDyABKAVSGmltcGxpY2l0bHlEZXByZWNhdGVkT3B0aW9uQgO4AQFiBnByb3RvMw", [fileDesc_google_protobuf_empty, fileDesc_google_protobuf_descriptor]);
 
 // Describes the message spec.ImplicitlyDeprecatedMessage. Use `create(ImplicitlyDeprecatedMessageDesc)` to create a new ImplicitlyDeprecatedMessage.
 export const ImplicitlyDeprecatedMessageDesc = /*@__PURE__*/
@@ -43,4 +43,10 @@ export const ImplicitlyDeprecatedEnum = /*@__PURE__*/
  */
 export const ImplicitlyDeprecatedService = /*@__PURE__*/
   serviceDesc(fileDesc_extra_deprecation_implicit, 0);
+
+/**
+ * @generated from extension: int32 implicitly_deprecated_option = 2001;
+ */
+export const implicitly_deprecated_option = /*@__PURE__*/
+  extDesc(fileDesc_extra_deprecation_implicit, 0);
 

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -16,14 +16,14 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
-import { enumDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Empty } from "@bufbuild/protobuf/wkt";
-import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
+import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import { enumDesc, extDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
+import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
+import { fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
 export const fileDesc_extra_deprecation_explicit: GenDescFile = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIATJWChFEZXByZWNhdGVkU2VydmljZRI8CgpEZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GgOIAgEymgEKFERlcHJlY2F0ZWRScGNTZXJ2aWNlEkEKCkRlcHJlY2F0ZWQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkiA4gCARI/Cg1Ob3REZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5YgZwcm90bzM", [fileDesc_google_protobuf_empty]);
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIATJWChFEZXByZWNhdGVkU2VydmljZRI8CgpEZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GgOIAgEymgEKFERlcHJlY2F0ZWRScGNTZXJ2aWNlEkEKCkRlcHJlY2F0ZWQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkiA4gCARI/Cg1Ob3REZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5OmQKHGV4cGxpY2l0bHlfZGVwcmVjYXRlZF9vcHRpb24SHS5nb29nbGUucHJvdG9idWYuRmllbGRPcHRpb25zGNEPIAEoBUICGAFSGmV4cGxpY2l0bHlEZXByZWNhdGVkT3B0aW9uYgZwcm90bzM", [fileDesc_google_protobuf_empty, fileDesc_google_protobuf_descriptor]);
 
 /**
  * The entire message is deprecated
@@ -159,4 +159,13 @@ export const DeprecatedRpcService: GenDescService<{
 }
 > = /*@__PURE__*/
   serviceDesc(fileDesc_extra_deprecation_explicit, 1);
+
+/**
+ * This extension is deprecated
+ *
+ * @generated from extension: int32 explicitly_deprecated_option = 2001 [deprecated = true];
+ * @deprecated
+ */
+export const explicitly_deprecated_option: GenDescExtension<FieldOptions, number> = /*@__PURE__*/
+  extDesc(fileDesc_extra_deprecation_explicit, 0);
 

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -16,12 +16,14 @@
 // @generated from file extra/deprecation-explicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescEnum, GenDescFile, GenDescMessage } from "@bufbuild/protobuf/codegenv1";
-import { enumDesc, fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
+import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import { enumDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
+import type { Empty } from "@bufbuild/protobuf/wkt";
+import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
 export const fileDesc_extra_deprecation_explicit: GenDescFile = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIAWIGcHJvdG8z");
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1leHBsaWNpdC5wcm90bxIEc3BlYyImChFEZXByZWNhdGVkTWVzc2FnZRINCgVmaWVsZBgBIAEoCToCGAEiTQoWRGVwcmVjYXRlZEZpZWxkTWVzc2FnZRIcChBkZXByZWNhdGVkX2ZpZWxkGAEgASgJQgIYARIVCg1jdXJyZW50X2ZpZWxkGAIgASgJKkIKDkRlcHJlY2F0ZWRFbnVtEhUKEURFUFJFQ0FURURfRU5VTV9BEAASFQoRREVQUkVDQVRFRF9FTlVNX0IQARoCGAEqbAoTRGVwcmVjYXRlZFZhbHVlRW51bRIlCiFERVBSRUNBVEVEX1ZBTFVFX0VOVU1fVU5TUEVDSUZJRUQQABIuCiZERVBSRUNBVEVEX1ZBTFVFX0VOVU1fREVQUkVDQVRFRF9WQUxVRRABGgIIATJWChFEZXByZWNhdGVkU2VydmljZRI8CgpEZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GgOIAgEymgEKFERlcHJlY2F0ZWRScGNTZXJ2aWNlEkEKCkRlcHJlY2F0ZWQSFi5nb29nbGUucHJvdG9idWYuRW1wdHkaFi5nb29nbGUucHJvdG9idWYuRW1wdHkiA4gCARI/Cg1Ob3REZXByZWNhdGVkEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5YgZwcm90bzM", [fileDesc_google_protobuf_empty]);
 
 /**
  * The entire message is deprecated
@@ -111,4 +113,50 @@ export enum DeprecatedValueEnum {
 // Describes the enum spec.DeprecatedValueEnum.
 export const DeprecatedValueEnumDesc: GenDescEnum<DeprecatedValueEnum> = /*@__PURE__*/
   enumDesc(fileDesc_extra_deprecation_explicit, 1);
+
+/**
+ * The entire service is deprecated
+ *
+ * @generated from service spec.DeprecatedService
+ * @deprecated
+ */
+export const DeprecatedService: GenDescService<{
+  /**
+   * @generated from rpc spec.DeprecatedService.Deprecated
+   */
+  deprecated: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+}
+> = /*@__PURE__*/
+  serviceDesc(fileDesc_extra_deprecation_explicit, 0);
+
+/**
+ * A single RPC of this service is deprecated
+ *
+ * @generated from service spec.DeprecatedRpcService
+ */
+export const DeprecatedRpcService: GenDescService<{
+  /**
+   * @generated from rpc spec.DeprecatedRpcService.Deprecated
+   * @deprecated
+   */
+  deprecated: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+  /**
+   * @generated from rpc spec.DeprecatedRpcService.NotDeprecated
+   */
+  notDeprecated: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+}
+> = /*@__PURE__*/
+  serviceDesc(fileDesc_extra_deprecation_explicit, 1);
 

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
@@ -16,22 +16,60 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescFile, GenDescMessage } from "@bufbuild/protobuf/codegenv1";
-import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
+import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import { enumDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
+import type { Empty } from "@bufbuild/protobuf/wkt";
+import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
 export const fileDesc_extra_deprecation_implicit: GenDescFile = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyIdChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2VCA7gBAWIGcHJvdG8z");
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyJCChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2USIwobaW1wbGljaXRseV9kZXByZWNhdGVkX2ZpZWxkGAEgASgJKkYKGEltcGxpY2l0bHlEZXByZWNhdGVkRW51bRIqCiZJTVBMSUNJVExZX0RFUFJFQ0FURURfRU5VTV9VTlNQRUNJRklFRBAAMmgKG0ltcGxpY2l0bHlEZXByZWNhdGVkU2VydmljZRJJChdJbXBsaWNpdGx5RGVwcmVjYXRlZFJwYxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eUIDuAEBYgZwcm90bzM", [fileDesc_google_protobuf_empty]);
 
 /**
  * @generated from message spec.ImplicitlyDeprecatedMessage
  * @deprecated
  */
 export type ImplicitlyDeprecatedMessage = Message<"spec.ImplicitlyDeprecatedMessage"> & {
+  /**
+   * @generated from field: string implicitly_deprecated_field = 1;
+   */
+  implicitlyDeprecatedField: string;
 };
 
 // Describes the message spec.ImplicitlyDeprecatedMessage.
 // Use `create(ImplicitlyDeprecatedMessageDesc)` to create a new ImplicitlyDeprecatedMessage.
 export const ImplicitlyDeprecatedMessageDesc: GenDescMessage<ImplicitlyDeprecatedMessage> = /*@__PURE__*/
   messageDesc(fileDesc_extra_deprecation_implicit, 0);
+
+/**
+ * @generated from enum spec.ImplicitlyDeprecatedEnum
+ * @deprecated
+ */
+export enum ImplicitlyDeprecatedEnum {
+  /**
+   * @generated from enum value: IMPLICITLY_DEPRECATED_ENUM_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+}
+
+// Describes the enum spec.ImplicitlyDeprecatedEnum.
+export const ImplicitlyDeprecatedEnumDesc: GenDescEnum<ImplicitlyDeprecatedEnum> = /*@__PURE__*/
+  enumDesc(fileDesc_extra_deprecation_implicit, 0);
+
+/**
+ * @generated from service spec.ImplicitlyDeprecatedService
+ * @deprecated
+ */
+export const ImplicitlyDeprecatedService: GenDescService<{
+  /**
+   * @generated from rpc spec.ImplicitlyDeprecatedService.ImplicitlyDeprecatedRpc
+   */
+  implicitlyDeprecatedRpc: {
+    kind: "unary";
+    I: Empty;
+    O: Empty;
+  },
+}
+> = /*@__PURE__*/
+  serviceDesc(fileDesc_extra_deprecation_implicit, 0);
 

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
@@ -16,14 +16,14 @@
 // @generated from file extra/deprecation-implicit.proto (package spec, syntax proto3)
 /* eslint-disable */
 
-import type { GenDescEnum, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
-import { enumDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Empty } from "@bufbuild/protobuf/wkt";
-import { fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
+import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import { enumDesc, extDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
+import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
+import { fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
 export const fileDesc_extra_deprecation_implicit: GenDescFile = /*@__PURE__*/
-  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyJCChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2USIwobaW1wbGljaXRseV9kZXByZWNhdGVkX2ZpZWxkGAEgASgJKkYKGEltcGxpY2l0bHlEZXByZWNhdGVkRW51bRIqCiZJTVBMSUNJVExZX0RFUFJFQ0FURURfRU5VTV9VTlNQRUNJRklFRBAAMmgKG0ltcGxpY2l0bHlEZXByZWNhdGVkU2VydmljZRJJChdJbXBsaWNpdGx5RGVwcmVjYXRlZFJwYxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eUIDuAEBYgZwcm90bzM", [fileDesc_google_protobuf_empty]);
+  fileDesc("CiBleHRyYS9kZXByZWNhdGlvbi1pbXBsaWNpdC5wcm90bxIEc3BlYyJCChtJbXBsaWNpdGx5RGVwcmVjYXRlZE1lc3NhZ2USIwobaW1wbGljaXRseV9kZXByZWNhdGVkX2ZpZWxkGAEgASgJKkYKGEltcGxpY2l0bHlEZXByZWNhdGVkRW51bRIqCiZJTVBMSUNJVExZX0RFUFJFQ0FURURfRU5VTV9VTlNQRUNJRklFRBAAMmgKG0ltcGxpY2l0bHlEZXByZWNhdGVkU2VydmljZRJJChdJbXBsaWNpdGx5RGVwcmVjYXRlZFJwYxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eTpgChxpbXBsaWNpdGx5X2RlcHJlY2F0ZWRfb3B0aW9uEh0uZ29vZ2xlLnByb3RvYnVmLkZpZWxkT3B0aW9ucxjRDyABKAVSGmltcGxpY2l0bHlEZXByZWNhdGVkT3B0aW9uQgO4AQFiBnByb3RvMw", [fileDesc_google_protobuf_empty, fileDesc_google_protobuf_descriptor]);
 
 /**
  * @generated from message spec.ImplicitlyDeprecatedMessage
@@ -72,4 +72,10 @@ export const ImplicitlyDeprecatedService: GenDescService<{
 }
 > = /*@__PURE__*/
   serviceDesc(fileDesc_extra_deprecation_implicit, 0);
+
+/**
+ * @generated from extension: int32 implicitly_deprecated_option = 2001;
+ */
+export const implicitly_deprecated_option: GenDescExtension<FieldOptions, number> = /*@__PURE__*/
+  extDesc(fileDesc_extra_deprecation_implicit, 0);
 


### PR DESCRIPTION
To make sure we generate the appropriate JSDoc `@deprecated` tags for the Protobuf option `deprecated`, this extends the test protos with more cases.