### PR TITLE
V2: Add `method` field to `DescMethod`; Improve generated service types

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 123,775 b | 64,241 b | 14,974 b |
-| protobuf-es | 4 | 125,970 b | 65,745 b | 15,652 b |
-| protobuf-es | 8 | 128,748 b | 67,516 b | 16,179 b |
-| protobuf-es | 16 | 139,256 b | 75,497 b | 18,508 b |
-| protobuf-es | 32 | 167,151 b | 97,519 b | 23,990 b |
+| protobuf-es | 1 | 123,862 b | 64,285 b | 15,000 b |
+| protobuf-es | 4 | 126,057 b | 65,789 b | 15,698 b |
+| protobuf-es | 8 | 128,835 b | 67,560 b | 16,188 b |
+| protobuf-es | 16 | 139,343 b | 75,541 b | 18,515 b |
+| protobuf-es | 32 | 167,238 b | 97,563 b | 23,959 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.5931640625 140,245.673046875 280,244.18056640625 420,237.584765625 560,222.0595703125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.51953125 140,245.5427734375 280,244.155078125 420,237.56494140625 560,222.14736328125">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.5931640625" r="4" fill="#ffa600"><title>protobuf-es 14.62 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.673046875" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.18056640625" r="4" fill="#ffa600"><title>protobuf-es 15.8 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.584765625" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.0595703125" r="4" fill="#ffa600"><title>protobuf-es 23.43 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.51953125" r="4" fill="#ffa600"><title>protobuf-es 14.65 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.5427734375" r="4" fill="#ffa600"><title>protobuf-es 15.33 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.155078125" r="4" fill="#ffa600"><title>protobuf-es 15.81 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.56494140625" r="4" fill="#ffa600"><title>protobuf-es 18.08 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.14736328125" r="4" fill="#ffa600"><title>protobuf-es 23.4 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/bundle-size/src/gen/protobuf-es/google/bytestream/bytestream_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/bytestream/bytestream_pb.ts
@@ -262,9 +262,9 @@ export const ByteStream: GenDescService<{
    * @generated from rpc google.bytestream.ByteStream.Read
    */
   read: {
-    kind: "server_streaming";
-    I: typeof ReadRequestDesc;
-    O: typeof ReadResponseDesc;
+    methodKind: "server_streaming";
+    input: typeof ReadRequestDesc;
+    output: typeof ReadResponseDesc;
   },
   /**
    * `Write()` is used to send the contents of a resource as a sequence of
@@ -293,9 +293,9 @@ export const ByteStream: GenDescService<{
    * @generated from rpc google.bytestream.ByteStream.Write
    */
   write: {
-    kind: "client_streaming";
-    I: typeof WriteRequestDesc;
-    O: typeof WriteResponseDesc;
+    methodKind: "client_streaming";
+    input: typeof WriteRequestDesc;
+    output: typeof WriteResponseDesc;
   },
   /**
    * `QueryWriteStatus()` is used to find the `committed_size` for a resource
@@ -316,9 +316,9 @@ export const ByteStream: GenDescService<{
    * @generated from rpc google.bytestream.ByteStream.QueryWriteStatus
    */
   queryWriteStatus: {
-    kind: "unary";
-    I: typeof QueryWriteStatusRequestDesc;
-    O: typeof QueryWriteStatusResponseDesc;
+    methodKind: "unary";
+    input: typeof QueryWriteStatusRequestDesc;
+    output: typeof QueryWriteStatusResponseDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
@@ -350,9 +350,9 @@ export const Operations: GenDescService<{
    * @generated from rpc google.longrunning.Operations.ListOperations
    */
   listOperations: {
-    kind: "unary";
-    I: typeof ListOperationsRequestDesc;
-    O: typeof ListOperationsResponseDesc;
+    methodKind: "unary";
+    input: typeof ListOperationsRequestDesc;
+    output: typeof ListOperationsResponseDesc;
   },
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
@@ -362,9 +362,9 @@ export const Operations: GenDescService<{
    * @generated from rpc google.longrunning.Operations.GetOperation
    */
   getOperation: {
-    kind: "unary";
-    I: typeof GetOperationRequestDesc;
-    O: typeof OperationDesc;
+    methodKind: "unary";
+    input: typeof GetOperationRequestDesc;
+    output: typeof OperationDesc;
   },
   /**
    * Deletes a long-running operation. This method indicates that the client is
@@ -375,9 +375,9 @@ export const Operations: GenDescService<{
    * @generated from rpc google.longrunning.Operations.DeleteOperation
    */
   deleteOperation: {
-    kind: "unary";
-    I: typeof DeleteOperationRequestDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof DeleteOperationRequestDesc;
+    output: typeof EmptyDesc;
   },
   /**
    * Starts asynchronous cancellation on a long-running operation.  The server
@@ -394,9 +394,9 @@ export const Operations: GenDescService<{
    * @generated from rpc google.longrunning.Operations.CancelOperation
    */
   cancelOperation: {
-    kind: "unary";
-    I: typeof CancelOperationRequestDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof CancelOperationRequestDesc;
+    output: typeof EmptyDesc;
   },
   /**
    * Waits until the specified long-running operation is done or reaches at most
@@ -412,9 +412,9 @@ export const Operations: GenDescService<{
    * @generated from rpc google.longrunning.Operations.WaitOperation
    */
   waitOperation: {
-    kind: "unary";
-    I: typeof WaitOperationRequestDesc;
-    O: typeof OperationDesc;
+    methodKind: "unary";
+    input: typeof WaitOperationRequestDesc;
+    output: typeof OperationDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
@@ -131,9 +131,9 @@ export declare const DeprecatedService: GenDescService<{
    * @generated from rpc spec.DeprecatedService.Deprecated
    */
   deprecated: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
 }
 >;
@@ -149,17 +149,17 @@ export declare const DeprecatedRpcService: GenDescService<{
    * @deprecated
    */
   deprecated: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
   /**
    * @generated from rpc spec.DeprecatedRpcService.NotDeprecated
    */
   notDeprecated: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-implicit_pb.d.ts
@@ -70,9 +70,9 @@ export declare const ImplicitlyDeprecatedService: GenDescService<{
    * @generated from rpc spec.ImplicitlyDeprecatedService.ImplicitlyDeprecatedRpc
    */
   implicitlyDeprecatedRpc: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -980,33 +980,33 @@ export declare const ReservedPropertyNamesService: GenDescService<{
    * @generated from rpc spec.ReservedPropertyNamesService.constructor
    */
   constructor$: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.toString
    */
   toString$: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.to_JSON
    */
   to_JSON: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.value_of
    */
   value_of: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/option-usage_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/option-usage_pb.d.ts
@@ -74,9 +74,9 @@ export declare const ServiceWithOptions: GenDescService<{
    * @generated from rpc spec.ServiceWithOptions.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof MessageWithOptionsDesc;
-    O: typeof MessageWithOptionsDesc;
+    methodKind: "unary";
+    input: typeof MessageWithOptionsDesc;
+    output: typeof MessageWithOptionsDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/service-all_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/service-all_pb.d.ts
@@ -32,34 +32,34 @@ export declare const ServiceAll: GenDescService<{
    * @generated from rpc spec.ServiceAll.Unary
    */
   unary: {
-    kind: "unary";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "unary";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ServerStream
    */
   serverStream: {
-    kind: "server_streaming";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "server_streaming";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ClientStream
    */
   clientStream: {
-    kind: "client_streaming";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "client_streaming";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.Bidi
    * @deprecated
    */
   bidi: {
-    kind: "bidi_streaming";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "bidi_streaming";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/extra/service-example_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/service-example_pb.d.ts
@@ -149,33 +149,33 @@ export declare const ExampleService: GenDescService<{
    * @generated from rpc spec.ExampleService.Unary
    */
   unary: {
-    kind: "unary";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "unary";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ServerStream
    */
   serverStream: {
-    kind: "server_streaming";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "server_streaming";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ClientStream
    */
   clientStream: {
-    kind: "client_streaming";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "client_streaming";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.Bidi
    */
   bidi: {
-    kind: "bidi_streaming";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "bidi_streaming";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -678,9 +678,9 @@ export declare const TestServiceWithCustomOptions: GenDescService<{
    * @generated from rpc protobuf_unittest.TestServiceWithCustomOptions.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof CustomOptionFooRequestDesc;
-    O: typeof CustomOptionFooResponseDesc;
+    methodKind: "unary";
+    input: typeof CustomOptionFooRequestDesc;
+    output: typeof CustomOptionFooResponseDesc;
   },
 }
 >;
@@ -693,9 +693,9 @@ export declare const AggregateService: GenDescService<{
    * @generated from rpc protobuf_unittest.AggregateService.Method
    */
   method: {
-    kind: "unary";
-    I: typeof AggregateMessageDesc;
-    O: typeof AggregateMessageDesc;
+    methodKind: "unary";
+    input: typeof AggregateMessageDesc;
+    output: typeof AggregateMessageDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_no_generic_services_pb.d.ts
@@ -65,9 +65,9 @@ export declare const TestService: GenDescService<{
    * @generated from rpc protobuf_unittest.no_generic_services_test.TestService.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof TestMessageDesc;
-    O: typeof TestMessageDesc;
+    methodKind: "unary";
+    input: typeof TestMessageDesc;
+    output: typeof TestMessageDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -6794,17 +6794,17 @@ export declare const TestService: GenDescService<{
    * @generated from rpc protobuf_unittest.TestService.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof FooRequestDesc;
-    O: typeof FooResponseDesc;
+    methodKind: "unary";
+    input: typeof FooRequestDesc;
+    output: typeof FooResponseDesc;
   },
   /**
    * @generated from rpc protobuf_unittest.TestService.Bar
    */
   bar: {
-    kind: "unary";
-    I: typeof BarRequestDesc;
-    O: typeof BarResponseDesc;
+    methodKind: "unary";
+    input: typeof BarRequestDesc;
+    output: typeof BarResponseDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
@@ -147,9 +147,9 @@ export declare const Service: GenDescService<{
    * @generated from rpc protobuf_unittest.Service.DoStuff
    */
   doStuff: {
-    kind: "unary";
-    I: typeof TopLevelMessageDesc;
-    O: typeof TopLevelMessageDesc;
+    methodKind: "unary";
+    input: typeof TopLevelMessageDesc;
+    output: typeof TopLevelMessageDesc;
   },
 }
 >;

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -138,9 +138,9 @@ export const DeprecatedService: GenDescService<{
    * @generated from rpc spec.DeprecatedService.Deprecated
    */
   deprecated: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
 }
 > = /*@__PURE__*/
@@ -157,17 +157,17 @@ export const DeprecatedRpcService: GenDescService<{
    * @deprecated
    */
   deprecated: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
   /**
    * @generated from rpc spec.DeprecatedRpcService.NotDeprecated
    */
   notDeprecated: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-implicit_pb.ts
@@ -75,9 +75,9 @@ export const ImplicitlyDeprecatedService: GenDescService<{
    * @generated from rpc spec.ImplicitlyDeprecatedService.ImplicitlyDeprecatedRpc
    */
   implicitlyDeprecatedRpc: {
-    kind: "unary";
-    I: typeof EmptyDesc;
-    O: typeof EmptyDesc;
+    methodKind: "unary";
+    input: typeof EmptyDesc;
+    output: typeof EmptyDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -1023,33 +1023,33 @@ export const ReservedPropertyNamesService: GenDescService<{
    * @generated from rpc spec.ReservedPropertyNamesService.constructor
    */
   constructor$: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.toString
    */
   toString$: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.to_JSON
    */
   to_JSON: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
   /**
    * @generated from rpc spec.ReservedPropertyNamesService.value_of
    */
   value_of: {
-    kind: "unary";
-    I: typeof ErrorDesc;
-    O: typeof ErrorDesc;
+    methodKind: "unary";
+    input: typeof ErrorDesc;
+    output: typeof ErrorDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/option-usage_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/option-usage_pb.ts
@@ -79,9 +79,9 @@ export const ServiceWithOptions: GenDescService<{
    * @generated from rpc spec.ServiceWithOptions.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof MessageWithOptionsDesc;
-    O: typeof MessageWithOptionsDesc;
+    methodKind: "unary";
+    input: typeof MessageWithOptionsDesc;
+    output: typeof MessageWithOptionsDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/service-all_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/service-all_pb.ts
@@ -35,34 +35,34 @@ export const ServiceAll: GenDescService<{
    * @generated from rpc spec.ServiceAll.Unary
    */
   unary: {
-    kind: "unary";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "unary";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ServerStream
    */
   serverStream: {
-    kind: "server_streaming";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "server_streaming";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.ClientStream
    */
   clientStream: {
-    kind: "client_streaming";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "client_streaming";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
   /**
    * @generated from rpc spec.ServiceAll.Bidi
    * @deprecated
    */
   bidi: {
-    kind: "bidi_streaming";
-    I: typeof StringValueDesc;
-    O: typeof Int32ValueDesc;
+    methodKind: "bidi_streaming";
+    input: typeof StringValueDesc;
+    output: typeof Int32ValueDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/service-example_pb.ts
@@ -154,33 +154,33 @@ export const ExampleService: GenDescService<{
    * @generated from rpc spec.ExampleService.Unary
    */
   unary: {
-    kind: "unary";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "unary";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ServerStream
    */
   serverStream: {
-    kind: "server_streaming";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "server_streaming";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.ClientStream
    */
   clientStream: {
-    kind: "client_streaming";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "client_streaming";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
   /**
    * @generated from rpc spec.ExampleService.Bidi
    */
   bidi: {
-    kind: "bidi_streaming";
-    I: typeof ExampleRequestDesc;
-    O: typeof ExampleResponseDesc;
+    methodKind: "bidi_streaming";
+    input: typeof ExampleRequestDesc;
+    output: typeof ExampleResponseDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -720,9 +720,9 @@ export const TestServiceWithCustomOptions: GenDescService<{
    * @generated from rpc protobuf_unittest.TestServiceWithCustomOptions.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof CustomOptionFooRequestDesc;
-    O: typeof CustomOptionFooResponseDesc;
+    methodKind: "unary";
+    input: typeof CustomOptionFooRequestDesc;
+    output: typeof CustomOptionFooResponseDesc;
   },
 }
 > = /*@__PURE__*/
@@ -736,9 +736,9 @@ export const AggregateService: GenDescService<{
    * @generated from rpc protobuf_unittest.AggregateService.Method
    */
   method: {
-    kind: "unary";
-    I: typeof AggregateMessageDesc;
-    O: typeof AggregateMessageDesc;
+    methodKind: "unary";
+    input: typeof AggregateMessageDesc;
+    output: typeof AggregateMessageDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_no_generic_services_pb.ts
@@ -69,9 +69,9 @@ export const TestService: GenDescService<{
    * @generated from rpc protobuf_unittest.no_generic_services_test.TestService.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof TestMessageDesc;
-    O: typeof TestMessageDesc;
+    methodKind: "unary";
+    input: typeof TestMessageDesc;
+    output: typeof TestMessageDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -6992,17 +6992,17 @@ export const TestService: GenDescService<{
    * @generated from rpc protobuf_unittest.TestService.Foo
    */
   foo: {
-    kind: "unary";
-    I: typeof FooRequestDesc;
-    O: typeof FooResponseDesc;
+    methodKind: "unary";
+    input: typeof FooRequestDesc;
+    output: typeof FooResponseDesc;
   },
   /**
    * @generated from rpc protobuf_unittest.TestService.Bar
    */
   bar: {
-    kind: "unary";
-    I: typeof BarRequestDesc;
-    O: typeof BarResponseDesc;
+    methodKind: "unary";
+    input: typeof BarRequestDesc;
+    output: typeof BarResponseDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
@@ -157,9 +157,9 @@ export const Service: GenDescService<{
    * @generated from rpc protobuf_unittest.Service.DoStuff
    */
   doStuff: {
-    kind: "unary";
-    I: typeof TopLevelMessageDesc;
-    O: typeof TopLevelMessageDesc;
+    methodKind: "unary";
+    input: typeof TopLevelMessageDesc;
+    output: typeof TopLevelMessageDesc;
   },
 }
 > = /*@__PURE__*/

--- a/packages/protobuf-test/src/generate-code.test.ts
+++ b/packages/protobuf-test/src/generate-code.test.ts
@@ -158,24 +158,24 @@ test("ts generated code is assignable to js", () => {
 test("service generates as expected", () => {
   type Expected = {
     unary: {
-      kind: "unary";
-      I: typeof StringValueDesc;
-      O: typeof Int32ValueDesc;
+      methodKind: "unary";
+      input: typeof StringValueDesc;
+      output: typeof Int32ValueDesc;
     };
     serverStream: {
-      kind: "server_streaming";
-      I: typeof StringValueDesc;
-      O: typeof Int32ValueDesc;
+      methodKind: "server_streaming";
+      input: typeof StringValueDesc;
+      output: typeof Int32ValueDesc;
     };
     clientStream: {
-      kind: "client_streaming";
-      I: typeof StringValueDesc;
-      O: typeof Int32ValueDesc;
+      methodKind: "client_streaming";
+      input: typeof StringValueDesc;
+      output: typeof Int32ValueDesc;
     };
     bidi: {
-      kind: "bidi_streaming";
-      I: typeof StringValueDesc;
-      O: typeof Int32ValueDesc;
+      methodKind: "bidi_streaming";
+      input: typeof StringValueDesc;
+      output: typeof Int32ValueDesc;
     };
   };
   type Actual<T> = T extends GenDescService<infer Shape> ? Shape : never;

--- a/packages/protobuf/src/codegenv1/service.ts
+++ b/packages/protobuf/src/codegenv1/service.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { GenDescService, GenDescServiceShape } from "./types.js";
+import type { GenDescService, GenDescServiceMethods } from "./types.js";
 import type { DescFile } from "../descriptors.js";
 
 /**
@@ -20,7 +20,7 @@ import type { DescFile } from "../descriptors.js";
  *
  * @private
  */
-export function serviceDesc<T extends GenDescServiceShape>(
+export function serviceDesc<T extends GenDescServiceMethods>(
   file: DescFile,
   path: number,
   ...paths: number[]

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -75,7 +75,7 @@ export type GenDescExtension<
  *
  * @private
  */
-export type GenDescService<RuntimeShape extends GenDescServiceShape> = Omit<
+export type GenDescService<RuntimeShape extends GenDescServiceMethods> = Omit<
   DescService,
   "method"
 > & {
@@ -85,13 +85,10 @@ export type GenDescService<RuntimeShape extends GenDescServiceShape> = Omit<
 /**
  * @private
  */
-export type GenDescServiceShape = {
-  [localName: string]: {
-    input: DescMessage;
-    output: DescMessage;
-    methodKind: DescMethod["methodKind"];
-  };
-};
+export type GenDescServiceMethods = Record<
+  string,
+  Pick<DescMethod, "input" | "output" | "methodKind">
+>;
 
 class brand<A, B = unknown> {
   protected a: A | boolean = false;

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -19,6 +19,7 @@ import type {
   DescField,
   DescFile,
   DescMessage,
+  DescMethod,
   DescService,
 } from "../descriptors.js";
 
@@ -75,16 +76,18 @@ export type GenDescExtension<
  * @private
  */
 export type GenDescService<RuntimeShape extends GenDescServiceShape> =
-  DescService & brand<RuntimeShape>;
+  DescService & {
+    method: { [K in keyof RuntimeShape]: RuntimeShape[K] & DescMethod };
+  };
 
 /**
  * @private
  */
 export type GenDescServiceShape = {
   [localName: string]: {
-    kind: "unary" | "server_streaming" | "client_streaming" | "bidi_streaming";
-    I: DescMessage;
-    O: DescMessage;
+    input: DescMessage;
+    output: DescMessage;
+    methodKind: DescMethod["methodKind"];
   };
 };
 

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -75,10 +75,12 @@ export type GenDescExtension<
  *
  * @private
  */
-export type GenDescService<RuntimeShape extends GenDescServiceShape> =
-  DescService & {
-    method: { [K in keyof RuntimeShape]: RuntimeShape[K] & DescMethod };
-  };
+export type GenDescService<RuntimeShape extends GenDescServiceShape> = Omit<
+  DescService,
+  "method"
+> & {
+  method: { [K in keyof RuntimeShape]: RuntimeShape[K] & DescMethod };
+};
 
 /**
  * @private
@@ -104,9 +106,9 @@ class brand<A, B = unknown> {
 type MessageFieldNames<T extends Message> = Message extends T ? string :
   Exclude<keyof {
     [P in keyof T as
-      P extends ("$typeName" | "$unknown") ? never
-        : T[P] extends Oneof<infer K> ? K
-          : P
+    P extends ("$typeName" | "$unknown") ? never
+    : T[P] extends Oneof<infer K> ? K
+    : P
     ]-?: true;
   }, number | symbol>;
 

--- a/packages/protobuf/src/descriptors.ts
+++ b/packages/protobuf/src/descriptors.ts
@@ -667,6 +667,10 @@ export interface DescService {
    */
   readonly methods: DescMethod[];
   /**
+   * All methods of this service by their "localName".
+   */
+  readonly method: Record<string, DescMethod>;
+  /**
    * Marked as deprecated in the protobuf source.
    */
   readonly deprecated: boolean;

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -670,6 +670,7 @@ function addService(
     name: proto.name,
     typeName: makeTypeName(proto, undefined, file),
     methods: [],
+    method: {},
     toString(): string {
       return `service ${this.typeName}`;
     },
@@ -677,7 +678,9 @@ function addService(
   file.services.push(desc);
   reg.add(desc);
   for (const methodProto of proto.method) {
-    desc.methods.push(newMethod(methodProto, desc, reg));
+    const method = newMethod(methodProto, desc, reg);
+    desc.methods.push(method);
+    desc.method[method.localName] = method;
   }
 }
 

--- a/packages/protobuf/src/types.ts
+++ b/packages/protobuf/src/types.ts
@@ -80,9 +80,6 @@ export type UnknownField = {
   readonly data: Uint8Array;
 };
 
-// TODO ServiceShape?
-// TODO MethodShape?
-
 /**
  * The init type for a message, which makes all fields optional.
  * The init type is accepted by the function create().

--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -299,9 +299,9 @@ function getServiceShapeExpr(f: GeneratedFile, service: DescService): Printable 
   for (const method of service.methods) {
     print(f.jsDoc(method, "  "));
     print("  ", method.localName, ": {");
-    print("    kind: ", f.string(method.methodKind), ";");
-    print("    I: typeof ", f.importDesc(method.input, true), ";");
-    print("    O: typeof ", f.importDesc(method.output, true), ";");
+    print("    methodKind: ", f.string(method.methodKind), ";");
+    print("    input: typeof ", f.importDesc(method.input, true), ";");
+    print("    output: typeof ", f.importDesc(method.output, true), ";");
     print("  },");
   }
   print("}");

--- a/packages/protoplugin-example/src/gen/connectrpc/eliza_pb.ts
+++ b/packages/protoplugin-example/src/gen/connectrpc/eliza_pb.ts
@@ -77,9 +77,9 @@ export const ElizaService: GenDescService<{
    * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
    */
   say: {
-    kind: "unary";
-    I: typeof SayRequestDesc;
-    O: typeof SayResponseDesc;
+    methodKind: "unary";
+    input: typeof SayRequestDesc;
+    output: typeof SayResponseDesc;
   },
 }
 > = /*@__PURE__*/


### PR DESCRIPTION
Add `method` to `DescMethod` similar to `field` in `DescMessage`. This gives users easy access to method descriptors using their `localName`. 

This also aligns the generated types to match the value of this new field, the resulting type a is a strongly typed method descriptor.