### PR TITLE
V2: Standardize error messages for int32, float32, uint64

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 124,016 b | 64,256 b | 15,007 b |
-| protobuf-es | 4 | 126,211 b | 65,762 b | 15,654 b |
-| protobuf-es | 8 | 128,989 b | 67,533 b | 16,171 b |
-| protobuf-es | 16 | 139,497 b | 75,514 b | 18,520 b |
-| protobuf-es | 32 | 167,392 b | 97,539 b | 23,910 b |
+| protobuf-es | 1 | 124,006 b | 64,288 b | 14,945 b |
+| protobuf-es | 4 | 126,201 b | 65,796 b | 15,622 b |
+| protobuf-es | 8 | 128,979 b | 67,567 b | 16,151 b |
+| protobuf-es | 16 | 139,487 b | 75,548 b | 18,493 b |
+| protobuf-es | 32 | 167,382 b | 97,572 b | 23,949 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 124,006 b | 64,288 b | 14,945 b |
-| protobuf-es | 4 | 126,201 b | 65,796 b | 15,622 b |
-| protobuf-es | 8 | 128,979 b | 67,567 b | 16,151 b |
-| protobuf-es | 16 | 139,487 b | 75,548 b | 18,493 b |
-| protobuf-es | 32 | 167,382 b | 97,572 b | 23,949 b |
+| protobuf-es | 1 | 123,997 b | 64,338 b | 14,978 b |
+| protobuf-es | 4 | 126,192 b | 65,847 b | 15,673 b |
+| protobuf-es | 8 | 128,970 b | 67,618 b | 16,184 b |
+| protobuf-es | 16 | 139,478 b | 75,599 b | 18,501 b |
+| protobuf-es | 32 | 167,373 b | 97,621 b | 23,927 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.67529296875 140,245.7580078125 280,244.25986328125 420,237.62724609375 560,222.17568359375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.5818359375 140,245.61357421875 280,244.16640625 420,237.60458984375 560,222.23798828125">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.67529296875" r="4" fill="#ffa600"><title>protobuf-es 14.59 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.7580078125" r="4" fill="#ffa600"><title>protobuf-es 15.26 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.25986328125" r="4" fill="#ffa600"><title>protobuf-es 15.77 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.62724609375" r="4" fill="#ffa600"><title>protobuf-es 18.06 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.17568359375" r="4" fill="#ffa600"><title>protobuf-es 23.39 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.5818359375" r="4" fill="#ffa600"><title>protobuf-es 14.63 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.61357421875" r="4" fill="#ffa600"><title>protobuf-es 15.31 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.16640625" r="4" fill="#ffa600"><title>protobuf-es 15.8 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.60458984375" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.23798828125" r="4" fill="#ffa600"><title>protobuf-es 23.37 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.49970703125 140,245.6673828125 280,244.20322265625 420,237.55078125 560,222.2861328125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.67529296875 140,245.7580078125 280,244.25986328125 420,237.62724609375 560,222.17568359375">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.49970703125" r="4" fill="#ffa600"><title>protobuf-es 14.66 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.6673828125" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.20322265625" r="4" fill="#ffa600"><title>protobuf-es 15.79 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.55078125" r="4" fill="#ffa600"><title>protobuf-es 18.09 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.2861328125" r="4" fill="#ffa600"><title>protobuf-es 23.35 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.67529296875" r="4" fill="#ffa600"><title>protobuf-es 14.59 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.7580078125" r="4" fill="#ffa600"><title>protobuf-es 15.26 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.25986328125" r="4" fill="#ffa600"><title>protobuf-es 15.77 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.62724609375" r="4" fill="#ffa600"><title>protobuf-es 18.06 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.17568359375" r="4" fill="#ffa600"><title>protobuf-es 23.39 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/json.test.ts
+++ b/packages/protobuf-test/src/json.test.ts
@@ -826,7 +826,7 @@ describe("JSON parse errors", () => {
   test("singular scalar", () => {
     expectJsonParseError(
       { optionalInt32: "abc" },
-      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_int32 from JSON: "abc": invalid int 32: NaN`,
+      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_int32 from JSON: "abc": invalid int32: NaN`,
     );
     expectJsonParseError(
       { optionalInt32: true },
@@ -865,7 +865,7 @@ describe("JSON parse errors", () => {
     );
     expectJsonParseError(
       { repeatedInt32: ["abc"] },
-      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.repeated_int32 from JSON: "abc": invalid int 32: NaN`,
+      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.repeated_int32 from JSON: "abc": invalid int32: NaN`,
     );
     expectJsonParseError(
       { repeatedInt32: [true] },
@@ -958,7 +958,7 @@ describe("JSON parse errors", () => {
     );
     expectJsonParseError(
       { recursiveMessage: { optionalInt32: "abc" } },
-      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_int32 from JSON: "abc": invalid int 32: NaN`,
+      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_int32 from JSON: "abc": invalid int32: NaN`,
     );
   });
 
@@ -981,7 +981,7 @@ describe("JSON parse errors", () => {
     );
     expectJsonParseError(
       { repeatedNestedMessage: [{ corecursive: { optionalInt32: "abc" } }] },
-      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_int32 from JSON: "abc": invalid int 32: NaN`,
+      `cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_int32 from JSON: "abc": invalid int32: NaN`,
     );
   });
 
@@ -1008,11 +1008,11 @@ describe("JSON parse errors", () => {
     );
     expectJsonParseError(
       { mapInt32Int32: { "not-an-int32": 123 } },
-      `cannot decode map key for field protobuf_test_messages.proto3.TestAllTypesProto3.map_int32_int32 from JSON: "not-an-int32": invalid int 32: NaN`,
+      `cannot decode map key for field protobuf_test_messages.proto3.TestAllTypesProto3.map_int32_int32 from JSON: "not-an-int32": invalid int32: NaN`,
     );
     expectJsonParseError(
       { mapInt32Int32: { 123: "not-an-int32" } },
-      `cannot decode map value for field protobuf_test_messages.proto3.TestAllTypesProto3.map_int32_int32 from JSON: "not-an-int32": invalid int 32: NaN`,
+      `cannot decode map value for field protobuf_test_messages.proto3.TestAllTypesProto3.map_int32_int32 from JSON: "not-an-int32": invalid int32: NaN`,
     );
   });
 

--- a/packages/protobuf-test/src/proto-int64.test.ts
+++ b/packages/protobuf-test/src/proto-int64.test.ts
@@ -187,7 +187,7 @@ describe("protoInt64", function () {
     test("should fail to encode invalid", () => {
       if (protoInt64.supported) {
         expect(() => protoInt64.enc(BigInt("18446744073709551615"))).toThrow(
-          "int64 invalid: 18446744073709551615",
+          "invalid int64: 18446744073709551615",
         );
       }
     });
@@ -217,21 +217,21 @@ describe("protoInt64", function () {
     test("should fail to encode invalid", () => {
       if (protoInt64.supported) {
         expect(() => protoInt64.uEnc(BigInt(-127))).toThrow(
-          "uint64 invalid: -127",
+          "invalid uint64: -127",
         );
         expect(() => protoInt64.uEnc(BigInt("-9007199254740991"))).toThrow(
-          "uint64 invalid: -9007199254740991",
+          "invalid uint64: -9007199254740991",
         );
         expect(() => protoInt64.uEnc(BigInt("-9223372036854775808"))).toThrow(
-          "uint64 invalid: -9223372036854775808",
+          "invalid uint64: -9223372036854775808",
         );
       }
-      expect(() => protoInt64.uEnc(-127)).toThrow("uint64 invalid: -127");
+      expect(() => protoInt64.uEnc(-127)).toThrow("invalid uint64: -127");
       expect(() => protoInt64.uEnc("-9007199254740991")).toThrow(
-        "uint64 invalid: -9007199254740991",
+        "invalid uint64: -9007199254740991",
       );
       expect(() => protoInt64.uEnc("-9223372036854775808")).toThrow(
-        "uint64 invalid: -9223372036854775808",
+        "invalid uint64: -9223372036854775808",
       );
     });
   });

--- a/packages/protobuf/src/codegenv1/boot.ts
+++ b/packages/protobuf/src/codegenv1/boot.ts
@@ -29,7 +29,6 @@ import type {
 import type { DescFile } from "../descriptors.js";
 import { restoreJsonNames } from "./restore-json-names.js";
 import { createFileRegistry } from "../registry.js";
-import { assert } from "../reflect/assert.js";
 
 /**
  * Hydrate a file descriptor for google/protobuf/descriptor.proto from a plain
@@ -43,9 +42,8 @@ export function boot(boot: FileDescriptorProtoBoot): DescFile {
   const root = bootFileDescriptorProto(boot);
   root.messageType.forEach(restoreJsonNames);
   const reg = createFileRegistry(root, () => undefined);
-  const file = reg.getFile(root.name);
-  assert(file);
-  return file;
+  // non-null assertion because we just created the registry from the file we look up
+  return reg.getFile(root.name)!;
 }
 
 /**

--- a/packages/protobuf/src/codegenv1/file.ts
+++ b/packages/protobuf/src/codegenv1/file.ts
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { base64Decode } from "../wire/index.js";
+import { base64Decode } from "../wire/base64-encoding.js";
 import { FileDescriptorProtoDesc } from "../wkt/gen/google/protobuf/descriptor_pb.js";
 import type { DescFile } from "../descriptors.js";
 import { createFileRegistry } from "../registry.js";
-import { assert } from "../reflect/assert.js";
 import { restoreJsonNames } from "./restore-json-names.js";
 import { fromBinary } from "../from-binary.js";
 
@@ -32,7 +31,6 @@ export function fileDesc(b64: string, imports?: DescFile[]): DescFile {
   const reg = createFileRegistry(root, (protoFileName) =>
     imports?.find((f) => f.proto.name === protoFileName),
   );
-  const file = reg.getFile(root.name);
-  assert(file);
-  return file;
+  // non-null assertion because we just created the registry from the file we look up
+  return reg.getFile(root.name)!;
 }

--- a/packages/protobuf/src/extensions.ts
+++ b/packages/protobuf/src/extensions.ts
@@ -24,7 +24,6 @@ import type {
   DescOneof,
   DescService,
 } from "./descriptors.js";
-import { assert } from "./reflect/assert.js";
 import { create } from "./create.js";
 import { readField } from "./from-binary.js";
 import type { ReflectMessage } from "./reflect/reflect-types.js";
@@ -252,8 +251,9 @@ export function createExtensionContainer<Desc extends DescExtension>(
 }
 
 function assertExtendee(extension: DescExtension, message: Message) {
-  assert(
-    extension.extendee.typeName == message.$typeName,
-    `extension ${extension.typeName} can only be applied to message ${extension.extendee.typeName}`,
-  );
+  if (extension.extendee.typeName != message.$typeName) {
+    throw new Error(
+      `extension ${extension.typeName} can only be applied to message ${extension.extendee.typeName}`,
+    );
+  }
 }

--- a/packages/protobuf/src/proto-int64.ts
+++ b/packages/protobuf/src/proto-int64.ts
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { assert } from "./reflect/assert.js";
 import {
   int64FromString,
   int64ToString,
   uInt64ToString,
 } from "./wire/varint.js";
+
+/**
+ * Int64Support for the current environment.
+ */
+export const protoInt64: Int64Support = /*@__PURE__*/ makeInt64Support();
 
 /**
  * We use the `bigint` primitive to represent 64-bit integral types. If bigint
@@ -137,14 +141,14 @@ function makeInt64Support(): Int64Support {
       parse(value: string | number | bigint): bigint {
         const bi = typeof value == "bigint" ? value : BigInt(value);
         if (bi > MAX || bi < MIN) {
-          throw new Error(`int64 invalid: ${value}`);
+          throw new Error(`invalid int64: ${value}`);
         }
         return bi;
       },
       uParse(value: string | number | bigint): bigint {
         const bi = typeof value == "bigint" ? value : BigInt(value);
         if (bi > UMAX || bi < UMIN) {
-          throw new Error(`uint64 invalid: ${value}`);
+          throw new Error(`invalid uint64: ${value}`);
         }
         return bi;
       },
@@ -174,10 +178,6 @@ function makeInt64Support(): Int64Support {
       },
     };
   }
-  const assertInt64String = (value: string) =>
-    assert(/^-?[0-9]+$/.test(value), `int64 invalid: ${value}`);
-  const assertUInt64String = (value: string) =>
-    assert(/^[0-9]+$/.test(value), `uint64 invalid: ${value}`);
   return {
     zero: "0" as unknown as 0n,
     supported: false,
@@ -218,4 +218,14 @@ function makeInt64Support(): Int64Support {
   };
 }
 
-export const protoInt64: Int64Support = makeInt64Support();
+function assertInt64String(value: string) {
+  if (!/^-?[0-9]+$/.test(value)) {
+    throw new Error("invalid int64: " + value);
+  }
+}
+
+function assertUInt64String(value: string) {
+  if (!/^[0-9]+$/.test(value)) {
+    throw new Error("invalid uint64: " + value);
+  }
+}

--- a/packages/protobuf/src/reflect/assert.ts
+++ b/packages/protobuf/src/reflect/assert.ts
@@ -32,19 +32,18 @@ const FLOAT32_MAX = 3.4028234663852886e38,
  * Assert a valid signed protobuf 32-bit integer.
  */
 export function assertInt32(arg: unknown): asserts arg is number {
-  if (typeof arg !== "number") throw new Error("invalid int 32: " + typeof arg);
+  if (typeof arg !== "number") throw new Error("invalid int32: " + typeof arg);
   if (!Number.isInteger(arg) || arg > INT32_MAX || arg < INT32_MIN)
-    throw new Error("invalid int 32: " + arg); // eslint-disable-line @typescript-eslint/restrict-plus-operands -- we want the implicit conversion to string
+    throw new Error("invalid int32: " + arg);
 }
 
 /**
  * Assert a valid unsigned protobuf 32-bit integer.
  */
 export function assertUInt32(arg: unknown): asserts arg is number {
-  if (typeof arg !== "number")
-    throw new Error("invalid uint 32: " + typeof arg);
+  if (typeof arg !== "number") throw new Error("invalid uint32: " + typeof arg);
   if (!Number.isInteger(arg) || arg > UINT32_MAX || arg < 0)
-    throw new Error("invalid uint 32: " + arg); // eslint-disable-line @typescript-eslint/restrict-plus-operands -- we want the implicit conversion to string
+    throw new Error("invalid uint32: " + arg);
 }
 
 /**
@@ -52,8 +51,7 @@ export function assertUInt32(arg: unknown): asserts arg is number {
  */
 export function assertFloat32(arg: unknown): asserts arg is number {
   if (typeof arg !== "number")
-    throw new Error("invalid float 32: " + typeof arg);
-  if (!Number.isFinite(arg)) return;
-  if (arg > FLOAT32_MAX || arg < FLOAT32_MIN)
-    throw new Error("invalid float 32: " + arg); // eslint-disable-line @typescript-eslint/restrict-plus-operands -- we want the implicit conversion to string
+    throw new Error("invalid float32: " + typeof arg);
+  if (Number.isFinite(arg) && (arg > FLOAT32_MAX || arg < FLOAT32_MIN))
+    throw new Error("invalid float32: " + arg);
 }

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -845,23 +845,13 @@ function newField(
     if (mapEntry) {
       // map field
       field.fieldKind = "map";
-      const keyField = mapEntry.fields.find((f) => f.number === 1);
-      assert(keyField);
-      assert(keyField.fieldKind == "scalar");
-      assert(
-        keyField.scalar != ScalarType.BYTES &&
-          keyField.scalar != ScalarType.FLOAT &&
-          keyField.scalar != ScalarType.DOUBLE,
-      );
-      const valueField = mapEntry.fields.find((f) => f.number === 2);
-      assert(valueField);
-      assert(valueField.fieldKind != "list" && valueField.fieldKind != "map");
-      field.mapKey = keyField.scalar;
-      field.mapKind = valueField.fieldKind;
-      field.message = valueField.message;
+      const { key, value } = findMapEntryFields(mapEntry);
+      field.mapKey = key.scalar;
+      field.mapKind = value.fieldKind;
+      field.message = value.message;
       field.delimitedEncoding = false; // map fields are always LENGTH_PREFIXED
-      field.enum = valueField.enum;
-      field.scalar = valueField.scalar;
+      field.enum = value.enum;
+      field.scalar = value.scalar;
       return field as DescField;
     }
     // list field
@@ -1135,6 +1125,28 @@ function isPackedField(
       parent,
     })
   );
+}
+
+/**
+ * Find the key and value fields of a synthetic map entry message.
+ */
+function findMapEntryFields(mapEntry: DescMessage): {
+  key: DescField & { fieldKind: "scalar" };
+  value: DescField & { fieldKind: "enum" | "scalar" | "message" };
+} {
+  const key = mapEntry.fields.find((f) => f.number === 1);
+  const value = mapEntry.fields.find((f) => f.number === 2);
+  assert(
+    key &&
+      key.fieldKind == "scalar" &&
+      key.scalar != ScalarType.BYTES &&
+      key.scalar != ScalarType.FLOAT &&
+      key.scalar != ScalarType.DOUBLE &&
+      value &&
+      value.fieldKind != "list" &&
+      value.fieldKind != "map",
+  );
+  return { key, value };
 }
 
 /**

--- a/packages/protobuf/src/wire/text-format.ts
+++ b/packages/protobuf/src/wire/text-format.ts
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import { type DescEnum, ScalarType } from "../descriptors.js";
-import { assert } from "../reflect/assert.js";
 import { protoInt64 } from "../proto-int64.js";
+
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 
 /**
  * Parse an enum value from the Protobuf text format.
@@ -26,7 +27,9 @@ export function parseTextFormatEnumValue(
   value: string,
 ): number {
   const enumValue = descEnum.values.find((v) => v.name === value);
-  assert(enumValue, `cannot parse ${descEnum.name} default value: ${value}`);
+  if (!enumValue) {
+    throw new Error(`cannot parse ${descEnum} default value: ${value}`);
+  }
   return enumValue.number;
 }
 


### PR DESCRIPTION
We have been using several forms for our error messages, for example "int64 invalid" and "invalid int 32". This standardizes on "invalid int32".

As an aside, this PR also cleans up some usage of our `assert` function. We can safely remove some assertions, or replace with a simple error.
