### PR TITLE
V2: Brand types in codegenv1 with version

### DIFF
--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -42,7 +42,7 @@ export type GenDescFile = DescFile;
 export type GenDescMessage<RuntimeShape extends Message> =
   & Omit<DescMessage, "field">
   & { field: Record<MessageFieldNames<RuntimeShape>, DescField> }
-  & brand<RuntimeShape>;
+  & brandv1<RuntimeShape>;
 
 /**
  * Describes an enumeration in a protobuf source file.
@@ -52,7 +52,7 @@ export type GenDescMessage<RuntimeShape extends Message> =
  *
  * @private
  */
-export type GenDescEnum<RuntimeShape> = DescEnum & brand<RuntimeShape>;
+export type GenDescEnum<RuntimeShape> = DescEnum & brandv1<RuntimeShape>;
 
 /**
  * Describes an extension in a protobuf source file.
@@ -65,7 +65,7 @@ export type GenDescEnum<RuntimeShape> = DescEnum & brand<RuntimeShape>;
 export type GenDescExtension<
   Extendee extends Message = Message,
   RuntimeShape = unknown,
-> = DescExtension & brand<Extendee, RuntimeShape>;
+> = DescExtension & brandv1<Extendee, RuntimeShape>;
 
 /**
  * Describes a service declaration in a protobuf source file.
@@ -90,7 +90,8 @@ export type GenDescServiceMethods = Record<
   Pick<DescMethod, "input" | "output" | "methodKind">
 >;
 
-class brand<A, B = unknown> {
+class brandv1<A, B = unknown> {
+  protected v = "codegenv1" as const;
   protected a: A | boolean = false;
   protected b: B | boolean = false;
 }


### PR DESCRIPTION
Generated code imports from `@bufbuild/protobuf/codegenv1`. We use this subpath to control errors in case versions of generated code and runtime mismatch, or to provide backwards compatibility.

The types defined in this subpath are not intended to be used directly (they are all marked private), only through stable types such as `MessageShape`. In order to provide backwards compatibility for the types, we have to be able to reliably distinguish between an old version and the current version, which is currently not possible.

This PR adds a version brand to the types in the subpath, which let's us distinguish reliably.