### PR TITLE
Prevent toBinary error with undefined fields

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -15,11 +15,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 79,466 b | 34,303 b | 9,800 b |
-| protobuf-es | 4 | 92,563 b | 37,277 b | 10,113 b |
-| protobuf-es | 8 | 101,904 b | 41,775 b | 10,824 b |
-| protobuf-es | 16 | 165,584 b | 67,020 b | 13,312 b |
-| protobuf-es | 32 | 343,363 b | 147,051 b | 20,063 b |
+| protobuf-es | 1 | 79,470 b | 34,316 b | 9,803 b |
+| protobuf-es | 4 | 92,567 b | 37,290 b | 10,117 b |
+| protobuf-es | 8 | 101,908 b | 41,788 b | 10,817 b |
+| protobuf-es | 16 | 165,588 b | 67,033 b | 13,328 b |
+| protobuf-es | 32 | 343,367 b | 147,064 b | 20,048 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,262.24609375 140,261.35966796875 280,259.34609375 420,252.3 560,233.18095703125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,262.23759765625 140,261.34833984375 280,259.36591796875 420,252.2546875 560,233.2234375">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="262.24609375" r="4" fill="#ffa600"><title>protobuf-es 9.57 KiB for 1 files</title></circle>
-<circle cx="140" cy="261.35966796875" r="4" fill="#ffa600"><title>protobuf-es 9.88 KiB for 4 files</title></circle>
-<circle cx="280" cy="259.34609375" r="4" fill="#ffa600"><title>protobuf-es 10.57 KiB for 8 files</title></circle>
-<circle cx="420" cy="252.3" r="4" fill="#ffa600"><title>protobuf-es 13 KiB for 16 files</title></circle>
-<circle cx="560" cy="233.18095703125" r="4" fill="#ffa600"><title>protobuf-es 19.59 KiB for 32 files</title></circle>
+<circle cx="0" cy="262.23759765625" r="4" fill="#ffa600"><title>protobuf-es 9.57 KiB for 1 files</title></circle>
+<circle cx="140" cy="261.34833984375" r="4" fill="#ffa600"><title>protobuf-es 9.88 KiB for 4 files</title></circle>
+<circle cx="280" cy="259.36591796875" r="4" fill="#ffa600"><title>protobuf-es 10.56 KiB for 8 files</title></circle>
+<circle cx="420" cy="252.2546875" r="4" fill="#ffa600"><title>protobuf-es 13.02 KiB for 16 files</title></circle>
+<circle cx="560" cy="233.2234375" r="4" fill="#ffa600"><title>protobuf-es 19.58 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/extra/proto3.proto
+++ b/packages/protobuf-test/extra/proto3.proto
@@ -35,6 +35,13 @@ message Proto3UnlabelledMessage {
   repeated uint64 uint64_field = 3;
 }
 
