### PR TITLE
V2: Change return type of merge functions

### DIFF
--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -77,7 +77,7 @@ export function mergeFromBinary<Desc extends DescMessage>(
   target: MessageShape<Desc>,
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
-): MessageShape<Desc> {
+): void {
   readMessage(
     reflect(messageDesc, target),
     new BinaryReader(bytes),
@@ -85,7 +85,6 @@ export function mergeFromBinary<Desc extends DescMessage>(
     false,
     bytes.byteLength,
   );
-  return target;
 }
 
 /**

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -110,8 +110,8 @@ export function mergeFromJsonString<Desc extends DescMessage>(
   target: MessageShape<Desc>,
   json: string,
   options?: Partial<JsonReadOptions>,
-): MessageShape<Desc> {
-  return mergeFromJson(
+): void {
+  mergeFromJson(
     messageDesc,
     target,
     parseJsonString(json, messageDesc.typeName),
@@ -156,7 +156,7 @@ export function mergeFromJson<Desc extends DescMessage>(
   target: MessageShape<Desc>,
   json: JsonValue,
   options?: Partial<JsonReadOptions>,
-): MessageShape<Desc> {
+): void {
   try {
     readMessage(reflect(messageDesc, target), json, makeReadOptions(options));
   } catch (e) {
@@ -168,7 +168,6 @@ export function mergeFromJson<Desc extends DescMessage>(
     }
     throw e;
   }
-  return target;
 }
 
 function readMessage(


### PR DESCRIPTION
The current function signatures of `mergeFromBinary`, `mergeFromJson`, and `mergeFromJsonString` ambiguous: It is not obvious whether the function mutates the message given as an argument, or whether it clones the message first, and returns the mutated clone.

To remove this ambiguity, this PR changes the return types to `void`, making it obvious that the functions mutate the argument.

To be honest, it seems that it would be most idiomatic to return a copy. But in some use cases, that can be a prohibitively expensive operation. So mutating the argument seems to be the best choice. In case we're wrong about that, we can still add variants that return a clone, for example as `mergeBinary`.
