### PR TITLE
V2: Speed up reflect with classes

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,105 b      | 65,235 b | 15,901 b |
+| protobuf-es         | 126,685 b      | 66,254 b | 15,996 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf/src/reflect/reflect-types.ts
+++ b/packages/protobuf/src/reflect/reflect-types.ts
@@ -144,7 +144,7 @@ export interface ReflectMessage {
    */
   addListItem<Field extends DescField & { fieldKind: "list" }>(
     field: Field,
-    value: NewListItem<Field>,
+    value: ReflectAddListItemValue<Field>,
   ): FieldError | undefined;
 
   /**
@@ -153,7 +153,7 @@ export interface ReflectMessage {
   setMapEntry<Field extends DescField & { fieldKind: "map" }>(
     field: Field,
     key: MapEntryKey,
-    value: NewMapEntryValue<Field>,
+    value: ReflectSetMapEntryValue<Field>,
   ): FieldError | undefined;
 
   /**
@@ -264,12 +264,18 @@ export interface ReflectMap<K extends MapEntryKey = MapEntryKey, V = unknown>
   [unsafeLocal]: Record<string, unknown>;
 }
 
+/**
+ * A ReflectMap key.
+ */
 export type MapEntryKey = string | number | bigint | boolean;
 
 type enumVal = number;
 
+/**
+ * The return type of ReflectMessage.get()
+ */
 // prettier-ignore
-type ReflectGetValue<Field extends DescField = DescField> = (
+export type ReflectGetValue<Field extends DescField = DescField> = (
   Field extends { fieldKind: "map" } ? (
     Field extends { mapKind: "message" } ? ReflectMap<MapEntryKey, ReflectMessage> :
     Field extends { mapKind: "enum" } ? ReflectMap<MapEntryKey, enumVal> :
@@ -283,8 +289,11 @@ type ReflectGetValue<Field extends DescField = DescField> = (
   never
 );
 
+/**
+ * The type of the "value" argument of ReflectMessage.set()
+ */
 // prettier-ignore
-type ReflectSetValue<Field extends DescField = DescField> = (
+export type ReflectSetValue<Field extends DescField = DescField> = (
   Field extends { fieldKind: "map" } ? ReflectMap :
   Field extends { fieldKind: "list" } ? ReflectList :
   Field extends { fieldKind: "enum" } ? number :
@@ -293,16 +302,22 @@ type ReflectSetValue<Field extends DescField = DescField> = (
   never
 );
 
+/**
+ * The type of the "value" argument of ReflectMessage.addListItem()
+ */
 // prettier-ignore
-type NewListItem<Field extends DescField & { fieldKind: "list" }> = (
+export type ReflectAddListItemValue<Field extends DescField & { fieldKind: "list" }> = (
   Field extends { listKind: "scalar"; scalar: infer T } ? ScalarValue<T> :
   Field extends { listKind: "enum" } ? enumVal :
   Field extends { listKind: "message" } ? ReflectMessage :
   never
 );
 
+/**
+ * The type of the "value" argument of ReflectMessage.setMapEntry()
+ */
 // prettier-ignore
-type NewMapEntryValue<Field extends DescField & { fieldKind: "map" }> = (
+export type ReflectSetMapEntryValue<Field extends DescField & { fieldKind: "map" }> = (
   Field extends { mapKind: "enum" } ? enumVal :
   Field extends { mapKind: "message" } ? ReflectMessage :
   Field extends { mapKind: "scalar"; scalar: infer T } ? ScalarValue<T, LongType.BIGINT> :


### PR DESCRIPTION
Following https://github.com/bufbuild/protobuf-es/pull/836, we can make another performance improvement by using classes for `ReflectMessage`, `ReflectList` and `ReflectMap`:

```diff
- fromBinary perf-payload.bin x 5,094 ops/sec ±0.51% (97 runs sampled)
+ fromBinary perf-payload.bin x 7,040 ops/sec ±0.67% (98 runs sampled)
```