### PR TITLE
V2: Add typeOnly argument to GeneratedFile.import

### DIFF
--- a/packages/protoplugin-test/src/file-import.test.ts
+++ b/packages/protoplugin-test/src/file-import.test.ts
@@ -52,4 +52,14 @@ describe("GeneratedFile.import", () => {
       },
     });
   });
+  test("should honor typeOnly argument", async function () {
+    await createTestPluginAndRun({
+      proto: `syntax="proto3";`,
+      parameter: "target=ts",
+      generateAny(f) {
+        const imp = f.import("Foo", "@scope/pkg", true);
+        expect(imp.typeOnly).toBe(true);
+      },
+    });
+  });
 });

--- a/packages/protoplugin/src/generated-file.ts
+++ b/packages/protoplugin/src/generated-file.ts
@@ -134,11 +134,16 @@ export interface GeneratedFile {
    * relative to the project root. The import path is automatically made
    * relative to the current file.
    */
-  import(name: string, from: string): ImportSymbol;
+  import(name: string, from: string, typeOnly?: boolean): ImportSymbol;
 
   /**
    * In case you need full control over exports and imports, use print() and
    * formulate your own imports and exports based on this property.
+   *
+   * With the plugin option `js_import_style=legacy_commonjs`, this property
+   * reports "legacy_commonjs", but only if the current target is "js".
+   * This matches the behavior of import(), which also only generates CommonJS
+   * under this condition.
    */
   readonly jsImportStyle: "module" | "legacy_commonjs";
 
@@ -239,8 +244,8 @@ export function createGeneratedFile(
     importShape(desc) {
       return resolveShapeImport(desc);
     },
-    import(name, from) {
-      return createImportSymbol(name, from);
+    import(name, from, typeOnly = false) {
+      return createImportSymbol(name, from, typeOnly);
     },
     jsImportStyle,
     runtime,


### PR DESCRIPTION
GeneratedFile.importDesc has an optional typeOnly argument - GeneratedFile.import should have it too.