### PR TITLE
Update buf CLI and make use of the `clean` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -642,9 +642,9 @@
       "dev": true
     },
     "node_modules/@bufbuild/buf": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.35.1.tgz",
-      "integrity": "sha512-POtbb4wRhvgCmmClnuaQTpkHL4ukhFItuS/AaD7QDY0kamn4ExNJz4XlHG5jeJODaQ1Wq3f9qn7UIgUr6CUODw==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.36.0.tgz",
+      "integrity": "sha512-IhUx4aSlCGGD9wJQMsccs+jYsLowdbVPLtJnjJJvLWjxvatKV224iuKn6jP930k0rvejt/c6n/0sSWVu12zksQ==",
       "hasInstallScript": true,
       "bin": {
         "buf": "bin/buf",
@@ -655,18 +655,18 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@bufbuild/buf-darwin-arm64": "1.35.1",
-        "@bufbuild/buf-darwin-x64": "1.35.1",
-        "@bufbuild/buf-linux-aarch64": "1.35.1",
-        "@bufbuild/buf-linux-x64": "1.35.1",
-        "@bufbuild/buf-win32-arm64": "1.35.1",
-        "@bufbuild/buf-win32-x64": "1.35.1"
+        "@bufbuild/buf-darwin-arm64": "1.36.0",
+        "@bufbuild/buf-darwin-x64": "1.36.0",
+        "@bufbuild/buf-linux-aarch64": "1.36.0",
+        "@bufbuild/buf-linux-x64": "1.36.0",
+        "@bufbuild/buf-win32-arm64": "1.36.0",
+        "@bufbuild/buf-win32-x64": "1.36.0"
       }
     },
     "node_modules/@bufbuild/buf-darwin-arm64": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.35.1.tgz",
-      "integrity": "sha512-Yy+sk+8sg3LDvMSZLGUIoMCkZajkQSZkdxO96mpqJagKlEYPLGTtakVFCVNX9KgK/sv1bd9sU55iMGXE3+eIYw==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.36.0.tgz",
+      "integrity": "sha512-0sXbTAedj9KY7NSHbf4536SLQKjV4yhlREw44f9mV9kGFI3Jr2Dj1z8UDzB80Ti3YFgpVu2BbcOMXIDzQ6dleA==",
       "cpu": [
         "arm64"
       ],
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@bufbuild/buf-darwin-x64": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.35.1.tgz",
-      "integrity": "sha512-LcscoNTCHFeb5y9sitw4w6HWZtJ4Ja/MDBCUU9A8/OGHJSESV0JjhbvVHGNOIsKUbPq5p/SVjYA/Ab/wlmmpaA==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.36.0.tgz",
+      "integrity": "sha512-zKuE+awq1Bslv7WcJ5Rq2npCxAGeEFnQJ4tAMD0RjY8MZ9SjJRETmngU0xGeFdh/FM91+A8f8JehXtUX4D5/3g==",
       "cpu": [
         "x64"
       ],
@@ -694,9 +694,9 @@
       }
     },
     "node_modules/@bufbuild/buf-linux-aarch64": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.35.1.tgz",
-      "integrity": "sha512-bPeiSURl8WFxCdawtJjAjUOMqknVTw763NLIDcbYSH1/wTiUbM5QeXCORRlHKXtMGM89SYU5AatcY9UhQ+sn9g==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.36.0.tgz",
+      "integrity": "sha512-GaDGNezX2i2P2bpCwMwjhhoJcu0CKnFzK3c3loS7ErP9e+y3D+AubHkB+Y5MVnmzlV65GD7HcwWnygeUI1rBSg==",
       "cpu": [
         "arm64"
       ],
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@bufbuild/buf-linux-x64": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.35.1.tgz",
-      "integrity": "sha512-n6ziazYjNH9H1JjHiacGi20rIyZuKnsHjF8qWisO8KGajhnS/7tpq0VzYdorqqWyJ1TcnLBWHj+dWYuGay9Nag==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.36.0.tgz",
+      "integrity": "sha512-gF2itk9vZrEYvHX1TobPdwDxh16DGTbfN4W5X66BUDKTZmdgctWBDRrj15UfAZO9oSjEc3oMQM+HkoWkOtsCxw==",
       "cpu": [
         "x64"
       ],
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@bufbuild/buf-win32-arm64": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.35.1.tgz",
-      "integrity": "sha512-3B65+iA1i/LDjJBseEpAvrkEI7VJqrvW39PyYVkIXSHHT917O+n95g74pn38A0XkggN5lEibLEkipBMDUfwMew==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.36.0.tgz",
+      "integrity": "sha512-YQDM6hnk4gj4KNrC/rJGLeplD9Lntf2J6b9E1xIlJ7YfMLkXKt72iXT351lLUygN4MNjVhdWTP+GU+tdqMrfPQ==",
       "cpu": [
         "arm64"
       ],
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@bufbuild/buf-win32-x64": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.35.1.tgz",
-      "integrity": "sha512-iafrcs+1FMlD+3ZjI1kVBHGOluT6YcoAUETrGMbQjRha6dL5s2Ldr0G7zCKLIT13yEKG5QTyP8z8gVEpk8C8wg==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.36.0.tgz",
+      "integrity": "sha512-qp+TuO7mHDBpJf/CtMZmIM77txcoUhGJpbjSkW+4WGpcPtwmNtQqciTYqLHXwlBVDSq9GhxpNTyx/W+kXCJS/g==",
       "cpu": [
         "x64"
       ],
