### PR TITLE
V2: Clarify map behavior with message_encoding = DELIMITED

### DIFF
--- a/packages/protobuf-test/extra/edition2023-map-encoding.proto
+++ b/packages/protobuf-test/extra/edition2023-map-encoding.proto
@@ -19,7 +19,10 @@ option features.message_encoding = DELIMITED;
 
 // Map fields are syntactic sugar for a repeated message field with field 1 for
 // key and field 2 for value. Despite that, the file feature message_encoding =
-// DELIMITED should NOT apply to this "synthetic" message.
+// DELIMITED should NOT apply to this "synthetic" message, and it should also
+// not apply to map message values.
 message Edition2023MapEncodingMessage {
-  map<int32, bool> map_field = 77;
+  map<int32, string> string_map = 77;
+  map<int32, Child> message_map = 88;
+  message Child {}
 }

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.d.ts
@@ -28,15 +28,21 @@ export declare const fileDesc_extra_edition2023_map_encoding: GenDescFile;
 /**
  * Map fields are syntactic sugar for a repeated message field with field 1 for
  * key and field 2 for value. Despite that, the file feature message_encoding =
- * DELIMITED should NOT apply to this "synthetic" message.
+ * DELIMITED should NOT apply to this "synthetic" message, and it should also
+ * not apply to map message values.
  *
  * @generated from message spec.Edition2023MapEncodingMessage
  */
 export declare type Edition2023MapEncodingMessage = Message<"spec.Edition2023MapEncodingMessage"> & {
   /**
-   * @generated from field: map<int32, bool> map_field = 77;
+   * @generated from field: map<int32, string> string_map = 77;
    */
-  mapField: { [key: number]: boolean };
+  stringMap: { [key: number]: string };
+
+  /**
+   * @generated from field: map<int32, spec.Edition2023MapEncodingMessage.Child> message_map = 88;
+   */
+  messageMap: { [key: number]: Edition2023MapEncodingMessage_Child };
 };
 
 /**
@@ -44,4 +50,16 @@ export declare type Edition2023MapEncodingMessage = Message<"spec.Edition2023Map
  * Use `create(Edition2023MapEncodingMessageDesc)` to create a new message.
  */
 export declare const Edition2023MapEncodingMessageDesc: GenDescMessage<Edition2023MapEncodingMessage>;
+
+/**
+ * @generated from message spec.Edition2023MapEncodingMessage.Child
+ */
+export declare type Edition2023MapEncodingMessage_Child = Message<"spec.Edition2023MapEncodingMessage.Child"> & {
+};
+
+/**
+ * Describes the message spec.Edition2023MapEncodingMessage.Child.
+ * Use `create(Edition2023MapEncodingMessage_ChildDesc)` to create a new message.
+ */
+export declare const Edition2023MapEncodingMessage_ChildDesc: GenDescMessage<Edition2023MapEncodingMessage_Child>;
 

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-map-encoding_pb.js
@@ -23,7 +23,7 @@ import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv1";
  * Describes the file extra/edition2023-map-encoding.proto.
  */
 export const fileDesc_extra_edition2023_map_encoding = /*@__PURE__*/
-  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMilgEKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkQKCW1hcF9maWVsZBhNIAMoCzIxLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuTWFwRmllbGRFbnRyeRovCg1NYXBGaWVsZEVudHJ5EgsKA2tleRgBIAEoBRINCgV2YWx1ZRgCIAEoCDoCOAFCBZIDAigCYghlZGl0aW9uc3DoBw");
+  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMiygIKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkYKCnN0cmluZ19tYXAYTSADKAsyMi5zcGVjLkVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlLlN0cmluZ01hcEVudHJ5EkgKC21lc3NhZ2VfbWFwGFggAygLMjMuc3BlYy5FZGl0aW9uMjAyM01hcEVuY29kaW5nTWVzc2FnZS5NZXNzYWdlTWFwRW50cnkaMAoOU3RyaW5nTWFwRW50cnkSCwoDa2V5GAEgASgFEg0KBXZhbHVlGAIgASgJOgI4ARpcCg9NZXNzYWdlTWFwRW50cnkSCwoDa2V5GAEgASgFEjgKBXZhbHVlGAIgASgLMikuc3BlYy5FZGl0aW9uMjAyM01hcEVuY29kaW5nTWVzc2FnZS5DaGlsZDoCOAEaBwoFQ2hpbGRCBZIDAigCYghlZGl0aW9uc3DoBw");
 
 /**
  * Describes the message spec.Edition2023MapEncodingMessage.
@@ -31,4 +31,11 @@ export const fileDesc_extra_edition2023_map_encoding = /*@__PURE__*/
  */
 export const Edition2023MapEncodingMessageDesc = /*@__PURE__*/
   messageDesc(fileDesc_extra_edition2023_map_encoding, 0);
+
+/**
+ * Describes the message spec.Edition2023MapEncodingMessage.Child.
+ * Use `create(Edition2023MapEncodingMessage_ChildDesc)` to create a new message.
+ */
+export const Edition2023MapEncodingMessage_ChildDesc = /*@__PURE__*/
+  messageDesc(fileDesc_extra_edition2023_map_encoding, 0, 0);
 

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023-map-encoding_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023-map-encoding_pb.ts
@@ -25,20 +25,26 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file extra/edition2023-map-encoding.proto.
  */
 export const fileDesc_extra_edition2023_map_encoding: GenDescFile = /*@__PURE__*/
