### PR TITLE
V2: Bump Node.js and npm versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "protobuf-es",
       "workspaces": [
         "./packages/protobuf",
         "./packages/protoc-gen-es",
@@ -35,8 +36,8 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=16",
-        "npm": ">=8"
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "protobuf-es",
   "private": true,
   "workspaces": [
     "./packages/protobuf",
@@ -16,8 +17,8 @@
   "type": "module",
   "engineStrict": true,
   "engines": {
-    "node": ">=16",
-    "npm": ">=8"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "licenseHeader": {
     "licenseType": "apache",
@@ -38,7 +39,7 @@
     "prettier": "^3.2.4",
     "typescript": "^5.3.3"
   },
-  "//": "avoid hoisting, see packages/protoplugin/src/ecmascript/transpile.ts",
+  "//": "avoid hoisting of @typescript/vfs, see packages/protoplugin/src/transpile.ts",
   "dependencies": {
     "@typescript/vfs": "1.0.0"
   }


### PR DESCRIPTION
Node.js v16 has been EOL since last year. We can update the "engine" field of the project's package.json to v18, along with npm.
