### PR TITLE
V2: Avoid duplicate checks in fromJson and reflect

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 123,997 b | 64,338 b | 14,978 b |
-| protobuf-es | 4 | 126,192 b | 65,847 b | 15,673 b |
-| protobuf-es | 8 | 128,970 b | 67,618 b | 16,184 b |
-| protobuf-es | 16 | 139,478 b | 75,599 b | 18,501 b |
-| protobuf-es | 32 | 167,373 b | 97,621 b | 23,927 b |
+| protobuf-es | 1 | 123,995 b | 64,336 b | 14,983 b |
+| protobuf-es | 4 | 126,190 b | 65,845 b | 15,664 b |
+| protobuf-es | 8 | 128,968 b | 67,616 b | 16,187 b |
+| protobuf-es | 16 | 139,476 b | 75,597 b | 18,492 b |
+| protobuf-es | 32 | 167,371 b | 97,619 b | 23,949 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.5818359375 140,245.61357421875 280,244.16640625 420,237.60458984375 560,222.23798828125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.56767578125 140,245.6390625 280,244.15791015625 420,237.630078125 560,222.17568359375">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.5818359375" r="4" fill="#ffa600"><title>protobuf-es 14.63 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.61357421875" r="4" fill="#ffa600"><title>protobuf-es 15.31 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.16640625" r="4" fill="#ffa600"><title>protobuf-es 15.8 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.60458984375" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.23798828125" r="4" fill="#ffa600"><title>protobuf-es 23.37 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.56767578125" r="4" fill="#ffa600"><title>protobuf-es 14.63 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.6390625" r="4" fill="#ffa600"><title>protobuf-es 15.3 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.15791015625" r="4" fill="#ffa600"><title>protobuf-es 15.81 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.630078125" r="4" fill="#ffa600"><title>protobuf-es 18.06 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.17568359375" r="4" fill="#ffa600"><title>protobuf-es 23.39 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -391,7 +391,7 @@ function durationToJson(val: Duration) {
     Number(val.seconds) < -315576000000
   ) {
     throw new Error(
-      `cannot encode ${val.$typeName} to JSON: value out of range`,
+      `cannot encode message ${val.$typeName} to JSON: value out of range`,
     );
   }
   let text = val.seconds.toString();
@@ -417,7 +417,7 @@ function fieldMaskToJson(val: FieldMask) {
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if (p.match(/_[0-9]?_/g) || p.match(/[A-Z]/g)) {
         throw new Error(
-          `cannot encode ${val.$typeName} to JSON: lowerCamelCase of path name "` +
+          `cannot encode message ${val.$typeName} to JSON: lowerCamelCase of path name "` +
             p +
             '" is irreversible',
         );
@@ -468,12 +468,12 @@ function timestampToJson(val: Timestamp) {
     ms > Date.parse("9999-12-31T23:59:59Z")
   ) {
     throw new Error(
-      `cannot encode ${val.$typeName} to JSON: must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive`,
+      `cannot encode message ${val.$typeName} to JSON: must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive`,
     );
   }
   if (val.nanos < 0) {
     throw new Error(
-      `cannot encode ${val.$typeName} to JSON: nanos must not be negative`,
+      `cannot encode message ${val.$typeName} to JSON: nanos must not be negative`,
     );
   }
   let z = "Z";

--- a/packages/protobuf/src/wire/base64-encoding.ts
+++ b/packages/protobuf/src/wire/base64-encoding.ts
@@ -51,7 +51,7 @@ export function base64Decode(base64Str: string) {
         case " ":
           continue; // skip white-space, and padding
         default:
-          throw Error("invalid base64 string.");
+          throw Error("invalid base64 string");
       }
     }
     switch (groupPos) {
@@ -75,7 +75,7 @@ export function base64Decode(base64Str: string) {
         break;
     }
   }
-  if (groupPos == 1) throw Error("invalid base64 string.");
+  if (groupPos == 1) throw Error("invalid base64 string");
   return bytes.subarray(0, bytePos);
 }
 


### PR DESCRIPTION
Currently, scalar values are validated by both readScalar() and checkScalarValue() when parsing JSON. This PR changes the internals so that fromJson() relies on reflect to validate scalar values.

As a result, error messages are improved, for example:

```diff
- cannot decode field ... from JSON: "abc": invalid int32: NaN
+ cannot decode field ... from JSON: expected number (int32), got "abc"
```

The internal functions `assertInt32`, `assertUInt32`, `assertFloat32` have only a single call site remaining now. As a follow-up, they can be co-located.
