### PR TITLE
Make DescField.presence available for all fields

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,937 b      | 65,433 b | 15,946 b |
+| protobuf-es         | 126,590 b      | 65,292 b | 15,928 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/helpers.ts
+++ b/packages/protobuf-test/src/helpers.ts
@@ -75,6 +75,13 @@ export async function compileField(proto: string) {
   return firstField;
 }
 
+export async function compileExtension(proto: string) {
+  const file = await compileFile(proto);
+  const firstExt = file.extensions[0];
+  assert(firstExt);
+  return firstExt;
+}
+
 export async function compileService(proto: string) {
   const file = await compileFile(proto);
   const firstService = file.services[0];

--- a/packages/protobuf-test/src/reflect/registry.test.ts
+++ b/packages/protobuf-test/src/reflect/registry.test.ts
@@ -25,7 +25,6 @@ import {
 import type {
   DescEnum,
   DescExtension,
-  DescField,
   DescFile,
   DescMessage,
   DescOneof,
@@ -39,6 +38,7 @@ import {
 } from "@bufbuild/protobuf/wkt";
 import {
   compileEnum,
+  compileExtension,
   compileField,
   compileFile,
   compileFileDescriptorSet,
@@ -639,13 +639,6 @@ describe("DescEnum", () => {
 
 describe("DescField", () => {
   describe("presence", () => {
-    function getPresence(field: DescField) {
-      return field.fieldKind == "scalar" ||
-        field.fieldKind == "message" ||
-        field.fieldKind == "enum"
-        ? field.presence
-        : undefined;
-    }
     test("proto2 optional is EXPLICIT", async () => {
       const field = await compileField(`
         syntax="proto2";
@@ -653,7 +646,7 @@ describe("DescField", () => {
           optional int32 f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
     test("proto2 optional message is EXPLICIT", async () => {
       const field = await compileField(`
@@ -662,7 +655,7 @@ describe("DescField", () => {
           optional M f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
     test("proto2 required is LEGACY_REQUIRED", async () => {
       const field = await compileField(`
@@ -671,7 +664,7 @@ describe("DescField", () => {
           required int32 f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
     });
     test("proto2 required message is LEGACY_REQUIRED", async () => {
       const field = await compileField(`
@@ -680,7 +673,25 @@ describe("DescField", () => {
           required M f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
+    });
+    test("proto2 list is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto2";
+        message M { 
+          repeated int32 f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("proto2 map is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto2";
+        message M { 
+          map <int32, int32> f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
     test("proto2 oneof is EXPLICIT", async () => {
       const field = await compileField(`
@@ -691,7 +702,7 @@ describe("DescField", () => {
           }
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
     test("proto3 is IMPLICIT", async () => {
       const field = await compileField(`
@@ -700,7 +711,7 @@ describe("DescField", () => {
           int32 f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.IMPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
     test("proto3 optional is EXPLICIT", async () => {
       const field = await compileField(`
@@ -709,7 +720,25 @@ describe("DescField", () => {
           optional int32 f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
+    });
+    test("proto3 list is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto3";
+        message M { 
+          repeated int32 f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("proto3 map is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto3";
+        message M { 
+          map <int32, int32> f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
     test("proto3 oneof is EXPLICIT", async () => {
       const field = await compileField(`
@@ -720,7 +749,7 @@ describe("DescField", () => {
           }
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
     test("proto3 message is EXPLICIT", async () => {
       const field = await compileField(`
@@ -729,7 +758,7 @@ describe("DescField", () => {
           M f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
     test("proto3 optional message is EXPLICIT", async () => {
       const field = await compileField(`
@@ -738,7 +767,26 @@ describe("DescField", () => {
           optional M f = 1;
         }
       `);
-      expect(getPresence(field)).toBe(FeatureSet_FieldPresence.EXPLICIT);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
+    });
+    test("edition2023 scalar is EXPLICIT", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M { 
+          int32 f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
+    });
+    test("edition2023 inherited features.field_presence is IMPLICIT", async () => {
+      const field = await compileField(`
+        edition="2023";
+        option features.field_presence = IMPLICIT;
+        message M { 
+          int32 f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
   });
   describe("delimitedEncoding", () => {
@@ -1284,6 +1332,133 @@ describe("DescField", () => {
         break;
       }
     }
+  });
+});
+
+describe("DescExtension", () => {
+  test("typeName", async () => {
+    const ext = await compileExtension(`
+      syntax="proto2";
+      extend M {
+        optional int32 ext = 1;
+      }
+      message M { extensions 1; }
+    `);
+    expect(ext.typeName).toBe("ext");
+  });
+  test("typeName with package", async () => {
+    const ext = await compileExtension(`
+      syntax="proto2";
+      package test;
+      extend M {
+        optional int32 ext = 1;
+      }
+      message M { extensions 1; }
+    `);
+    expect(ext.typeName).toBe("test.ext");
+  });
+  test("typeName for nested package", async () => {
+    const message = await compileMessage(`
+      syntax="proto2";
+      package test;
+      message C {
+        extend M {
+          optional int32 ext = 1;
+        }
+      }
+      message M { extensions 1; }
+    `);
+    const ext = message.nestedExtensions[0];
+    expect(ext.typeName).toBe("test.C.ext");
+  });
+  test("jsonName", async () => {
+    const message = await compileMessage(`
+      syntax="proto2";
+      package test;
+      message C {
+        extend M {
+          optional int32 ext = 1;
+        }
+      }
+      message M { extensions 1; }
+    `);
+    const ext = message.nestedExtensions[0];
+    expect(ext.jsonName).toBe("[test.C.ext]");
+  });
+  test("extendee", async () => {
+    const file = await compileFile(`
+      syntax="proto2";
+      package test;
+      extend M {
+        optional int32 ext = 1;
+      }
+      message M { extensions 1; }
+    `);
+    const ext = file.extensions[0];
+    const M = file.messages[0];
+    expect(ext.extendee).toBe(M);
+  });
+  test("parent", async () => {
+    const message = await compileMessage(`
+      syntax="proto2";
+      package test;
+      message C {
+        extend M {
+          optional int32 ext = 1;
+        }
+      }
+      message M { extensions 1; }
+    `);
+    const ext = message.nestedExtensions[0];
+    expect(ext.parent).toBe(message);
+  });
+  describe("presence", () => {
+    test("proto3 implicit field is EXPLICIT", async () => {
+      const ext = await compileExtension(`
+        syntax="proto3";
+        import "google/protobuf/descriptor.proto";
+        extend google.protobuf.FieldOptions {
+          int32 ext = 1001;
+        }
+      `);
+      expect(ext.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
+    });
+    test("proto3 list is IMPLICIT", async () => {
+      const ext = await compileExtension(`
+        syntax="proto3";
+        import "google/protobuf/descriptor.proto";
+        extend google.protobuf.FieldOptions {
+          repeated int32 ext = 1001;
+        }
+      `);
+      expect(ext.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+  });
+  describe("delimitedEncoding", () => {
+    test("true for proto2 group", async () => {
+      const ext = await compileExtension(`
+        syntax="proto2";
+        extend M {
+          optional group GroupExt = 1 {}
+        }
+        message M { extensions 1; }
+      `);
+      expect(
+        ext.fieldKind == "message" ? ext.delimitedEncoding : undefined,
+      ).toBe(true);
+    });
+    test("true for field with features.message_encoding = DELIMITED", async () => {
+      const ext = await compileExtension(`
+        edition="2023";
+        extend M {
+          M f = 1 [features.message_encoding = DELIMITED];
+        }
+        message M { extensions 1; }
+      `);
+      expect(
+        ext.fieldKind == "message" ? ext.delimitedEncoding : undefined,
+      ).toBe(true);
+    });
   });
 });
 

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -28,8 +28,6 @@ import type {
 
 // bootstrap-inject google.protobuf.Edition.EDITION_PROTO3: const $name: Edition.$localName = $number;
 const EDITION_PROTO3: Edition.EDITION_PROTO3 = 999;
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.EXPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
-const EXPLICIT: FeatureSet_FieldPresence.EXPLICIT = 1;
 // bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
 const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
 
@@ -182,19 +180,9 @@ function createZeroMessage(desc: DescMessage): Message {
     // the `optional` keyword generate an optional property.
     msg = {};
     for (const member of desc.members) {
-      if (member.kind == "field") {
-        if (
-          member.fieldKind == "scalar" ||
-          member.fieldKind == "enum" ||
-          member.fieldKind == "message"
-        ) {
-          if (member.presence == EXPLICIT) {
-            // skips message fields and optional scalar/enum
-            continue;
-          }
-        }
+      if (member.kind == "oneof" || member.presence == IMPLICIT) {
+        msg[localName(member)] = createZeroField(member);
       }
-      msg[localName(member)] = createZeroField(member);
     }
   } else {
     // for everything but proto3, we support default values, and track presence
@@ -219,8 +207,8 @@ function createZeroMessage(desc: DescMessage): Message {
           continue;
         }
         if (member.presence == IMPLICIT) {
-          // implicit presence tracks field presence by zero values
-          // e.g. 0, false, "", are unset, 1, true, "x" are set
+          // implicit presence tracks field presence by zero values - e.g. 0, false, "", are unset, 1, true, "x" are set.
+          // message, map, list fields are mutable, and also have IMPLICIT presence.
           continue;
         }
         members.add(member);

--- a/packages/protobuf/src/desc-types.ts
+++ b/packages/protobuf/src/desc-types.ts
@@ -309,6 +309,11 @@ interface descFieldAndExtensionShared {
    */
   readonly deprecated: boolean;
   /**
+   * Presence of the field.
+   * See https://protobuf.dev/programming-guides/field_presence/
+   */
+  readonly presence: SupportedFieldPresence;
+  /**
    * The compiler-generated descriptor.
    */
   readonly proto: FieldDescriptorProto;
@@ -325,11 +330,6 @@ type descFieldSingularCommon = {
    * This does not include synthetic oneofs for proto3 optionals.
    */
   readonly oneof: DescOneof | undefined;
-  /**
-   * Presence of the field.
-   * See https://protobuf.dev/programming-guides/field_presence/
-   */
-  readonly presence: SupportedFieldPresence;
 };
 
 type descFieldScalar<T extends ScalarType = ScalarType> = T extends T

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -70,11 +70,7 @@ function writeFields(
 ): BinaryWriter {
   for (const f of msg.sortedFields) {
     if (!msg.isSet(f)) {
-      if (
-        f.fieldKind != "map" &&
-        f.fieldKind != "list" &&
-        f.presence == LEGACY_REQUIRED
-      ) {
+      if (f.presence == LEGACY_REQUIRED) {
         throw new Error(
           `cannot encode field ${msg.desc.typeName}.${f.name} to binary: required field not set`,
         );


### PR DESCRIPTION
The property `DescField.presence` tells whether a field tracks presence, but only for singular fields. This change makes it available for all fields. The values match with the [documentation](https://protobuf.dev/programming-guides/field_presence/), which should be helpful for users who want to take a closer look at the schema.

The property is also available for extension descriptors. It's not well documented, but implicit presence (e.g. a proto3 singular scalar field) does not apply to extensions. Otherwise, setting an extension value `0` would be ambigous.

