### PR TITLE
V2: Add GeneratedFile.array

### DIFF
--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -29,12 +29,7 @@ import {
   type Schema,
   type Target,
 } from "@bufbuild/protoplugin";
-import {
-  arrayLiteral,
-  fieldJsonType,
-  fieldTypeScriptType,
-  functionCall,
-} from "./util";
+import { fieldJsonType, fieldTypeScriptType, functionCall } from "./util";
 import { version } from "../package.json";
 import { RawPluginOptions } from "@bufbuild/protoplugin/dist/cjs/parameter";
 
@@ -345,7 +340,7 @@ function getFileDescCall(f: GeneratedFile, file: DescFile, schema: Schema) {
     }));
     return functionCall(fileDesc, [
       f.string(info.base64()),
-      arrayLiteral(deps),
+      f.array(deps),
     ]);
   }
   return functionCall(fileDesc, [f.string(info.base64())]);

--- a/packages/protoc-gen-es/src/util.ts
+++ b/packages/protoc-gen-es/src/util.ts
@@ -230,10 +230,6 @@ export function functionCall(
   return [fn, ...tp, "(", commaSeparate(args), ")"];
 }
 
-export function arrayLiteral(elements: Printable[]): Printable {
-  return ["[", commaSeparate(elements), "]"];
-}
-
 function commaSeparate(elements: Printable[]): Printable {
   const r: Printable[] = [];
   for (let i = 0; i < elements.length; i++) {

--- a/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
+++ b/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
@@ -38,7 +38,7 @@ function generateTs(schema: Schema<PluginOptions>) {
     f.preamble(file);
     for (const service of file.services) {
       f.print(f.jsDoc(service));
-      f.print(f.export("class", safeIdentifier(service.name) + "Client"), " {");
+      f.print(f.export("class", safeIdentifier(service.name + "Client")), " {");
       f.print();
 
       // To support the custom option we defined in customoptions/default_host.proto,

--- a/packages/protoplugin-test/src/file-array.test.ts
+++ b/packages/protoplugin-test/src/file-array.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2021-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "@jest/globals";
+import type { Printable } from "@bufbuild/protoplugin";
+import { createTestPluginAndRun } from "./helpers.js";
+
+describe("GeneratedFile.array", () => {
+  test("creates an array literal", async () => {
+    const lines = await createTestPluginAndRun({
+      proto: `syntax="proto3";`,
+      parameter: "target=ts",
+      returnLinesOfFirstFile: true,
+      generateAny: (f) => {
+        const arr: Printable = f.array(["foo", 1, true]);
+        f.print(arr);
+      },
+    });
+    expect(lines).toStrictEqual(["[foo, 1, true]"]);
+  });
+});

--- a/packages/protoplugin/src/generated-file.ts
+++ b/packages/protoplugin/src/generated-file.ts
@@ -81,6 +81,11 @@ export interface GeneratedFile {
   string(string: string): Printable;
 
   /**
+   * Create an array literal.
+   */
+  array(elements: Printable[]): Printable;
+
+  /**
    * Create a JSDoc comment block with the given text. Line breaks and white-space
    * stay intact.
    */
@@ -237,6 +242,18 @@ export function createGeneratedFile(
         kind: "es_string",
         value: string,
       };
+    },
+    array(elements) {
+      const p: Printable = [];
+      p.push("[");
+      for (const [index, element] of elements.entries()) {
+        p.push(element);
+        if (index < elements.length - 1) {
+          p.push(", ");
+        }
+      }
+      p.push("]");
+      return p;
     },
     jsDoc(textOrSchema, indentation) {
       return {

--- a/packages/protoplugin/src/safe-identifier.ts
+++ b/packages/protoplugin/src/safe-identifier.ts
@@ -83,9 +83,11 @@ const reservedIdentifiers = new Set([
 ]);
 
 /**
- * Escapes names that are reserved identifiers in ECMAScript, TypeScript.
+ * Escapes reserved words in ECMAScript and TypeScript identifiers, by appending
+ * a dollar sign.
  *
- * Also see safeObjectProperty() from @bufbuild/protoplugin/reflect.
+ * This function is intended for use with identifiers from Protobuf. The passed
+ * string must be a valid identifier (e.g. not start with a digit).
  */
 export function safeIdentifier(name: string): string {
   return reservedIdentifiers.has(name) ? name + "$" : name;

--- a/packages/protoplugin/src/safe-identifier.ts
+++ b/packages/protoplugin/src/safe-identifier.ts
@@ -88,6 +88,8 @@ const reservedIdentifiers = new Set([
  *
  * This function is intended for use with identifiers from Protobuf. The passed
  * string must be a valid identifier (e.g. not start with a digit).
+ *
+ * Also see safeObjectProperty() from @bufbuild/protoplugin/reflect.
  */
 export function safeIdentifier(name: string): string {
   return reservedIdentifiers.has(name) ? name + "$" : name;


### PR DESCRIPTION
`GeneratedFile` already has the method `string()` to escape string literals. We already have an internal function for array literals. This promotes it to be a method on `GeneratedFile` as well.

```ts
import { GeneratedFile } from "@bufbuild/protoplugin";

declare f: GeneratedFile;

f.print("const arr = ", f.array([1, 2, 3]), ";");
// const arr = [1, 2, 3];
```