### PR TITLE
Properly reset BinaryWriter after finish

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   126,123 b |  65,653 b |   15,258 b |
-| Protobuf-ES         |     4 |   128,312 b |  67,161 b |   15,970 b |
-| Protobuf-ES         |     8 |   131,074 b |  68,932 b |   16,481 b |
-| Protobuf-ES         |    16 |   141,524 b |  76,913 b |   18,797 b |
-| Protobuf-ES         |    32 |   169,315 b |  98,931 b |   24,268 b |
+| Protobuf-ES         |     1 |   126,179 b |  65,684 b |   15,268 b |
+| Protobuf-ES         |     4 |   128,368 b |  67,192 b |   15,925 b |
+| Protobuf-ES         |     8 |   131,130 b |  68,963 b |   16,458 b |
+| Protobuf-ES         |    16 |   141,580 b |  76,944 b |   18,756 b |
+| Protobuf-ES         |    32 |   169,371 b |  98,962 b |   24,290 b |
 | protobuf-javascript |     1 |   334,193 b | 255,820 b |   42,481 b |
 | protobuf-javascript |     4 |   360,861 b | 271,092 b |   43,912 b |
 | protobuf-javascript |     8 |   382,904 b | 283,409 b |   45,038 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.7888671875 140,244.7724609375 280,243.32529296875 420,236.76630859375 560,221.272265625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.760546875 140,244.89990234375 280,243.3904296875 420,236.882421875 560,221.2099609375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.7888671875" r="4" fill="#ffa600"><title>Protobuf-ES 14.9 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.7724609375" r="4" fill="#ffa600"><title>Protobuf-ES 15.6 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.32529296875" r="4" fill="#ffa600"><title>Protobuf-ES 16.09 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.76630859375" r="4" fill="#ffa600"><title>Protobuf-ES 18.36 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.272265625" r="4" fill="#ffa600"><title>Protobuf-ES 23.7 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.760546875" r="4" fill="#ffa600"><title>Protobuf-ES 14.91 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.89990234375" r="4" fill="#ffa600"><title>Protobuf-ES 15.55 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.3904296875" r="4" fill="#ffa600"><title>Protobuf-ES 16.07 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.882421875" r="4" fill="#ffa600"><title>Protobuf-ES 18.32 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.2099609375" r="4" fill="#ffa600"><title>Protobuf-ES 23.72 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,169.69248046875 140,165.63984375 280,162.4509765625 420,142.15664062500002 560,66.892578125">

--- a/packages/protobuf-test/src/wire/binary-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/binary-encoding.test.ts
@@ -135,12 +135,12 @@ describe("BinaryWriter", () => {
     );
   });
   it("should be completely reset after finish", () => {
-    const writer = new BinaryWriter()
+    const writer = new BinaryWriter();
     // Make sure we have both a chunk and a buffer
-    writer.raw(new Uint8Array([1,2,3])).int32(1);
+    writer.raw(new Uint8Array([1, 2, 3])).int32(1);
     const bytes = writer.finish();
     // Reuse the same writer to write the same data
-    writer.raw(new Uint8Array([1,2,3])).int32(1);
+    writer.raw(new Uint8Array([1, 2, 3])).int32(1);
     const bytes2 = writer.finish();
     expect(bytes2).toStrictEqual(bytes);
   });

--- a/packages/protobuf-test/src/wire/binary-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/binary-encoding.test.ts
@@ -134,6 +134,16 @@ describe("BinaryWriter", () => {
       },
     );
   });
+  it("should be completely reset after finish", () => {
+    const writer = new BinaryWriter()
+    // Make sure we have both a chunk and a buffer
+    writer.raw(new Uint8Array([1,2,3])).int32(1);
+    const bytes = writer.finish();
+    // Reuse the same writer to write the same data
+    writer.raw(new Uint8Array([1,2,3])).int32(1);
+    const bytes2 = writer.finish();
+    expect(bytes2).toStrictEqual(bytes);
+  });
 });
 
 describe("BinaryReader", () => {

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -133,7 +133,10 @@ export class BinaryWriter {
    * Return all bytes written and reset this writer.
    */
   finish(): Uint8Array {
-    this.chunks.push(new Uint8Array(this.buf)); // flush the buffer
+    if (this.buf.length) {
+      this.chunks.push(new Uint8Array(this.buf)); // flush the buffer
+      this.buf = [];
+    }
     let len = 0;
     for (let i = 0; i < this.chunks.length; i++) len += this.chunks[i].length;
     let bytes = new Uint8Array(len);


### PR DESCRIPTION
I noticed this while reading the BinaryWriter code - `finish` didn't properly reset the writer, so if it were reused the output would be invalid. I doubt anyone reuses writers, but it wasn't a hard fix.