### PR TITLE
V2: Rename JSON serialization option emitDefaultValues

### DIFF
--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -987,7 +987,7 @@ Options for `Message.toJson` and `Message.toJsonString`:
 
 - `alwaysEmitImplicit?: boolean`<br/>
   By default, fields with implicit presence are not serialized if they are
-  unset. For example, an empty list field or a proto3 in32 field with 0 is
+  unset. For example, an empty list field or a proto3 int32 field with 0 is
   not serialized. With this option enabled, such fields are included in the 
   output.
 - `enumAsInteger?: boolean`<br/>

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -988,7 +988,8 @@ Options for `Message.toJson` and `Message.toJsonString`:
 - `alwaysEmitImplicit?: boolean`<br/>
   By default, fields with implicit presence are not serialized if they are
   unset. For example, an empty list field or a proto3 in32 field with 0 is
-  not serialized. With this option, such fields are included in the output.
+  not serialized. With this option enabled, such fields are included in the 
+  output.
 - `enumAsInteger?: boolean`<br/>
   The name of an enum value is used by default in JSON output. This option
   overrides the behavior to use the numeric value of the enum value instead.

--- a/docs/runtime_api.md
+++ b/docs/runtime_api.md
@@ -985,10 +985,10 @@ Options for `Message.fromJson` and `Message.fromJsonString`:
 
 Options for `Message.toJson` and `Message.toJsonString`:
 
-- `emitDefaultValues?: boolean`<br/>
-  Fields with default values are omitted by default in JSON output.
-  This option overrides this behavior and outputs fields with
-  their default values.
+- `alwaysEmitImplicit?: boolean`<br/>
+  By default, fields with implicit presence are not serialized if they are
+  unset. For example, an empty list field or a proto3 in32 field with 0 is
+  not serialized. With this option, such fields are included in the output.
 - `enumAsInteger?: boolean`<br/>
   The name of an enum value is used by default in JSON output. This option
   overrides the behavior to use the numeric value of the enum value instead.
@@ -1020,7 +1020,7 @@ this function directly.
 
 Serializing a message with `JSON.stringify()` is equivalent to calling `toJsonString`
 on the message, with the [serialization option](#json-serialization-options)
-`emitDefaultValues: true`.
+`alwaysEmitImplicit: true`.
 
 
 ### Unknown fields

--- a/packages/protobuf-test/src/json.test.ts
+++ b/packages/protobuf-test/src/json.test.ts
@@ -704,7 +704,7 @@ describe("extensions in JSON", () => {
 });
 
 describe("JsonWriteOptions", () => {
-  describe("emitDefaultValues", () => {
+  describe("alwaysEmitImplicit", () => {
     test("emits proto3 implicit fields", async () => {
       const descMessage = await compileMessage(`
         syntax="proto3";
@@ -716,7 +716,7 @@ describe("JsonWriteOptions", () => {
         }
       `);
       const json = toJson(descMessage, create(descMessage), {
-        emitDefaultValues: true,
+        alwaysEmitImplicit: true,
       });
       expect(json).toStrictEqual({
         int32Field: 0,
@@ -736,7 +736,7 @@ describe("JsonWriteOptions", () => {
         }
       `);
       const json = toJson(descMessage, create(descMessage), {
-        emitDefaultValues: true,
+        alwaysEmitImplicit: true,
       });
       expect(json).toStrictEqual({});
     });
@@ -750,7 +750,7 @@ describe("JsonWriteOptions", () => {
         }
       `);
       const json = toJson(descMessage, create(descMessage), {
-        emitDefaultValues: true,
+        alwaysEmitImplicit: true,
       });
       expect(json).toStrictEqual({
         listField: [],

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -57,7 +57,8 @@ export interface JsonWriteOptions {
   /**
    * By default, fields with implicit presence are not serialized if they are
    * unset. For example, an empty list field or a proto3 in32 field with 0 is
-   * not serialized. With this option, such fields are included in the output.
+   * not serialized. With this option enabled, such fields are included in the
+   * output.
    */
   alwaysEmitImplicit: boolean;
 

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -56,7 +56,7 @@ const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
 export interface JsonWriteOptions {
   /**
    * By default, fields with implicit presence are not serialized if they are
-   * unset. For example, an empty list field or a proto3 in32 field with 0 is
+   * unset. For example, an empty list field or a proto3 int32 field with 0 is
    * not serialized. With this option enabled, such fields are included in the
    * output.
    */

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -55,11 +55,11 @@ const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
  */
 export interface JsonWriteOptions {
   /**
-   * Emit fields with default values: Fields with default values are omitted
-   * by default in proto3 JSON output. This option overrides this behavior
-   * and outputs fields with their default values.
+   * By default, fields with implicit presence are not serialized if they are
+   * unset. For example, an empty list field or a proto3 in32 field with 0 is
+   * not serialized. With this option, such fields are included in the output.
    */
-  emitDefaultValues: boolean;
+  alwaysEmitImplicit: boolean;
 
   /**
    * Emit enum values as integers instead of strings: The name of an enum
@@ -94,7 +94,7 @@ export interface JsonWriteStringOptions extends JsonWriteOptions {
 
 // Default options for serializing to JSON.
 const jsonWriteDefaults: Readonly<JsonWriteOptions> = {
-  emitDefaultValues: false,
+  alwaysEmitImplicit: false,
   enumAsInteger: false,
   useProtoFieldName: false,
 };
@@ -143,7 +143,7 @@ function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
           `cannot encode field ${msg.desc.typeName}.${f.name} to JSON: required field not set`,
         );
       }
-      if (!opts.emitDefaultValues || f.presence !== IMPLICIT) {
+      if (!opts.alwaysEmitImplicit || f.presence !== IMPLICIT) {
         // Fields with implicit presence omit zero values (e.g. empty string) by default
         continue;
       }
@@ -220,7 +220,7 @@ function mapToJson(map: ReflectMap, opts: JsonWriteOptions) {
       }
       break;
   }
-  return opts.emitDefaultValues || map.size > 0 ? jsonObj : undefined;
+  return opts.alwaysEmitImplicit || map.size > 0 ? jsonObj : undefined;
 }
 
 function listToJson(list: ReflectList, opts: JsonWriteOptions) {
@@ -243,7 +243,7 @@ function listToJson(list: ReflectList, opts: JsonWriteOptions) {
       }
       break;
   }
-  return opts.emitDefaultValues || jsonArr.length > 0 ? jsonArr : undefined;
+  return opts.alwaysEmitImplicit || jsonArr.length > 0 ? jsonArr : undefined;
 }
 
 function enumToJson(


### PR DESCRIPTION
The [documentation for the suggested JSON options](https://protobuf.dev/programming-guides/proto3/#json-options) has been updated recently. The documentation originally only applied to proto3, where the name `emitDefaultValues` fits. With Editions, this name has become ambiguous: The option does not actually emit field default values (which would change data with a serialization roundtrip), it only emits empty maps and lists, and zero values for proto3 singular scalar fields (fields with implicit presence). 

This PR renames the option to `alwaysEmitImplicit`, and updates the documentation accordingly:

```ts
/**
 * By default, fields with implicit presence are not serialized if they are
 * unset. For example, an empty list field or a proto3 int32 field with 0 is
 * not serialized. With this option enabled, such fields are included in the 
 * output.
 */
alwaysEmitImplicit: boolean;
```