### PR TITLE
Skip null values in message initializer object

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -15,11 +15,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 79,466 b | 34,303 b | 9,800 b |
-| protobuf-es | 4 | 92,563 b | 37,277 b | 10,113 b |
-| protobuf-es | 8 | 101,904 b | 41,775 b | 10,824 b |
-| protobuf-es | 16 | 165,584 b | 67,020 b | 13,312 b |
-| protobuf-es | 32 | 344,962 b | 147,972 b | 20,177 b |
+| protobuf-es | 1 | 79,463 b | 34,300 b | 9,781 b |
+| protobuf-es | 4 | 92,560 b | 37,274 b | 10,114 b |
+| protobuf-es | 8 | 101,901 b | 41,772 b | 10,808 b |
+| protobuf-es | 16 | 165,581 b | 67,017 b | 13,320 b |
+| protobuf-es | 32 | 344,959 b | 147,969 b | 20,175 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,262.24609375 140,261.35966796875 280,259.34609375 420,252.3 560,232.85810546875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,262.29990234375 140,261.3568359375 280,259.39140625 420,252.27734375 560,232.86376953125">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="262.24609375" r="4" fill="#ffa600"><title>protobuf-es 9.57 KiB for 1 files</title></circle>
-<circle cx="140" cy="261.35966796875" r="4" fill="#ffa600"><title>protobuf-es 9.88 KiB for 4 files</title></circle>
-<circle cx="280" cy="259.34609375" r="4" fill="#ffa600"><title>protobuf-es 10.57 KiB for 8 files</title></circle>
-<circle cx="420" cy="252.3" r="4" fill="#ffa600"><title>protobuf-es 13 KiB for 16 files</title></circle>
-<circle cx="560" cy="232.85810546875" r="4" fill="#ffa600"><title>protobuf-es 19.7 KiB for 32 files</title></circle>
+<circle cx="0" cy="262.29990234375" r="4" fill="#ffa600"><title>protobuf-es 9.55 KiB for 1 files</title></circle>
+<circle cx="140" cy="261.3568359375" r="4" fill="#ffa600"><title>protobuf-es 9.88 KiB for 4 files</title></circle>
+<circle cx="280" cy="259.39140625" r="4" fill="#ffa600"><title>protobuf-es 10.55 KiB for 8 files</title></circle>
+<circle cx="420" cy="252.27734375" r="4" fill="#ffa600"><title>protobuf-es 13.01 KiB for 16 files</title></circle>
+<circle cx="560" cy="232.86376953125" r="4" fill="#ffa600"><title>protobuf-es 19.7 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/constructor.test.ts
+++ b/packages/protobuf-test/src/constructor.test.ts
@@ -21,6 +21,8 @@ import { TestAllTypesProto3 as JS_TestAllTypesProto3 } from "./gen/js/google/pro
 import { JSTypeStringMessage as TS_JSTypeStringMessage } from "./gen/ts/extra/jstype_pb.js";
 import { JSTypeStringMessage as JS_JSTypeStringMessage } from "./gen/js/extra/jstype_pb.js";
 import { testMT } from "./helpers.js";
+import { Proto3OptionalMessage as TS_Proto3OptionalMessage } from "./gen/ts/extra/proto3_pb.js";
+import { Proto3OptionalMessage as JS_Proto3OptionalMessage } from "./gen/js/extra/proto3_pb.js";
 
 describe("constructor initializes jstype=JS_STRING with string", function () {
   testMT(
@@ -176,6 +178,50 @@ describe("constructor takes partial message for map value", function () {
         t.repeatedNestedMessage[0]?.corecursive?.repeatedNestedMessage[0]
           ?.corecursive?.repeatedNestedMessage[0]?.a,
       ).toBe(0);
+    },
+  );
+});
+
+describe("constructor skips undefined values", () => {
+  testMT(
+    { ts: TS_Proto3OptionalMessage, js: JS_Proto3OptionalMessage },
+    (messageType) => {
+      const m = new messageType({
+        stringField: undefined,
+      });
+      expect(m.stringField).toBeUndefined();
+    },
+  );
+  testMT(
+    { ts: TS_TestAllTypesProto3, js: JS_TestAllTypesProto3 },
+    (messageType) => {
+      const m = new messageType({
+        optionalInt32: undefined,
+      });
+      expect(m.optionalInt32).toBe(0);
+    },
+  );
+});
+
+describe("constructor skips null values", () => {
+  testMT(
+    { ts: TS_Proto3OptionalMessage, js: JS_Proto3OptionalMessage },
+    (messageType) => {
+      const m = new messageType({
+        // @ts-expect-error TS 2322
+        stringField: null,
+      });
+      expect(m.stringField).toBeUndefined();
+    },
+  );
+  testMT(
+    { ts: TS_TestAllTypesProto3, js: JS_TestAllTypesProto3 },
+    (messageType) => {
+      const m = new messageType({
+        // @ts-expect-error TS 2322
+        optionalInt32: null,
+      });
+      expect(m.optionalInt32).toBe(0);
     },
   );
 });

--- a/packages/protobuf/src/private/util-common.ts
+++ b/packages/protobuf/src/private/util-common.ts
@@ -38,7 +38,7 @@ export function makeUtilCommon(): Omit<Util, "newFieldList" | "initFields"> {
         const localName = member.localName,
           t = target as AnyMessage,
           s = source as PartialMessage<AnyMessage>;
-        if (s[localName] === undefined) {
+        if (s[localName] == null) {
           // TODO if source is a Message instance, we should use isFieldSet() here to support future field presence
           continue;
         }


### PR DESCRIPTION

When constructing a message, fields can be omitted, or set to `undefined`:

```ts
const user = new User({
  firstName: undefined, // same as omitting the field
});
```

In some situations - see https://github.com/bufbuild/protobuf-es/issues/860 for example, users set a field to `null`, and have not configured TypeScript to raise an error for the type mismatch, which leads to a runtime error later on.

With this change, the constructor will skip `null` values, just like `undefined`:

```ts
const user = new User({
  firstName: null, // same as omitting the field, or setting it to `undefined`
});
```

Note that our types still only allow `string | undefined` in the constructor, but it seems reasonable to handle this case gracefully. We are already supporting this behavior in the upcoming [version 2](https://github.com/bufbuild/protobuf-es/releases/tag/v2.0.0-alpha.1).
