### PR TITLE
V2: Relax validation in BinaryWriter

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 123,019 b | 63,933 b | 14,930 b |
-| protobuf-es | 4 | 125,214 b | 65,443 b | 15,592 b |
-| protobuf-es | 8 | 127,992 b | 67,214 b | 16,104 b |
-| protobuf-es | 16 | 138,500 b | 75,195 b | 18,432 b |
-| protobuf-es | 32 | 166,395 b | 97,210 b | 23,848 b |
+| protobuf-es | 1 | 123,350 b | 64,136 b | 14,970 b |
+| protobuf-es | 4 | 125,545 b | 65,646 b | 15,662 b |
+| protobuf-es | 8 | 128,323 b | 67,417 b | 16,196 b |
+| protobuf-es | 16 | 138,831 b | 75,398 b | 18,504 b |
+| protobuf-es | 32 | 166,726 b | 97,413 b | 23,953 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.7177734375 140,245.84296875 280,244.39296875 420,237.8 560,222.46171875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.6044921875 140,245.6447265625 280,244.132421875 420,237.59609375 560,222.16435546875">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.7177734375" r="4" fill="#ffa600"><title>protobuf-es 14.58 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.84296875" r="4" fill="#ffa600"><title>protobuf-es 15.23 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.39296875" r="4" fill="#ffa600"><title>protobuf-es 15.73 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.8" r="4" fill="#ffa600"><title>protobuf-es 18 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.46171875" r="4" fill="#ffa600"><title>protobuf-es 23.29 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.6044921875" r="4" fill="#ffa600"><title>protobuf-es 14.62 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.6447265625" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.132421875" r="4" fill="#ffa600"><title>protobuf-es 15.82 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.59609375" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.16435546875" r="4" fill="#ffa600"><title>protobuf-es 23.39 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf/src/reflect/guard.ts
+++ b/packages/protobuf/src/reflect/guard.ts
@@ -21,7 +21,6 @@ import type {
 } from "./reflect-types.js";
 import { unsafeLocal } from "./unsafe.js";
 import type { DescField, DescMessage } from "../descriptors.js";
-import { isMessage } from "../is-message.js";
 
 export function isObject(arg: unknown): arg is Record<string, unknown> {
   return arg !== null && typeof arg == "object" && !Array.isArray(arg);
@@ -102,8 +101,9 @@ export function isReflectMessage(
   return (
     isObject(arg) &&
     unsafeLocal in arg &&
-    "message" in arg &&
-    isMessage(arg.message) &&
-    (messageDesc === undefined || arg.message.$typeName == messageDesc.typeName)
+    "desc" in arg &&
+    isObject(arg.desc) &&
+    arg.desc.kind === "message" &&
+    (messageDesc === undefined || arg.desc.typeName == messageDesc.typeName)
   );
 }

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -568,29 +568,55 @@ export class BinaryReader {
 }
 
 /**
- * Assert a valid signed protobuf 32-bit integer.
+ * Assert a valid signed protobuf 32-bit integer as a number or string.
  */
 function assertInt32(arg: unknown): asserts arg is number {
-  if (typeof arg !== "number") throw new Error("invalid int32: " + typeof arg);
-  if (!Number.isInteger(arg) || arg > INT32_MAX || arg < INT32_MIN)
+  if (typeof arg == "string") {
+    arg = Number(arg);
+  } else if (typeof arg != "number") {
+    throw new Error("invalid int32: " + typeof arg);
+  }
+  if (
+    !Number.isInteger(arg) ||
+    (arg as number) > INT32_MAX ||
+    (arg as number) < INT32_MIN
+  )
     throw new Error("invalid int32: " + arg);
 }
 
 /**
- * Assert a valid unsigned protobuf 32-bit integer.
+ * Assert a valid unsigned protobuf 32-bit integer as a number or string.
  */
 function assertUInt32(arg: unknown): asserts arg is number {
-  if (typeof arg !== "number") throw new Error("invalid uint32: " + typeof arg);
-  if (!Number.isInteger(arg) || arg > UINT32_MAX || arg < 0)
+  if (typeof arg == "string") {
+    arg = Number(arg);
+  } else if (typeof arg != "number") {
+    throw new Error("invalid uint32: " + typeof arg);
+  }
+  if (
+    !Number.isInteger(arg) ||
+    (arg as number) > UINT32_MAX ||
+    (arg as number) < 0
+  )
     throw new Error("invalid uint32: " + arg);
 }
 
 /**
- * Assert a valid protobuf float value.
+ * Assert a valid protobuf float value as a number or string.
  */
 function assertFloat32(arg: unknown): asserts arg is number {
-  if (typeof arg !== "number")
+  if (typeof arg == "string") {
+    const o = arg;
+    arg = Number(arg);
+    if (isNaN(arg as number) && o !== "NaN") {
+      throw new Error("invalid float32: " + o);
+    }
+  } else if (typeof arg != "number") {
     throw new Error("invalid float32: " + typeof arg);
-  if (Number.isFinite(arg) && (arg > FLOAT32_MAX || arg < FLOAT32_MIN))
+  }
+  if (
+    Number.isFinite(arg) &&
+    ((arg as number) > FLOAT32_MAX || (arg as number) < FLOAT32_MIN)
+  )
     throw new Error("invalid float32: " + arg);
 }


### PR DESCRIPTION
BinaryWriter implements the Protobuf wire encoding. Its methods `int32`, `uint32`, `float`, `fixed32`, `sfixed32`, and `sint32` validate that the numbers passed in meet the constraint of the numeric type. For example, a `uint32` - an unsigned 32-bit integer - must not be negative.

The methods accept the TypeScript type `number`, but the implementation actually functions correctly if a string is passed, because of ECMAScript's implicit conversion.

This PR changes the validation to also accept a string, and covers the correct behavior with tests. The reason for this change is to make the BinaryWriter more useful outside of the protobuf-es runtime.

This PR does not change the method signatures. The intended use is still to pass in a number, the support for string is just for resilience.