### PR TITLE
V2: Fix stale links in documentation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1731,8 +1731,8 @@ The companion function `hasOption` returns true if an option is present. The fun
 
 > [!TIP]
 >
-> Custom options can be read from generated code, or from the schema passed to a plugin. See the example in
-> our [guide for writing plugins](#writing-plugins).
+> Custom options can be read from generated code, from the schema passed to a [plugin](#writing-plugins), or from any
+> other [descriptor](#descriptors).
 >
 > To learn more about custom options in Protobuf, see the [language guide][protobuf.dev/customoptions].
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ From here, you can begin to work with your schema.
 
 - [Manual](MANUAL.md) - Explains all aspects of using Protobuf with ECMAScript.
 - [Code example](packages/protobuf-example) - Example code that uses Protobuf to manage a persistent list of users.
-- [Plugin guide](packages/protoplugin-example) - Shows how to write your own plugin with `@bufbuild/protoplugin`.
+- [Plugin example](packages/protoplugin-example) - Shows how to write a custom plugin to generate Twirp clients from
+  Protobuf service definitions.
 
 ## Packages
 

--- a/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
+++ b/packages/protoplugin-example/src/protoc-gen-twirp-es.ts
@@ -89,7 +89,7 @@ interface PluginOptions {
   logRequests: boolean;
 }
 
-// Our example plugin support the option "log_requests". We parse it here.
+// Our example plugin supports the option "log_requests". We parse it here.
 function parseOptions(
   options: {
     key: string;


### PR DESCRIPTION
Following up on https://github.com/bufbuild/protobuf-es/pull/936, this fixes the now incorrect wording for two links.