### PR TITLE
V2: Bump `typescript` version in protoplugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "protobuf-es-5",
+  "name": "protobuf-es",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9321,8 +9321,8 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "dependencies": {
         "@bufbuild/protobuf": "2.0.0-alpha.4",
-        "@typescript/vfs": "^1.4.0",
-        "typescript": "4.5.2"
+        "@typescript/vfs": "^1.5.2",
+        "typescript": "5.4.5"
       },
       "devDependencies": {
         "@types/lz-string": "^1.5.0"
@@ -9358,23 +9358,11 @@
       }
     },
     "packages/protoplugin/node_modules/@typescript/vfs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.0.tgz",
-      "integrity": "sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.2.tgz",
+      "integrity": "sha512-RDp35jQj3/T5hiV8XQm6PDReqDoI8XI/dricpksgZ3LBlp4JUsL6AtKBXCOw5sdvvjrCtIrHONbVJz5row+IfQ==",
       "dependencies": {
         "debug": "^4.1.1"
-      }
-    },
-    "packages/protoplugin/node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/typescript-compat/v4.9.x": {

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "2.0.0-alpha.4",
-    "@typescript/vfs": "^1.4.0",
-    "typescript": "4.5.2"
+    "@typescript/vfs": "^1.5.2",
+    "typescript": "5.4.5"
   },
   "files": [
     "dist/**"

--- a/packages/protoplugin/src/transpile.ts
+++ b/packages/protoplugin/src/transpile.ts
@@ -45,7 +45,7 @@ const defaultOptions: ts.CompilerOptions = {
 
   // Language and Environment
   lib: [],
-  moduleDetection: "force",
+  moduleDetection: ts.ModuleDetectionKind.Force,
   target: ts.ScriptTarget.ES2017,
 
   // Completeness


### PR DESCRIPTION
Bump the `typescript` version for protoplugin. This reduces the download size, addressing #763.