### PR TITLE
V2: Update generated service types to use generated desc types

### DIFF
--- a/packages/bundle-size/src/gen/protobuf-es/google/bytestream/bytestream_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/bytestream/bytestream_pb.ts
@@ -263,8 +263,8 @@ export const ByteStream: GenDescService<{
    */
   read: {
     kind: "server_streaming";
-    I: ReadRequest;
-    O: ReadResponse;
+    I: typeof ReadRequestDesc;
+    O: typeof ReadResponseDesc;
   },
   /**
    * `Write()` is used to send the contents of a resource as a sequence of
@@ -294,8 +294,8 @@ export const ByteStream: GenDescService<{
    */
   write: {
     kind: "client_streaming";
-    I: WriteRequest;
-    O: WriteResponse;
+    I: typeof WriteRequestDesc;
+    O: typeof WriteResponseDesc;
   },
   /**
    * `QueryWriteStatus()` is used to find the `committed_size` for a resource
@@ -317,8 +317,8 @@ export const ByteStream: GenDescService<{
    */
   queryWriteStatus: {
     kind: "unary";
-    I: QueryWriteStatusRequest;
-    O: QueryWriteStatusResponse;
+    I: typeof QueryWriteStatusRequestDesc;
+    O: typeof QueryWriteStatusResponseDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
@@ -20,7 +20,7 @@ import type { GenDescExtension, GenDescFile, GenDescMessage, GenDescService } fr
 import { extDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc_google_api_annotations } from "../api/annotations_pb";
 import { fileDesc_google_api_client } from "../api/client_pb";
-import type { Any, Duration, Empty, MethodOptions } from "@bufbuild/protobuf/wkt";
+import type { Any, Duration, EmptyDesc, MethodOptions } from "@bufbuild/protobuf/wkt";
 import { fileDesc_google_protobuf_any, fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_duration, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Status } from "../rpc/status_pb";
 import { fileDesc_google_rpc_status } from "../rpc/status_pb";
@@ -351,8 +351,8 @@ export const Operations: GenDescService<{
    */
   listOperations: {
     kind: "unary";
-    I: ListOperationsRequest;
-    O: ListOperationsResponse;
+    I: typeof ListOperationsRequestDesc;
+    O: typeof ListOperationsResponseDesc;
   },
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
@@ -363,8 +363,8 @@ export const Operations: GenDescService<{
    */
   getOperation: {
     kind: "unary";
-    I: GetOperationRequest;
-    O: Operation;
+    I: typeof GetOperationRequestDesc;
+    O: typeof OperationDesc;
   },
   /**
    * Deletes a long-running operation. This method indicates that the client is
@@ -376,8 +376,8 @@ export const Operations: GenDescService<{
    */
   deleteOperation: {
     kind: "unary";
-    I: DeleteOperationRequest;
-    O: Empty;
+    I: typeof DeleteOperationRequestDesc;
+    O: typeof EmptyDesc;
   },
   /**
    * Starts asynchronous cancellation on a long-running operation.  The server
@@ -395,8 +395,8 @@ export const Operations: GenDescService<{
    */
   cancelOperation: {
     kind: "unary";
-    I: CancelOperationRequest;
-    O: Empty;
+    I: typeof CancelOperationRequestDesc;
+    O: typeof EmptyDesc;
   },
   /**
    * Waits until the specified long-running operation is done or reaches at most
@@ -413,8 +413,8 @@ export const Operations: GenDescService<{
    */
   waitOperation: {
     kind: "unary";
-    I: WaitOperationRequest;
-    O: Operation;
+    I: typeof WaitOperationRequestDesc;
+    O: typeof OperationDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
@@ -18,7 +18,7 @@
 
 import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
-import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
+import type { EmptyDesc, FieldOptions } from "@bufbuild/protobuf/wkt";
 
 /**
  * Describes the file extra/deprecation-explicit.proto.
@@ -132,8 +132,8 @@ export declare const DeprecatedService: GenDescService<{
    */
   deprecated: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
 }
 >;
@@ -150,16 +150,16 @@ export declare const DeprecatedRpcService: GenDescService<{
    */
   deprecated: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
   /**
    * @generated from rpc spec.DeprecatedRpcService.NotDeprecated
    */
   notDeprecated: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
@@ -18,7 +18,7 @@
 
 import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
-import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
+import type { EmptyDesc, FieldOptions } from "@bufbuild/protobuf/wkt";
 
 /**
  * Describes the file extra/deprecation-implicit.proto.
@@ -71,8 +71,8 @@ export declare const ImplicitlyDeprecatedService: GenDescService<{
    */
   implicitlyDeprecatedRpc: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -981,32 +981,32 @@ export declare const ReservedPropertyNamesService: GenDescService<{
    */
   constructor$: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.toString
    */
   toString$: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.to_JSON
    */
   to_JSON: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.value_of
    */
   value_of: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/option-usage_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/option-usage_pb.d.ts
@@ -75,8 +75,8 @@ export declare const ServiceWithOptions: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: MessageWithOptions;
-    O: MessageWithOptions;
+    I: typeof MessageWithOptionsDesc;
+    O: typeof MessageWithOptionsDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/service-all_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/service-all_pb.d.ts
@@ -17,7 +17,7 @@
 /* eslint-disable */
 
 import type { GenDescFile, GenDescService } from "@bufbuild/protobuf/codegenv1";
-import type { Int32Value, StringValue } from "@bufbuild/protobuf/wkt";
+import type { Int32ValueDesc, StringValueDesc } from "@bufbuild/protobuf/wkt";
 
 /**
  * Describes the file extra/service-all.proto.
@@ -33,24 +33,24 @@ export declare const ServiceAll: GenDescService<{
    */
   unary: {
     kind: "unary";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ServerStream
    */
   serverStream: {
     kind: "server_streaming";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ClientStream
    */
   clientStream: {
     kind: "client_streaming";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.Bidi
@@ -58,8 +58,8 @@ export declare const ServiceAll: GenDescService<{
    */
   bidi: {
     kind: "bidi_streaming";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/service-example_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/service-example_pb.d.ts
@@ -150,32 +150,32 @@ export declare const ExampleService: GenDescService<{
    */
   unary: {
     kind: "unary";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ServerStream
    */
   serverStream: {
     kind: "server_streaming";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ClientStream
    */
   clientStream: {
     kind: "client_streaming";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.Bidi
    */
   bidi: {
     kind: "bidi_streaming";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -679,8 +679,8 @@ export declare const TestServiceWithCustomOptions: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: CustomOptionFooRequest;
-    O: CustomOptionFooResponse;
+    I: typeof CustomOptionFooRequestDesc;
+    O: typeof CustomOptionFooResponseDesc;
   },
 }
 >;
@@ -694,8 +694,8 @@ export declare const AggregateService: GenDescService<{
    */
   method: {
     kind: "unary";
-    I: AggregateMessage;
-    O: AggregateMessage;
+    I: typeof AggregateMessageDesc;
+    O: typeof AggregateMessageDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
@@ -66,8 +66,8 @@ export declare const TestService: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: TestMessage;
-    O: TestMessage;
+    I: typeof TestMessageDesc;
+    O: typeof TestMessageDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -6795,16 +6795,16 @@ export declare const TestService: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: FooRequest;
-    O: FooResponse;
+    I: typeof FooRequestDesc;
+    O: typeof FooResponseDesc;
   },
   /**
    * @generated from rpc protobuf_unittest.TestService.Bar
    */
   bar: {
     kind: "unary";
-    I: BarRequest;
-    O: BarResponse;
+    I: typeof BarRequestDesc;
+    O: typeof BarResponseDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
@@ -148,8 +148,8 @@ export declare const Service: GenDescService<{
    */
   doStuff: {
     kind: "unary";
-    I: TopLevelMessage;
-    O: TopLevelMessage;
+    I: typeof TopLevelMessageDesc;
+    O: typeof TopLevelMessageDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -18,7 +18,7 @@
 
 import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import { enumDesc, extDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
+import type { EmptyDesc, FieldOptions } from "@bufbuild/protobuf/wkt";
 import { fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
@@ -139,8 +139,8 @@ export const DeprecatedService: GenDescService<{
    */
   deprecated: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
 }
 > = /*@__PURE__*/
@@ -158,16 +158,16 @@ export const DeprecatedRpcService: GenDescService<{
    */
   deprecated: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
   /**
    * @generated from rpc spec.DeprecatedRpcService.NotDeprecated
    */
   notDeprecated: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
@@ -18,7 +18,7 @@
 
 import type { GenDescEnum, GenDescExtension, GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import { enumDesc, extDesc, fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Empty, FieldOptions } from "@bufbuild/protobuf/wkt";
+import type { EmptyDesc, FieldOptions } from "@bufbuild/protobuf/wkt";
 import { fileDesc_google_protobuf_descriptor, fileDesc_google_protobuf_empty } from "@bufbuild/protobuf/wkt";
 import type { Message } from "@bufbuild/protobuf";
 
@@ -76,8 +76,8 @@ export const ImplicitlyDeprecatedService: GenDescService<{
    */
   implicitlyDeprecatedRpc: {
     kind: "unary";
-    I: Empty;
-    O: Empty;
+    I: typeof EmptyDesc;
+    O: typeof EmptyDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -1024,32 +1024,32 @@ export const ReservedPropertyNamesService: GenDescService<{
    */
   constructor$: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.toString
    */
   toString$: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.to_JSON
    */
   to_JSON: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.value_of
    */
   value_of: {
     kind: "unary";
-    I: Error;
-    O: Error;
+    I: typeof ErrorDesc;
+    O: typeof ErrorDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/option-usage_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/option-usage_pb.ts
@@ -80,8 +80,8 @@ export const ServiceWithOptions: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: MessageWithOptions;
-    O: MessageWithOptions;
+    I: typeof MessageWithOptionsDesc;
+    O: typeof MessageWithOptionsDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/service-all_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/service-all_pb.ts
@@ -18,7 +18,7 @@
 
 import type { GenDescFile, GenDescService } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Int32Value, StringValue } from "@bufbuild/protobuf/wkt";
+import type { Int32ValueDesc, StringValueDesc } from "@bufbuild/protobuf/wkt";
 import { fileDesc_google_protobuf_wrappers } from "@bufbuild/protobuf/wkt";
 
 /**
@@ -36,24 +36,24 @@ export const ServiceAll: GenDescService<{
    */
   unary: {
     kind: "unary";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ServerStream
    */
   serverStream: {
     kind: "server_streaming";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ClientStream
    */
   clientStream: {
     kind: "client_streaming";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.Bidi
@@ -61,8 +61,8 @@ export const ServiceAll: GenDescService<{
    */
   bidi: {
     kind: "bidi_streaming";
-    I: StringValue;
-    O: Int32Value;
+    I: typeof StringValueDesc;
+    O: typeof Int32ValueDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
@@ -155,32 +155,32 @@ export const ExampleService: GenDescService<{
    */
   unary: {
     kind: "unary";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ServerStream
    */
   serverStream: {
     kind: "server_streaming";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ClientStream
    */
   clientStream: {
     kind: "client_streaming";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.Bidi
    */
   bidi: {
     kind: "bidi_streaming";
-    I: ExampleRequest;
-    O: ExampleResponse;
+    I: typeof ExampleRequestDesc;
+    O: typeof ExampleResponseDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -721,8 +721,8 @@ export const TestServiceWithCustomOptions: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: CustomOptionFooRequest;
-    O: CustomOptionFooResponse;
+    I: typeof CustomOptionFooRequestDesc;
+    O: typeof CustomOptionFooResponseDesc;
   },
 }
 > = /*@__PURE__*/
@@ -737,8 +737,8 @@ export const AggregateService: GenDescService<{
    */
   method: {
     kind: "unary";
-    I: AggregateMessage;
-    O: AggregateMessage;
+    I: typeof AggregateMessageDesc;
+    O: typeof AggregateMessageDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
@@ -70,8 +70,8 @@ export const TestService: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: TestMessage;
-    O: TestMessage;
+    I: typeof TestMessageDesc;
+    O: typeof TestMessageDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -6993,16 +6993,16 @@ export const TestService: GenDescService<{
    */
   foo: {
     kind: "unary";
-    I: FooRequest;
-    O: FooResponse;
+    I: typeof FooRequestDesc;
+    O: typeof FooResponseDesc;
   },
   /**
    * @generated from rpc protobuf_unittest.TestService.Bar
    */
   bar: {
     kind: "unary";
-    I: BarRequest;
-    O: BarResponse;
+    I: typeof BarRequestDesc;
+    O: typeof BarResponseDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
@@ -158,8 +158,8 @@ export const Service: GenDescService<{
    */
   doStuff: {
     kind: "unary";
-    I: TopLevelMessage;
-    O: TopLevelMessage;
+    I: typeof TopLevelMessageDesc;
+    O: typeof TopLevelMessageDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/generate-code.test.ts
+++ b/packages/protobuf-test/src/generate-code.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, test, expect } from "@jest/globals";
-import type { Int32Value, StringValue } from "@bufbuild/protobuf/wkt";
+import type { Int32ValueDesc, StringValueDesc } from "@bufbuild/protobuf/wkt";
 import { hasExtension } from "@bufbuild/protobuf";
 import type { GenDescService } from "@bufbuild/protobuf/codegenv1";
 import * as proto2_ts from "./gen/ts/extra/proto2_pb.js";
@@ -159,23 +159,23 @@ test("service generates as expected", () => {
   type Expected = {
     unary: {
       kind: "unary";
-      I: StringValue;
-      O: Int32Value;
+      I: typeof StringValueDesc;
+      O: typeof Int32ValueDesc;
     };
     serverStream: {
       kind: "server_streaming";
-      I: StringValue;
-      O: Int32Value;
+      I: typeof StringValueDesc;
+      O: typeof Int32ValueDesc;
     };
     clientStream: {
       kind: "client_streaming";
-      I: StringValue;
-      O: Int32Value;
+      I: typeof StringValueDesc;
+      O: typeof Int32ValueDesc;
     };
     bidi: {
       kind: "bidi_streaming";
-      I: StringValue;
-      O: Int32Value;
+      I: typeof StringValueDesc;
+      O: typeof Int32ValueDesc;
     };
   };
   type Actual<T> = T extends GenDescService<infer Shape> ? Shape : never;

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -83,8 +83,8 @@ export type GenDescService<RuntimeShape extends GenDescServiceShape> =
 export type GenDescServiceShape = {
   [localName: string]: {
     kind: "unary" | "server_streaming" | "client_streaming" | "bidi_streaming";
-    I: Message;
-    O: Message;
+    I: DescMessage;
+    O: DescMessage;
   };
 };
 

--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -59,7 +59,7 @@ function generateTs(schema: Schema) {
       switch (desc.kind) {
         case "message": {
           generateMessageShape(f, desc, "ts");
-          const {GenDescMessage, messageDesc} = f.runtime.codegen;
+          const { GenDescMessage, messageDesc } = f.runtime.codegen;
           const MessageShape = f.importShape(desc);
           const name = f.importDesc(desc).name;
           generateDescDoc(f, desc);
@@ -71,7 +71,7 @@ function generateTs(schema: Schema) {
         }
         case "enum": {
           generateEnumShape(f, desc);
-          const {GenDescEnum, enumDesc} = f.runtime.codegen;
+          const { GenDescEnum, enumDesc } = f.runtime.codegen;
           const EnumShape = f.importShape(desc);
           generateDescDoc(f, desc);
           const name = f.importDesc(desc).name;
@@ -94,7 +94,7 @@ function generateTs(schema: Schema) {
           break;
         }
         case "service": {
-          const { GenDescService, serviceDesc} = f.runtime.codegen;
+          const { GenDescService, serviceDesc } = f.runtime.codegen;
           const name = f.importDesc(desc).name;
           const call = functionCall(serviceDesc, [fileDesc, ...pathInFileDesc(desc)]);
           f.print(f.jsDoc(desc));
@@ -121,7 +121,7 @@ function generateJs(schema: Schema) {
     for (const desc of schema.typesInFile(file)) {
       switch (desc.kind) {
         case "message": {
-          const { messageDesc} = f.runtime.codegen;
+          const { messageDesc } = f.runtime.codegen;
           const name = f.importDesc(desc).name;
           generateDescDoc(f, desc);
           const call = functionCall(messageDesc, [fileDesc, ...pathInFileDesc(desc)]);
@@ -163,7 +163,7 @@ function generateJs(schema: Schema) {
           break;
         }
         case "service": {
-          const { serviceDesc} = f.runtime.codegen;
+          const { serviceDesc } = f.runtime.codegen;
           const name = f.importDesc(desc).name;
           f.print(f.jsDoc(desc));
           const call = functionCall(serviceDesc, [fileDesc, ...pathInFileDesc(desc)]);
@@ -300,8 +300,8 @@ function getServiceShapeExpr(f: GeneratedFile, service: DescService): Printable 
     print(f.jsDoc(method, "  "));
     print("  ", method.localName, ": {");
     print("    kind: ", f.string(method.methodKind), ";");
-    print("    I: ", f.importShape(method.input), ";");
-    print("    O: ", f.importShape(method.output), ";");
+    print("    I: typeof ", f.importDesc(method.input, true), ";");
+    print("    O: typeof ", f.importDesc(method.output, true), ";");
     print("  },");
   }
   print("}");

--- a/packages/protoplugin-example/src/gen/connectrpc/eliza_pb.ts
+++ b/packages/protoplugin-example/src/gen/connectrpc/eliza_pb.ts
@@ -78,8 +78,8 @@ export const ElizaService: GenDescService<{
    */
   say: {
     kind: "unary";
-    I: SayRequest;
-    O: SayResponse;
+    I: typeof SayRequestDesc;
+    O: typeof SayResponseDesc;
   },
 }
 > = /*@__PURE__*/


### PR DESCRIPTION
Right now we use the message shapes in the generated service descriptors. All of our utility types are oriented around descriptors (`MessageInitShape`, `MessageShape`). Moving this to descriptors will let us use these types.

We can make some form utility types that can do the other way around but then there would two sets of types.