### PR TITLE
V2: Fix create() with wrapper oneof field

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 123,170 b | 64,097 b | 14,966 b |
-| protobuf-es | 4 | 125,365 b | 65,607 b | 15,622 b |
-| protobuf-es | 8 | 128,143 b | 67,378 b | 16,140 b |
-| protobuf-es | 16 | 138,651 b | 75,359 b | 18,439 b |
-| protobuf-es | 32 | 166,546 b | 97,374 b | 23,911 b |
+| protobuf-es | 1 | 123,186 b | 64,107 b | 14,974 b |
+| protobuf-es | 4 | 125,381 b | 65,617 b | 15,624 b |
+| protobuf-es | 8 | 128,159 b | 67,388 b | 16,147 b |
+| protobuf-es | 16 | 138,667 b | 75,369 b | 18,490 b |
+| protobuf-es | 32 | 166,562 b | 97,384 b | 23,962 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.6158203125 140,245.7580078125 280,244.291015625 420,237.78017578125 560,222.28330078124998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.5931640625 140,245.75234375 280,244.27119140625 420,237.6357421875 560,222.1388671875">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="247.6158203125" r="4" fill="#ffa600"><title>protobuf-es 14.62 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.7580078125" r="4" fill="#ffa600"><title>protobuf-es 15.26 KiB for 4 files</title></circle>
-<circle cx="280" cy="244.291015625" r="4" fill="#ffa600"><title>protobuf-es 15.76 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.78017578125" r="4" fill="#ffa600"><title>protobuf-es 18.01 KiB for 16 files</title></circle>
-<circle cx="560" cy="222.28330078124998" r="4" fill="#ffa600"><title>protobuf-es 23.35 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.5931640625" r="4" fill="#ffa600"><title>protobuf-es 14.62 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.75234375" r="4" fill="#ffa600"><title>protobuf-es 15.26 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.27119140625" r="4" fill="#ffa600"><title>protobuf-es 15.77 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.6357421875" r="4" fill="#ffa600"><title>protobuf-es 18.06 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.1388671875" r="4" fill="#ffa600"><title>protobuf-es 23.4 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/create.test.ts
+++ b/packages/protobuf-test/src/create.test.ts
@@ -846,9 +846,7 @@ describe("create()", () => {
               value: 123,
             },
           },
-          repeatedWrappedUint32Field: [
-            { value: 123 }
-          ],
+          repeatedWrappedUint32Field: [{ value: 123 }],
           mapInt32WrappedUint32Field: {
             123: {
               value: 123,
@@ -858,13 +856,19 @@ describe("create()", () => {
         expect(msg.singularWrappedUint32Field).toBe(123);
         expect(msg.either.case).toBe("oneofWrappedUint32Field");
         if (msg.either.case == "oneofWrappedUint32Field") {
-          expect(msg.either.value.$typeName).toBe("google.protobuf.UInt32Value");
+          expect(msg.either.value.$typeName).toBe(
+            "google.protobuf.UInt32Value",
+          );
           expect(msg.either.value.value).toBe(123);
         }
         expect(msg.repeatedWrappedUint32Field.length).toBe(1);
-        expect(msg.repeatedWrappedUint32Field[0].$typeName).toBe("google.protobuf.UInt32Value");
+        expect(msg.repeatedWrappedUint32Field[0].$typeName).toBe(
+          "google.protobuf.UInt32Value",
+        );
         expect(msg.repeatedWrappedUint32Field[0].value).toBe(123);
-        expect(msg.mapInt32WrappedUint32Field[123].$typeName).toBe("google.protobuf.UInt32Value");
+        expect(msg.mapInt32WrappedUint32Field[123].$typeName).toBe(
+          "google.protobuf.UInt32Value",
+        );
         expect(msg.mapInt32WrappedUint32Field[123].value).toBe(123);
       });
     });

--- a/packages/protobuf-test/src/create.test.ts
+++ b/packages/protobuf-test/src/create.test.ts
@@ -837,11 +837,35 @@ describe("create()", () => {
       });
     });
     describe("wkt wrapper field", () => {
-      test("accepts unwrapped value", () => {
+      test("accepts unwrapped value only for singular field", () => {
         const msg = create(proto3_ts.Proto3MessageDesc, {
           singularWrappedUint32Field: 123,
+          either: {
+            case: "oneofWrappedUint32Field",
+            value: {
+              value: 123,
+            },
+          },
+          repeatedWrappedUint32Field: [
+            { value: 123 }
+          ],
+          mapInt32WrappedUint32Field: {
+            123: {
+              value: 123,
+            },
+          },
         });
         expect(msg.singularWrappedUint32Field).toBe(123);
+        expect(msg.either.case).toBe("oneofWrappedUint32Field");
+        if (msg.either.case == "oneofWrappedUint32Field") {
+          expect(msg.either.value.$typeName).toBe("google.protobuf.UInt32Value");
+          expect(msg.either.value.value).toBe(123);
+        }
+        expect(msg.repeatedWrappedUint32Field.length).toBe(1);
+        expect(msg.repeatedWrappedUint32Field[0].$typeName).toBe("google.protobuf.UInt32Value");
+        expect(msg.repeatedWrappedUint32Field[0].value).toBe(123);
+        expect(msg.mapInt32WrappedUint32Field[123].$typeName).toBe("google.protobuf.UInt32Value");
+        expect(msg.mapInt32WrappedUint32Field[123].value).toBe(123);
       });
     });
   });

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -83,7 +83,7 @@ function initMessage<Desc extends DescMessage>(
     // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- no need to convert enum
     switch (field.fieldKind) {
       case "message":
-        if (isWrapperDesc(field.message)) {
+        if (!field.oneof && isWrapperDesc(field.message)) {
           value = initScalar(field.message.fields[0], value);
         } else {
           value = toMessage(value, field.message);


### PR DESCRIPTION
A field using one of the message from google/protobuf/wrappers.proto is automatically "unboxed" to it's primitive in generated code.

This is only the case for plain fields (not repeated, not in a map, not in a oneof), but `create()` erroneously applies the logic to wrapper fields in `oneof` groups.