### PR TITLE
V2: Rely on ReflectMessage for jstype=JS_STRING

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,937 b      | 65,433 b | 15,946 b |
+| protobuf-es         | 126,284 b      | 65,142 b | 15,854 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |


### PR DESCRIPTION
ReflectMessage converts bigint to string for us if necessary, so we do not have to support it in fromBinary and fromJson.