+message Proto3Message {
+  string string_field = 1;
+  bytes bytes_field = 2;
+  Proto3Enum enum_field = 3;
+  Proto3Message message_field = 4;
+}
+
 message Proto3OptionalMessage {
   optional string string_field = 1;
   optional bytes bytes_field = 2;

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
@@ -142,6 +142,45 @@ export declare class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMes
 }
 
 /**
+ * @generated from message spec.Proto3Message
+ */
+export declare class Proto3Message extends Message<Proto3Message> {
+  /**
+   * @generated from field: string string_field = 1;
+   */
+  stringField: string;
+
+  /**
+   * @generated from field: bytes bytes_field = 2;
+   */
+  bytesField: Uint8Array;
+
+  /**
+   * @generated from field: spec.Proto3Enum enum_field = 3;
+   */
+  enumField: Proto3Enum;
+
+  /**
+   * @generated from field: spec.Proto3Message message_field = 4;
+   */
+  messageField?: Proto3Message;
+
+  constructor(data?: PartialMessage<Proto3Message>);
+
+  static readonly runtime: typeof proto3;
+  static readonly typeName = "spec.Proto3Message";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto3Message;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Proto3Message;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Proto3Message;
+
+  static equals(a: Proto3Message | PlainMessage<Proto3Message> | undefined, b: Proto3Message | PlainMessage<Proto3Message> | undefined): boolean;
+}
+
+/**
  * @generated from message spec.Proto3OptionalMessage
  */
 export declare class Proto3OptionalMessage extends Message<Proto3OptionalMessage> {

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.js
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.js
@@ -67,6 +67,19 @@ export const Proto3UnlabelledMessage = /*@__PURE__*/ proto3.makeMessageType(
 );
 
 /**
+ * @generated from message spec.Proto3Message
+ */
+export const Proto3Message = /*@__PURE__*/ proto3.makeMessageType(
+  "spec.Proto3Message",
+  () => [
+    { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum) },
+    { no: 4, name: "message_field", kind: "message", T: Proto3Message },
+  ],
+);
+
+/**
  * @generated from message spec.Proto3OptionalMessage
  */
 export const Proto3OptionalMessage = /*@__PURE__*/ proto3.makeMessageType(

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -193,6 +193,61 @@ export class Proto3UnlabelledMessage extends Message<Proto3UnlabelledMessage> {
 }
 
 /**
+ * @generated from message spec.Proto3Message
+ */
+export class Proto3Message extends Message<Proto3Message> {
+  /**
+   * @generated from field: string string_field = 1;
+   */
+  stringField = "";
+
+  /**
+   * @generated from field: bytes bytes_field = 2;
+   */
+  bytesField = new Uint8Array(0);
+
+  /**
+   * @generated from field: spec.Proto3Enum enum_field = 3;
+   */
+  enumField = Proto3Enum.UNSPECIFIED;
+
+  /**
+   * @generated from field: spec.Proto3Message message_field = 4;
+   */
+  messageField?: Proto3Message;
+
+  constructor(data?: PartialMessage<Proto3Message>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "spec.Proto3Message";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "string_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "bytes_field", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "enum_field", kind: "enum", T: proto3.getEnumType(Proto3Enum) },
+    { no: 4, name: "message_field", kind: "message", T: Proto3Message },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Proto3Message {
+    return new Proto3Message().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Proto3Message {
+    return new Proto3Message().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Proto3Message {
+    return new Proto3Message().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: Proto3Message | PlainMessage<Proto3Message> | undefined, b: Proto3Message | PlainMessage<Proto3Message> | undefined): boolean {
+    return proto3.util.equals(Proto3Message, a, b);
+  }
+}
+
+/**
  * @generated from message spec.Proto3OptionalMessage
  */
 export class Proto3OptionalMessage extends Message<Proto3OptionalMessage> {

--- a/packages/protobuf-test/src/proto3.test.ts
+++ b/packages/protobuf-test/src/proto3.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, test } from "@jest/globals";
 import * as TS from "./gen/ts/extra/proto3_pb.js";
 import * as JS from "./gen/js/extra/proto3_pb.js";
-import { describeMT } from "./helpers.js";
+import { describeMT, testMT } from "./helpers.js";
 
 describe("proto3 field info packed", () => {
   // Also see msg-scalars.test.ts
@@ -70,4 +70,15 @@ describe("proto3 field info optional / required", () => {
       });
     },
   );
+});
+
+describe("proto3 toBinary", () => {
+  describe("toBinary does not raise an error with fields that were set to undefined", () => {
+    testMT({ ts: TS.Proto3Message, js: JS.Proto3Message }, (messageType) => {
+      const message = new messageType();
+      message.stringField = undefined as unknown as string;
+      const serializedMessage = message.toBinary();
+      expect(serializedMessage).toBeDefined();
+    });
+  });
 });

--- a/packages/protobuf/src/private/binary-format.ts
+++ b/packages/protobuf/src/private/binary-format.ts
@@ -143,7 +143,7 @@ export function makeBinaryFormat(): BinaryFormat {
         const value = field.oneof
           ? (message as AnyMessage)[field.oneof.localName].value
           : (message as AnyMessage)[field.localName];
-        writeField(field, value, writer, options);
+        this.writeField(field, value, writer, options);
       }
       if (options.writeUnknownFields) {
         this.writeUnknownFields(message, writer);


### PR DESCRIPTION
I noticed that there was a subtle behavioral change introduced in version 1.8.0 that causes an error in `toBinary` when a field was set to `undefined` explicitly on a `Message` instance. At runtime this can be fairly common when setting proto fields based on the result of less type-safe functions.

I am not sure if this behavioral change was intentional or not. The proposed fix is a one-line change to use the custom `writeField` implementation that handles the `undefined` case explicitly.