-  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMilgEKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkQKCW1hcF9maWVsZBhNIAMoCzIxLnNwZWMuRWRpdGlvbjIwMjNNYXBFbmNvZGluZ01lc3NhZ2UuTWFwRmllbGRFbnRyeRovCg1NYXBGaWVsZEVudHJ5EgsKA2tleRgBIAEoBRINCgV2YWx1ZRgCIAEoCDoCOAFCBZIDAigCYghlZGl0aW9uc3DoBw");
+  fileDesc("CiRleHRyYS9lZGl0aW9uMjAyMy1tYXAtZW5jb2RpbmcucHJvdG8SBHNwZWMiygIKHUVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlEkYKCnN0cmluZ19tYXAYTSADKAsyMi5zcGVjLkVkaXRpb24yMDIzTWFwRW5jb2RpbmdNZXNzYWdlLlN0cmluZ01hcEVudHJ5EkgKC21lc3NhZ2VfbWFwGFggAygLMjMuc3BlYy5FZGl0aW9uMjAyM01hcEVuY29kaW5nTWVzc2FnZS5NZXNzYWdlTWFwRW50cnkaMAoOU3RyaW5nTWFwRW50cnkSCwoDa2V5GAEgASgFEg0KBXZhbHVlGAIgASgJOgI4ARpcCg9NZXNzYWdlTWFwRW50cnkSCwoDa2V5GAEgASgFEjgKBXZhbHVlGAIgASgLMikuc3BlYy5FZGl0aW9uMjAyM01hcEVuY29kaW5nTWVzc2FnZS5DaGlsZDoCOAEaBwoFQ2hpbGRCBZIDAigCYghlZGl0aW9uc3DoBw");
 
 /**
  * Map fields are syntactic sugar for a repeated message field with field 1 for
  * key and field 2 for value. Despite that, the file feature message_encoding =
- * DELIMITED should NOT apply to this "synthetic" message.
+ * DELIMITED should NOT apply to this "synthetic" message, and it should also
+ * not apply to map message values.
  *
  * @generated from message spec.Edition2023MapEncodingMessage
  */
 export type Edition2023MapEncodingMessage = Message<"spec.Edition2023MapEncodingMessage"> & {
   /**
-   * @generated from field: map<int32, bool> map_field = 77;
+   * @generated from field: map<int32, string> string_map = 77;
    */
-  mapField: { [key: number]: boolean };
+  stringMap: { [key: number]: string };
+
+  /**
+   * @generated from field: map<int32, spec.Edition2023MapEncodingMessage.Child> message_map = 88;
+   */
+  messageMap: { [key: number]: Edition2023MapEncodingMessage_Child };
 };
 
 /**
@@ -47,4 +53,17 @@ export type Edition2023MapEncodingMessage = Message<"spec.Edition2023MapEncoding
  */
 export const Edition2023MapEncodingMessageDesc: GenDescMessage<Edition2023MapEncodingMessage> = /*@__PURE__*/
   messageDesc(fileDesc_extra_edition2023_map_encoding, 0);
+
+/**
+ * @generated from message spec.Edition2023MapEncodingMessage.Child
+ */
+export type Edition2023MapEncodingMessage_Child = Message<"spec.Edition2023MapEncodingMessage.Child"> & {
+};
+
+/**
+ * Describes the message spec.Edition2023MapEncodingMessage.Child.
+ * Use `create(Edition2023MapEncodingMessage_ChildDesc)` to create a new message.
+ */
+export const Edition2023MapEncodingMessage_ChildDesc: GenDescMessage<Edition2023MapEncodingMessage_Child> = /*@__PURE__*/
+  messageDesc(fileDesc_extra_edition2023_map_encoding, 0, 0);
 

--- a/packages/protobuf/src/desc-types.ts
+++ b/packages/protobuf/src/desc-types.ts
@@ -500,7 +500,8 @@ type descFieldMapCommon<T extends ScalarType = ScalarType> = T extends Exclude<S
   readonly oneof: undefined;
   /**
    * Encode the map entry message delimited (a.k.a. proto2 group encoding),
-   * or length-prefixed? This is always false for map fields.
+   * or length-prefixed? As of Edition 2023, this is always false for map fields,
+   * and also applies to map values, if they are messages.
    */
   readonly delimitedEncoding: false;
 } : never;


### PR DESCRIPTION
Map fields are syntactic sugar for a repeated message field with field 1 for key and field 2 for value.

In Edition 2023, a file option `features.message_encoding = DELIMITED` does not apply to this map entry message, and does not apply to the value field (which can be a message field).

This behavior was clarified in https://github.com/protocolbuffers/protobuf/pull/16576 (specifically [this line](https://github.com/protocolbuffers/protobuf/blob/d9ff109888b60a37de1c4f69cea023f89886e86b/src/google/protobuf/descriptor_unittest.cc#L8871) for the map entry and [this line](https://github.com/protocolbuffers/protobuf/blob/d9ff109888b60a37de1c4f69cea023f89886e86b/src/google/protobuf/descriptor_unittest.cc#L8875) for the map value - both would be TYPE_GROUP with DELIMITED).

Our implementation already matched the behavior, this PR just adds additional test coverage. 

Our implementation has just one property `delimitedEncoding` on map field descriptors that applies to both the map entry and map values. If a future edition changes the behavior, it is possible that we have to provide two distinct properties. IF necessary, we can expose the map entry message for this purpose, which will not be a breaking change.
