### PR TITLE
V2: Avoid check in fromBinary

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 123,305 b | 64,143 b | 15,010 b |
-| protobuf-es | 4 | 125,500 b | 65,653 b | 15,656 b |
-| protobuf-es | 8 | 128,278 b | 67,424 b | 16,182 b |
-| protobuf-es | 16 | 138,786 b | 75,405 b | 18,508 b |
-| protobuf-es | 32 | 166,681 b | 97,420 b | 23,963 b |
+| protobuf-es | 1 | 123,170 b | 64,097 b | 14,966 b |
+| protobuf-es | 4 | 125,365 b | 65,607 b | 15,622 b |
+| protobuf-es | 8 | 128,143 b | 67,378 b | 16,140 b |
+| protobuf-es | 16 | 138,651 b | 75,359 b | 18,439 b |
+| protobuf-es | 32 | 166,546 b | 97,374 b | 23,911 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.4912109375 140,245.66171875 280,244.1720703125 420,237.584765625 560,222.13603515625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.6158203125 140,245.7580078125 280,244.291015625 420,237.78017578125 560,222.28330078124998">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.4912109375" r="4" fill="#ffa600"><title>protobuf-es 14.66 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.66171875" r="4" fill="#ffa600"><title>protobuf-es 15.29 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.1720703125" r="4" fill="#ffa600"><title>protobuf-es 15.8 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.584765625" r="4" fill="#ffa600"><title>protobuf-es 18.07 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.13603515625" r="4" fill="#ffa600"><title>protobuf-es 23.4 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.6158203125" r="4" fill="#ffa600"><title>protobuf-es 14.62 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.7580078125" r="4" fill="#ffa600"><title>protobuf-es 15.26 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.291015625" r="4" fill="#ffa600"><title>protobuf-es 15.76 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.78017578125" r="4" fill="#ffa600"><title>protobuf-es 18.01 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.28330078124998" r="4" fill="#ffa600"><title>protobuf-es 23.35 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/reflect/reflect-list.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect-list.test.ts
@@ -100,19 +100,6 @@ describe("ReflectList", () => {
       list.add("c");
       expect(local).toStrictEqual(["a", "b", "c"]);
     });
