### PR TITLE
V2: Introduce DescMessage.field

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,685 b      | 66,254 b | 15,996 b |
+| protobuf-es         | 126,744 b      | 66,286 b | 16,005 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/codegenv1/boot.test.ts
+++ b/packages/protobuf-test/src/codegenv1/boot.test.ts
@@ -18,24 +18,22 @@ import { UpstreamProtobuf } from "upstream-protobuf";
 import { join as joinPath } from "node:path";
 import { readFileSync } from "fs";
 import { clearField, equals, fromBinary, toBinary } from "@bufbuild/protobuf";
-import type {
-  DescriptorProto,
-  FileDescriptorProto,
-} from "@bufbuild/protobuf/wkt";
 import {
+  type DescriptorProto,
+  type FileDescriptorProto,
   DescriptorProtoDesc,
-  FieldDescriptorProtoDesc,
   FileDescriptorProtoDesc,
   FileDescriptorSetDesc,
+  FieldDescriptorProtoDesc,
   FieldOptionsDesc,
 } from "@bufbuild/protobuf/wkt";
 import assert from "node:assert";
 import {
+  boot,
   bootFileDescriptorProto,
   createFileDescriptorProtoBoot,
   embedFileDesc,
 } from "@bufbuild/protobuf/codegenv1";
