### PR TITLE
V2: Fix createFileRegistry() with empty arguments

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| protobuf-es         |     1 |   125,880 b |  65,631 b |   15,280 b |
-| protobuf-es         |     4 |   128,069 b |  67,139 b |   15,961 b |
-| protobuf-es         |     8 |   130,831 b |  68,910 b |   16,456 b |
-| protobuf-es         |    16 |   141,281 b |  76,891 b |   18,790 b |
-| protobuf-es         |    32 |   169,072 b |  98,909 b |   24,236 b |
+| protobuf-es         |     1 |   125,927 b |  65,653 b |   15,282 b |
+| protobuf-es         |     4 |   128,116 b |  67,161 b |   15,966 b |
+| protobuf-es         |     8 |   130,878 b |  68,932 b |   16,469 b |
+| protobuf-es         |    16 |   141,328 b |  76,913 b |   18,799 b |
+| protobuf-es         |    32 |   169,119 b |  98,931 b |   24,243 b |
 | protobuf-javascript |     1 |   334,193 b | 255,820 b |   42,481 b |
 | protobuf-javascript |     4 |   360,861 b | 271,092 b |   43,912 b |
 | protobuf-javascript |     8 |   382,904 b | 283,409 b |   45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.7265625 140,244.79794921875 280,243.39609375 420,236.7861328125 560,221.36289062499998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.7208984375 140,244.7837890625 280,243.35927734375 420,236.76064453125 560,221.34306640625">
     <title>protobuf-es</title>
   </polyline>
-<circle cx="0" cy="246.7265625" r="4" fill="#ffa600"><title>protobuf-es 14.92 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.79794921875" r="4" fill="#ffa600"><title>protobuf-es 15.59 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.39609375" r="4" fill="#ffa600"><title>protobuf-es 16.07 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.7861328125" r="4" fill="#ffa600"><title>protobuf-es 18.35 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.36289062499998" r="4" fill="#ffa600"><title>protobuf-es 23.67 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.7208984375" r="4" fill="#ffa600"><title>protobuf-es 14.92 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.7837890625" r="4" fill="#ffa600"><title>protobuf-es 15.59 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.35927734375" r="4" fill="#ffa600"><title>protobuf-es 16.08 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.76064453125" r="4" fill="#ffa600"><title>protobuf-es 18.36 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.34306640625" r="4" fill="#ffa600"><title>protobuf-es 23.67 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -437,6 +437,13 @@ describe("createFileRegistry()", function () {
       expect(t).toThrow(/^Unable to resolve c.proto, imported by a.proto$/);
     });
   });
+  test("accepts empty arguments", function () {
+    const registry = createFileRegistry();
+    const types = Array.from(registry);
+    const files = Array.from(registry.files);
+    expect(types.length).toBe(0);
+    expect(files.length).toBe(0);
+  });
   test("raises error on unsupported edition from the past", function () {
     testFileDescriptorSet.file[0].syntax = "editions";
     testFileDescriptorSet.file[0].edition = Edition.EDITION_1_TEST_ONLY;

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -210,6 +210,9 @@ export function createFileRegistry(
     | FileRegistry[]
 ): FileRegistry {
   const registry = createBaseRegistry();
+  if (!args.length) {
+    return registry;
+  }
   if (
     "$typeName" in args[0] &&
     args[0].$typeName == "google.protobuf.FileDescriptorSet"


### PR DESCRIPTION
The signature allows a call without arguments, but the function crashes. Fix the crash by an early exit.