### PR TITLE
Fix examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "clean": "git clean -Xdf",
-    "all": "turbo run build generate test lint attw bundle-size format license-header bootstrap:inject bootstrap:wkt",
+    "all": "turbo run --ui tui build generate test lint attw bundle-size format license-header bootstrap:inject bootstrap:wkt",
     "setversion": "node scripts/set-workspace-version.js",
     "postsetversion": "npm run all",
     "release": "npm run all && node scripts/release.js",

--- a/packages/protobuf-example/README.md
+++ b/packages/protobuf-example/README.md
@@ -9,23 +9,17 @@ Note that this example can be easily implemented in other languages, because
 the serialization format is standardized. That means you could add a user to the
 list with Dart, and list people with TypeScript interchangeably.
 
-### Build and run the example
+### Run the example
 
-To run the example, you only need npm or Yarn.
-[Download the source](https://github.com/bufbuild/protobuf-es/archive/refs/heads/main.zip),
-then run the following commands:
+You need [Node](https://nodejs.org/en/download/) version 20.17.0 or later installed.
+Download the example project and install its dependencies:
 
-From the project root, first install and build all required packages:
+```shell
+curl -L https://github.com/bufbuild/protobuf-es/archive/refs/heads/main.zip > protobuf-es-main.zip
+unzip protobuf-es-main.zip 'protobuf-es-main/packages/protobuf-example/*'
 
-```shellsession
-npm ci
-npm run generate --filter ./packages/protobuf-example
-```
-
-Next, `cd` into the example directory:
-
-```shellsession
-cd packages/protobuf-example
+cd protobuf-es-main/packages/protobuf-example
+npm install
 ```
 
 To add a user:

--- a/packages/protobuf-example/package.json
+++ b/packages/protobuf-example/package.json
@@ -1,22 +1,23 @@
 {
   "name": "@bufbuild/protobuf-example",
+  "version": "2.1.0",
   "private": true,
-  "license": "(Apache-2.0 AND BSD-3-Clause)",
   "scripts": {
     "build": "../../node_modules/typescript/bin/tsc --noEmit",
     "add": "tsx src/add.ts",
     "list": "tsx src/list.ts",
     "generate": "buf generate",
-    "postgenerate": "license-header src/gen",
     "format": "prettier --write --ignore-unknown '.' '!.turbo' '!src/gen/**'",
     "license-header": "license-header",
     "lint": "eslint --max-warnings 0 ."
   },
+  "license": "Apache-2.0",
   "type": "module",
   "dependencies": {
     "@bufbuild/buf": "^1.36.0",
     "@bufbuild/protobuf": "2.1.0",
     "@bufbuild/protoc-gen-es": "2.1.0",
+    "tsx": "^4.16.1",
     "typescript": "^5.5.4"
   }
 }

--- a/packages/protoplugin-example/README.md
+++ b/packages/protoplugin-example/README.md
@@ -5,7 +5,7 @@ clients from service definitions in Protobuf files.
 
 ## Run the example
 
-You need [Node](https://nodejs.org/en/download/) version 18.17.0 or later installed.
+You need [Node](https://nodejs.org/en/download/) version 20.17.0 or later installed.
 Download the example project and install its dependencies:
 
 ```shell

--- a/packages/protoplugin-example/package.json
+++ b/packages/protoplugin-example/package.json
@@ -7,7 +7,6 @@
     "start": "npx esbuild src/index.ts --serve=localhost:3000 --servedir=www --outdir=www --bundle --global-name=eliza",
     "test": "tsx --test test/*.ts",
     "generate": "buf generate",
-    "postgenerate": "license-header src/gen",
     "format": "prettier --write --ignore-unknown '.' '!.turbo' '!src/gen/**'",
     "license-header": "license-header",
     "lint": "eslint --max-warnings 0 ."


### PR DESCRIPTION
The Protobuf and protoplugin examples use a "postgenerate" script that fails when the sources are obtained from the GitHub ZIP archive. This PR removes the scripts (they are not necessary since generated code already has the expected license header), and makes some minor changes for consistency between the two examples.