-import { boot } from "@bufbuild/protobuf/codegenv1";
 
 describe("boot()", () => {
   test("hydrates google/protobuf/descriptor.proto", async () => {
@@ -95,12 +93,12 @@ describe("bootFileDescriptorProto()", () => {
       d.messageType.forEach(stripLikeBoot);
       return;
     }
-    clearField(DescriptorProtoDesc, d, "reservedRange");
-    clearField(DescriptorProtoDesc, d, "reservedName");
+    clearField(d, DescriptorProtoDesc.field.reservedRange);
+    clearField(d, DescriptorProtoDesc.field.reservedName);
     for (const f of d.field) {
-      clearField(FieldDescriptorProtoDesc, f, "jsonName");
+      clearField(f, FieldDescriptorProtoDesc.field.jsonName);
       if (f.options) {
-        clearField(FieldOptionsDesc, f.options, "featureSupport");
+        clearField(f.options, FieldOptionsDesc.field.featureSupport);
       }
     }
     for (const n of d.nestedType) {

--- a/packages/protobuf-test/src/create.test.ts
+++ b/packages/protobuf-test/src/create.test.ts
@@ -540,7 +540,7 @@ describe("create()", () => {
             expect(created.either).toStrictEqual(filled.either);
             break;
           default:
-            expect(isFieldSet(desc, created, name)).toBe(true);
+            expect(isFieldSet(created, desc.field[name])).toBe(true);
             expect(created[name]).toStrictEqual(filled[name]);
         }
       });
@@ -561,7 +561,7 @@ describe("create()", () => {
             expect(created.either).toStrictEqual(filled.either);
             break;
           default:
-            expect(isFieldSet(desc, created, name)).toBe(true);
+            expect(isFieldSet(created, desc.field[name])).toBe(true);
             expect(created[name]).toStrictEqual(filled[name]);
         }
       });
@@ -582,7 +582,7 @@ describe("create()", () => {
             expect(created.either).toStrictEqual(filled.either);
             break;
           default:
-            expect(isFieldSet(desc, created, name)).toBe(true);
+            expect(isFieldSet(created, desc.field[name])).toBe(true);
             expect(created[name]).toStrictEqual(filled[name]);
         }
       });

--- a/packages/protobuf-test/src/fields.test.ts
+++ b/packages/protobuf-test/src/fields.test.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { beforeEach, describe, expect, test } from "@jest/globals";
-import type { DescMessage } from "@bufbuild/protobuf";
 import { clearField, create, isFieldSet } from "@bufbuild/protobuf";
 import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
 import * as proto2_ts from "./gen/ts/extra/proto2_pb.js";
@@ -26,41 +25,43 @@ import {
 } from "./helpers-edition2023.js";
 
 describe("isFieldSet()", () => {
-  test("accepts field names", () => {
+  test("returns true for set field", () => {
     const msg = create(proto3_ts.Proto3MessageDesc);
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "singularStringField");
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "optionalStringField");
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "repeatedStringField");
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "mapStringStringField");
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "oneofBoolField");
+    msg.optionalStringField = "abc";
+    const set = isFieldSet(
+      msg,
+      proto3_ts.Proto3MessageDesc.field.optionalStringField,
+    );
+    expect(set).toBe(true);
   });
-  test("rejects unknown field names", () => {
+  test("returns true for unset field", () => {
     const msg = create(proto3_ts.Proto3MessageDesc);
-    // @ts-expect-error TS2345
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "not a field name");
+    const set = isFieldSet(
+      msg,
+      proto3_ts.Proto3MessageDesc.field.optionalStringField,
+    );
+    expect(set).toBe(false);
   });
-  test("rejects oneof names", () => {
+  test("returns false for foreign field", () => {
     const msg = create(proto3_ts.Proto3MessageDesc);
-    // @ts-expect-error TS2345
-    isFieldSet(proto3_ts.Proto3MessageDesc, msg, "either");
-  });
-  test("accepts string for anonymous message", () => {
-    const desc: DescMessage = proto3_ts.Proto3MessageDesc;
-    const msg = create(desc);
-    const set = isFieldSet(desc, msg, "not a field name");
+    msg.optionalStringField = "abc";
+    const set = isFieldSet(
+      msg,
+      proto2_ts.Proto2MessageDesc.field.optionalStringField,
+    );
     expect(set).toBe(false);
   });
   describe("with proto3", () => {
     const desc = proto3_ts.Proto3MessageDesc;
     test.each(desc.fields)("%s is initially unset", (field) => {
       const msg = create(desc);
-      const set = isFieldSet(desc as DescMessage, msg, field.localName);
+      const set = isFieldSet(msg, field);
       expect(set).toBe(false);
     });
     test.each(fillProto3MessageNames())("%s is set", (name) => {
       const msg = create(desc);
       fillProto3Message(msg);
-      const set = isFieldSet(desc, msg, name);
+      const set = isFieldSet(msg, desc.field[name]);
       expect(set).toBe(true);
     });
   });
@@ -68,13 +69,13 @@ describe("isFieldSet()", () => {
     const desc = proto2_ts.Proto2MessageDesc;
     test.each(desc.fields)("%s is initially unset", (field) => {
       const msg = create(desc);
-      const set = isFieldSet(desc as DescMessage, msg, field.localName);
+      const set = isFieldSet(msg, field);
       expect(set).toBe(false);
     });
     test.each(fillProto2MessageNames())("%s is set", (name) => {
       const msg = create(desc);
       fillProto2Message(msg);
-      const set = isFieldSet(desc, msg, name);
+      const set = isFieldSet(msg, desc.field[name]);
       expect(set).toBe(true);
     });
   });
@@ -82,13 +83,13 @@ describe("isFieldSet()", () => {
     const desc = edition2023_ts.Edition2023MessageDesc;
     test.each(desc.fields)("%s is initially unset", (field) => {
       const msg = create(desc);
-      const set = isFieldSet(desc as DescMessage, msg, field.localName);
+      const set = isFieldSet(msg, field);
       expect(set).toBe(false);
     });
     test.each(fillEdition2023MessageNames())("%s is set", (name) => {
       const msg = create(desc);
       fillEdition2023Message(msg);
-      const set = isFieldSet(desc, msg, name);
+      const set = isFieldSet(msg, desc.field[name]);
       expect(set).toBe(true);
     });
   });
@@ -105,9 +106,9 @@ describe("clearField()", () => {
       fillProto3Message(msg);
     });
     test.each(fillProto3MessageNames())("%s", (name) => {
-      expect(isFieldSet(desc, msg, name)).toBe(true);
-      clearField(desc, msg, name);
-      expect(isFieldSet(desc, msg, name)).toBe(false);
+      expect(isFieldSet(msg, desc.field[name])).toBe(true);
+      clearField(msg, desc.field[name]);
+      expect(isFieldSet(msg, desc.field[name])).toBe(false);
       switch (name) {
         case "oneofBoolField":
           expect(msg.either).toStrictEqual(zero.either);
@@ -135,9 +136,9 @@ describe("clearField()", () => {
       fillProto2Message(msg);
     });
     test.each(fillProto2MessageNames())("%s", (name) => {
-      expect(isFieldSet(desc, msg, name)).toBe(true);
-      clearField(desc, msg, name);
-      expect(isFieldSet(desc, msg, name)).toBe(false);
+      expect(isFieldSet(msg, desc.field[name])).toBe(true);
+      clearField(msg, desc.field[name]);
+      expect(isFieldSet(msg, desc.field[name])).toBe(false);
       switch (name) {
         case "oneofBoolField":
           expect(msg.either).toStrictEqual(zero.either);
@@ -162,9 +163,9 @@ describe("clearField()", () => {
       fillEdition2023Message(msg);
     });
     test.each(fillEdition2023MessageNames())("%s", (name) => {
-      expect(isFieldSet(desc, msg, name)).toBe(true);
-      clearField(desc, msg, name);
-      expect(isFieldSet(desc, msg, name)).toBe(false);
+      expect(isFieldSet(msg, desc.field[name])).toBe(true);
+      clearField(msg, desc.field[name]);
+      expect(isFieldSet(msg, desc.field[name])).toBe(false);
       switch (name) {
         case "oneofBoolField":
           expect(msg.either).toStrictEqual(zero.either);

--- a/packages/protobuf-test/src/generate-code.test.ts
+++ b/packages/protobuf-test/src/generate-code.test.ts
@@ -225,8 +225,13 @@ describe("ts generated code is equal to js generated code", () => {
           if (id !== undefined) {
             return id;
           }
-          if ("toString" in value) {
-            id = String(value) + "@" + seen.size;
+          if (
+            "toString" in value &&
+            typeof value.toString == "function" &&
+            Object.prototype.hasOwnProperty.call(value, "toString")
+          ) {
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string -- we're not calling Object.toString
+            id = value.toString() + "@" + seen.size;
           } else {
             id = "unknown@" + seen.size;
           }
@@ -236,4 +241,12 @@ describe("ts generated code is equal to js generated code", () => {
       }),
     );
   }
+});
+
+describe("GenDescMessage.field", () => {
+  test("is type safe", () => {
+    proto3_ts.Proto3MessageDesc.field.optionalStringField;
+    // @ts-expect-error TS2339: Property foo does not exist on type
+    proto3_ts.Proto3MessageDesc.field.foo;
+  });
 });

--- a/packages/protobuf-test/src/helpers.ts
+++ b/packages/protobuf-test/src/helpers.ts
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescMessage } from "@bufbuild/protobuf";
 import { UpstreamProtobuf } from "upstream-protobuf";
 import { createFileRegistry } from "@bufbuild/protobuf/reflect";
-import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
-import type { DescField } from "@bufbuild/protobuf";
 import { fromBinary } from "@bufbuild/protobuf";
 import type { FileDescriptorSet } from "@bufbuild/protobuf/wkt";
 import { FileDescriptorSetDesc } from "@bufbuild/protobuf/wkt";
@@ -94,41 +91,4 @@ export async function compileMethod(proto: string) {
   const firstMethod = service.methods[0];
   assert(firstMethod);
   return firstMethod;
-}
-
-export function getFieldByLocalName(desc: DescMessage, name: string): DescField;
-export function getFieldByLocalName(
-  desc: DescMessage,
-  name: string,
-  fieldKind: "message",
-): DescField & { fieldKind: "message" };
-export function getFieldByLocalName(
-  desc: DescMessage,
-  name: string,
-  fieldKind: "list",
-): DescField & { fieldKind: "list" };
-export function getFieldByLocalName(
-  desc: DescMessage,
-  name: string,
-  fieldKind: "map",
-): DescField & { fieldKind: "map" };
-export function getFieldByLocalName(
-  desc: DescMessage,
-  name: string,
-  fieldKind?: string,
-): DescField {
-  const field = proto3_ts.Proto3MessageDesc.fields.find(
-    (f) => f.localName === name,
-  );
-  if (!field) {
-    throw new Error(`getFieldByLocalName: ${name} not found`);
-  }
-  if (fieldKind !== undefined) {
-    if (field.fieldKind != fieldKind) {
-      throw new Error(
-        `getFieldByLocalName: ${name} is not a ${fieldKind} field`,
-      );
-    }
-  }
-  return field;
 }

--- a/packages/protobuf-test/src/reflect/reflect-list.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect-list.test.ts
@@ -19,54 +19,38 @@ import {
   reflect,
   isReflectMessage,
 } from "@bufbuild/protobuf/reflect";
-import { getFieldByLocalName } from "../helpers.js";
 import * as proto3_ts from "../gen/ts/extra/proto3_pb.js";
 import { create, protoInt64 } from "@bufbuild/protobuf";
 import { UserDesc } from "../gen/ts/extra/example_pb.js";
+import assert from "node:assert";
 
 describe("reflectList()", () => {
   test("creates ReflectList", () => {
-    const f = getFieldByLocalName(
-      proto3_ts.Proto3MessageDesc,
-      "repeatedStringField",
-      "list",
-    );
+    const f = proto3_ts.Proto3MessageDesc.field.repeatedStringField;
+    assert(f.fieldKind == "list");
     const list = reflectList(f);
     expect(typeof list.field).toBe("function");
     expect(isReflectList(list)).toBe(true);
   });
   test("creates ReflectList with unsafe input", () => {
-    const f = getFieldByLocalName(
-      proto3_ts.Proto3MessageDesc,
-      "repeatedStringField",
-      "list",
-    );
+    const f = proto3_ts.Proto3MessageDesc.field.repeatedStringField;
+    assert(f.fieldKind == "list");
     const list = reflectList(f, [1, 2, 3]);
     expect(isReflectList(list)).toBe(true);
   });
 });
 
 describe("ReflectList", () => {
-  const repeatedStringField = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "repeatedStringField",
-    "list",
-  );
-  const repeatedInt64Field = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "repeatedInt64Field",
-    "list",
-  );
-  const repeatedInt64JsStringField = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "repeatedInt64JsStringField",
-    "list",
-  );
-  const repeatedMessageField = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "repeatedMessageField",
-    "list",
-  );
+  const {
+    repeatedStringField,
+    repeatedInt64Field,
+    repeatedInt64JsStringField,
+    repeatedMessageField,
+  } = proto3_ts.Proto3MessageDesc.field;
+  assert(repeatedStringField.fieldKind == "list");
+  assert(repeatedInt64Field.fieldKind == "list");
+  assert(repeatedInt64JsStringField.fieldKind == "list");
+  assert(repeatedMessageField.fieldKind == "list");
   const n0 = protoInt64.zero;
   const n1 = protoInt64.parse(1);
   const n2 = protoInt64.parse(2);

--- a/packages/protobuf-test/src/reflect/reflect-map.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect-map.test.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { getFieldByLocalName } from "../helpers.js";
 import * as proto3_ts from "../gen/ts/extra/proto3_pb.js";
 import {
   isReflectMap,
@@ -24,51 +23,36 @@ import {
 import { protoInt64 } from "@bufbuild/protobuf";
 import { UserDesc } from "../gen/ts/extra/example_pb.js";
 import { create } from "@bufbuild/protobuf";
+import assert from "node:assert";
 
 describe("reflectMap()", () => {
   test("creates ReflectMap", () => {
-    const mapStringStringField = getFieldByLocalName(
-      proto3_ts.Proto3MessageDesc,
-      "mapStringStringField",
-      "map",
-    );
-    const map = reflectMap(mapStringStringField);
+    const f = proto3_ts.Proto3MessageDesc.field.mapStringStringField;
+    assert(f.fieldKind == "map");
+    const map = reflectMap(f);
     expect(typeof map.field).toBe("function");
     expect(isReflectMap(map)).toBe(true);
   });
   test("creates ReflectMap with unsafe input", () => {
-    const mapStringStringField = getFieldByLocalName(
-      proto3_ts.Proto3MessageDesc,
-      "mapStringStringField",
-      "map",
-    );
-    const map = reflectMap(mapStringStringField, { x: 123 });
+    const f = proto3_ts.Proto3MessageDesc.field.mapStringStringField;
+    assert(f.fieldKind == "map");
+    const map = reflectMap(f, { x: 123 });
     expect(typeof map.field).toBe("function");
     expect(isReflectMap(map)).toBe(true);
   });
 });
 
 describe("ReflectMap", () => {
-  const mapStringStringField = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "mapStringStringField",
-    "map",
-  );
-  const mapInt64Int64Field = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "mapInt64Int64Field",
-    "map",
-  );
-  const mapInt32Int32Field = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "mapInt32Int32Field",
-    "map",
-  );
-  const mapInt32MessageField = getFieldByLocalName(
-    proto3_ts.Proto3MessageDesc,
-    "mapInt32MessageField",
-    "map",
-  );
+  const {
+    mapStringStringField,
+    mapInt64Int64Field,
+    mapInt32Int32Field,
+    mapInt32MessageField,
+  } = proto3_ts.Proto3MessageDesc.field;
+  assert(mapStringStringField.fieldKind == "map");
+  assert(mapInt64Int64Field.fieldKind == "map");
+  assert(mapInt32Int32Field.fieldKind == "map");
+  assert(mapInt32MessageField.fieldKind == "map");
   const n1 = protoInt64.parse(1);
   const n2 = protoInt64.parse(2);
   const n3 = protoInt64.parse(3);

--- a/packages/protobuf-test/src/reflect/registry.test.ts
+++ b/packages/protobuf-test/src/reflect/registry.test.ts
@@ -543,6 +543,45 @@ describe("DescFile", () => {
   });
 });
 
+describe("DescMessage", () => {
+  describe("deprecated", () => {
+    test("is false by default", async () => {
+      const descMessage = await compileMessage(`
+        syntax="proto3";
+        option deprecated = true;
+        message Foo {}
+      `);
+      expect(descMessage.deprecated).toBe(false);
+    });
+    test("is true with option", async () => {
+      const descMessage = await compileMessage(`
+        syntax="proto3";
+        message Foo {
+          option deprecated = true;
+        }
+      `);
+      expect(descMessage.deprecated).toBe(true);
+    });
+  });
+  describe("field", () => {
+    test("contains field by localName", async () => {
+      const descMessage = await compileMessage(`
+        syntax="proto3";
+        message Foo {
+          int32 foo_bar = 1;
+          oneof kind {
+            int32 oneof_field = 2;
+          }
+        }
+      `);
+      expect(Object.keys(descMessage.field).sort()).toStrictEqual([
+        "fooBar",
+        "oneofField",
+      ]);
+    });
+  });
+});
+
 describe("DescEnum", () => {
   describe("open", () => {
     test("proto3 enum is open", async () => {

--- a/packages/protobuf/src/codegenv1/embed.ts
+++ b/packages/protobuf/src/codegenv1/embed.ts
@@ -71,8 +71,8 @@ export function embedFileDesc(
     bootable: false,
     proto() {
       const stripped = clone(FileDescriptorProtoDesc, file);
-      clearField(FileDescriptorProtoDesc, stripped, "dependency");
-      clearField(FileDescriptorProtoDesc, stripped, "sourceCodeInfo");
+      clearField(stripped, FileDescriptorProtoDesc.field.dependency);
+      clearField(stripped, FileDescriptorProtoDesc.field.sourceCodeInfo);
       stripped.messageType.map(stripJsonNames);
       return stripped;
     },
@@ -95,7 +95,7 @@ export function embedFileDesc(
 function stripJsonNames(d: DescriptorProto): void {
   for (const f of d.field) {
     if (f.jsonName === protoCamelCase(f.name)) {
-      clearField(FieldDescriptorProtoDesc, f, "jsonName");
+      clearField(f, FieldDescriptorProtoDesc.field.jsonName);
     }
   }
   for (const n of d.nestedType) {
@@ -214,12 +214,12 @@ function createDescriptorBoot(proto: DescriptorProto) {
 function createFieldDescriptorBoot(
   proto: FieldDescriptorProto,
 ): FieldDescriptorProtoBoot {
-  assert(isFieldSet(FieldDescriptorProtoDesc, proto, "name"));
-  assert(isFieldSet(FieldDescriptorProtoDesc, proto, "number"));
-  assert(isFieldSet(FieldDescriptorProtoDesc, proto, "type"));
-  assert(!isFieldSet(FieldDescriptorProtoDesc, proto, "oneofIndex"));
+  assert(isFieldSet(proto, FieldDescriptorProtoDesc.field.name));
+  assert(isFieldSet(proto, FieldDescriptorProtoDesc.field.number));
+  assert(isFieldSet(proto, FieldDescriptorProtoDesc.field.type));
+  assert(!isFieldSet(proto, FieldDescriptorProtoDesc.field.oneofIndex));
   assert(
-    !isFieldSet(FieldDescriptorProtoDesc, proto, "jsonName") ||
+    !isFieldSet(proto, FieldDescriptorProtoDesc.field.jsonName) ||
       proto.jsonName === protoCamelCase(proto.name),
   );
   const b: FieldDescriptorProtoBoot = {
@@ -227,16 +227,16 @@ function createFieldDescriptorBoot(
     number: proto.number,
     type: proto.type,
   };
-  if (isFieldSet(FieldDescriptorProtoDesc, proto, "label")) {
+  if (isFieldSet(proto, FieldDescriptorProtoDesc.field.label)) {
     b.label = proto.label;
   }
-  if (isFieldSet(FieldDescriptorProtoDesc, proto, "typeName")) {
+  if (isFieldSet(proto, FieldDescriptorProtoDesc.field.typeName)) {
     b.typeName = proto.typeName;
   }
-  if (isFieldSet(FieldDescriptorProtoDesc, proto, "extendee")) {
+  if (isFieldSet(proto, FieldDescriptorProtoDesc.field.extendee)) {
     b.extendee = proto.extendee;
   }
-  if (isFieldSet(FieldDescriptorProtoDesc, proto, "defaultValue")) {
+  if (isFieldSet(proto, FieldDescriptorProtoDesc.field.defaultValue)) {
     b.defaultValue = proto.defaultValue;
   }
   if (proto.options) {
@@ -247,19 +247,19 @@ function createFieldDescriptorBoot(
 
 function createFieldOptionsBoot(proto: FieldOptions): FieldOptionsBoot {
   const b: FieldOptionsBoot = {};
-  assert(!isFieldSet(FieldOptionsDesc, proto, "ctype"));
-  if (isFieldSet(FieldOptionsDesc, proto, "packed")) {
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.ctype));
+  if (isFieldSet(proto, FieldOptionsDesc.field.packed)) {
     b.packed = proto.packed;
   }
-  assert(!isFieldSet(FieldOptionsDesc, proto, "jstype"));
-  assert(!isFieldSet(FieldOptionsDesc, proto, "lazy"));
-  assert(!isFieldSet(FieldOptionsDesc, proto, "unverifiedLazy"));
-  if (isFieldSet(FieldOptionsDesc, proto, "deprecated")) {
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.jstype));
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.lazy));
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.unverifiedLazy));
+  if (isFieldSet(proto, FieldOptionsDesc.field.deprecated)) {
     b.deprecated = proto.deprecated;
   }
-  assert(!isFieldSet(FieldOptionsDesc, proto, "weak"));
-  assert(!isFieldSet(FieldOptionsDesc, proto, "debugRedact"));
-  if (isFieldSet(FieldOptionsDesc, proto, "retention")) {
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.weak));
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.debugRedact));
+  if (isFieldSet(proto, FieldOptionsDesc.field.retention)) {
     b.retention = proto.retention;
   }
   if (proto.targets.length) {
@@ -273,8 +273,8 @@ function createFieldOptionsBoot(proto: FieldOptions): FieldOptionsBoot {
       }),
     );
   }
-  assert(!isFieldSet(FieldOptionsDesc, proto, "features"));
-  assert(!isFieldSet(FieldOptionsDesc, proto, "uninterpretedOption"));
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.features));
+  assert(!isFieldSet(proto, FieldOptionsDesc.field.uninterpretedOption));
   return b;
 }
 

--- a/packages/protobuf/src/desc-types.ts
+++ b/packages/protobuf/src/desc-types.ts
@@ -210,6 +210,10 @@ export interface DescMessage {
    */
   readonly fields: DescField[];
   /**
+   * All fields of this message by their "localName".
+   */
+  readonly field: Record<string, DescField>;
+  /**
    * Oneof groups declared for this message.
    * This does not include synthetic oneofs for proto3 optionals.
    */

--- a/packages/protobuf/src/reflect/registry.ts
+++ b/packages/protobuf/src/reflect/registry.ts
@@ -543,6 +543,7 @@ function addFields(
     const oneof = findOneof(proto, allOneofs);
     const field = newField(proto, message, reg, oneof, mapEntries);
     message.fields.push(field);
+    message.field[field.localName] = field;
     if (oneof === undefined) {
       message.members.push(field);
     } else {
@@ -629,6 +630,7 @@ function addMessage(
     name: proto.name,
     typeName: makeTypeName(proto, parent, file),
     fields: [],
+    field: {},
     oneofs: [],
     members: [],
     nestedEnums: [],

--- a/packages/protoplugin/src/source-code-info.ts
+++ b/packages/protoplugin/src/source-code-info.ts
@@ -36,6 +36,10 @@ import {
   FieldOptionsDesc,
   FeatureSetDesc,
   SourceCodeInfo_LocationDesc,
+  FileDescriptorProtoDesc,
+  DescriptorProtoDesc,
+  EnumDescriptorProtoDesc,
+  ServiceDescriptorProtoDesc,
 } from "@bufbuild/protobuf/wkt";
 
 /**
@@ -43,7 +47,7 @@ import {
  */
 export function getPackageComments(desc: DescFile): DescComments {
   return findComments(desc.proto.sourceCodeInfo, [
-    FieldNumber.FileDescriptorProto_Package,
+    FileDescriptorProtoDesc.field.package.number,
   ]);
 }
 
@@ -52,7 +56,7 @@ export function getPackageComments(desc: DescFile): DescComments {
  */
 export function getSyntaxComments(desc: DescFile): DescComments {
   return findComments(desc.proto.sourceCodeInfo, [
-    FieldNumber.FileDescriptorProto_Syntax,
+    FileDescriptorProtoDesc.field.syntax.number,
   ]);
 }
 
@@ -67,11 +71,11 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
       path = desc.parent
         ? [
             ...getComments(desc.parent).sourcePath,
-            FieldNumber.DescriptorProto_EnumType,
+            DescriptorProtoDesc.field.enumType.number,
             desc.parent.proto.enumType.indexOf(desc.proto),
           ]
         : [
-            FieldNumber.FileDescriptorProto_EnumType,
+            FileDescriptorProtoDesc.field.enumType.number,
             desc.file.proto.enumType.indexOf(desc.proto),
           ];
       file = desc.file;
@@ -79,7 +83,7 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
     case "oneof":
       path = [
         ...getComments(desc.parent).sourcePath,
-        FieldNumber.DescriptorProto_OneofDecl,
+        DescriptorProtoDesc.field.oneofDecl.number,
         desc.parent.proto.oneofDecl.indexOf(desc.proto),
       ];
       file = desc.parent.file;
@@ -88,11 +92,11 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
       path = desc.parent
         ? [
             ...getComments(desc.parent).sourcePath,
-            FieldNumber.DescriptorProto_NestedType,
+            DescriptorProtoDesc.field.nestedType.number,
             desc.parent.proto.nestedType.indexOf(desc.proto),
           ]
         : [
-            FieldNumber.FileDescriptorProto_MessageType,
+            FileDescriptorProtoDesc.field.messageType.number,
             desc.file.proto.messageType.indexOf(desc.proto),
           ];
       file = desc.file;
@@ -100,7 +104,7 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
     case "enum_value":
       path = [
         ...getComments(desc.parent).sourcePath,
-        FieldNumber.EnumDescriptorProto_Value,
+        EnumDescriptorProtoDesc.field.value.number,
         desc.parent.proto.value.indexOf(desc.proto),
       ];
       file = desc.parent.file;
@@ -108,7 +112,7 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
     case "field":
       path = [
         ...getComments(desc.parent).sourcePath,
-        FieldNumber.DescriptorProto_Field,
+        DescriptorProtoDesc.field.field.number,
         desc.parent.proto.field.indexOf(desc.proto),
       ];
       file = desc.parent.file;
@@ -117,18 +121,18 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
       path = desc.parent
         ? [
             ...getComments(desc.parent).sourcePath,
-            FieldNumber.DescriptorProto_Extension,
+            DescriptorProtoDesc.field.extension.number,
             desc.parent.proto.extension.indexOf(desc.proto),
           ]
         : [
-            FieldNumber.FileDescriptorProto_Extension,
+            FileDescriptorProtoDesc.field.extension.number,
             desc.file.proto.extension.indexOf(desc.proto),
           ];
       file = desc.file;
       break;
     case "service":
       path = [
-        FieldNumber.FileDescriptorProto_Service,
+        FileDescriptorProtoDesc.field.service.number,
         desc.file.proto.service.indexOf(desc.proto),
       ];
       file = desc.file;
@@ -136,7 +140,7 @@ export function getComments(desc: Exclude<AnyDesc, DescFile>): DescComments {
     case "rpc":
       path = [
         ...getComments(desc.parent).sourcePath,
-        FieldNumber.ServiceDescriptorProto_Method,
+        ServiceDescriptorProtoDesc.field.method.number,
         desc.parent.proto.method.indexOf(desc.proto),
       ];
       file = desc.parent.file;
@@ -219,11 +223,11 @@ export function getDeclarationString(
   const protoOptions = desc.proto.options;
   if (
     protoOptions !== undefined &&
-    isFieldSet(FieldOptionsDesc, protoOptions, "packed")
+    isFieldSet(protoOptions, FieldOptionsDesc.field.packed)
   ) {
     options.push(`packed = ${protoOptions.packed.toString()}`);
   }
-  if (isFieldSet(FieldDescriptorProtoDesc, desc.proto, "defaultValue")) {
+  if (isFieldSet(desc.proto, FieldDescriptorProtoDesc.field.defaultValue)) {
     let defaultValue = desc.proto.defaultValue;
     if (
       desc.proto.type == FieldDescriptorProto_Type.BYTES ||
@@ -238,13 +242,13 @@ export function getDeclarationString(
   }
   if (
     protoOptions !== undefined &&
-    isFieldSet(FieldOptionsDesc, protoOptions, "jstype")
+    isFieldSet(protoOptions, FieldOptionsDesc.field.jstype)
   ) {
     options.push(`jstype = ${FieldOptions_JSType[protoOptions.jstype]}`);
   }
   if (
     protoOptions !== undefined &&
-    isFieldSet(FieldOptionsDesc, protoOptions, "deprecated")
+    isFieldSet(protoOptions, FieldOptionsDesc.field.deprecated)
   ) {
     options.push(`deprecated = true`);
   }
@@ -309,16 +313,14 @@ function findComments(
     return {
       leadingDetached: location.leadingDetachedComments,
       leading: isFieldSet(
-        SourceCodeInfo_LocationDesc,
         location,
-        "leadingComments",
+        SourceCodeInfo_LocationDesc.field.leadingComments,
       )
         ? location.leadingComments
         : undefined,
       trailing: isFieldSet(
-        SourceCodeInfo_LocationDesc,
         location,
-        "trailingComments",
+        SourceCodeInfo_LocationDesc.field.trailingComments,
       )
         ? location.trailingComments
         : undefined,
@@ -329,24 +331,4 @@ function findComments(
     leadingDetached: [],
     sourcePath,
   };
-}
-
-/**
- * The following field numbers are used to find comments in
- * google.protobuf.SourceCodeInfo.
- */
-enum FieldNumber {
-  FileDescriptorProto_Package = 2,
-  FileDescriptorProto_MessageType = 4,
-  FileDescriptorProto_EnumType = 5,
-  FileDescriptorProto_Service = 6,
-  FileDescriptorProto_Extension = 7,
-  FileDescriptorProto_Syntax = 12,
-  DescriptorProto_Field = 2, // eslint-disable-line @typescript-eslint/no-duplicate-enum-values
-  DescriptorProto_NestedType = 3,
-  DescriptorProto_EnumType = 4, // eslint-disable-line @typescript-eslint/no-duplicate-enum-values
-  DescriptorProto_Extension = 6, // eslint-disable-line @typescript-eslint/no-duplicate-enum-values
-  DescriptorProto_OneofDecl = 8,
-  EnumDescriptorProto_Value = 2, // eslint-disable-line @typescript-eslint/no-duplicate-enum-values
-  ServiceDescriptorProto_Method = 2, // eslint-disable-line @typescript-eslint/no-duplicate-enum-values
 }


### PR DESCRIPTION
In some situations, it's useful to be able to refer to a field by name. 

`DescMessage` provides all fields in the property `fields: DescField[]` - that's convenient to loop through all fields, but it's awkward to pick a field by name.

This PR adds another property to `DescMessage`:

```ts
/**
 * All fields of this message by their "localName".
 */
readonly field: Record<string, DescField>;
```

In generated code, the property is a type-safe record. You get autocomplete for field names, and a typo is a compile-time error:


```ts
import { UserDesc } from "./gen/example_pb.js";

UserDesc.field.firstName; // DescField
UserDesc.field.firstNam; // type error
```

This PR also changes the signatures of `isFieldSet` and `clearField` to make use of this new feature. Instead of having to pass in the message descriptor, the message, and the field name, both functions only require two arguments now: The message, and the field:

```ts
import { create, clearField } from "@bufbuild/protobuf";
import { UserDesc } from "./gen/example_pb.js";

const user = create(UserDesc);
clearField(user, UserDesc.field.firstName);
```