### PR TITLE
V2: Avoid JIT deoptimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 /packages/*/dist
 /packages/typescript-compat/*/dist
 /packages/protobuf-test/*.0x
+/packages/protobuf-test/*-v8.log
 /.tmp
 /packages/*/.tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "protobuf-es",
+  "name": "protobuf-es-9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -3584,6 +3584,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/dexnode": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/dexnode/-/dexnode-1.2.2.tgz",
+      "integrity": "sha512-L+rnDz6kO/taBvaRfkKei8X66wEAtfbqNp6l8VOWH67CYQbds3Oq+Z0xdBckkwREis1qcBp9cKA6JrHNeJ3DZQ==",
+      "dependencies": {
+        "semver": "^7.3.8",
+        "winreg": "^1.2.4"
+      },
+      "bin": {
+        "dexnode": "bin/dexnode.js"
       }
     },
     "node_modules/diff-sequences": {
@@ -8975,6 +8987,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/winreg": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.5.tgz",
+      "integrity": "sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw=="
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "dev": true,
@@ -9108,6 +9125,7 @@
         "@types/benchmark": "^2.1.5",
         "0x": "^5.7.0",
         "benchmark": "^2.1.4",
+        "dexnode": "^1.2.2",
         "long": "~5.2.3",
         "upstream-protobuf": "*"
       }

--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 125,973 b      | 65,131 b | 15,859 b |
+| protobuf-es         | 126,105 b      | 65,235 b | 15,901 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -12,7 +12,7 @@
     "generate:ts": "protoc --es_out=src/gen/ts --es_opt=ts_nocheck=false,target=ts,import_extension=.js     --proto_path=. $(buf ls-files extra) --proto_path=$(upstream-include test) $(upstream-files test) google/protobuf/type.proto",
     "generate:js": "protoc --es_out=src/gen/js --es_opt=ts_nocheck=false,target=js+dts,import_extension=.js --proto_path=. $(buf ls-files extra) --proto_path=$(upstream-include test) $(upstream-files test) google/protobuf/type.proto",
     "postgenerate": "license-header src/gen",
-    "perf": "tsx src/perf.ts benchmark 'fromBinary perf-payload.bin'",
+    "perf": "tsx src/perf.ts benchmark '.*'",
     "profile": "dexnode dist/esm/perf.js run 'fromBinary perf-payload.bin' 10000",
     "flamegraph": "npx 0x -- node dist/esm/perf.js run 'fromBinary perf-payload.bin' 10000",
     "test": "npm run test:bigint && npm run test:string",

--- a/packages/protobuf-test/package.json
+++ b/packages/protobuf-test/package.json
@@ -12,7 +12,8 @@
     "generate:ts": "protoc --es_out=src/gen/ts --es_opt=ts_nocheck=false,target=ts,import_extension=.js     --proto_path=. $(buf ls-files extra) --proto_path=$(upstream-include test) $(upstream-files test) google/protobuf/type.proto",
     "generate:js": "protoc --es_out=src/gen/js --es_opt=ts_nocheck=false,target=js+dts,import_extension=.js --proto_path=. $(buf ls-files extra) --proto_path=$(upstream-include test) $(upstream-files test) google/protobuf/type.proto",
     "postgenerate": "license-header src/gen",
-    "perf": "tsx src/perf.ts benchmark '.*'",
+    "perf": "tsx src/perf.ts benchmark 'fromBinary perf-payload.bin'",
+    "profile": "dexnode dist/esm/perf.js run 'fromBinary perf-payload.bin' 10000",
     "flamegraph": "npx 0x -- node dist/esm/perf.js run 'fromBinary perf-payload.bin' 10000",
     "test": "npm run test:bigint && npm run test:string",
     "test:bigint": "BUF_BIGINT_DISABLE=0 NODE_OPTIONS=--experimental-vm-modules npx jest",
@@ -29,6 +30,7 @@
     "@types/benchmark": "^2.1.5",
     "0x": "^5.7.0",
     "benchmark": "^2.1.4",
+    "dexnode": "^1.2.2",
     "long": "~5.2.3",
     "upstream-protobuf": "*"
   }

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -158,19 +158,18 @@ export function readField(
       readListField(message, reader, options, field, wireType);
       break;
     case "map":
-      // eslint-disable-next-line no-case-declarations
-      const [key, val] = readMapEntry(field, reader, options);
-      message.setMapEntry(field, key, val);
+      readMapEntry(message, field, reader, options);
       break;
   }
 }
 
 // Read a map field, expecting key field = 1, value field = 2
 function readMapEntry(
+  message: ReflectMessage,
   field: DescField & { fieldKind: "map" },
   reader: BinaryReader,
   options: BinaryReadOptions,
-): [MapEntryKey, ScalarValue | ReflectMessage] {
+): void {
   let key: MapEntryKey | undefined,
     val: ScalarValue | ReflectMessage | undefined;
   const end = reader.pos + reader.uint32();
@@ -211,7 +210,7 @@ function readMapEntry(
         break;
     }
   }
-  return [key, val];
+  message.setMapEntry(field, key, val);
 }
 
 function readListField(

--- a/packages/protobuf/src/reflect/registry.ts
+++ b/packages/protobuf/src/reflect/registry.ts
@@ -784,6 +784,7 @@ function newField(
     | keyof (DescField & { fieldKind: "list" })
     | keyof (DescField & { fieldKind: "scalar" });
   const field: Partial<Record<AllKeys, unknown>> = {
+    kind: "field",
     proto,
     deprecated: proto.options?.deprecated ?? false,
     name: proto.name,
@@ -792,6 +793,13 @@ function newField(
     message: undefined,
     enum: undefined,
     presence: getFieldPresence(proto, oneof, isExtension, parentOrFile),
+    listKind: undefined,
+    mapKind: undefined,
+    mapKey: undefined,
+    delimitedEncoding: undefined,
+    packed: undefined,
+    longType: undefined,
+    getDefaultValue: undefined,
   };
   if (isExtension) {
     // extension field
@@ -815,7 +823,6 @@ function newField(
     // regular field
     const parent = parentOrFile;
     assert(parent.kind == "message");
-    field.kind = "field";
     field.parent = parent;
     field.oneof = oneof;
     field.localName = oneof


### PR DESCRIPTION
Following https://github.com/bufbuild/protobuf-es/pull/834, we can make another - but smaller - performance improvement by avoiding a couple of deopts in v8:

```diff
- fromBinary perf-payload.bin x 4,548 ops/sec ±0.54% (93 runs sampled)
+ fromBinary perf-payload.bin x 5,094 ops/sec ±0.51% (97 runs sampled)
```