### PR TITLE
V2: Avoid Array.flatMap

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 <!--- TABLE-START -->
 | code generator  | files    | bundle size             | minified               | compressed         |
 |-----------------|----------|------------------------:|-----------------------:|-------------------:|
-| protobuf-es | 1 | 125,833 b | 65,603 b | 15,257 b |
-| protobuf-es | 4 | 128,022 b | 67,111 b | 15,948 b |
-| protobuf-es | 8 | 130,784 b | 68,882 b | 16,433 b |
-| protobuf-es | 16 | 141,234 b | 76,863 b | 18,756 b |
-| protobuf-es | 32 | 169,025 b | 98,881 b | 24,210 b |
+| protobuf-es | 1 | 125,817 b | 65,597 b | 15,272 b |
+| protobuf-es | 4 | 128,006 b | 67,105 b | 15,919 b |
+| protobuf-es | 8 | 130,768 b | 68,876 b | 16,418 b |
+| protobuf-es | 16 | 141,218 b | 76,857 b | 18,753 b |
+| protobuf-es | 32 | 169,009 b | 98,875 b | 24,198 b |
 | protobuf-javascript | 1 | 339,613 b | 255,820 b | 42,481 b |
 | protobuf-javascript | 4 | 366,281 b | 271,092 b | 43,912 b |
 | protobuf-javascript | 8 | 388,324 b | 283,409 b | 45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.79169921875 140,244.834765625 280,243.46123046875 420,236.882421875 560,221.4365234375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.74921875 140,244.91689453125 280,243.5037109375 420,236.89091796875 560,221.4705078125">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="246.79169921875" r="4" fill="#ffa600"><title>protobuf-es 14.9 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.834765625" r="4" fill="#ffa600"><title>protobuf-es 15.57 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.46123046875" r="4" fill="#ffa600"><title>protobuf-es 16.05 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.882421875" r="4" fill="#ffa600"><title>protobuf-es 18.32 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.4365234375" r="4" fill="#ffa600"><title>protobuf-es 23.64 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.74921875" r="4" fill="#ffa600"><title>protobuf-es 14.91 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.91689453125" r="4" fill="#ffa600"><title>protobuf-es 15.55 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.5037109375" r="4" fill="#ffa600"><title>protobuf-es 16.03 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.89091796875" r="4" fill="#ffa600"><title>protobuf-es 18.31 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.4705078125" r="4" fill="#ffa600"><title>protobuf-es 23.63 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-conformance/tsconfig.json
+++ b/packages/protobuf-conformance/tsconfig.json
@@ -2,10 +2,9 @@
   "include": ["src/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": [
-      "ES2016",
-      // ES2020.BigInt for the bigint representation of 64-bit integers
-      "ES2020.BigInt"
+    "types": [
+      // The conformance testee uses Node.js APIs
+      "node"
     ]
   }
 }

--- a/packages/protobuf-example/tsconfig.json
+++ b/packages/protobuf-example/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "files": ["src/add-person.ts", "src/list-people.ts"],
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2017",
+    "moduleResolution": "Node10",
     "strict": true,
-    "moduleResolution": "Node"
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/packages/protobuf/src/proto-int64.ts
+++ b/packages/protobuf/src/proto-int64.ts
@@ -118,6 +118,12 @@ interface Int64Support {
   uDec(lo: number, hi: number): bigint;
 }
 
+// The environment variable BUF_BIGINT_DISABLE=1 disables bigint support for
+// testing.
+declare const process: {
+  env: Record<string, string>;
+};
+
 function makeInt64Support(): Int64Support {
   const dv = new DataView(new ArrayBuffer(8));
   // note that Safari 14 implements BigInt, but not the DataView methods

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -248,7 +248,7 @@ export function createFileRegistry(
           deps.push(dep);
         }
       }
-      return [...deps, ...deps.flatMap((dep) => recurseDeps(dep))];
+      return deps.concat(...deps.map(recurseDeps));
     }
     for (const file of [input, ...recurseDeps(input)].reverse()) {
       addFile(file, registry);

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -44,8 +44,12 @@ export function configureTextEncoding(textEncoding: TextEncoding): void {
 
 export function getTextEncoding() {
   if ((globalThis as GlobalWithTextEncoding)[symbol] == undefined) {
-    const te = new globalThis.TextEncoder();
-    const td = new globalThis.TextDecoder();
+    const te = new (
+      globalThis as unknown as GlobalWithTextEncoderDecoder
+    ).TextEncoder();
+    const td = new (
+      globalThis as unknown as GlobalWithTextEncoderDecoder
+    ).TextDecoder();
     (globalThis as GlobalWithTextEncoding)[symbol] = {
       encodeUtf8(text: string): Uint8Array {
         return te.encode(text);
@@ -68,4 +72,17 @@ export function getTextEncoding() {
 
 type GlobalWithTextEncoding = {
   [symbol]?: TextEncoding;
+};
+
+type GlobalWithTextEncoderDecoder = {
+  TextEncoder: {
+    new (): {
+      encode(text: string): Uint8Array;
+    };
+  };
+  TextDecoder: {
+    new (): {
+      decode(data: Uint8Array): string;
+    };
+  };
 };

--- a/packages/protobuf/tsconfig.json
+++ b/packages/protobuf/tsconfig.json
@@ -6,14 +6,5 @@
     "src/wkt/index.ts",
     "src/wire/index.ts"
   ],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "lib": [
-      "ES2017",
-      // ES2020.BigInt for the bigint representation of 64-bit integers
-      // Note that these are only required for using bigint literals
-      // or the BigInt constructor function.
-      "ES2020.BigInt"
-    ]
-  }
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/protoplugin-example/tsconfig.json
+++ b/packages/protoplugin-example/tsconfig.json
@@ -3,10 +3,8 @@
   "compilerOptions": {
     "target": "es2017",
     "moduleResolution": "Node10",
-    "esModuleInterop": false,
     "resolveJsonModule": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "verbatimModuleSyntax": true
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/packages/protoplugin/tsconfig.json
+++ b/packages/protoplugin/tsconfig.json
@@ -3,6 +3,14 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": [
+      // src/run-node.ts uses Node.js APIs
+      "node"
+    ],
+    "lib": [
+      // @typescript/vfs references the LocalStorage type
+      "dom"
+    ]
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,9 +1,24 @@
 {
   "compilerOptions": {
+    // We target ES2017, but require the Text Encoding API, and optionally
+    // BigInt and AsyncIterable, see below.
     "target": "es2017",
+    "lib": [
+      "ES2017",
+      // ES2020.BigInt for the bigint representation of 64-bit integers
+      // Note that these are only required for using bigint literals
+      // or the BigInt constructor function.
+      "ES2020.BigInt",
+      // AsyncIterable is required only for src/wire/size-delimited.ts.
+      "ES2018.AsyncIterable"
+    ],
+    // Prevent tsc from picking up @types/node and others
+    "types": [],
+    // We don't have dependencies that require interop
     "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
+    // As strict as possible
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
@@ -15,7 +30,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-    // We need node's module resolution, so we do not have to skip lib checks
+    // We're building with Node16 module resolution
     "moduleResolution": "Node16",
     "module": "Node16",
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
Array.flatMap is part of ES2019, but we target ES2017. This replaces the call with an alternative.

This slipped through because `tsc` automatically picks up `@types/node`, which includes a declaration for `flatMap`. We're setting the compiler option `"types": []` to prevent this, and add "node" where necessary. 