### PR TITLE
V2: Add example for a default registry with a custom toJson() function

### DIFF
--- a/packages/protobuf-test/src/to-json-default-registry.test.ts
+++ b/packages/protobuf-test/src/to-json-default-registry.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  create,
+  createRegistry,
+  toJson as toJsonOriginal,
+} from "@bufbuild/protobuf";
+import { anyPack, AnySchema, DurationSchema } from "@bufbuild/protobuf/wkt";
+import { describe, expect, test } from "@jest/globals";
+
+/* eslint-disable @typescript-eslint/no-unsafe-return,@typescript-eslint/no-explicit-any */
+
+describe("default registry with custom toJson()", () => {
+  // Define you own standard registry
+  const registry = createRegistry(
+    // You can register as many types as you need. In this example, we only
+    // register google.protobuf.Duration.
+    DurationSchema,
+  );
+
+  // Define your own toJson function that uses your standard registry
+  const toJson: typeof toJsonOriginal = (schema, message, options) => {
+    return toJsonOriginal(
+      schema,
+      message,
+      options ?? { registry: registry },
+    ) as any;
+  };
+
+  test("works as expected", () => {
+    // Create a google.protobuf.Any that holds a google.protobuf.Duration
+    const duration = create(DurationSchema, { nanos: 123 });
+    const any = anyPack(DurationSchema, duration);
+
+    // Serializing to JSON requires a registry that contains google.protobuf.Duration
+    const json = toJson(AnySchema, any);
+
+    expect(json).toStrictEqual({
+      "@type": "type.googleapis.com/google.protobuf.Duration",
+      value: "0.000000123s",
+    });
+  });
+});

--- a/packages/protobuf-test/src/to-json-default-registry.test.ts
+++ b/packages/protobuf-test/src/to-json-default-registry.test.ts
@@ -23,14 +23,14 @@ import { describe, expect, test } from "@jest/globals";
 /* eslint-disable @typescript-eslint/no-unsafe-return,@typescript-eslint/no-explicit-any */
 
 describe("default registry with custom toJson()", () => {
-  // Define you own standard registry
+  // Define you own default registry
   const registry = createRegistry(
     // You can register as many types as you need. In this example, we only
     // register google.protobuf.Duration.
     DurationSchema,
   );
 
-  // Define your own toJson function that uses your standard registry
+  // Define your own toJson function that uses your default registry
   const toJson: typeof toJsonOriginal = (schema, message, options) => {
     return toJsonOriginal(schema, message, options ?? { registry }) as any;
   };

--- a/packages/protobuf-test/src/to-json-default-registry.test.ts
+++ b/packages/protobuf-test/src/to-json-default-registry.test.ts
@@ -32,11 +32,7 @@ describe("default registry with custom toJson()", () => {
 
   // Define your own toJson function that uses your standard registry
   const toJson: typeof toJsonOriginal = (schema, message, options) => {
-    return toJsonOriginal(
-      schema,
-      message,
-      options ?? { registry: registry },
-    ) as any;
+    return toJsonOriginal(schema, message, options ?? { registry }) as any;
   };
 
   test("works as expected", () => {


### PR DESCRIPTION
If a project frequently uses `google.protobuf.Any` and calls `toJson()` in many places, developers have to take care to always provide a registry. 

Since `toJson` is just a function, it's trivial to add a custom `toJson` function to a project that supplies a default registry:

```ts
import { createRegistry, toJson as toJsonOriginal } from "@bufbuild/protobuf";

// Define your own default registry
const registry = createRegistry(
  // You can register as many types as you need. In this example, we only
  // register google.protobuf.Duration.
  DurationSchema,
);

// Define your own toJson function that uses your default registry
export const toJson: typeof toJsonOriginal = (schema, message, options) => {
  return toJsonOriginal(schema, message, options ?? { registry }) as any;
};
```

Until we add a default registry as a feature (which is not without caveats), this seems like a acceptable workaround for users who need it. We should have this in our documentation for v2.