### PR TITLE
V2: Replace LongType with a boolean

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 124,299 b | 64,356 b | 15,017 b |
-| protobuf-es | 4 | 126,494 b | 65,860 b | 15,694 b |
-| protobuf-es | 8 | 129,272 b | 67,631 b | 16,231 b |
-| protobuf-es | 16 | 139,780 b | 75,612 b | 18,547 b |
-| protobuf-es | 32 | 167,675 b | 97,639 b | 24,024 b |
+| protobuf-es | 1 | 123,984 b | 64,216 b | 14,981 b |
+| protobuf-es | 4 | 126,179 b | 65,722 b | 15,659 b |
+| protobuf-es | 8 | 128,957 b | 67,493 b | 16,165 b |
+| protobuf-es | 16 | 139,465 b | 75,474 b | 18,514 b |
+| protobuf-es | 32 | 167,360 b | 97,499 b | 23,962 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.47138671875 140,245.5541015625 280,244.03330078125 420,237.47431640625 560,221.96328125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.57333984375 140,245.65322265625 280,244.22021484375 420,237.5677734375 560,222.1388671875">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.47138671875" r="4" fill="#ffa600"><title>protobuf-es 14.67 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.5541015625" r="4" fill="#ffa600"><title>protobuf-es 15.33 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.03330078125" r="4" fill="#ffa600"><title>protobuf-es 15.85 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.47431640625" r="4" fill="#ffa600"><title>protobuf-es 18.11 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.96328125" r="4" fill="#ffa600"><title>protobuf-es 23.46 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.57333984375" r="4" fill="#ffa600"><title>protobuf-es 14.63 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.65322265625" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.22021484375" r="4" fill="#ffa600"><title>protobuf-es 15.79 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.5677734375" r="4" fill="#ffa600"><title>protobuf-es 18.08 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.1388671875" r="4" fill="#ffa600"><title>protobuf-es 23.4 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -24,7 +24,6 @@ import {
   type DescMessage,
   type DescOneof,
   type DescService,
-  LongType,
   ScalarType,
 } from "@bufbuild/protobuf";
 import { protoCamelCase } from "@bufbuild/protobuf/reflect";
@@ -951,8 +950,8 @@ describe("DescField", () => {
       ).toBe(false);
     });
   });
