### PR TITLE
V2: Throw errors in ReflectMessage instead of returning them

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 123,350 b | 64,136 b | 14,970 b |
-| protobuf-es | 4 | 125,545 b | 65,646 b | 15,662 b |
-| protobuf-es | 8 | 128,323 b | 67,417 b | 16,196 b |
-| protobuf-es | 16 | 138,831 b | 75,398 b | 18,504 b |
-| protobuf-es | 32 | 166,726 b | 97,413 b | 23,953 b |
+| protobuf-es | 1 | 123,305 b | 64,143 b | 15,010 b |
+| protobuf-es | 4 | 125,500 b | 65,653 b | 15,656 b |
+| protobuf-es | 8 | 128,278 b | 67,424 b | 16,182 b |
+| protobuf-es | 16 | 138,786 b | 75,405 b | 18,508 b |
+| protobuf-es | 32 | 166,681 b | 97,420 b | 23,963 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.6044921875 140,245.6447265625 280,244.132421875 420,237.59609375 560,222.16435546875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.4912109375 140,245.66171875 280,244.1720703125 420,237.584765625 560,222.13603515625">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.6044921875" r="4" fill="#ffa600"><title>protobuf-es 14.62 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.6447265625" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.132421875" r="4" fill="#ffa600"><title>protobuf-es 15.82 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.59609375" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.16435546875" r="4" fill="#ffa600"><title>protobuf-es 23.39 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.4912109375" r="4" fill="#ffa600"><title>protobuf-es 14.66 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.66171875" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.1720703125" r="4" fill="#ffa600"><title>protobuf-es 15.8 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.584765625" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.13603515625" r="4" fill="#ffa600"><title>protobuf-es 23.4 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/helpers.ts
+++ b/packages/protobuf-test/src/helpers.ts
@@ -16,7 +16,19 @@ import { UpstreamProtobuf } from "upstream-protobuf";
 import { fromBinary, createFileRegistry } from "@bufbuild/protobuf";
 import type { FileDescriptorSet } from "@bufbuild/protobuf/wkt";
 import { FileDescriptorSetDesc } from "@bufbuild/protobuf/wkt";
+import { FieldError } from "@bufbuild/protobuf/reflect";
 import assert from "node:assert";
+
+export function catchFieldError(fn: () => unknown): FieldError | undefined {
+  try {
+    fn();
+  } catch (e) {
+    if (e instanceof FieldError) {
+      return e;
+    }
+  }
+  return undefined;
+}
 
 let upstreamProtobuf: UpstreamProtobuf | undefined;
 

--- a/packages/protobuf-test/src/reflect/reflect-list.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect-list.test.ts
@@ -23,6 +23,7 @@ import * as proto3_ts from "../gen/ts/extra/proto3_pb.js";
 import { create, protoInt64 } from "@bufbuild/protobuf";
 import { UserDesc } from "../gen/ts/extra/example_pb.js";
 import assert from "node:assert";
