### PR TITLE
Print diagnostics when a protoplugin fails to emit files

### DIFF
--- a/packages/protoplugin-test/src/transpile.test.ts
+++ b/packages/protoplugin-test/src/transpile.test.ts
@@ -97,4 +97,66 @@ describe("built-in transpile", () => {
       ]);
     });
   });
+
+  describe("failing to emit", () => {
+    test("raises error with helpful message", async () => {
+      await expect(async () =>
+        testTranspileToDts([
+          `export interface Foo {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+        ]),
+      ).rejects.toThrow(
+        /^A problem occurred during transpilation and files were not generated\. {2}Contact the plugin author for support\.\n/,
+      );
+    });
+    test("raises error with diagnostics", async () => {
+      await expect(async () =>
+        testTranspileToDts([
+          `export interface Foo {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+        ]),
+      ).rejects.toThrow(
+        /test\.ts\(3,17\): error TS4033: Property 'p' of exported interface has or is using private name 'P'\.$/,
+      );
+    });
+    test("raises error with 3 diagnostics, and elides the rest", async () => {
+      await expect(async () =>
+        testTranspileToDts([
+          `export interface Foo1 {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+          `export interface Foo2 {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+          `export interface Foo3 {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+          `export interface Foo4 {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+          `export interface Foo5 {`,
+          `  p: {`,
+          `    [K in keyof P]: string;`,
+          `  },`,
+          `}`,
+        ]),
+      ).rejects.toThrow(
+        /(?:test\.ts\(\d+,\d+\): .+\n){3}2 more diagnostics elided/,
+      );
+    });
+  });
 });

--- a/packages/protoplugin/src/transpile.ts
+++ b/packages/protoplugin/src/transpile.ts
@@ -165,7 +165,7 @@ export function transpile(
 
     // When compilation fails, this error will be shown in the results of the NPM install error log.
     throw Error(
-      `A problem occurred during transpilation and files were not generated.  Contact the plugin author for support.\n\nGenerating Files:\n\n${fileNames}\n\nDiagnostics:\n\n${diagnosticMessages}`
+      `A problem occurred during transpilation and files were not generated.  Contact the plugin author for support.\n\nGenerating Files:\n\n${fileNames}\n\nDiagnostics:\n\n${diagnosticMessages}`,
     );
   }
   return results;

--- a/packages/protoplugin/src/transpile.ts
+++ b/packages/protoplugin/src/transpile.ts
@@ -158,8 +158,14 @@ export function transpile(
     throw err;
   }
   if (result.emitSkipped) {
+    const fileNames = files.map((f) => f.name).join("\n");
+    const diagnosticMessages = result.diagnostics
+      .map((d) => d.messageText)
+      .join("\n");
+
+    // When compilation fails, this error will be shown in the results of the NPM install error log.
     throw Error(
-      "A problem occurred during transpilation and files were not generated.  Contact the plugin author for support.",
+      `A problem occurred during transpilation and files were not generated.  Contact the plugin author for support.\n\nGenerating Files:\n\n${fileNames}\n\nDiagnostics:\n\n${diagnosticMessages}`
     );
   }
   return results;


### PR DESCRIPTION
When trying to publish a custom plugin to the BSR, I had some trouble figuring out why it was failing to generate an SDK.

I ended up debugging the problem by implementing a custom transpiler that prints extra diagnostic information when results are skipped, since these errors show up in the npm install log when it fails to generate.

So, this seems like it could be useful for others trying to debug SDK generation failures in the future.

This generates an error like:

```
protoc-gen-es-required: A problem occurred during transpilation and files were not generated.

Generating Files:

buf/validate/validate_required.ts
factory_execution/cycle_time/v1/cycle_time_required.ts

Diagnostics:

Property 'in' of exported interface has or is using private name 'Uint8Array'.
Property 'notIn' of exported interface has or is using private name 'Uint8Array'.
Property 'example' of exported interface has or is using private name 'Uint8Array'.
```