### PR TITLE
V2: Add $typeName first

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "clean": "git clean -Xdf",
-    "bundle-size": "turbo run report -F ./packages/bundle-size",
+    "bundle-size": "turbo run bundle-size -F ./packages/bundle-size",
     "perf": "turbo run perf -F ./packages/protobuf-test",
     "all": "turbo run build generate test lint attw bundle-size format license-header bootstrap:inject bootstrap:wkt",
     "setversion": "node scripts/set-workspace-version.js && npm run all",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
   ],
   "scripts": {
     "clean": "git clean -Xdf",
-    "bundle-size": "turbo run bundle-size -F ./packages/bundle-size",
-    "perf": "turbo run perf -F ./packages/protobuf-test",
     "all": "turbo run build generate test lint attw bundle-size format license-header bootstrap:inject bootstrap:wkt",
     "setversion": "node scripts/set-workspace-version.js && npm run all",
     "release": "npm run all && node scripts/release.js",

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -10,23 +10,23 @@ usually do. We repeat this for an increasing number of files.
 
 ![chart](./chart.svg)
 
-<details><summary>Tabular data< /summary>
+<details><summary>Tabular data</summary>
 
-<!--- TABLE-START -->
+<!-- TABLE-START -->
 
 | code generator      | files | bundle size |  minified | compressed |
-| ------------------- | ----- | ----------: | --------: | ---------: |
-| protobuf-es         | 1     |   125,817 b |  65,597 b |   15,272 b |
-| protobuf-es         | 4     |   128,006 b |  67,105 b |   15,919 b |
-| protobuf-es         | 8     |   130,768 b |  68,876 b |   16,418 b |
-| protobuf-es         | 16    |   141,218 b |  76,857 b |   18,753 b |
-| protobuf-es         | 32    |   169,009 b |  98,875 b |   24,198 b |
-| protobuf-javascript | 1     |   339,613 b | 255,820 b |   42,481 b |
-| protobuf-javascript | 4     |   366,281 b | 271,092 b |   43,912 b |
-| protobuf-javascript | 8     |   388,324 b | 283,409 b |   45,038 b |
-| protobuf-javascript | 16    |   548,365 b | 378,100 b |   52,204 b |
-| protobuf-javascript | 32    | 1,240,889 b | 819,610 b |   78,780 b |
+| ------------------- | ----: | ----------: | --------: | ---------: |
+| protobuf-es         |     1 |   125,855 b |  65,617 b |   15,259 b |
+| protobuf-es         |     4 |   128,044 b |  67,125 b |   15,961 b |
+| protobuf-es         |     8 |   130,806 b |  68,896 b |   16,468 b |
+| protobuf-es         |    16 |   141,256 b |  76,877 b |   18,761 b |
+| protobuf-es         |    32 |   169,047 b |  98,895 b |   24,249 b |
+| protobuf-javascript |     1 |   334,193 b | 255,820 b |   42,481 b |
+| protobuf-javascript |     4 |   360,861 b | 271,092 b |   43,912 b |
+| protobuf-javascript |     8 |   382,904 b | 283,409 b |   45,038 b |
+| protobuf-javascript |    16 |   542,945 b | 378,100 b |   52,204 b |
+| protobuf-javascript |    32 | 1,235,469 b | 819,610 b |   78,780 b |
 
-<!--- TABLE-END -->
+<!-- TABLE-END -->
 
 </details>

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.74921875 140,244.91689453125 280,243.5037109375 420,236.89091796875 560,221.4705078125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.78603515625 140,244.79794921875 280,243.362109375 420,236.86826171875 560,221.32607421875">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="246.74921875" r="4" fill="#ffa600"><title>protobuf-es 14.91 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.91689453125" r="4" fill="#ffa600"><title>protobuf-es 15.55 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.5037109375" r="4" fill="#ffa600"><title>protobuf-es 16.03 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.89091796875" r="4" fill="#ffa600"><title>protobuf-es 18.31 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.4705078125" r="4" fill="#ffa600"><title>protobuf-es 23.63 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.78603515625" r="4" fill="#ffa600"><title>protobuf-es 14.9 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.79794921875" r="4" fill="#ffa600"><title>protobuf-es 15.59 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.362109375" r="4" fill="#ffa600"><title>protobuf-es 16.08 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.86826171875" r="4" fill="#ffa600"><title>protobuf-es 18.32 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.32607421875" r="4" fill="#ffa600"><title>protobuf-es 23.68 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/bundle-size/package.json
+++ b/packages/bundle-size/package.json
@@ -2,7 +2,7 @@
   "name": "@bufbuild/bundle-size",
   "private": true,
   "scripts": {
-    "report": "tsx src/report.ts",
+    "bundle-size": "tsx src/report.ts",
     "pregenerate": "rm -rf src/gen",
     "generate": "buf generate buf.build/googleapis/googleapis:9475e2896f8a46d09806149f9382e538",
     "postgenerate": "license-header .",

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -200,7 +200,9 @@ const messagePrototypes = new WeakMap<
 function createZeroMessage(desc: DescMessage): Message {
   let msg: Record<string, unknown>;
   if (!needsPrototypeChain(desc)) {
-    msg = {};
+    msg = {
+      $typeName: desc.typeName,
+    };
     for (const member of desc.members) {
       if (member.kind == "oneof" || member.presence == IMPLICIT) {
         msg[member.localName] = createZeroField(member);
@@ -238,6 +240,7 @@ function createZeroMessage(desc: DescMessage): Message {
       messagePrototypes.set(desc, { prototype, members });
     }
     msg = Object.create(prototype) as Record<string, unknown>;
+    msg.$typeName = desc.typeName;
     for (const member of desc.members) {
       if (members.has(member)) {
         continue;
@@ -255,7 +258,6 @@ function createZeroMessage(desc: DescMessage): Message {
       msg[member.localName] = createZeroField(member);
     }
   }
-  msg.$typeName = desc.typeName;
   return msg as Message;
 }
 


### PR DESCRIPTION
In `create()`, add the `$typeName` property first. When logging objects with `console`, `$typeName` currently comes last. With this change, it comes first:

```
{
  '$typeName': 'example.User',
  firstName: 'Homer',
  lastName: '',
  active: true,
  locations: [],
  projects: {},
}
```