### PR TITLE
Backport binary encoding from "wire" subpath

### DIFF
--- a/packages/protobuf-test/src/wire/binary-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/binary-encoding.test.ts
@@ -1,0 +1,230 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "@jest/globals";
+import { BinaryReader, BinaryWriter, WireType } from "@bufbuild/protobuf/wire";
+import { User } from "../gen/ts/extra/example_pb.js";
+
+it("wire/BinaryReader and wire/BinaryWriter interop with message classes", () => {
+  const user = new User({
+    firstName: "Homer",
+    active: true,
+  });
+  const bytes = user.toBinary({
+    writerFactory() {
+      return new BinaryWriter();
+    },
+  });
+  const user2 = User.fromBinary(bytes, {
+    readerFactory(bytes) {
+      return new BinaryReader(bytes);
+    },
+  });
+  expect(user2.firstName).toBe("Homer");
+  expect(user2.active).toBe(true);
+});
+
+describe("BinaryWriter", () => {
+  it("example should work as expected", () => {
+    const bytes = new BinaryWriter()
+      // string first_name = 1
+      .tag(1, WireType.LengthDelimited)
+      .string("Homer")
+      // bool active = 3
+      .tag(3, WireType.Varint)
+      .bool(true)
+      .finish();
+    const user = User.fromBinary(bytes);
+    expect(user.firstName).toBe("Homer");
+    expect(user.active).toBe(true);
+  });
+  describe("float32()", () => {
+    it.each([
+      1024,
+      3.142,
+      -3.142,
+      -1024,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.NaN,
+    ])("should encode %s", (val) => {
+      const bytes = new BinaryWriter().float(val).finish();
+      expect(bytes.length).toBeGreaterThan(0);
+      // @ts-expect-error test string
+      const bytesStr = new BinaryWriter().float(val.toString()).finish();
+      expect(bytesStr.length).toBeGreaterThan(0);
+      expect(bytesStr).toStrictEqual(bytes);
+    });
+    it.each([
+      { val: null, err: "invalid float32: object" },
+      { val: new Date(), err: "invalid float32: object" },
+      { val: undefined, err: "invalid float32: undefined" },
+      { val: true, err: "invalid float32: bool" },
+    ])("should error for wrong type $val", ({ val, err }) => {
+      // @ts-expect-error test wrong type
+      expect(() => new BinaryWriter().float(val)).toThrow(err);
+    });
+    it.each([Number.MAX_VALUE, -Number.MAX_VALUE])(
+      "should error for value out of range %s",
+      (val) => {
+        expect(() => new BinaryWriter().float(val)).toThrow(
+          /^invalid float32: .*/,
+        );
+        // @ts-expect-error test string
+        expect(() => new BinaryWriter().float(val.toString())).toThrow(
+          /^invalid float32: .*/,
+        );
+      },
+    );
+  });
+  // sfixed32, sint32, and int32 are signed 32-bit integers, just with different encoding
+  describe.each(["sfixed32", "sint32", "int32"] as const)("%s()", (type) => {
+    it.each([-0x80000000, 1024, 0x7fffffff])("should encode %s", (val) => {
+      const bytes = new BinaryWriter()[type](val).finish();
+      expect(bytes.length).toBeGreaterThan(0);
+      // @ts-expect-error test string
+      const bytesStr = new BinaryWriter()[type](val.toString()).finish();
+      expect(bytesStr.length).toBeGreaterThan(0);
+      expect(bytesStr).toStrictEqual(bytes);
+    });
+    it.each([
+      { val: null, err: "invalid int32: object" },
+      { val: new Date(), err: "invalid int32: object" },
+      { val: undefined, err: "invalid int32: undefined" },
+      { val: true, err: "invalid int32: bool" },
+    ])("should error for wrong type $val", ({ val, err }) => {
+      // @ts-expect-error TS2345
+      expect(() => new BinaryWriter()[type](val)).toThrow(err);
+    });
+    it.each([0x7fffffff + 1, -0x80000000 - 1, 3.142])(
+      "should error for value out of range %s",
+      (val) => {
+        expect(() => new BinaryWriter()[type](val)).toThrow(
+          /^invalid int32: .*/,
+        );
+        // @ts-expect-error test string
+        expect(() => new BinaryWriter()[type](val.toString())).toThrow(
+          /^invalid int32: .*/,
+        );
+      },
+    );
+  });
+  // fixed32 and uint32 are unsigned 32-bit integers, just with different encoding
+  describe.each(["fixed32", "uint32"] as const)("%s()", (type) => {
+    it.each([0, 1024, 0xffffffff])("should encode %s", (val) => {
+      const bytes = new BinaryWriter()[type](val).finish();
+      expect(bytes.length).toBeGreaterThan(0);
+      // @ts-expect-error test string
+      const bytesStr = new BinaryWriter()[type](val.toString()).finish();
+      expect(bytesStr.length).toBeGreaterThan(0);
+      expect(bytesStr).toStrictEqual(bytes);
+    });
+    it.each([
+      { val: null, err: `invalid uint32: object` },
+      { val: new Date(), err: `invalid uint32: object` },
+      { val: undefined, err: `invalid uint32: undefined` },
+      { val: true, err: `invalid uint32: bool` },
+    ])("should error for wrong type $val", ({ val, err }) => {
+      // @ts-expect-error TS2345
+      expect(() => new BinaryWriter()[type](val)).toThrow(err);
+    });
+    it.each([0xffffffff + 1, -1, 3.142])(
+      "should error for value out of range %s",
+      (val) => {
+        expect(() => new BinaryWriter()[type](val)).toThrow(
+          /^invalid uint32: .*/,
+        );
+        // @ts-expect-error test string
+        expect(() => new BinaryWriter()[type](val.toString())).toThrow(
+          /^invalid uint32: .*/,
+        );
+      },
+    );
+  });
+});
+
+describe("BinaryReader", () => {
+  describe("skip", () => {
+    it("should skip group", () => {
+      const reader = new BinaryReader(
+        new BinaryWriter()
+          .tag(1, WireType.StartGroup)
+          .tag(33, WireType.Varint)
+          .bool(true)
+          .tag(1, WireType.EndGroup)
+          .finish(),
+      );
+      const [fieldNo, wireType] = reader.tag();
+      expect(fieldNo).toBe(1);
+      expect(wireType).toBe(WireType.StartGroup);
+      reader.skip(WireType.StartGroup, 1);
+      expect(reader.pos).toBe(reader.len);
+    });
+    it("should skip nested group", () => {
+      const reader = new BinaryReader(
+        new BinaryWriter()
+          .tag(1, WireType.StartGroup)
+          .tag(1, WireType.StartGroup)
+          .tag(1, WireType.EndGroup)
+          .tag(1, WireType.EndGroup)
+          .finish(),
+      );
+      const [fieldNo, wireType] = reader.tag();
+      expect(fieldNo).toBe(1);
+      expect(wireType).toBe(WireType.StartGroup);
+      reader.skip(WireType.StartGroup, 1);
+      expect(reader.pos).toBe(reader.len);
+    });
+    it("should error on unexpected end group field number", () => {
+      const reader = new BinaryReader(
+        new BinaryWriter()
+          .tag(1, WireType.StartGroup)
+          .tag(2, WireType.EndGroup)
+          .finish(),
+      );
+      const [fieldNo, wireType] = reader.tag();
+      expect(fieldNo).toBe(1);
+      expect(wireType).toBe(WireType.StartGroup);
+      expect(() => {
+        reader.skip(WireType.StartGroup, 1);
+      }).toThrow(/^invalid end group tag$/);
+    });
+    it("should return skipped group data", () => {
+      const reader = new BinaryReader(
+        new BinaryWriter()
+          .tag(1, WireType.StartGroup)
+          .tag(33, WireType.Varint)
+          .bool(true)
+          .tag(1, WireType.EndGroup)
+          .finish(),
+      );
+      reader.tag();
+      const skipped = reader.skip(WireType.StartGroup, 1);
+      const sr = new BinaryReader(skipped);
+      {
+        const [fieldNo, wireType] = sr.tag();
+        expect(fieldNo).toBe(33);
+        expect(wireType).toBe(WireType.Varint);
+        const bool = sr.bool();
+        expect(bool).toBe(true);
+      }
+      {
+        const [fieldNo, wireType] = sr.tag();
+        expect(fieldNo).toBe(1);
+        expect(wireType).toBe(WireType.EndGroup);
+        expect(sr.pos).toBe(sr.len);
+      }
+    });
+  });
+});

