### PR TITLE
Add @bufbuild/protocompile to MANUAL.md

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1376,7 +1376,7 @@ just with some additional type information attached.
 >
 > You can find a deep dive into the model in [Buf's reference about descriptors][buf.build/descriptors].
 >
-> You can fetch descriptors from the [Buf Schema Registry][bsr-reflection]. In tests, you can use [@bufbuild/protocompile] 
+> You can fetch descriptors from the [Buf Schema Registry][bsr-reflection]. In tests, you can use [@bufbuild/protocompile]
 > to compile inline Protobuf source to a descriptor.
 
 ### Walking through a schema

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1376,7 +1376,8 @@ just with some additional type information attached.
 >
 > You can find a deep dive into the model in [Buf's reference about descriptors][buf.build/descriptors].
 >
-> You can fetch descriptors from the [Buf Schema Registry][bsr-reflection].
+> You can fetch descriptors from the [Buf Schema Registry][bsr-reflection]. In tests, you can use [@bufbuild/protocompile] 
+> to compile inline Protobuf source to a descriptor.
 
 ### Walking through a schema
 
@@ -2503,6 +2504,7 @@ Serialization to JSON and binary is deterministic within a version of protobuf-e
 [@bufbuild/protobuf]: https://www.npmjs.com/package/@bufbuild/protobuf
 [@bufbuild/protoc-gen-es]: https://www.npmjs.com/package/@bufbuild/protoc-gen-es
 [@bufbuild/protoplugin]: https://www.npmjs.com/package/@bufbuild/protoplugin
+[@bufbuild/protocompile]: https://www.npmjs.com/package/@bufbuild/protocompile
 [tsx]: https://www.npmjs.com/package/tsx
 [bigint-compat]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#browser_compatibility
 [blog-post]: https://buf.build/blog/protobuf-conformance


### PR DESCRIPTION
Add [@bufbuild/protocompile](https://www.npmjs.com/package/@bufbuild/protocompile) to the MANUAL.md.

When writing code using the [reflection API](https://github.com/bufbuild/protobuf-es/blob/v2.2.0/MANUAL.md#reflection-api), getting good test coverage can be challenging. It's easy enough to generate code (which includes descriptors) or build descriptors with `buf build`, but co-locating Protobuf source with a test gives better confidence. 

With the `compileMessage` function, you can compile inline Protobuf source to a message descriptor:

```ts
import { compileMessage } from "@bufbuild/protocompile";
import { redact } from "./redact.js";

describe("redact", () => {
  it("should redact string field", () => {
    const schema = compileMessage(`
      syntax = "proto3";
      message Example {
        string foo = 1 [ debug_redact = true ];
      }
    `);
    const message: Message & Record<string, unknown> = create(schema, {
      foo: "abc",
    });
    redact(message);
    expect(message.foo).toBe("");
  });
});
```

The package also exports functions to compile Protobuf descriptors for all other types, such as enumerations and services.

Under the hood, the functions shell out to the `buf build` command. You need [@bufbuild/buf](https://www.npmjs.com/package/@bufbuild/buf) as a peer dependency to use them.

Note that the functions return anonymous descriptors. They are functionally identical to generated descriptors, but do not have generated type information attached.