@@ -9663,7 +9663,7 @@
     "packages/bundle-size": {
       "name": "@bufbuild/bundle-size",
       "dependencies": {
-        "@bufbuild/buf": "^1.35.1",
+        "@bufbuild/buf": "^1.36.0",
         "@bufbuild/protobuf": "2.0.0",
         "@bufbuild/protoc-gen-es": "2.0.0",
         "@bufbuild/protoplugin": "2.0.0",
@@ -9696,7 +9696,7 @@
       "name": "@bufbuild/protobuf-example",
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "dependencies": {
-        "@bufbuild/buf": "^1.35.1",
+        "@bufbuild/buf": "^1.36.0",
         "@bufbuild/protobuf": "2.0.0",
         "@bufbuild/protoc-gen-es": "2.0.0",
         "typescript": "^5.5.4"
@@ -9756,7 +9756,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/buf": "^1.35.1",
+        "@bufbuild/buf": "^1.36.0",
         "@bufbuild/protobuf": "^2.0.0",
         "@bufbuild/protoc-gen-es": "^2.0.0",
         "@bufbuild/protoplugin": "^2.0.0",

--- a/packages/bundle-size/buf.gen.yaml
+++ b/packages/bundle-size/buf.gen.yaml
@@ -1,5 +1,7 @@
 # Learn more: https://buf.build/docs/configuration/v2/buf-gen-yaml
 version: v2
+# Deletes the directories specified in the `out` field for all plugins before running code generation.
+clean: true
 plugins:
   - local: protoc-gen-es
     opt: target=ts

--- a/packages/bundle-size/package.json
+++ b/packages/bundle-size/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "scripts": {
     "bundle-size": "tsx src/report.ts",
-    "pregenerate": "rm -rf src/gen",
     "generate": "buf generate buf.build/googleapis/googleapis:9475e2896f8a46d09806149f9382e538",
     "postgenerate": "license-header .",
     "format": "prettier --write --ignore-unknown '.' '!src/gen/**' '!.turbo'",
@@ -11,7 +10,7 @@
     "lint": "eslint --max-warnings 0 ."
   },
   "dependencies": {
-    "@bufbuild/buf": "^1.35.1",
+    "@bufbuild/buf": "^1.36.0",
     "@bufbuild/protobuf": "2.0.0",
     "@bufbuild/protoplugin": "2.0.0",
     "@bufbuild/protoc-gen-es": "2.0.0",

--- a/packages/protobuf-example/buf.gen.yaml
+++ b/packages/protobuf-example/buf.gen.yaml
@@ -2,6 +2,8 @@
 version: v2
 inputs:
   - directory: proto
+# Deletes the directories specified in the `out` field for all plugins before running code generation.
+clean: true
 plugins:
   # The code generator is installed with `npm install @bufbuild/protoc-gen-es`.
   - local: protoc-gen-es

--- a/packages/protobuf-example/package.json
+++ b/packages/protobuf-example/package.json
@@ -6,7 +6,6 @@
     "build": "../../node_modules/typescript/bin/tsc --noEmit",
     "add": "tsx src/add.ts",
     "list": "tsx src/list.ts",
-    "pregenerate": "rm -rf src/gen",
     "generate": "buf generate",
     "postgenerate": "license-header src/gen",
     "format": "prettier --write --ignore-unknown '.' '!.turbo' '!src/gen/**'",
@@ -15,7 +14,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@bufbuild/buf": "^1.35.1",
+    "@bufbuild/buf": "^1.36.0",
     "@bufbuild/protobuf": "2.0.0",
     "@bufbuild/protoc-gen-es": "2.0.0",
     "typescript": "^5.5.4"

--- a/packages/protoplugin-example/package.json
+++ b/packages/protoplugin-example/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@bufbuild/buf": "^1.35.1",
+    "@bufbuild/buf": "^1.36.0",
     "@bufbuild/protobuf": "^2.0.0",
     "@bufbuild/protoc-gen-es": "^2.0.0",
     "@bufbuild/protoplugin": "^2.0.0",


### PR DESCRIPTION
[v1.36.0](https://github.com/bufbuild/buf/releases/tag/v1.36.0) of the buf CLI adds the top-level option `clean` to `buf.gen.yaml`. We can replace our npm scripts with this option.