### PR TITLE
V2: Add mutable registry

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -11,16 +11,16 @@ usually do. We repeat this for an increasing number of files.
 ![chart](./chart.svg)
 
 
-<details><summary>Tabular data</summary>
+<details><summary>Tabular data< /summary>
 
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 125,758 b | 65,554 b | 15,210 b |
-| protobuf-es | 4 | 127,947 b | 67,062 b | 15,882 b |
-| protobuf-es | 8 | 130,709 b | 68,833 b | 16,446 b |
-| protobuf-es | 16 | 141,159 b | 76,814 b | 18,708 b |
-| protobuf-es | 32 | 168,950 b | 98,830 b | 24,189 b |
+| protobuf-es | 1 | 125,535 b | 65,455 b | 15,230 b |
+| protobuf-es | 4 | 127,724 b | 66,962 b | 15,891 b |
+| protobuf-es | 8 | 130,486 b | 68,733 b | 16,411 b |
+| protobuf-es | 16 | 140,936 b | 76,714 b | 18,716 b |
+| protobuf-es | 32 | 168,727 b | 98,732 b | 24,208 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.9248046875 140,245.0216796875 280,243.4244140625 420,237.018359375 560,221.49599609375002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.8681640625 140,244.99619140625 280,243.52353515625 420,236.995703125 560,221.4421875">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="246.9248046875" r="4" fill="#ffa600"><title>protobuf-es 14.85 KiB for 1 files</title></circle>
-<circle cx="140" cy="245.0216796875" r="4" fill="#ffa600"><title>protobuf-es 15.51 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.4244140625" r="4" fill="#ffa600"><title>protobuf-es 16.06 KiB for 8 files</title></circle>
-<circle cx="420" cy="237.018359375" r="4" fill="#ffa600"><title>protobuf-es 18.27 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.49599609375002" r="4" fill="#ffa600"><title>protobuf-es 23.62 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.8681640625" r="4" fill="#ffa600"><title>protobuf-es 14.87 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.99619140625" r="4" fill="#ffa600"><title>protobuf-es 15.52 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.52353515625" r="4" fill="#ffa600"><title>protobuf-es 16.03 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.995703125" r="4" fill="#ffa600"><title>protobuf-es 18.28 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.4421875" r="4" fill="#ffa600"><title>protobuf-es 23.64 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -427,28 +427,23 @@ describe("createFileRegistry()", function () {
           return testFileReg.getFile(protoFileName);
         });
       }
-
       expect(t).toThrow(/^Unable to resolve c.proto, imported by a.proto$/);
     });
   });
   test("raises error on unsupported edition from the past", function () {
     testFileDescriptorSet.file[0].syntax = "editions";
     testFileDescriptorSet.file[0].edition = Edition.EDITION_1_TEST_ONLY;
-
     function t() {
       createFileRegistry(testFileDescriptorSet);
     }
-
     expect(t).toThrow(/^d.proto: unsupported edition$/);
   });
   test("raises error on unsupported edition from the future", function () {
     testFileDescriptorSet.file[0].syntax = "editions";
     testFileDescriptorSet.file[0].edition = Edition.EDITION_99999_TEST_ONLY;
-
     function t() {
       createFileRegistry(testFileDescriptorSet);
     }
-
     expect(t).toThrow(/^d.proto: unsupported edition$/);
   });
   describe("from FileRegistry", function () {


### PR DESCRIPTION
This PR adds a mutable registry:

```ts
import { createMutableRegistry } from "@bufbuild/protobuf";
import { MyMessageSchema } from "./gen/example_pb";

const registry = createMutableRegistry();

// Adds a message, enum, extension, or service descriptor to the registry
registry.add(MyMessageSchema);

// Removes a descriptor
registry.remove(MyMessageSchema);

registry.getMessage("MyMessage"); // undefined
```

Note that registries - mutable and immutable ones - also support composition:

```ts
import { createRegistry } from "@bufbuild/protobuf";
import { MyMessageSchema, file_example } from "./gen/example_pb";

// The variadic function accepts any number of arguments
const registry = createRegistry(
  MyMessageSchema, // Initialize with a message, enum, extension, or service descriptor
  file_example, // Passing a file descriptor adds all types defined in the Protobuf file
  otherRegistry, // Adds all types from the other registry
);
```

Closes #679.