-    test("adds items", () => {
-      const local: unknown[] = [];
-      const list = reflectList(repeatedStringField, local);
-      list.add("a", "b", "c");
-      expect(local).toStrictEqual(["a", "b", "c"]);
-    });
-    test("does not add any item if one of several items is invalid", () => {
-      const local: unknown[] = [];
-      const list = reflectList(repeatedStringField, local);
-      const err = catchFieldError(() => list.add("a", "b", true));
-      expect(err).toBeDefined();
-      expect(local).toStrictEqual([]);
-    });
     test("converts number, string, bigint to bigint for 64-bit integer field", () => {
       const local: unknown[] = [];
       const list = reflectList(repeatedInt64Field, local);
@@ -129,14 +116,14 @@ describe("ReflectList", () => {
       list.add(n3);
       expect(local).toStrictEqual(["1", "2", "3"]);
     });
-    test("returns error for wrong message type", () => {
+    test("throws error for wrong message type", () => {
       const list = reflectList(repeatedMessageField, []);
       const err = catchFieldError(() => list.add(reflect(UserDesc)));
       expect(err?.message).toMatch(
         /^list item #1: expected ReflectMessage \(spec.Proto3Message\), got ReflectMessage \(docs.User\)$/,
       );
     });
-    test("returns error for invalid scalar", () => {
+    test("throws error for invalid scalar", () => {
       const list = reflectList(repeatedStringField, []);
       const err = catchFieldError(() => list.add(true));
       expect(err?.message).toMatch(/^list item #1: expected string, got true$/);

--- a/packages/protobuf-test/src/reflect/reflect.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect.test.ts
@@ -46,9 +46,7 @@ describe("reflect()", () => {
   });
   test("accepts option to disable field check", () => {
     const msg = create(proto3_ts.Proto3MessageDesc);
-    const r = reflect(proto3_ts.Proto3MessageDesc, msg, {
-      disableFieldValueCheck: true,
-    });
+    const r = reflect(proto3_ts.Proto3MessageDesc, msg, false);
     const field = r.findNumber(3);
     expect(field?.name).toBe("singular_int32_field");
     if (field) {

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -57,7 +57,7 @@ export function fromBinary<Desc extends DescMessage>(
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
 ): MessageShape<Desc> {
-  const msg = reflect(messageDesc);
+  const msg = reflect(messageDesc, undefined, false);
   readMessage(
     msg,
     new BinaryReader(bytes),
@@ -84,7 +84,7 @@ export function mergeFromBinary<Desc extends DescMessage>(
   options?: Partial<BinaryReadOptions>,
 ): MessageShape<Desc> {
   readMessage(
-    reflect(messageDesc, target),
+    reflect(messageDesc, target, false),
     new BinaryReader(bytes),
     makeReadOptions(options),
     false,
@@ -211,7 +211,7 @@ function readMapEntry(
         val = field.enum.values[0].number;
         break;
       case "message":
-        val = reflect(field.message);
+        val = reflect(field.message, undefined, false);
         break;
     }
   }
@@ -251,7 +251,7 @@ function readMessageField(
   mergeMessage?: ReflectMessage,
 ): ReflectMessage {
   const delimited = field.delimitedEncoding;
-  const message = mergeMessage ?? reflect(field.message);
+  const message = mergeMessage ?? reflect(field.message, undefined, false);
   readMessage(
     message,
     reader,

--- a/packages/protobuf/src/reflect/reflect-types.ts
+++ b/packages/protobuf/src/reflect/reflect-types.ts
@@ -184,10 +184,10 @@ export interface ReflectList<V = unknown> extends Iterable<V> {
   get(index: number): V | undefined;
 
   /**
-   * Adds an item - or several items - at the end of the list.
+   * Adds an item at the end of the list.
    * Throws an error if an item is invalid for this list.
    */
-  add(...item: V[]): void;
+  add(item: V): void;
 
   /**
    * Replaces the item at the specified index with the specified item.

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -49,26 +49,19 @@ import { isReflectList, isReflectMap, isReflectMessage } from "./guard.js";
 export function reflect<Desc extends DescMessage>(
   messageDesc: Desc,
   message?: MessageShape<Desc>,
-  // TODO either remove this option, or support it in reflect-list and reflect-map as well
-  opt?: {
-    /**
-     * By default, field values are validated when setting them. For example,
-     * a value for an uint32 field must be a ECMAScript Number >= 0.
-     *
-     * Note that setting a message field validates the type of the message,
-     * but does not check its fields.
-     *
-     * In some contexts, field values are trusted, and performance can be
-     * improved by disabling validation by setting disableFieldValueCheck to
-     * `false`.
-     */
-    disableFieldValueCheck?: boolean;
-  },
+  /**
+   * By default, field values are validated when setting them. For example,
+   * a value for an uint32 field must be a ECMAScript Number >= 0.
+   *
+   * When field values are trusted, performance can be improved by disabling
+   * checks.
+   */
+  check = true,
 ): ReflectMessage {
   return new ReflectMessageImpl<Desc>(
     messageDesc,
     message,
-    opt?.disableFieldValueCheck !== true,
+    check,
   );
 }
 
@@ -96,7 +89,6 @@ class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
   constructor(
     messageDesc: Desc,
     message?: MessageShape<Desc>,
-    // TODO either remove this option, or support it in reflect-list and reflect-map as well
     check = true,
   ) {
     this.check = check;
@@ -234,6 +226,13 @@ function assertOwn(owner: Message, member: DescField | DescOneof) {
 export function reflectList<V>(
   field: DescField & { fieldKind: "list" },
   unsafeInput?: unknown[],
+  /**
+   * By default, field values are validated when setting them. For example,
+   * a value for an uint32 field must be a ECMAScript Number >= 0.
+   *
+   * When field values are trusted, performance can be improved by disabling
+   * checks.
+   */
   check = true,
 ): ReflectList<V> {
   return new ReflectListImpl<V>(field, unsafeInput ?? [], check);
@@ -282,18 +281,14 @@ class ReflectListImpl<V> implements ReflectList<V> {
     }
     this._arr[index] = listItemToLocal(this._field, item);
   }
-  add(...items: V[]) {
+  add(item: V) {
     if (this.check) {
-      for (let i = 0; i < items.length; i++) {
-        const err = checkListItem(this._field, this._arr.length + i, items[i]);
-        if (err) {
-          throw err;
-        }
+      const err = checkListItem(this._field, this._arr.length, item);
+      if (err) {
+        throw err;
       }
     }
-    for (const item of items) {
-      this._arr.push(listItemToLocal(this._field, item));
-    }
+    this._arr.push(listItemToLocal(this._field, item));
     return undefined;
   }
   clear() {
@@ -323,6 +318,13 @@ class ReflectListImpl<V> implements ReflectList<V> {
 export function reflectMap<K extends MapEntryKey, V>(
   field: DescField & { fieldKind: "map" },
   unsafeInput?: Record<string, unknown>,
+  /**
+   * By default, field values are validated when setting them. For example,
+   * a value for an uint32 field must be a ECMAScript Number >= 0.
+   *
+   * When field values are trusted, performance can be improved by disabling
+   * checks.
+   */
   check = true,
 ): ReflectMap<K, V> {
   return new ReflectMapImpl(field, unsafeInput, check);

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -58,11 +58,7 @@ export function reflect<Desc extends DescMessage>(
    */
   check = true,
 ): ReflectMessage {
-  return new ReflectMessageImpl<Desc>(
-    messageDesc,
-    message,
-    check,
-  );
+  return new ReflectMessageImpl<Desc>(messageDesc, message, check);
 }
 
 class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
@@ -86,11 +82,7 @@ class ReflectMessageImpl<Desc extends DescMessage> implements ReflectMessage {
   private lists = new Map<DescField, ReflectList>();
   private maps = new Map<DescField, ReflectMap>();
 
-  constructor(
-    messageDesc: Desc,
-    message?: MessageShape<Desc>,
-    check = true,
-  ) {
+  constructor(messageDesc: Desc, message?: MessageShape<Desc>, check = true) {
     this.check = check;
     this.desc = messageDesc;
     this.message = this[unsafeLocal] = message ?? create(messageDesc);


### PR DESCRIPTION
When we parse from binary, we currently validate parsed values in the reflect API. This is not necessary, since types are already known when parsing from binary using the schema.

Skipping the checks increases performance:

```diff
- fromBinary perf-payload.bin x 7,026 ops/sec ±0.51% (92 runs sampled)
+ fromBinary perf-payload.bin x 9,546 ops/sec ±0.25% (97 runs sampled)
```

Tangentially, the signature of ReflectList.add is changed: It no longer uses a variadic argument, and accepts only a single value. This makes the API simpler and helps to improve performance.