--- a/packages/protobuf-test/src/wire/text-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/text-encoding.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  getTextEncoding,
+  configureTextEncoding,
+} from "@bufbuild/protobuf/wire";
+import { afterEach } from "node:test";
+
+describe("getTextEncoding()", () => {
+  test("returns TextEncoding", () => {
+    const te = getTextEncoding();
+    expect(te).toBeDefined();
+  });
+  test("returns same TextEncoding", () => {
+    const te1 = getTextEncoding();
+    const te2 = getTextEncoding();
+    expect(te2).toBe(te1);
+  });
+  describe("encodeUtf8()", () => {
+    test("encodes", () => {
+      const bytes = getTextEncoding().encodeUtf8("hello 🌍");
+      expect(bytes).toStrictEqual(
+        new Uint8Array([104, 101, 108, 108, 111, 32, 240, 159, 140, 141]),
+      );
+    });
+  });
+  describe("decodeUtf8()", () => {
+    test("decodes", () => {
+      const text = getTextEncoding().decodeUtf8(
+        new Uint8Array([104, 101, 108, 108, 111, 32, 240, 159, 140, 141]),
+      );
+      expect(text).toBe("hello 🌍");
+    });
+  });
+  describe("checkUtf8()", () => {
+    test("returns true for valid", () => {
+      const valid = "🌍";
+      const ok = getTextEncoding().checkUtf8(valid);
+      expect(ok).toBe(true);
+    });
+    test("returns false for invalid", () => {
+      const invalid = "🌍".substring(0, 1);
+      const ok = getTextEncoding().checkUtf8(invalid);
+      expect(ok).toBe(false);
+    });
+  });
+});
+
+describe("configureTextEncoding()", () => {
+  let backup: ReturnType<typeof getTextEncoding>;
+  beforeEach(() => {
+    backup = getTextEncoding();
+  });
+  afterEach(() => {
+    configureTextEncoding(backup);
+  });
+  test("configures checkUtf8", () => {
+    configureTextEncoding({
+      checkUtf8(text: string): boolean {
+        if (text === "valid") {
+          return true;
+        }
+        return false;
+      },
+      decodeUtf8: backup.decodeUtf8,
+      encodeUtf8: backup.encodeUtf8,
+    });
+    expect(getTextEncoding().checkUtf8("valid")).toBe(true);
+    expect(getTextEncoding().checkUtf8("no valid")).toBe(false);
+  });
+  test("configures checkUtf8", () => {
+    configureTextEncoding({
+      checkUtf8: backup.checkUtf8,
+      decodeUtf8: backup.decodeUtf8,
+      encodeUtf8: backup.encodeUtf8,
+    });
+    expect(getTextEncoding().checkUtf8("valid")).toBe(true);
+    expect(getTextEncoding().checkUtf8("no valid")).toBe(false);
+  });
+  test("configures decodeUtf8", () => {
+    let arg: Uint8Array | undefined;
+    configureTextEncoding({
+      checkUtf8: backup.checkUtf8,
+      decodeUtf8(bytes: Uint8Array): string {
+        arg = bytes;
+        return "custom decodeUtf8";
+      },
+      encodeUtf8: backup.encodeUtf8,
+    });
+    const bytes = new Uint8Array(10);
+    const text = getTextEncoding().decodeUtf8(bytes);
+    expect(text).toBe("custom decodeUtf8");
+    expect(arg).toBe(bytes);
+  });
+  test("configures encodeUtf8", () => {
+    let arg: string | undefined;
+    configureTextEncoding({
+      checkUtf8: backup.checkUtf8,
+      decodeUtf8: backup.decodeUtf8,
+      encodeUtf8(text: string): Uint8Array {
+        arg = text;
+        return new Uint8Array(10);
+      },
+    });
+    expect(getTextEncoding().encodeUtf8("test")).toStrictEqual(
+      new Uint8Array(10),
+    );
+    expect(arg).toBe("test");
+  });
+});

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -26,6 +26,17 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./wire": {
+      "import": "./dist/esm/wire/index.js",
+      "require": "./dist/cjs/wire/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "wire": [
+        "./dist/cjs/wire/index.d.ts"
+      ]
     }
   },
   "devDependencies": {

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -1,0 +1,622 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  varint32read,
+  varint32write,
+  varint64read,
+  varint64write,
+} from "../google/varint.js";
+import { protoInt64 } from "../proto-int64.js";
+import { getTextEncoding } from "./text-encoding.js";
+
+/* eslint-disable prefer-const,no-case-declarations,@typescript-eslint/restrict-plus-operands */
+
+/**
+ * Protobuf binary format wire types.
+ *
+ * A wire type provides just enough information to find the length of the
+ * following value.
+ *
+ * See https://developers.google.com/protocol-buffers/docs/encoding#structure
+ */
+export enum WireType {
+  /**
+   * Used for int32, int64, uint32, uint64, sint32, sint64, bool, enum
+   */
+  Varint = 0,
+
+  /**
+   * Used for fixed64, sfixed64, double.
+   * Always 8 bytes with little-endian byte order.
+   */
+  Bit64 = 1,
+
+  /**
+   * Used for string, bytes, embedded messages, packed repeated fields
+   *
+   * Only repeated numeric types (types which use the varint, 32-bit,
+   * or 64-bit wire types) can be packed. In proto3, such fields are
+   * packed by default.
+   */
+  LengthDelimited = 2,
+
+  /**
+   * Start of a tag-delimited aggregate, such as a proto2 group, or a message
+   * in editions with message_encoding = DELIMITED.
+   */
+  StartGroup = 3,
+
+  /**
+   * End of a tag-delimited aggregate.
+   */
+  EndGroup = 4,
+
+  /**
+   * Used for fixed32, sfixed32, float.
+   * Always 4 bytes with little-endian byte order.
+   */
+  Bit32 = 5,
+}
+
+/**
+ * Maximum value for a 32-bit floating point value (Protobuf FLOAT).
+ */
+export const FLOAT32_MAX = 3.4028234663852886e38;
+
+/**
+ * Minimum value for a 32-bit floating point value (Protobuf FLOAT).
+ */
+export const FLOAT32_MIN = -3.4028234663852886e38;
+
+/**
+ * Maximum value for an unsigned 32-bit integer (Protobuf UINT32, FIXED32).
+ */
+export const UINT32_MAX = 0xffffffff;
+
+/**
+ * Maximum value for a signed 32-bit integer (Protobuf INT32, SFIXED32, SINT32).
+ */
+export const INT32_MAX = 0x7fffffff;
+
+/**
+ * Minimum value for a signed 32-bit integer (Protobuf INT32, SFIXED32, SINT32).
+ */
+export const INT32_MIN = -0x80000000;
+
+export class BinaryWriter {
+  /**
+   * We cannot allocate a buffer for the entire output
+   * because we don't know it's size.
+   *
+   * So we collect smaller chunks of known size and
+   * concat them later.
+   *
+   * Use `raw()` to push data to this array. It will flush
+   * `buf` first.
+   */
+  private chunks: Uint8Array[];
+
+  /**
+   * A growing buffer for byte values. If you don't know
+   * the size of the data you are writing, push to this
+   * array.
+   */
+  protected buf: number[];
+
+  /**
+   * Previous fork states.
+   */
+  private stack: Array<{ chunks: Uint8Array[]; buf: number[] }> = [];
+
+  constructor(
+    private readonly encodeUtf8: (
+      text: string,
+    ) => Uint8Array = getTextEncoding().encodeUtf8,
+  ) {
+    this.chunks = [];
+    this.buf = [];
+  }
+
+  /**
+   * Return all bytes written and reset this writer.
+   */
+  finish(): Uint8Array {
+    this.chunks.push(new Uint8Array(this.buf)); // flush the buffer
+    let len = 0;
+    for (let i = 0; i < this.chunks.length; i++) len += this.chunks[i].length;
+    let bytes = new Uint8Array(len);
+    let offset = 0;
+    for (let i = 0; i < this.chunks.length; i++) {
+      bytes.set(this.chunks[i], offset);
+      offset += this.chunks[i].length;
+    }
+    this.chunks = [];
+    return bytes;
+  }
+
+  /**
+   * Start a new fork for length-delimited data like a message
+   * or a packed repeated field.
+   *
+   * Must be joined later with `join()`.
+   */
+  fork(): this {
+    this.stack.push({ chunks: this.chunks, buf: this.buf });
+    this.chunks = [];
+    this.buf = [];
+    return this;
+  }
+
+  /**
+   * Join the last fork. Write its length and bytes, then
+   * return to the previous state.
+   */
+  join(): this {
+    // get chunk of fork
+    let chunk = this.finish();
+
+    // restore previous state
+    let prev = this.stack.pop();
+    if (!prev) throw new Error("invalid state, fork stack empty");
+    this.chunks = prev.chunks;
+    this.buf = prev.buf;
+
+    // write length of chunk as varint
+    this.uint32(chunk.byteLength);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Writes a tag (field number and wire type).
+   *
+   * Equivalent to `uint32( (fieldNo << 3 | type) >>> 0 )`.
+   *
+   * Generated code should compute the tag ahead of time and call `uint32()`.
+   */
+  tag(fieldNo: number, type: WireType): this {
+    return this.uint32(((fieldNo << 3) | type) >>> 0);
+  }
+
+  /**
+   * Write a chunk of raw bytes.
+   */
+  raw(chunk: Uint8Array): this {
+    if (this.buf.length) {
+      this.chunks.push(new Uint8Array(this.buf));
+      this.buf = [];
+    }
+    this.chunks.push(chunk);
+    return this;
+  }
+
+  /**
+   * Write a `uint32` value, an unsigned 32 bit varint.
+   */
+  uint32(value: number): this {
+    assertUInt32(value);
+
+    // write value as varint 32, inlined for speed
+    while (value > 0x7f) {
+      this.buf.push((value & 0x7f) | 0x80);
+      value = value >>> 7;
+    }
+    this.buf.push(value);
+
+    return this;
+  }
+
+  /**
+   * Write a `int32` value, a signed 32 bit varint.
+   */
+  int32(value: number): this {
+    assertInt32(value);
+    varint32write(value, this.buf);
+    return this;
+  }
+
+  /**
+   * Write a `bool` value, a variant.
+   */
+  bool(value: boolean): this {
+    this.buf.push(value ? 1 : 0);
+    return this;
+  }
+
+  /**
+   * Write a `bytes` value, length-delimited arbitrary data.
+   */
+  bytes(value: Uint8Array): this {
+    this.uint32(value.byteLength); // write length of chunk as varint
+    return this.raw(value);
+  }
+
+  /**
+   * Write a `string` value, length-delimited data converted to UTF-8 text.
+   */
+  string(value: string): this {
+    let chunk = this.encodeUtf8(value);
+    this.uint32(chunk.byteLength); // write length of chunk as varint
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `float` value, 32-bit floating point number.
+   */
+  float(value: number): this {
+    assertFloat32(value);
+    let chunk = new Uint8Array(4);
+    new DataView(chunk.buffer).setFloat32(0, value, true);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `double` value, a 64-bit floating point number.
+   */
+  double(value: number): this {
+    let chunk = new Uint8Array(8);
+    new DataView(chunk.buffer).setFloat64(0, value, true);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `fixed32` value, an unsigned, fixed-length 32-bit integer.
+   */
+  fixed32(value: number): this {
+    assertUInt32(value);
+    let chunk = new Uint8Array(4);
+    new DataView(chunk.buffer).setUint32(0, value, true);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `sfixed32` value, a signed, fixed-length 32-bit integer.
+   */
+  sfixed32(value: number): this {
+    assertInt32(value);
+    let chunk = new Uint8Array(4);
+    new DataView(chunk.buffer).setInt32(0, value, true);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `sint32` value, a signed, zigzag-encoded 32-bit varint.
+   */
+  sint32(value: number): this {
+    assertInt32(value);
+    // zigzag encode
+    value = ((value << 1) ^ (value >> 31)) >>> 0;
+    varint32write(value, this.buf);
+    return this;
+  }
+
+  /**
+   * Write a `fixed64` value, a signed, fixed-length 64-bit integer.
+   */
+  sfixed64(value: string | number | bigint): this {
+    let chunk = new Uint8Array(8),
+      view = new DataView(chunk.buffer),
+      tc = protoInt64.enc(value);
+    view.setInt32(0, tc.lo, true);
+    view.setInt32(4, tc.hi, true);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `fixed64` value, an unsigned, fixed-length 64 bit integer.
+   */
+  fixed64(value: string | number | bigint): this {
+    let chunk = new Uint8Array(8),
+      view = new DataView(chunk.buffer),
+      tc = protoInt64.uEnc(value);
+    view.setInt32(0, tc.lo, true);
+    view.setInt32(4, tc.hi, true);
+    return this.raw(chunk);
+  }
+
+  /**
+   * Write a `int64` value, a signed 64-bit varint.
+   */
+  int64(value: string | number | bigint): this {
+    let tc = protoInt64.enc(value);
+    varint64write(tc.lo, tc.hi, this.buf);
+    return this;
+  }
+
+  /**
+   * Write a `sint64` value, a signed, zig-zag-encoded 64-bit varint.
+   */
+  sint64(value: string | number | bigint): this {
+    let tc = protoInt64.enc(value),
+      // zigzag encode
+      sign = tc.hi >> 31,
+      lo = (tc.lo << 1) ^ sign,
+      hi = ((tc.hi << 1) | (tc.lo >>> 31)) ^ sign;
+    varint64write(lo, hi, this.buf);
+    return this;
+  }
+
+  /**
+   * Write a `uint64` value, an unsigned 64-bit varint.
+   */
+  uint64(value: string | number | bigint): this {
+    let tc = protoInt64.uEnc(value);
+    varint64write(tc.lo, tc.hi, this.buf);
+    return this;
+  }
+}
+
+export class BinaryReader {
+  /**
+   * Current position.
+   */
+  pos: number;
+
+  /**
+   * Number of bytes available in this reader.
+   */
+  readonly len: number;
+
+  protected readonly buf: Uint8Array;
+  private readonly view: DataView;
+
+  constructor(
+    buf: Uint8Array,
+    private readonly decodeUtf8: (
+      bytes: Uint8Array,
+    ) => string = getTextEncoding().decodeUtf8,
+  ) {
+    this.buf = buf;
+    this.len = buf.length;
+    this.pos = 0;
+    this.view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+
+  /**
+   * Reads a tag - field number and wire type.
+   */
+  tag(): [number, WireType] {
+    let tag = this.uint32(),
+      fieldNo = tag >>> 3,
+      wireType = tag & 7;
+    if (fieldNo <= 0 || wireType < 0 || wireType > 5)
+      throw new Error(
+        "illegal tag: field no " + fieldNo + " wire type " + wireType,
+      );
+    return [fieldNo, wireType];
+  }
+
+  /**
+   * Skip one element and return the skipped data.
+   *
+   * When skipping StartGroup, provide the tags field number to check for
+   * matching field number in the EndGroup tag.
+   */
+  skip(wireType: WireType, fieldNo?: number): Uint8Array {
+    let start = this.pos;
+    switch (wireType) {
+      case WireType.Varint:
+        while (this.buf[this.pos++] & 0x80) {
+          // ignore
+        }
+        break;
+      // eslint-disable-next-line
+      // @ts-expect-error TS7029: Fallthrough case in switch
+      case WireType.Bit64:
+        this.pos += 4;
+      // eslint-disable-next-line no-fallthrough
+      case WireType.Bit32:
+        this.pos += 4;
+        break;
+      case WireType.LengthDelimited:
+        let len = this.uint32();
+        this.pos += len;
+        break;
+      case WireType.StartGroup:
+        for (;;) {
+          const [fn, wt] = this.tag();
+          if (wt === WireType.EndGroup) {
+            if (fieldNo !== undefined && fn !== fieldNo) {
+              throw new Error("invalid end group tag");
+            }
+            break;
+          }
+          this.skip(wt, fn);
+        }
+        break;
+      default:
+        throw new Error("cant skip wire type " + wireType);
+    }
+    this.assertBounds();
+    return this.buf.subarray(start, this.pos);
+  }
+
+  protected varint64 = varint64read as () => [number, number]; // dirty cast for `this`
+
+  /**
+   * Throws error if position in byte array is out of range.
+   */
+  protected assertBounds(): void {
+    if (this.pos > this.len) throw new RangeError("premature EOF");
+  }
+
+  /**
+   * Read a `uint32` field, an unsigned 32 bit varint.
+   */
+  uint32: () => number = varint32read;
+
+  /**
+   * Read a `int32` field, a signed 32 bit varint.
+   */
+  int32(): number {
+    return this.uint32() | 0;
+  }
+
+  /**
+   * Read a `sint32` field, a signed, zigzag-encoded 32-bit varint.
+   */
+  sint32(): number {
+    let zze = this.uint32();
+    // decode zigzag
+    return (zze >>> 1) ^ -(zze & 1);
+  }
+
+  /**
+   * Read a `int64` field, a signed 64-bit varint.
+   */
+  int64(): bigint | string {
+    return protoInt64.dec(...this.varint64());
+  }
+
+  /**
+   * Read a `uint64` field, an unsigned 64-bit varint.
+   */
+  uint64(): bigint | string {
+    return protoInt64.uDec(...this.varint64());
+  }
+
+  /**
+   * Read a `sint64` field, a signed, zig-zag-encoded 64-bit varint.
+   */
+  sint64(): bigint | string {
+    let [lo, hi] = this.varint64();
+    // decode zig zag
+    let s = -(lo & 1);
+    lo = ((lo >>> 1) | ((hi & 1) << 31)) ^ s;
+    hi = (hi >>> 1) ^ s;
+    return protoInt64.dec(lo, hi);
+  }
+
+  /**
+   * Read a `bool` field, a variant.
+   */
+  bool(): boolean {
+    let [lo, hi] = this.varint64();
+    return lo !== 0 || hi !== 0;
+  }
+
+  /**
+   * Read a `fixed32` field, an unsigned, fixed-length 32-bit integer.
+   */
+  fixed32(): number {
+    return this.view.getUint32((this.pos += 4) - 4, true);
+  }
+
+  /**
+   * Read a `sfixed32` field, a signed, fixed-length 32-bit integer.
+   */
+  sfixed32(): number {
+    return this.view.getInt32((this.pos += 4) - 4, true);
+  }
+
+  /**
+   * Read a `fixed64` field, an unsigned, fixed-length 64 bit integer.
+   */
+  fixed64(): bigint | string {
+    return protoInt64.uDec(this.sfixed32(), this.sfixed32());
+  }
+
+  /**
+   * Read a `fixed64` field, a signed, fixed-length 64-bit integer.
+   */
+  sfixed64(): bigint | string {
+    return protoInt64.dec(this.sfixed32(), this.sfixed32());
+  }
+
+  /**
+   * Read a `float` field, 32-bit floating point number.
+   */
+  float(): number {
+    return this.view.getFloat32((this.pos += 4) - 4, true);
+  }
+
+  /**
+   * Read a `double` field, a 64-bit floating point number.
+   */
+  double(): number {
+    return this.view.getFloat64((this.pos += 8) - 8, true);
+  }
+
+  /**
+   * Read a `bytes` field, length-delimited arbitrary data.
+   */
+  bytes(): Uint8Array {
+    let len = this.uint32(),
+      start = this.pos;
+    this.pos += len;
+    this.assertBounds();
+    return this.buf.subarray(start, start + len);
+  }
+
+  /**
+   * Read a `string` field, length-delimited data converted to UTF-8 text.
+   */
+  string(): string {
+    return this.decodeUtf8(this.bytes());
+  }
+}
+
+/**
+ * Assert a valid signed protobuf 32-bit integer as a number or string.
+ */
+function assertInt32(arg: unknown): asserts arg is number {
+  if (typeof arg == "string") {
+    arg = Number(arg);
+  } else if (typeof arg != "number") {
+    throw new Error("invalid int32: " + typeof arg);
+  }
+  if (
+    !Number.isInteger(arg) ||
+    (arg as number) > INT32_MAX ||
+    (arg as number) < INT32_MIN
+  )
+    throw new Error("invalid int32: " + arg);
+}
+
+/**
+ * Assert a valid unsigned protobuf 32-bit integer as a number or string.
+ */
+function assertUInt32(arg: unknown): asserts arg is number {
+  if (typeof arg == "string") {
+    arg = Number(arg);
+  } else if (typeof arg != "number") {
+    throw new Error("invalid uint32: " + typeof arg);
+  }
+  if (
+    !Number.isInteger(arg) ||
+    (arg as number) > UINT32_MAX ||
+    (arg as number) < 0
+  )
+    throw new Error("invalid uint32: " + arg);
+}
+
+/**
+ * Assert a valid protobuf float value as a number or string.
+ */
+function assertFloat32(arg: unknown): asserts arg is number {
+  if (typeof arg == "string") {
+    const o = arg;
+    arg = Number(arg);
+    if (isNaN(arg as number) && o !== "NaN") {
+      throw new Error("invalid float32: " + o);
+    }
+  } else if (typeof arg != "number") {
+    throw new Error("invalid float32: " + typeof arg);
+  }
+  if (
+    Number.isFinite(arg) &&
+    ((arg as number) > FLOAT32_MAX || (arg as number) < FLOAT32_MIN)
+  )
+    throw new Error("invalid float32: " + arg);
+}

--- a/packages/protobuf/src/wire/index.ts
+++ b/packages/protobuf/src/wire/index.ts
@@ -12,9 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { JsonValue } from "../json-format.js";
-
-/**
- *
- */
-export type OptionsMap = { readonly [extensionName: string]: JsonValue };
+export * from "./binary-encoding.js";
+export * from "./text-encoding.js";

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -1,0 +1,71 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const symbol = Symbol.for("@bufbuild/protobuf/text-encoding");
+
+interface TextEncoding {
+  /**
+   * Verify that the given text is valid UTF-8.
+   */
+  checkUtf8: (text: string) => boolean;
+  /**
+   * Encode UTF-8 text to binary.
+   */
+  encodeUtf8: (text: string) => Uint8Array;
+  /**
+   * Decode UTF-8 text from binary.
+   */
+  decodeUtf8: (bytes: Uint8Array) => string;
+}
+
+/**
+ * Protobuf-ES requires the Text Encoding API to convert UTF-8 from and to
+ * binary. This WHATWG API is widely available, but it is not part of the
+ * ECMAScript standard. On runtimes where it is not available, use this
+ * function to provide your own implementation.
+ *
+ * Note that the Text Encoding API does not provide a way to validate UTF-8.
+ * Our implementation falls back to use encodeURIComponent().
+ */
+export function configureTextEncoding(textEncoding: TextEncoding): void {
+  (globalThis as GlobalWithTextEncoding)[symbol] = textEncoding;
+}
+
+export function getTextEncoding() {
+  if ((globalThis as GlobalWithTextEncoding)[symbol] == undefined) {
+    const te = new globalThis.TextEncoder();
+    const td = new globalThis.TextDecoder();
+    (globalThis as GlobalWithTextEncoding)[symbol] = {
+      encodeUtf8(text: string): Uint8Array {
+        return te.encode(text);
+      },
+      decodeUtf8(bytes: Uint8Array): string {
+        return td.decode(bytes);
+      },
+      checkUtf8(text: string): boolean {
+        try {
+          encodeURIComponent(text);
+          return true;
+        } catch (e) {
+          return false;
+        }
+      },
+    };
+  }
+  return (globalThis as GlobalWithTextEncoding)[symbol] as TextEncoding;
+}
+
+type GlobalWithTextEncoding = {
+  [symbol]?: TextEncoding;
+};

--- a/packages/protobuf/tsconfig.json
+++ b/packages/protobuf/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "files": [
-    "src/index.ts",
-    "src/private/options-map.ts" // not yet exported, added here to satisfy the linter
-  ],
+  "files": ["src/index.ts", "src/wire/index.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": [


### PR DESCRIPTION
In the upcoming [version 2](https://github.com/bufbuild/protobuf-es/releases/tag/v2.0.0-alpha.1), we relaxed validation in BinaryWriter (see https://github.com/bufbuild/protobuf-es/pull/877), and provided a better way for users to bring their own UTF-8 encoder (see https://github.com/bufbuild/protobuf-es/commit/70805568da3058ba2454c614d864ad1266362074).

For better interoperability between v1 and v2, this PR backports the relevant parts of the "wire" subpath. 