-  describe("longType", () => {
-    test("returns default LongType.BIGINT for option omitted", async () => {
+  describe("longAsString", () => {
+    test("returns default false for option omitted", async () => {
       const { fields } = await compileMessage(`
         syntax="proto3";
         message M {
@@ -978,17 +977,17 @@ describe("DescField", () => {
           field.fieldKind == "scalar" ||
           (field.fieldKind == "list" && field.listKind == "scalar")
         ) {
-          expect(field.longType).toBe(LongType.BIGINT);
+          expect(field.longAsString).toBe(false);
         }
       }
     });
     test.each([
-      { jstype: "JS_NORMAL", longType: "BIGINT" },
-      { jstype: "JS_NUMBER", longType: "BIGINT" },
-      { jstype: "JS_STRING", longType: "STRING" },
+      { jstype: "JS_NORMAL", longAsString: false },
+      { jstype: "JS_NUMBER", longAsString: false },
+      { jstype: "JS_STRING", longAsString: true },
     ] as const)(
       "returns default LongType.$longType for jstype=$jstype",
-      async ({ jstype, longType }) => {
+      async ({ jstype, longAsString }) => {
         const { fields } = await compileMessage(`
         syntax="proto3";
         message M {
@@ -1014,7 +1013,7 @@ describe("DescField", () => {
             field.fieldKind == "scalar" ||
             (field.fieldKind == "list" && field.listKind == "scalar")
           ) {
-            expect(field.longType).toBe(LongType[longType]);
+            expect(field.longAsString).toBe(longAsString);
           }
         }
       },
@@ -1314,7 +1313,7 @@ describe("DescField", () => {
       }
       case "scalar": {
         // exclusive to scalar (list and singular)
-        field.longType;
+        field.longAsString;
 
         // exclusive to list
         // @ts-expect-error TS2339
@@ -1378,7 +1377,7 @@ describe("DescField", () => {
 
         switch (field.listKind) {
           case "scalar": {
-            field.longType;
+            field.longAsString;
             const scalar: ScalarType = field.scalar;
             const message: undefined = field.message;
             const enumeration: undefined = field.enum;

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -17,7 +17,6 @@ import {
   type DescField,
   type DescMessage,
   type DescOneof,
-  LongType,
   ScalarType,
 } from "./descriptors.js";
 import type { Message, MessageInitShape, MessageShape } from "./types.js";
@@ -273,11 +272,11 @@ function createZeroField(
   }
   const defaultValue = field.getDefaultValue();
   if (defaultValue !== undefined) {
-    return field.fieldKind == "scalar" && field.longType == LongType.STRING
+    return field.fieldKind == "scalar" && field.longAsString
       ? defaultValue.toString()
       : defaultValue;
   }
   return field.fieldKind == "scalar"
-    ? scalarZeroValue(field.scalar, field.longType)
+    ? scalarZeroValue(field.scalar, field.longAsString)
     : field.enum.values[0].number;
 }

--- a/packages/protobuf/src/descriptors.ts
+++ b/packages/protobuf/src/descriptors.ts
@@ -78,35 +78,6 @@ export enum ScalarType {
 }
 
 /**
- * JavaScript representation of fields with 64 bit integral types (int64, uint64,
- * sint64, fixed64, sfixed64).
- *
- * This is a subset of google.protobuf.FieldOptions.JSType, which defines JS_NORMAL,
- * JS_STRING, and JS_NUMBER. Protobuf-ES uses BigInt by default, but will use
- * String if `[jstype = JS_STRING]` is specified.
- *
- * ```protobuf
- * uint64 field_a = 1; // BigInt
- * uint64 field_b = 2 [jstype = JS_NORMAL]; // BigInt
- * uint64 field_b = 2 [jstype = JS_NUMBER]; // BigInt
- * uint64 field_b = 2 [jstype = JS_STRING]; // String
- * ```
- */
-export enum LongType {
-  /**
-   * Use JavaScript BigInt.
-   */
-  BIGINT = 0,
-
-  /**
-   * Use JavaScript String.
-   *
-   * Field option `[jstype = JS_STRING]`.
-   */
-  STRING = 1,
-}
-
-/**
  * A union of all descriptors, discriminated by a `kind` property.
  */
 export type AnyDesc =
@@ -419,10 +390,13 @@ type descFieldScalar<T extends ScalarType = ScalarType> = T extends T
        */
       readonly scalar: T;
       /**
-       * JavaScript type for 64 bit integral types (int64, uint64,
-       * sint64, fixed64, sfixed64).
+       * By default, 64-bit integral types (int64, uint64, sint64, fixed64,
+       * sfixed64) are represented with BigInt.
+       *
+       * If the field option `jstype = JS_STRING` is set, this property
+       * is true, and 64-bit integral types are represented with String.
        */
-      readonly longType: LongType;
+      readonly longAsString: boolean;
       /**
        * The message type, if it is a message field.
        */
@@ -517,10 +491,13 @@ type descFieldListScalar<T extends ScalarType = ScalarType> = T extends T
        */
       readonly scalar: T;
       /**
-       * JavaScript type for 64 bit integral types (int64, uint64,
-       * sint64, fixed64, sfixed64).
+       * By default, 64-bit integral types (int64, uint64, sint64, fixed64,
+       * sfixed64) are represented with BigInt.
+       *
+       * If the field option `jstype = JS_STRING` is set, this property
+       * is true, and 64-bit integral types are represented with String.
        */
-      readonly longType: LongType;
+      readonly longAsString: boolean;
     }
   : never;
 

--- a/packages/protobuf/src/extensions.ts
+++ b/packages/protobuf/src/extensions.ts
@@ -241,7 +241,7 @@ export function createExtensionContainer<Desc extends DescExtension>(
         if (isWrapperDesc(desc)) {
           return scalarZeroValue(
             desc.fields[0].scalar,
-            desc.fields[0].longType,
+            desc.fields[0].longAsString,
           ) as ExtensionValueShape<Desc>;
         }
         return create(desc) as ExtensionValueShape<Desc>;

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  type DescField,
-  type DescMessage,
-  LongType,
-  ScalarType,
-} from "./descriptors.js";
+import { type DescField, type DescMessage, ScalarType } from "./descriptors.js";
 import type { MessageShape } from "./types.js";
 import type { MapEntryKey, ReflectMessage } from "./reflect/index.js";
 import { scalarZeroValue } from "./reflect/scalar.js";
@@ -200,12 +195,12 @@ function readMapEntry(
     }
   }
   if (key === undefined) {
-    key = scalarZeroValue(field.mapKey, LongType.BIGINT);
+    key = scalarZeroValue(field.mapKey, false);
   }
   if (val === undefined) {
     switch (field.mapKind) {
       case "scalar":
-        val = scalarZeroValue(field.scalar, LongType.BIGINT);
+        val = scalarZeroValue(field.scalar, false);
         break;
       case "enum":
         val = field.enum.values[0].number;

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -20,7 +20,6 @@ import {
   type DescField,
   type DescMessage,
   type DescOneof,
-  LongType,
   ScalarType,
 } from "./descriptors.js";
 import type { JsonValue } from "./json-value.js";
@@ -478,7 +477,7 @@ function readScalar(
 ): ScalarValue | typeof tokenNull {
   if (json === null) {
     if (nullAsZeroValue) {
-      return scalarZeroValue(type, LongType.BIGINT);
+      return scalarZeroValue(type, false);
     }
     return tokenNull;
   }

--- a/packages/protobuf/src/reflect/reflect-types.ts
+++ b/packages/protobuf/src/reflect/reflect-types.ts
@@ -16,7 +16,6 @@ import {
   type DescField,
   type DescMessage,
   type DescOneof,
-  LongType,
 } from "../descriptors.js";
 import { FieldError } from "./error.js";
 import { unsafeLocal } from "./unsafe.js";
@@ -284,7 +283,7 @@ export type ReflectGetValue<Field extends DescField = DescField> = (
   Field extends { fieldKind: "map" } ? (
     Field extends { mapKind: "message" } ? ReflectMap<MapEntryKey, ReflectMessage> :
     Field extends { mapKind: "enum" } ? ReflectMap<MapEntryKey, enumVal> :
-    Field extends { mapKind: "scalar"; scalar: infer T } ? ReflectMap<MapEntryKey, ScalarValue<T, LongType.BIGINT>> :
+    Field extends { mapKind: "scalar"; scalar: infer T } ? ReflectMap<MapEntryKey, ScalarValue<T>> :
     never
   ) :
   Field extends { fieldKind: "list" } ? ReflectList :
@@ -325,6 +324,6 @@ export type ReflectAddListItemValue<Field extends DescField & { fieldKind: "list
 export type ReflectSetMapEntryValue<Field extends DescField & { fieldKind: "map" }> = (
   Field extends { mapKind: "enum" } ? enumVal :
   Field extends { mapKind: "message" } ? ReflectMessage :
-  Field extends { mapKind: "scalar"; scalar: infer T } ? ScalarValue<T, LongType.BIGINT> :
+  Field extends { mapKind: "scalar"; scalar: infer T } ? ScalarValue<T> :
   never
 );

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -16,7 +16,6 @@ import {
   type DescField,
   type DescMessage,
   type DescOneof,
-  LongType,
   ScalarType,
 } from "../descriptors.js";
 import type { Message, MessageShape, UnknownField } from "../types.js";
@@ -171,7 +170,7 @@ class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
       case "scalar":
         return (
           value === undefined
-            ? scalarZeroValue(field.scalar, LongType.BIGINT)
+            ? scalarZeroValue(field.scalar, false)
             : longToReflect(field, value)
         ) as ReflectGetValue<Field>;
       case "enum":
@@ -190,7 +189,7 @@ class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
         return err;
       }
     }
-    let local: unknown = value;
+    let local: unknown;
     if (isReflectMap(value) || isReflectList(value)) {
       local = value[unsafeLocal];
     } else if (isReflectMessage(value)) {
@@ -571,8 +570,8 @@ function longToReflect(field: DescField, value: unknown): unknown {
     case ScalarType.SFIXED64:
     case ScalarType.SINT64:
       if (
-        "longType" in field &&
-        field.longType == LongType.STRING &&
+        "longAsString" in field &&
+        field.longAsString &&
         typeof value == "string"
       ) {
         value = protoInt64.parse(value);
@@ -581,8 +580,8 @@ function longToReflect(field: DescField, value: unknown): unknown {
     case ScalarType.FIXED64:
     case ScalarType.UINT64:
       if (
-        "longType" in field &&
-        field.longType == LongType.STRING &&
+        "longAsString" in field &&
+        field.longAsString &&
         typeof value == "string"
       ) {
         value = protoInt64.uParse(value);
@@ -598,7 +597,7 @@ function longToLocal(field: DescField, value: unknown) {
     case ScalarType.INT64:
     case ScalarType.SFIXED64:
     case ScalarType.SINT64:
-      if ("longType" in field && field.longType == LongType.STRING) {
+      if ("longAsString" in field && field.longAsString) {
         value = String(value);
       } else if (typeof value == "string" || typeof value == "number") {
         value = protoInt64.parse(value);
@@ -606,7 +605,7 @@ function longToLocal(field: DescField, value: unknown) {
       break;
     case ScalarType.FIXED64:
     case ScalarType.UINT64:
-      if ("longType" in field && field.longType == LongType.STRING) {
+      if ("longAsString" in field && field.longAsString) {
         value = String(value);
       } else if (typeof value == "string" || typeof value == "number") {
         value = protoInt64.uParse(value);

--- a/packages/protobuf/src/reflect/unsafe.ts
+++ b/packages/protobuf/src/reflect/unsafe.ts
@@ -158,7 +158,7 @@ export function unsafeClear(
         target[name] = field.enum.values[0].number;
         break;
       case "scalar":
-        target[name] = scalarZeroValue(field.scalar, field.longType);
+        target[name] = scalarZeroValue(field.scalar, field.longAsString);
         break;
     }
   }

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -43,7 +43,6 @@ import {
   type DescMethod,
   type DescOneof,
   type DescService,
-  LongType,
   ScalarType,
   type SupportedEdition,
 } from "./descriptors.js";
@@ -801,7 +800,7 @@ function newField(
     mapKey: undefined,
     delimitedEncoding: undefined,
     packed: undefined,
-    longType: undefined,
+    longAsString: false,
     getDefaultValue: undefined,
   };
   if (isExtension) {
@@ -883,8 +882,7 @@ function newField(
       default:
         field.listKind = "scalar";
         field.scalar = type;
-        field.longType =
-          jstype == JS_STRING ? LongType.STRING : LongType.BIGINT;
+        field.longAsString = jstype == JS_STRING;
         break;
     }
     field.packed = isPackedField(proto, parentOrFile);
@@ -921,7 +919,7 @@ function newField(
     default: {
       field.fieldKind = "scalar";
       field.scalar = type;
-      field.longType = jstype == JS_STRING ? LongType.STRING : LongType.BIGINT;
+      field.longAsString = jstype == JS_STRING;
       field.getDefaultValue = () => {
         return unsafeIsSetExplicit(proto, "defaultValue")
           ? parseTextFormatScalarValue(

--- a/packages/protoc-gen-es/src/util.ts
+++ b/packages/protoc-gen-es/src/util.ts
@@ -15,7 +15,6 @@
 import {
   type DescExtension,
   type DescField,
-  LongType,
   ScalarType,
 } from "@bufbuild/protobuf";
 import { scalarTypeScriptType } from "@bufbuild/protobuf/reflect";
@@ -30,13 +29,13 @@ export function fieldTypeScriptType(field: DescField | DescExtension): {
   let optional = false;
   switch (field.fieldKind) {
     case "scalar":
-      typing.push(scalarTypeScriptType(field.scalar, field.longType));
+      typing.push(scalarTypeScriptType(field.scalar, field.longAsString));
       optional = field.proto.proto3Optional;
       break;
     case "message": {
       if (!field.oneof && isWrapperDesc(field.message)) {
         const baseType = field.message.fields[0].scalar;
-        typing.push(scalarTypeScriptType(baseType, LongType.BIGINT));
+        typing.push(scalarTypeScriptType(baseType, false));
       } else {
         typing.push({
           kind: "es_shape_ref",
@@ -66,7 +65,10 @@ export function fieldTypeScriptType(field: DescField | DescExtension): {
           );
           break;
         case "scalar":
-          typing.push(scalarTypeScriptType(field.scalar, field.longType), "[]");
+          typing.push(
+            scalarTypeScriptType(field.scalar, field.longAsString),
+            "[]",
+          );
           break;
         case "message": {
           typing.push(
@@ -97,7 +99,7 @@ export function fieldTypeScriptType(field: DescField | DescExtension): {
       let valueType: Printable;
       switch (field.mapKind) {
         case "scalar":
-          valueType = scalarTypeScriptType(field.scalar, LongType.BIGINT);
+          valueType = scalarTypeScriptType(field.scalar, false);
           break;
         case "message":
           valueType = {

--- a/packages/protoplugin-test/src/file-print.test.ts
+++ b/packages/protoplugin-test/src/file-print.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, test } from "@jest/globals";
-import { protoInt64, LongType, ScalarType } from "@bufbuild/protobuf";
+import { protoInt64, ScalarType } from "@bufbuild/protobuf";
 import type { GeneratedFile, Schema } from "@bufbuild/protoplugin/ecmascript";
 import { createImportSymbol } from "@bufbuild/protoplugin/ecmascript";
 import { createTestPluginAndRun } from "./helpers.js";
@@ -89,36 +89,36 @@ describe("GeneratedFile.print", () => {
   });
 
   describe(`should print "es_proto_int64" Printable`, () => {
-    test("should honor LongType.STRING", async () => {
+    test("should honor longAsString", async () => {
       const lines = await testGenerate((f) => {
         f.print({
           kind: "es_proto_int64",
           type: ScalarType.INT64,
-          longType: LongType.STRING,
+          longAsString: true,
           value: 123n,
         });
       });
       expect(lines).toStrictEqual([`"123"`]);
     });
 
-    test("should honor LongType.STRING for 0", async () => {
+    test("should honor longAsString for 0", async () => {
       const lines = await testGenerate((f) => {
         f.print({
           kind: "es_proto_int64",
           type: ScalarType.INT64,
-          longType: LongType.STRING,
+          longAsString: true,
           value: 0n,
         });
       });
       expect(lines).toStrictEqual([`"0"`]);
     });
 
-    test("should honor LongType.STRING for string value", async () => {
+    test("should honor longAsString for string value", async () => {
       const lines = await testGenerate((f) => {
         f.print({
           kind: "es_proto_int64",
           type: ScalarType.INT64,
-          longType: LongType.STRING,
+          longAsString: true,
           value: "123",
         });
       });
@@ -136,7 +136,7 @@ describe("GeneratedFile.print", () => {
           f.print({
             kind: "es_proto_int64",
             type: t,
-            longType: LongType.BIGINT,
+            longAsString: false,
             value: 0n,
           });
         });
@@ -151,7 +151,7 @@ describe("GeneratedFile.print", () => {
           f.print({
             kind: "es_proto_int64",
             type: t,
-            longType: LongType.BIGINT,
+            longAsString: false,
             value: 123n,
           });
         });
@@ -170,7 +170,7 @@ describe("GeneratedFile.print", () => {
           f.print({
             kind: "es_proto_int64",
             type: t,
-            longType: LongType.BIGINT,
+            longAsString: false,
             value: 0n,
           });
         });
@@ -185,7 +185,7 @@ describe("GeneratedFile.print", () => {
           f.print({
             kind: "es_proto_int64",
             type: t,
-            longType: LongType.BIGINT,
+            longAsString: false,
             value: 123n,
           });
         });

--- a/packages/protoplugin/src/ecmascript/generated-file.ts
+++ b/packages/protoplugin/src/ecmascript/generated-file.ts
@@ -20,7 +20,6 @@ import {
   type DescMessage,
   type DescService,
   protoInt64,
-  LongType,
   ScalarType,
 } from "@bufbuild/protobuf";
 import type { ImportSymbol } from "./import-symbol.js";
@@ -420,16 +419,13 @@ function printableToEl(opt: PrintableToElOpt, printables: Printable[]): void {
               el.push(escapeString(p.value));
               break;
             case "es_proto_int64":
-              switch (p.longType) {
-                case LongType.STRING:
-                  el.push(escapeString(p.value.toString()));
-                  break;
-                case LongType.BIGINT:
-                  if (p.value == protoInt64.zero) {
-                    // Loose comparison will match between 0n and 0.
-                    el.push(opt.runtime.protoInt64, ".zero");
-                    break;
-                  }
+              if (p.longAsString) {
+                el.push(escapeString(p.value.toString()));
+              } else {
+                if (p.value == protoInt64.zero) {
+                  // Loose comparison will match between 0n and 0.
+                  el.push(opt.runtime.protoInt64, ".zero");
+                } else {
                   switch (p.type) {
                     case ScalarType.UINT64:
                     case ScalarType.FIXED64:
@@ -449,6 +445,7 @@ function printableToEl(opt: PrintableToElOpt, printables: Printable[]): void {
                       );
                       break;
                   }
+                }
               }
               break;
             default:

--- a/packages/protoplugin/src/ecmascript/printable.ts
+++ b/packages/protoplugin/src/ecmascript/printable.ts
@@ -19,7 +19,6 @@ import type {
   DescMessage,
   DescService,
   ScalarType,
-  LongType,
 } from "@bufbuild/protobuf";
 import type { ImportSymbol } from "./import-symbol.js";
 
@@ -55,7 +54,7 @@ export type LiteralProtoInt64 = {
     | ScalarType.SFIXED64
     | ScalarType.UINT64
     | ScalarType.FIXED64;
-  longType: LongType;
+  longAsString: boolean;
   value: bigint | string;
 };
 


### PR DESCRIPTION
We're using the enum `LongType` for two states. Replacing it with a boolean gives us a tiny performance boost, a tiny reduction in bundle size, and - most importantly - better DX because it isn't necessary to import anything to use the property. It is unlikely that we'd ever need another state - before BigInt, there were numerous unsuccessful proposals for a 64-bit numeric type.