+import { catchFieldError } from "../helpers.js";
 
 describe("reflectList()", () => {
   test("creates ReflectList", () => {
@@ -95,48 +96,49 @@ describe("ReflectList", () => {
     test("adds item", () => {
       const local: unknown[] = ["a"];
       const list = reflectList(repeatedStringField, local);
-      expect(list.add("b")).toBeUndefined();
-      expect(list.add("c")).toBeUndefined();
+      list.add("b");
+      list.add("c");
       expect(local).toStrictEqual(["a", "b", "c"]);
     });
     test("adds items", () => {
       const local: unknown[] = [];
       const list = reflectList(repeatedStringField, local);
-      expect(list.add("a", "b", "c")).toBeUndefined();
+      list.add("a", "b", "c");
       expect(local).toStrictEqual(["a", "b", "c"]);
     });
     test("does not add any item if one of several items is invalid", () => {
       const local: unknown[] = [];
       const list = reflectList(repeatedStringField, local);
-      expect(list.add("a", "b", true)).toBeDefined();
+      const err = catchFieldError(() => list.add("a", "b", true));
+      expect(err).toBeDefined();
       expect(local).toStrictEqual([]);
     });
     test("converts number, string, bigint to bigint for 64-bit integer field", () => {
       const local: unknown[] = [];
       const list = reflectList(repeatedInt64Field, local);
-      expect(list.add(1)).toBeUndefined();
-      expect(list.add("2")).toBeUndefined();
-      expect(list.add(n3)).toBeUndefined();
+      list.add(1);
+      list.add("2");
+      list.add(n3);
       expect(local).toStrictEqual([n1, n2, n3]);
     });
     test("converts number, string, bigint to string for 64-bit integer field with jstype=JS_STRING", () => {
       const local: unknown[] = [];
       const list = reflectList(repeatedInt64JsStringField, local);
-      expect(list.add(1)).toBeUndefined();
-      expect(list.add("2")).toBeUndefined();
-      expect(list.add(n3)).toBeUndefined();
+      list.add(1);
+      list.add("2");
+      list.add(n3);
       expect(local).toStrictEqual(["1", "2", "3"]);
     });
     test("returns error for wrong message type", () => {
       const list = reflectList(repeatedMessageField, []);
-      const err = list.add(reflect(UserDesc));
+      const err = catchFieldError(() => list.add(reflect(UserDesc)));
       expect(err?.message).toMatch(
         /^list item #1: expected ReflectMessage \(spec.Proto3Message\), got ReflectMessage \(docs.User\)$/,
       );
     });
     test("returns error for invalid scalar", () => {
       const list = reflectList(repeatedStringField, []);
-      const err = list.add(true);
+      const err = catchFieldError(() => list.add(true));
       expect(err?.message).toMatch(/^list item #1: expected string, got true$/);
     });
   });
@@ -144,38 +146,38 @@ describe("ReflectList", () => {
     test("replaces item at index", () => {
       const local: unknown[] = ["a", "b"];
       const list = reflectList(repeatedStringField, local);
-      expect(list.set(0, "c")).toBeUndefined();
+      list.set(0, "c");
       expect(local).toStrictEqual(["c", "b"]);
     });
     test("converts number, string, bigint to bigint for 64-bit integer field", () => {
       const local: unknown[] = [n0, n0, n0];
       const list = reflectList(repeatedInt64Field, local);
-      expect(list.set(0, 1)).toBeUndefined();
-      expect(list.set(1, "2")).toBeUndefined();
-      expect(list.set(2, n3)).toBeUndefined();
+      list.set(0, 1);
+      list.set(1, "2");
+      list.set(2, n3);
       expect(local).toStrictEqual([n1, n2, n3]);
     });
     test("converts number, string, bigint to string for 64-bit integer field with jstype=JS_STRING", () => {
       const local: unknown[] = ["0", "0", "0"];
       const list = reflectList(repeatedInt64JsStringField, local);
-      expect(list.set(0, 1)).toBeUndefined();
-      expect(list.set(1, "2")).toBeUndefined();
-      expect(list.set(2, n3)).toBeUndefined();
+      list.set(0, 1);
+      list.set(1, "2");
+      list.set(2, n3);
       expect(local).toStrictEqual(["1", "2", "3"]);
     });
-    test("returns error if out of range", () => {
+    test("throws error if out of range", () => {
       const list = reflectList(repeatedStringField, []);
-      const err = list.set(0, "abc");
+      const err = catchFieldError(() => list.set(0, "abc"));
       expect(err?.message).toMatch(/^list item #1: out of range$/);
     });
-    test("returns error for invalid scalar", () => {
+    test("throws error for invalid scalar", () => {
       const list = reflectList(repeatedStringField, [null]);
-      const err = list.set(0, true);
+      const err = catchFieldError(() => list.set(0, true));
       expect(err?.message).toMatch(/^list item #1: expected string, got true$/);
     });
-    test("returns error for wrong message type", () => {
+    test("throws error for wrong message type", () => {
       const list = reflectList(repeatedMessageField, [null]);
-      const err = list.set(0, reflect(UserDesc));
+      const err = catchFieldError(() => list.set(0, reflect(UserDesc)));
       expect(err?.message).toMatch(
         /^list item #1: expected ReflectMessage \(spec.Proto3Message\), got ReflectMessage \(docs.User\)$/,
       );

--- a/packages/protobuf-test/src/reflect/reflect-map.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect-map.test.ts
@@ -24,6 +24,7 @@ import { protoInt64 } from "@bufbuild/protobuf";
 import { UserDesc } from "../gen/ts/extra/example_pb.js";
 import { create } from "@bufbuild/protobuf";
 import assert from "node:assert";
+import { catchFieldError } from "../helpers.js";
 
 describe("reflectMap()", () => {
   test("creates ReflectMap", () => {
@@ -166,15 +167,15 @@ describe("ReflectMap", () => {
     test("sets entry", () => {
       const local = {};
       const map = reflectMap(mapStringStringField, local);
-      expect(map.set("a", "A")).toBeUndefined();
+      map.set("a", "A");
       expect(local).toStrictEqual({ a: "A" });
     });
     test("converts key", () => {
       const local = {};
       const map = reflectMap(mapInt64Int64Field, local);
-      expect(map.set(1, n11)).toBeUndefined();
-      expect(map.set(n2, n22)).toBeUndefined();
-      expect(map.set("3", n33)).toBeUndefined();
+      map.set(1, n11);
+      map.set(n2, n22);
+      map.set("3", n33);
       expect(local).toStrictEqual({
         "1": n11,
         "2": n22,
@@ -184,32 +185,32 @@ describe("ReflectMap", () => {
     test("converts long value", () => {
       const local = {};
       const map = reflectMap(mapInt64Int64Field, local);
-      expect(map.set(n1, n11)).toBeUndefined();
-      expect(map.set(n2, 22)).toBeUndefined();
-      expect(map.set(n3, "33")).toBeUndefined();
+      map.set(n1, n11);
+      map.set(n2, n22);
+      map.set(n3, n33);
       expect(local).toStrictEqual({
         "1": n11,
         "2": n22,
         "3": n33,
       });
     });
-    test("returns error for invalid key", () => {
+    test("throws error for invalid key", () => {
       const map = reflectMap(mapInt32Int32Field, {});
-      const err = map.set(true, "A");
+      const err = catchFieldError(() => map.set(true, "A"));
       expect(err?.message).toMatch(
         /^invalid map key: expected number \(int32\), got true$/,
       );
     });
-    test("returns error for invalid scalar value", () => {
+    test("throws error for invalid scalar value", () => {
       const map = reflectMap(mapStringStringField, {});
-      const err = map.set("a", true);
+      const err = catchFieldError(() => map.set("a", true));
       expect(err?.message).toMatch(
         /^map entry "a": expected string, got true$/,
       );
     });
-    test("returns error for wrong message type", () => {
+    test("throws error for wrong message type", () => {
       const map = reflectMap(mapInt32MessageField, {});
-      const err = map.set(1, reflect(UserDesc));
+      const err = catchFieldError(() => map.set(1, reflect(UserDesc)));
       expect(err?.message).toMatch(
         /^map entry 1: expected ReflectMessage \(spec.Proto3Message\), got ReflectMessage \(docs.User\)$/,
       );

--- a/packages/protobuf/src/clone.ts
+++ b/packages/protobuf/src/clone.ts
@@ -37,20 +37,14 @@ function cloneReflect(i: ReflectMessage): ReflectMessage {
     }
     switch (f.fieldKind) {
       default: {
-        const err = o.set(f, cloneSingular(f, i.get(f)));
-        if (err) {
-          throw err;
-        }
+        o.set(f, cloneSingular(f, i.get(f)));
         break;
       }
       case "list":
         // eslint-disable-next-line no-case-declarations
         const list = o.get(f);
         for (const item of i.get(f)) {
-          const err = list.add(cloneSingular(f, item));
-          if (err) {
-            throw err;
-          }
+          list.add(cloneSingular(f, item));
         }
         break;
       case "map":
@@ -58,10 +52,7 @@ function cloneReflect(i: ReflectMessage): ReflectMessage {
         const map = o.get(f);
         for (const entry of i.get(f).entries()) {
           // @ts-expect-error TODO fix type error
-          const err = map.set(entry[0], cloneSingular(f, entry[1]));
-          if (err) {
-            throw err;
-          }
+          map.set(entry[0], cloneSingular(f, entry[1]));
         }
         break;
     }

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -294,10 +294,7 @@ function readMapField(map: ReflectMap, json: JsonValue, opts: JsonReadOptions) {
     const key = mapKeyFromJson(field.mapKey, jsonMapKey);
     // TODO fix types
     // @ts-expect-error TODO
-    const err = map.set(key, value);
-    if (err) {
-      throw err;
-    }
+    map.set(key, value);
   }
 }
 
@@ -335,10 +332,7 @@ function readListField(
         }
         break;
       case "scalar":
-        const err = list.add(scalarFromJson(field, jsonItem, true));
-        if (err) {
-          throw err;
-        }
+        list.add(scalarFromJson(field, jsonItem, true));
         break;
     }
   }
@@ -384,10 +378,7 @@ function readScalarField(
   } else {
     // TODO fix type error
     // @ts-expect-error TODO
-    const err = msg.set(field, scalarValue);
-    if (err) {
-      throw err;
-    }
+    msg.set(field, scalarValue);
   }
 }
 
@@ -650,13 +641,7 @@ function tryWktFromJson(
         if (jsonValue === null) {
           msg.clear(valueField);
         } else {
-          const err = msg.set(
-            valueField,
-            scalarFromJson(valueField, jsonValue, true),
-          );
-          if (err) {
-            throw err;
-          }
+          msg.set(valueField, scalarFromJson(valueField, jsonValue, true));
         }
         return true;
       }

--- a/packages/protobuf/src/reflect/reflect-types.ts
+++ b/packages/protobuf/src/reflect/reflect-types.ts
@@ -17,7 +17,6 @@ import {
   type DescMessage,
   type DescOneof,
 } from "../descriptors.js";
-import { FieldError } from "./error.js";
 import { unsafeLocal } from "./unsafe.js";
 import type { Message, UnknownField } from "../types.js";
 import type { ScalarValue } from "./scalar.js";
@@ -135,13 +134,13 @@ export interface ReflectMessage {
    * - Map fields:
    *   ReflectMap.
    *
-   * Returns an error if the value is invalid for the field. `undefined` is not
+   * Throws an error if the value is invalid for the field. `undefined` is not
    * a valid value. To reset a field, use clear().
    */
   set<Field extends DescField>(
     field: Field,
     value: ReflectSetValue<Field>,
-  ): FieldError | undefined;
+  ): void;
 
   /**
    * Returns the unknown fields of the message.
@@ -186,16 +185,16 @@ export interface ReflectList<V = unknown> extends Iterable<V> {
 
   /**
    * Adds an item - or several items - at the end of the list.
-   * Returns an error if an item is invalid for this list.
+   * Throws an error if an item is invalid for this list.
    */
-  add(...item: V[]): FieldError | undefined;
+  add(...item: V[]): void;
 
   /**
    * Replaces the item at the specified index with the specified item.
-   * Returns an error if the index is out of range (index < 0 || index >= size).
-   * Returns an error if the item is invalid for this list.
+   * Throws an error if the index is out of range (index < 0 || index >= size).
+   * Throws an error if the item is invalid for this list.
    */
-  set(index: number, item: V): FieldError | undefined;
+  set(index: number, item: V): void;
 
   /**
    * Removes all items from the list.
@@ -239,9 +238,9 @@ export interface ReflectMap<K extends MapEntryKey = MapEntryKey, V = unknown>
 
   /**
    * Sets or replaces the item at the specified key with the specified value.
-   * Returns an error if the key or value is invalid for this map.
+   * Throws an error if the key or value is invalid for this map.
    */
-  set(key: K, value: V): FieldError | undefined;
+  set(key: K, value: V): this;
 
   /**
    * Removes all entries from the map.

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -189,12 +189,12 @@ class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
   set<Field extends DescField>(
     field: Field,
     value: ReflectSetValue<Field>,
-  ): FieldError | undefined {
+  ): void {
     assertOwn(this.message, field);
     if (this.check) {
       const err = checkField(field, value);
       if (err) {
-        return err;
+        throw err;
       }
     }
     let local: unknown;
@@ -207,7 +207,6 @@ class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
       local = longToLocal(field, value);
     }
     unsafeSet(this.message, field, local);
-    return undefined;
   }
 
   getUnknown(): UnknownField[] | undefined {
@@ -270,7 +269,7 @@ class ReflectListImpl<V> implements ReflectList<V> {
   }
   set(index: number, item: V) {
     if (index < 0 || index >= this._arr.length) {
-      return new FieldError(
+      throw new FieldError(
         this._field,
         `list item #${index + 1}: out of range`,
       );
@@ -278,18 +277,17 @@ class ReflectListImpl<V> implements ReflectList<V> {
     if (this.check) {
       const err = checkListItem(this._field, index, item);
       if (err) {
-        return err;
+        throw err;
       }
     }
     this._arr[index] = listItemToLocal(this._field, item);
-    return undefined;
   }
   add(...items: V[]) {
     if (this.check) {
       for (let i = 0; i < items.length; i++) {
         const err = checkListItem(this._field, this._arr.length + i, items[i]);
         if (err) {
-          return err;
+          throw err;
         }
       }
     }
@@ -352,11 +350,11 @@ class ReflectMapImpl<K extends MapEntryKey, V> implements ReflectMap<K, V> {
     if (this.check) {
       const err = checkMapEntry(this._field, key, value);
       if (err) {
-        return err;
+        throw err;
       }
     }
     this.obj[mapKeyToLocal(key)] = mapValueToLocal(this._field, value);
-    return undefined;
+    return this;
   }
   delete(key: K) {
     const k = mapKeyToLocal(key);


### PR DESCRIPTION
The reflection API provided by `ReflectMessage`, `ReflectList`, and `ReflectMap` validates a value before setting it. The methods return an error for an invalid value. For example: 

```ts
import { UserDesc } from "./gen/ts/extra/example_pb.js";
import { create } from "@bufbuild/protobuf";
import { reflect } from "@bufbuild/protobuf/reflect";

const user = create(UserDesc);
const msg = reflect(UserDesc, user);

const err = msg.set(UserDesc.field.firstName, 123);
console.log(err.message); // expected string, got 123
```

The `firstName` field is a string, and calling `msg.set` returns an error.

While this pattern works well, returning errors is very uncommon. This PR changes the behavior to throw errors instead. To handle the error, the example above changes to:

```ts
const user = create(UserDesc);
const msg = reflect(UserDesc, user);

try {
  msg.set(UserDesc.field.firstName, 123);
} catch (e) {
  if (isFieldError(e)) {
    console.log(e.message); // expected string, got 123
  }
}
```