### PR TITLE
Move Registry to the top level exports

### DIFF
--- a/packages/protobuf-bench/README.md
+++ b/packages/protobuf-bench/README.md
@@ -10,5 +10,5 @@ server would usually do.
 
 | code generator      | bundle size             | minified               | compressed         |
 |---------------------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es         | 126,744 b      | 66,286 b | 16,005 b |
+| protobuf-es         | 126,776 b      | 66,286 b | 15,998 b |
 | protobuf-javascript | 394,384 b  | 288,654 b | 45,122 b |

--- a/packages/protobuf-test/src/reflect/registry.test.ts
+++ b/packages/protobuf-test/src/reflect/registry.test.ts
@@ -18,17 +18,17 @@ import {
   type FileRegistry,
   createFileRegistry,
   createRegistry,
-  LongType,
   protoCamelCase,
-  ScalarType,
 } from "@bufbuild/protobuf/reflect";
-import type {
-  DescEnum,
-  DescExtension,
-  DescFile,
-  DescMessage,
-  DescOneof,
-  DescService,
+import {
+  type DescEnum,
+  type DescExtension,
+  type DescFile,
+  type DescMessage,
+  type DescOneof,
+  type DescService,
+  LongType,
+  ScalarType,
 } from "@bufbuild/protobuf";
 import {
   type FileDescriptorSet,

--- a/packages/protobuf/src/clone.ts
+++ b/packages/protobuf/src/clone.ts
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 import type { MessageShape } from "./types.js";
-import type { DescField, DescMessage } from "./desc-types.js";
+import { type DescField, type DescMessage, ScalarType } from "./descriptors.js";
 import type { ReflectMessage } from "./reflect/reflect-types.js";
 import { reflect } from "./reflect/reflect.js";
 import { isReflectMessage } from "./reflect/guard.js";
-import { ScalarType } from "./reflect/scalar.js";
 
 /**
  * Create a deep copy of a message, including extensions and unknown fields.

--- a/packages/protobuf/src/codegenv1/boot.ts
+++ b/packages/protobuf/src/codegenv1/boot.ts
@@ -26,9 +26,9 @@ import type {
   FieldOptions,
   EnumDescriptorProto,
 } from "../wkt/gen/google/protobuf/descriptor_pb.js";
-import type { DescFile } from "../desc-types.js";
+import type { DescFile } from "../descriptors.js";
 import { restoreJsonNames } from "./restore-json-names.js";
-import { createFileRegistry } from "../reflect/registry.js";
+import { createFileRegistry } from "../registry.js";
 import { assert } from "../reflect/assert.js";
 
 /**

--- a/packages/protobuf/src/codegenv1/embed.ts
+++ b/packages/protobuf/src/codegenv1/embed.ts
@@ -17,7 +17,7 @@ import type {
   DescExtension,
   DescMessage,
   DescService,
-} from "../desc-types.js";
+} from "../descriptors.js";
 import { protoCamelCase } from "../reflect/names.js";
 import { assert } from "../reflect/assert.js";
 import { isFieldSet, clearField } from "../fields.js";

--- a/packages/protobuf/src/codegenv1/enum.ts
+++ b/packages/protobuf/src/codegenv1/enum.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescEnum, DescFile } from "../desc-types.js";
+import type { DescEnum, DescFile } from "../descriptors.js";
 import type { GenDescEnum } from "./types.js";
 
 /**

--- a/packages/protobuf/src/codegenv1/extension.ts
+++ b/packages/protobuf/src/codegenv1/extension.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { Message } from "../types.js";
-import type { DescFile } from "../desc-types.js";
+import type { DescFile } from "../descriptors.js";
 import type { GenDescExtension } from "./types.js";
 
 /**

--- a/packages/protobuf/src/codegenv1/file.ts
+++ b/packages/protobuf/src/codegenv1/file.ts
@@ -14,8 +14,8 @@
 
 import { base64Decode } from "../wire/index.js";
 import { FileDescriptorProtoDesc } from "../wkt/gen/google/protobuf/descriptor_pb.js";
-import type { DescFile } from "../desc-types.js";
-import { createFileRegistry } from "../reflect/registry.js";
+import type { DescFile } from "../descriptors.js";
+import { createFileRegistry } from "../registry.js";
 import { assert } from "../reflect/assert.js";
 import { restoreJsonNames } from "./restore-json-names.js";
 import { fromBinary } from "../from-binary.js";

--- a/packages/protobuf/src/codegenv1/message.ts
+++ b/packages/protobuf/src/codegenv1/message.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { Message } from "../types.js";
-import type { DescFile } from "../desc-types.js";
+import type { DescFile } from "../descriptors.js";
 import type { GenDescMessage } from "./types.js";
 
 /**

--- a/packages/protobuf/src/codegenv1/service.ts
+++ b/packages/protobuf/src/codegenv1/service.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { GenDescService, GenDescServiceShape } from "./types.js";
-import type { DescFile } from "../desc-types.js";
+import type { DescFile } from "../descriptors.js";
 
 /**
  * Hydrate a service descriptor.

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -20,7 +20,7 @@ import type {
   DescFile,
   DescMessage,
   DescService,
-} from "../desc-types.js";
+} from "../descriptors.js";
 
 /**
  * Describes a protobuf source file.

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -13,9 +13,15 @@
 // limitations under the License.
 
 import { isMessage } from "./is-message.js";
-import type { DescField, DescMessage, DescOneof } from "./desc-types.js";
+import {
+  type DescField,
+  type DescMessage,
+  type DescOneof,
+  LongType,
+  ScalarType,
+} from "./descriptors.js";
 import type { Message, MessageInitShape, MessageShape } from "./types.js";
-import { LongType, ScalarType, scalarZeroValue } from "./reflect/scalar.js";
+import { scalarZeroValue } from "./reflect/scalar.js";
 import { FieldError } from "./reflect/error.js";
 import { isObject, type OneofADT } from "./reflect/guard.js";
 import { unsafeGet, unsafeOneofCase, unsafeSet } from "./reflect/unsafe.js";

--- a/packages/protobuf/src/descriptors.ts
+++ b/packages/protobuf/src/descriptors.ts
@@ -25,7 +25,7 @@ import type {
   OneofDescriptorProto,
   ServiceDescriptorProto,
 } from "./wkt/gen/google/protobuf/descriptor_pb.js";
-import type { LongType, ScalarType, ScalarValue } from "./reflect/scalar.js";
+import type { ScalarValue } from "./reflect/scalar.js";
 
 export type SupportedEdition = Extract<
   Edition,
@@ -38,6 +38,73 @@ type SupportedFieldPresence = Extract<
   | FeatureSet_FieldPresence.IMPLICIT
   | FeatureSet_FieldPresence.LEGACY_REQUIRED
 >;
+
+/**
+ * Scalar value types. This is a subset of field types declared by protobuf
+ * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
+ * are omitted, but the numerical values are identical.
+ */
+export enum ScalarType {
+  // 0 is reserved for errors.
+  // Order is weird for historical reasons.
+  DOUBLE = 1,
+  FLOAT = 2,
+  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+  // negative values are likely.
+  INT64 = 3,
+  UINT64 = 4,
+  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+  // negative values are likely.
+  INT32 = 5,
+  FIXED64 = 6,
+  FIXED32 = 7,
+  BOOL = 8,
+  STRING = 9,
+  // Tag-delimited aggregate.
+  // Group type is deprecated and not supported in proto3. However, Proto3
+  // implementations should still be able to parse the group wire format and
+  // treat group fields as unknown fields.
+  // TYPE_GROUP = 10,
+  // TYPE_MESSAGE = 11,  // Length-delimited aggregate.
+
+  // New in version 2.
+  BYTES = 12,
+  UINT32 = 13,
+  // TYPE_ENUM = 14,
+  SFIXED32 = 15,
+  SFIXED64 = 16,
+  SINT32 = 17, // Uses ZigZag encoding.
+  SINT64 = 18, // Uses ZigZag encoding.
+}
+
+/**
+ * JavaScript representation of fields with 64 bit integral types (int64, uint64,
+ * sint64, fixed64, sfixed64).
+ *
+ * This is a subset of google.protobuf.FieldOptions.JSType, which defines JS_NORMAL,
+ * JS_STRING, and JS_NUMBER. Protobuf-ES uses BigInt by default, but will use
+ * String if `[jstype = JS_STRING]` is specified.
+ *
+ * ```protobuf
+ * uint64 field_a = 1; // BigInt
+ * uint64 field_b = 2 [jstype = JS_NORMAL]; // BigInt
+ * uint64 field_b = 2 [jstype = JS_NUMBER]; // BigInt
+ * uint64 field_b = 2 [jstype = JS_STRING]; // String
+ * ```
+ */
+export enum LongType {
+  /**
+   * Use JavaScript BigInt.
+   */
+  BIGINT = 0,
+
+  /**
+   * Use JavaScript String.
+   *
+   * Field option `[jstype = JS_STRING]`.
+   */
+  STRING = 1,
+}
 
 /**
  * A union of all descriptors, discriminated by a `kind` property.

--- a/packages/protobuf/src/equals.ts
+++ b/packages/protobuf/src/equals.ts
@@ -15,7 +15,7 @@
 import type { MessageShape } from "./types.js";
 import { scalarEquals } from "./reflect/scalar.js";
 import { reflect } from "./reflect/reflect.js";
-import type { DescField, DescMessage } from "./desc-types.js";
+import type { DescField, DescMessage } from "./descriptors.js";
 import type { MapEntryKey, ReflectMessage } from "./reflect/index.js";
 
 /**

--- a/packages/protobuf/src/extensions.ts
+++ b/packages/protobuf/src/extensions.ts
@@ -23,7 +23,7 @@ import type {
   DescMethod,
   DescOneof,
   DescService,
-} from "./desc-types.js";
+} from "./descriptors.js";
 import { assert } from "./reflect/assert.js";
 import { create } from "./create.js";
 import { readField } from "./from-binary.js";

--- a/packages/protobuf/src/fields.ts
+++ b/packages/protobuf/src/fields.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { MessageShape } from "./types.js";
-import type { DescField, DescMessage } from "./desc-types.js";
+import type { DescField, DescMessage } from "./descriptors.js";
 import { unsafeClear, unsafeIsSet } from "./reflect/unsafe.js";
 
 /**

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescField, DescMessage } from "./desc-types.js";
+import {
+  type DescField,
+  type DescMessage,
+  LongType,
+  ScalarType,
+} from "./descriptors.js";
 import type { MessageShape } from "./types.js";
 import type { MapEntryKey, ReflectMessage } from "./reflect/index.js";
-import { LongType, ScalarType, scalarZeroValue } from "./reflect/scalar.js";
+import { scalarZeroValue } from "./reflect/scalar.js";
 import type { ScalarValue } from "./reflect/scalar.js";
 import { reflect } from "./reflect/reflect.js";
 import { BinaryReader, WireType } from "./wire/binary-encoding.js";

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -14,27 +14,24 @@
 
 /* eslint-disable no-case-declarations */
 
-import type {
-  DescEnum,
-  DescExtension,
-  DescField,
-  DescMessage,
-  DescOneof,
-} from "./desc-types.js";
+import {
+  type DescEnum,
+  type DescExtension,
+  type DescField,
+  type DescMessage,
+  type DescOneof,
+  LongType,
+  ScalarType,
+} from "./descriptors.js";
 import type { JsonValue } from "./json-value.js";
 import { assertFloat32, assertInt32, assertUInt32 } from "./reflect/assert.js";
 import { protoInt64 } from "./proto-int64.js";
 import { create } from "./create.js";
-import type { Registry } from "./reflect/registry.js";
+import type { Registry } from "./registry.js";
 import type { MapEntryKey, ReflectMessage } from "./reflect/reflect-types.js";
 import { reflect } from "./reflect/reflect.js";
 import { formatVal } from "./reflect/reflect-check.js";
-import {
-  LongType,
-  ScalarType,
-  type ScalarValue,
-  scalarZeroValue,
-} from "./reflect/scalar.js";
+import { type ScalarValue, scalarZeroValue } from "./reflect/scalar.js";
 import type { MessageShape } from "./types.js";
 import { base64Decode } from "./wire/base64-encoding.js";
 import { getTextEncoding } from "./wire/text-encoding.js";

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -16,7 +16,7 @@ export * from "./types.js";
 export * from "./is-message.js";
 export * from "./create.js";
 export * from "./clone.js";
-export * from "./desc-types.js";
+export * from "./descriptors.js";
 export * from "./equals.js";
 export * from "./fields.js";
 export type { JsonValue, JsonObject } from "./json-value.js";

--- a/packages/protobuf/src/is-message.ts
+++ b/packages/protobuf/src/is-message.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { MessageShape } from "./types.js";
-import type { DescMessage } from "./desc-types.js";
+import type { DescMessage } from "./descriptors.js";
 
 /**
  * Determine whether the given `arg` is a message.

--- a/packages/protobuf/src/reflect/error.ts
+++ b/packages/protobuf/src/reflect/error.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescField, DescOneof } from "../desc-types.js";
+import type { DescField, DescOneof } from "../descriptors.js";
 
 const errorNames = [
   "FieldValueInvalidError",

--- a/packages/protobuf/src/reflect/guard.ts
+++ b/packages/protobuf/src/reflect/guard.ts
@@ -20,7 +20,7 @@ import type {
   ReflectMessage,
 } from "./reflect-types.js";
 import { unsafeLocal } from "./unsafe.js";
-import type { DescField, DescMessage } from "../desc-types.js";
+import type { DescField, DescMessage } from "../descriptors.js";
 import { isMessage } from "../is-message.js";
 
 export function isObject(arg: unknown): arg is Record<string, unknown> {

--- a/packages/protobuf/src/reflect/index.ts
+++ b/packages/protobuf/src/reflect/index.ts
@@ -17,6 +17,6 @@ export * from "./names.js";
 export * from "./nested-types.js";
 export * from "./reflect.js";
 export * from "./reflect-types.js";
-export * from "./registry.js";
+export * from "../registry.js";
 export * from "./scalar.js";
 export { isReflectList, isReflectMap, isReflectMessage } from "./guard.js";

--- a/packages/protobuf/src/reflect/nested-types.ts
+++ b/packages/protobuf/src/reflect/nested-types.ts
@@ -19,7 +19,7 @@ import type {
   DescFile,
   DescMessage,
   DescService,
-} from "../desc-types.js";
+} from "../descriptors.js";
 
 /**
  * Iterate over all types - enumerations, extensions, services, messages -

--- a/packages/protobuf/src/reflect/reflect-check.ts
+++ b/packages/protobuf/src/reflect/reflect-check.ts
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ScalarType, scalarTypeDescription } from "./scalar.js";
+import { scalarTypeDescription } from "./scalar.js";
 import type { InvalidScalarValueErr } from "./scalar.js";
 import { checkScalarValue } from "./scalar.js";
-import type { DescEnum, DescField, DescMessage } from "../desc-types.js";
+import {
+  type DescEnum,
+  type DescField,
+  type DescMessage,
+  ScalarType,
+} from "../descriptors.js";
 import { isMessage } from "../is-message.js";
 import { FieldError } from "./error.js";
 import { isReflectList, isReflectMap, isReflectMessage } from "./guard.js";

--- a/packages/protobuf/src/reflect/reflect-types.ts
+++ b/packages/protobuf/src/reflect/reflect-types.ts
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescField, DescMessage, DescOneof } from "../desc-types.js";
+import {
+  type DescField,
+  type DescMessage,
+  type DescOneof,
+  LongType,
+} from "../descriptors.js";
 import { FieldError } from "./error.js";
 import { unsafeLocal } from "./unsafe.js";
 import type { Message, UnknownField } from "../types.js";
-import type { LongType, ScalarValue } from "./scalar.js";
+import type { ScalarValue } from "./scalar.js";
 
 /**
  * ReflectMessage provides dynamic access and manipulation of a message.

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescField, DescMessage, DescOneof } from "../desc-types.js";
+import {
+  type DescField,
+  type DescMessage,
+  type DescOneof,
+  LongType,
+  ScalarType,
+} from "../descriptors.js";
 import type { Message, MessageShape, UnknownField } from "../types.js";
 import { checkField, checkListItem, checkMapEntry } from "./reflect-check.js";
 import { FieldError } from "./error.js";
@@ -38,7 +44,7 @@ import {
 } from "./unsafe.js";
 import { create } from "../create.js";
 import { isWrapper, isWrapperDesc } from "../wkt/wrappers.js";
-import { LongType, ScalarType, scalarZeroValue } from "./scalar.js";
+import { scalarZeroValue } from "./scalar.js";
 import { protoInt64 } from "../proto-int64.js";
 import { isReflectList, isReflectMap, isReflectMessage } from "./guard.js";
 

--- a/packages/protobuf/src/reflect/scalar.ts
+++ b/packages/protobuf/src/reflect/scalar.ts
@@ -14,73 +14,7 @@
 
 import { protoInt64 } from "../proto-int64.js";
 import { getTextEncoding } from "../wire/text-encoding.js";
-
-/**
- * Scalar value types. This is a subset of field types declared by protobuf
- * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
- * are omitted, but the numerical values are identical.
- */
-export enum ScalarType {
-  // 0 is reserved for errors.
-  // Order is weird for historical reasons.
-  DOUBLE = 1,
-  FLOAT = 2,
-  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-  // negative values are likely.
-  INT64 = 3,
-  UINT64 = 4,
-  // Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-  // negative values are likely.
-  INT32 = 5,
-  FIXED64 = 6,
-  FIXED32 = 7,
-  BOOL = 8,
-  STRING = 9,
-  // Tag-delimited aggregate.
-  // Group type is deprecated and not supported in proto3. However, Proto3
-  // implementations should still be able to parse the group wire format and
-  // treat group fields as unknown fields.
-  // TYPE_GROUP = 10,
-  // TYPE_MESSAGE = 11,  // Length-delimited aggregate.
-
-  // New in version 2.
-  BYTES = 12,
-  UINT32 = 13,
-  // TYPE_ENUM = 14,
-  SFIXED32 = 15,
-  SFIXED64 = 16,
-  SINT32 = 17, // Uses ZigZag encoding.
-  SINT64 = 18, // Uses ZigZag encoding.
-}
-
-/**
- * JavaScript representation of fields with 64 bit integral types (int64, uint64,
- * sint64, fixed64, sfixed64).
- *
- * This is a subset of google.protobuf.FieldOptions.JSType, which defines JS_NORMAL,
- * JS_STRING, and JS_NUMBER. Protobuf-ES uses BigInt by default, but will use
- * String if `[jstype = JS_STRING]` is specified.
- *
- * ```protobuf
- * uint64 field_a = 1; // BigInt
- * uint64 field_b = 2 [jstype = JS_NORMAL]; // BigInt
- * uint64 field_b = 2 [jstype = JS_NUMBER]; // BigInt
- * uint64 field_b = 2 [jstype = JS_STRING]; // String
- * ```
- */
-export enum LongType {
-  /**
-   * Use JavaScript BigInt.
-   */
-  BIGINT = 0,
-
-  /**
-   * Use JavaScript String.
-   *
-   * Field option `[jstype = JS_STRING]`.
-   */
-  STRING = 1,
-}
+import { LongType, ScalarType } from "../descriptors.js";
 
 /**
  * ScalarValue maps from a scalar field type to a TypeScript value type.
@@ -92,7 +26,6 @@ export type ScalarValue<
 > =
     T extends ScalarType.STRING   ? string
   : T extends ScalarType.INT32    ? number
-  : T extends ScalarType.UINT32   ? number
   : T extends ScalarType.UINT32   ? number
   : T extends ScalarType.SINT32   ? number
   : T extends ScalarType.FIXED32  ? number
@@ -159,28 +92,28 @@ export function scalarZeroValue<T extends ScalarType, L extends LongType>(
   longType: L,
 ): ScalarValue<T, L> {
   switch (type) {
+    case ScalarType.STRING:
+      return "" as ScalarValue<T>;
     case ScalarType.BOOL:
       return false as ScalarValue<T>;
-    case ScalarType.UINT64:
-    case ScalarType.FIXED64:
+    default:
+      // Handles INT32, UINT32, SINT32, FIXED32, SFIXED32.
+      // We do not use individual cases to save a few bytes code size.
+      return 0 as ScalarValue<T>;
+    case ScalarType.DOUBLE:
+    case ScalarType.FLOAT:
+      return 0.0 as ScalarValue<T>;
     case ScalarType.INT64:
+    case ScalarType.UINT64:
     case ScalarType.SFIXED64:
+    case ScalarType.FIXED64:
     case ScalarType.SINT64:
       return ((longType as number) == 0 ? protoInt64.zero : "0") as ScalarValue<
         T,
         L
       >;
-    case ScalarType.DOUBLE:
-    case ScalarType.FLOAT:
-      return 0.0 as ScalarValue<T>;
     case ScalarType.BYTES:
       return new Uint8Array(0) as ScalarValue<T>;
-    case ScalarType.STRING:
-      return "" as ScalarValue<T>;
-    default:
-      // Handles INT32, UINT32, SINT32, FIXED32, SFIXED32.
-      // We do not use individual cases to save a few bytes code size.
-      return 0 as ScalarValue<T>;
   }
 }
 

--- a/packages/protobuf/src/reflect/unsafe.ts
+++ b/packages/protobuf/src/reflect/unsafe.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescField, DescOneof } from "../desc-types.js";
+import type { DescField, DescOneof } from "../descriptors.js";
 import type { OneofADT } from "./guard.js";
 import { isScalarZeroValue, scalarZeroValue } from "./scalar.js";
 import type { FeatureSet_FieldPresence } from "../wkt/gen/google/protobuf/descriptor_pb.js";

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -32,27 +32,28 @@ import type {
   OneofDescriptorProto,
   ServiceDescriptorProto,
   EnumValueDescriptorProto,
-} from "../wkt/gen/google/protobuf/descriptor_pb.js";
-import { assert } from "./assert.js";
-import type {
-  DescEnum,
-  DescExtension,
-  DescField,
-  DescFile,
-  DescMessage,
-  DescMethod,
-  DescOneof,
-  DescService,
-  SupportedEdition,
-} from "../desc-types.js";
+} from "./wkt/gen/google/protobuf/descriptor_pb.js";
+import { assert } from "./reflect/assert.js";
+import {
+  type DescEnum,
+  type DescExtension,
+  type DescField,
+  type DescFile,
+  type DescMessage,
+  type DescMethod,
+  type DescOneof,
+  type DescService,
+  LongType,
+  ScalarType,
+  type SupportedEdition,
+} from "./descriptors.js";
 import {
   parseTextFormatEnumValue,
   parseTextFormatScalarValue,
-} from "../wire/text-format.js";
-import { LongType, ScalarType } from "./scalar.js";
-import { nestedTypes } from "./nested-types.js";
-import { unsafeIsSetExplicit } from "./unsafe.js";
-import { protoCamelCase, safeObjectProperty } from "./names.js";
+} from "./wire/text-format.js";
+import { nestedTypes } from "./reflect/nested-types.js";
+import { unsafeIsSetExplicit } from "./reflect/unsafe.js";
+import { protoCamelCase, safeObjectProperty } from "./reflect/names.js";
 
 /**
  * A set of descriptors for messages, enumerations, extensions,

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -17,8 +17,7 @@ import { reflect } from "./reflect/reflect.js";
 import { BinaryWriter, WireType } from "./wire/binary-encoding.js";
 import type { FeatureSet_FieldPresence } from "./wkt/gen/google/protobuf/descriptor_pb.js";
 import type { ScalarValue } from "./reflect/scalar.js";
-import { ScalarType } from "./reflect/scalar.js";
-import type { DescField, DescMessage } from "./desc-types.js";
+import { type DescField, type DescMessage, ScalarType } from "./descriptors.js";
 import type { ReflectList, ReflectMessage } from "./reflect/index.js";
 
 // bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name: FeatureSet_FieldPresence.$localName = $number;

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescEnum, DescField, DescMessage } from "./desc-types.js";
+import {
+  type DescEnum,
+  type DescField,
+  type DescMessage,
+  ScalarType,
+} from "./descriptors.js";
 import type { JsonObject, JsonValue } from "./json-value.js";
 import { assert } from "./reflect/assert.js";
 import { protoCamelCase } from "./reflect/names.js";
 import { reflect } from "./reflect/reflect.js";
-import { ScalarType } from "./reflect/scalar.js";
-import type { Registry } from "./reflect/registry.js";
+import type { Registry } from "./registry.js";
 import type {
   ReflectList,
   ReflectMap,

--- a/packages/protobuf/src/types.ts
+++ b/packages/protobuf/src/types.ts
@@ -17,7 +17,7 @@ import type {
   GenDescExtension,
   GenDescMessage,
 } from "./codegenv1/types.js";
-import type { DescEnum, DescExtension, DescMessage } from "./desc-types.js";
+import type { DescEnum, DescExtension, DescMessage } from "./descriptors.js";
 import type { OneofADT } from "./reflect/guard.js";
 import type { WireType } from "./wire/index.js";
 

--- a/packages/protobuf/src/wire/size-delimited.ts
+++ b/packages/protobuf/src/wire/size-delimited.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescMessage } from "../desc-types.js";
+import type { DescMessage } from "../descriptors.js";
 import type { BinaryWriteOptions } from "../to-binary.js";
 import { toBinary } from "../to-binary.js";
 import type { MessageShape } from "../types.js";

--- a/packages/protobuf/src/wire/text-format.ts
+++ b/packages/protobuf/src/wire/text-format.ts
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescEnum } from "../desc-types.js";
+import { type DescEnum, ScalarType } from "../descriptors.js";
 import { assert } from "../reflect/assert.js";
 import { protoInt64 } from "../proto-int64.js";
-import { ScalarType } from "../reflect/scalar.js";
 
 /**
  * Parse an enum value from the Protobuf text format.

--- a/packages/protobuf/src/wkt/any.ts
+++ b/packages/protobuf/src/wkt/any.ts
@@ -15,7 +15,7 @@
 import type { Message, MessageShape } from "../types.js";
 import type { Any } from "./gen/google/protobuf/any_pb.js";
 import { AnyDesc } from "./gen/google/protobuf/any_pb.js";
-import type { DescMessage } from "../desc-types.js";
+import type { DescMessage } from "../descriptors.js";
 import type { Registry } from "../reflect/index.js";
 import { create } from "../create.js";
 import { toBinary } from "../to-binary.js";

--- a/packages/protobuf/src/wkt/wrappers.ts
+++ b/packages/protobuf/src/wkt/wrappers.ts
@@ -24,7 +24,7 @@ import type {
   UInt32Value,
   UInt64Value,
 } from "./gen/google/protobuf/wrappers_pb.js";
-import type { DescField, DescMessage } from "../desc-types.js";
+import type { DescField, DescMessage } from "../descriptors.js";
 
 export function isWrapper(
   arg: Message,

--- a/packages/protoc-gen-es/src/util.ts
+++ b/packages/protoc-gen-es/src/util.ts
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescExtension, DescField } from "@bufbuild/protobuf";
 import {
+  type DescExtension,
+  type DescField,
   LongType,
   ScalarType,
-  scalarTypeScriptType,
-} from "@bufbuild/protobuf/reflect";
+} from "@bufbuild/protobuf";
+import { scalarTypeScriptType } from "@bufbuild/protobuf/reflect";
 import { isWrapperDesc } from "@bufbuild/protobuf/wkt";
 import type { Printable } from "@bufbuild/protoplugin/ecmascript";
 

--- a/packages/protoplugin-test/src/file-print.test.ts
+++ b/packages/protoplugin-test/src/file-print.test.ts
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { protoInt64 } from "@bufbuild/protobuf";
-import { LongType, ScalarType } from "@bufbuild/protobuf/reflect";
+import { protoInt64, LongType, ScalarType } from "@bufbuild/protobuf";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 import { createImportSymbol } from "@bufbuild/protoplugin/ecmascript";
 import { createTestPluginAndRun } from "./helpers.js";

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {
-  AnyDesc,
-  DescEnum,
-  DescExtension,
-  DescFile,
-  DescMessage,
-  DescService,
+import {
+  type AnyDesc,
+  type DescEnum,
+  type DescExtension,
+  type DescFile,
+  type DescMessage,
+  type DescService,
+  protoInt64,
+  LongType,
+  ScalarType,
 } from "@bufbuild/protobuf";
-import { protoInt64 } from "@bufbuild/protobuf";
-import { LongType, ScalarType } from "@bufbuild/protobuf/reflect";
 import type { ImportSymbol } from "./import-symbol.js";
 import { createImportSymbol } from "./import-symbol.js";
 import { makeImportPathRelative } from "./import-path.js";

--- a/packages/protoplugin/src/ecmascript/printable.ts
+++ b/packages/protoplugin/src/ecmascript/printable.ts
@@ -18,8 +18,9 @@ import type {
   DescFile,
   DescMessage,
   DescService,
+  ScalarType,
+  LongType,
 } from "@bufbuild/protobuf";
-import { ScalarType, LongType } from "@bufbuild/protobuf/reflect";
 import type { ImportSymbol } from "./import-symbol.js";
 
 /**

--- a/packages/protoplugin/src/source-code-info.ts
+++ b/packages/protoplugin/src/source-code-info.ts
@@ -20,12 +20,9 @@ import {
   type DescField,
   type DescFile,
   isFieldSet,
-} from "@bufbuild/protobuf";
-import {
-  protoCamelCase,
-  reflect,
   ScalarType,
-} from "@bufbuild/protobuf/reflect";
+} from "@bufbuild/protobuf";
+import { protoCamelCase, reflect } from "@bufbuild/protobuf/reflect";
 import {
   Edition,
   type SourceCodeInfo,


### PR DESCRIPTION
Registries are first-class primitives, so we're moving the type `Registry` from the subpath `@bufbuild/protobuf/reflect` to the top level `@bufbuild/protobuf`. 
