### PR TITLE
Support target prefix in plugin option rewrite_imports

### DIFF
--- a/packages/protoplugin-test/src/rewrite_imports.test.ts
+++ b/packages/protoplugin-test/src/rewrite_imports.test.ts
@@ -47,6 +47,34 @@ describe("rewrite_imports", function () {
       "Foo",
     ]);
   });
+  test("should rewrite to target with package prefix", async () => {
+    const lines = await testGenerate(
+      "target=ts,rewrite_imports=@scope/pkg:npm:@scope/pkg",
+      (f) => {
+        const Foo = f.import("Foo", "@scope/pkg");
+        f.print`${Foo}`;
+      },
+    );
+    expect(lines).toStrictEqual([
+      'import { Foo } from "npm:@scope/pkg";',
+      "",
+      "Foo",
+    ]);
+  });
+  test("should rewrite to target with package prefix and subpath", async () => {
+    const lines = await testGenerate(
+      "target=ts,rewrite_imports=@scope/pkg/subpath:npm:@scope/pkg/subpath",
+      (f) => {
+        const Foo = f.import("Foo", "@scope/pkg/subpath");
+        f.print`${Foo}`;
+      },
+    );
+    expect(lines).toStrictEqual([
+      'import { Foo } from "npm:@scope/pkg/subpath";',
+      "",
+      "Foo",
+    ]);
+  });
 
   async function testGenerate(
     parameter: string,

--- a/packages/protoplugin/src/parameter.ts
+++ b/packages/protoplugin/src/parameter.ts
@@ -164,15 +164,17 @@ export function parseParameter<T extends object>(
         }
         break;
       case "rewrite_imports": {
-        const parts = value.split(":");
-        if (parts.length !== 2) {
+        const i = value.indexOf(":");
+        if (i <= 0) {
           throw new PluginOptionError(
             raw,
             "must be in the form of <pattern>:<target>",
           );
         }
-        const [pattern, target] = parts;
-        rewriteImports.push({ pattern, target });
+        rewriteImports.push({
+          pattern: value.substring(0, i),
+          target: value.substring(i + 1),
+        });
         // rewrite_imports can be noisy and is more of an implementation detail
         // so we strip it out of the preamble
         sanitize = true;

--- a/packages/protoplugin/src/parameter.ts
+++ b/packages/protoplugin/src/parameter.ts
@@ -165,7 +165,7 @@ export function parseParameter<T extends object>(
         break;
       case "rewrite_imports": {
         const i = value.indexOf(":");
-        if (i <= 0) {
+        if (i < 0) {
           throw new PluginOptionError(
             raw,
             "must be in the form of <pattern>:<target>",


### PR DESCRIPTION
With the plugin option `rewrite_imports`, it's possible to modify generated import paths  - more details in https://github.com/bufbuild/protobuf-es/issues/947#issuecomment-2257889255.

It currently isn't possible to specify a target package with a colon:

```
protoc-gen-es: invalid option "rewrite_imports=@bufbuild/protobuf:npm:@bufbuild/protobuf": must be in the form of <pattern>:<target>
```

This relaxes the check to accept one or more colons in the target.

Closes https://github.com/bufbuild/protobuf-es/issues/992.