### PR TITLE
Doc: clarify which packages are dev dependencies

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -58,11 +58,11 @@ The quickstart below shows a simple example of code generation for a `.proto` fi
     npx tsc --init
     ```
 
-2.  Install the compiler [@bufbuild/buf], plugin, and runtime library:
+2.  Install the runtime library, code generator, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
 
     ```shellsession
-    npm install --save-dev @bufbuild/buf @bufbuild/protoc-gen-es
     npm install @bufbuild/protobuf
+    npm install --save-dev @bufbuild/buf @bufbuild/protoc-gen-es
     ```
 
 3.  Create a `buf.gen.yaml` file that looks like this:

--- a/README.md
+++ b/README.md
@@ -72,9 +72,25 @@ and then deserialized at its destination using the defined schema.
 
 1. Install the code generator, the runtime library, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
 
+   <details open>
+   <summary>npm</summary>
+     
    ```shellsession
-   npm install @bufbuild/protobuf @bufbuild/protoc-gen-es @bufbuild/buf
+   npm install @bufbuild/protobuf
+   npm install --save-dev @bufbuild/protoc-gen-es @bufbuild/buf
    ```
+     
+   </details>
+
+   <details>
+   <summary>yarn</summary>
+     
+   ```shellsession
+   yarn add @bufbuild/protobuf
+   yarn add -D @bufbuild/protoc-gen-es @bufbuild/buf
+   ```
+   
+   </details>
 
 2. Create a `buf.gen.yaml` file that looks like this:
 
@@ -98,9 +114,23 @@ and then deserialized at its destination using the defined schema.
 
 4. Generate your code with `buf` or [`protoc`]:
 
+   <details open>
+   <summary>npm</summary>
+     
    ```shellsession
    npx buf generate
    ```
+   
+   </details>
+
+   <details>
+   <summary>yarn</summary>
+     
+   ```shellsession
+   yarn buf generate
+   ```
+   
+   </details>
 
 You should now see a generated file at `src/gen/example_pb.ts` that contains a type `User`, and a schema `UserSchema`.
 From here, you can begin to work with your schema.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and then deserialized at its destination using the defined schema.
 ## Quickstart
 
 1. Install the runtime library, code generator, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
-     
+
    ```shellsession
    npm install @bufbuild/protobuf
    npm install --save-dev @bufbuild/protoc-gen-es @bufbuild/buf

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ and then deserialized at its destination using the defined schema.
 
 ## Quickstart
 
-1. Install the the runtime library, code generator, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
+1. Install the runtime library, code generator, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
      
    ```shellsession
    npm install @bufbuild/protobuf

--- a/README.md
+++ b/README.md
@@ -71,26 +71,11 @@ and then deserialized at its destination using the defined schema.
 ## Quickstart
 
 1. Install the the runtime library, code generator, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
-
-   <details open>
-   <summary>npm</summary>
      
    ```shellsession
    npm install @bufbuild/protobuf
    npm install --save-dev @bufbuild/protoc-gen-es @bufbuild/buf
    ```
-     
-   </details>
-
-   <details>
-   <summary>yarn</summary>
-     
-   ```shellsession
-   yarn add @bufbuild/protobuf
-   yarn add -D @bufbuild/protoc-gen-es @bufbuild/buf
-   ```
-   
-   </details>
 
 2. Create a `buf.gen.yaml` file that looks like this:
 
@@ -114,23 +99,9 @@ and then deserialized at its destination using the defined schema.
 
 4. Generate your code with `buf` or [`protoc`]:
 
-   <details open>
-   <summary>npm</summary>
-     
    ```shellsession
    npx buf generate
    ```
-   
-   </details>
-
-   <details>
-   <summary>yarn</summary>
-     
-   ```shellsession
-   yarn buf generate
-   ```
-   
-   </details>
 
 You should now see a generated file at `src/gen/example_pb.ts` that contains a type `User`, and a schema `UserSchema`.
 From here, you can begin to work with your schema.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ and then deserialized at its destination using the defined schema.
 
 ## Quickstart
 
-1. Install the code generator, the runtime library, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
+1. Install the the runtime library, code generator, and the [Buf CLI](https://buf.build/docs/ecosystem/cli-overview):
 
    <details open>
    <summary>npm</summary>

--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -9,16 +9,12 @@ The code generator plugin for Protocol Buffers for ECMAScript. Learn more about 
 schema. The generated code requires the runtime library [@bufbuild/protobuf](https://www.npmjs.com/package/@bufbuild/protobuf).
 It's compatible with Protocol Buffer compilers like [buf](https://github.com/bufbuild/buf) and [protoc](https://github.com/protocolbuffers/protobuf/releases).
 
-To install the plugin and the runtime library, run:
+To install the runtime library and the plugin, run:
 
 ```shell
-npm install --save-dev @bufbuild/protoc-gen-es
 npm install @bufbuild/protobuf
+npm install --save-dev @bufbuild/protoc-gen-es
 ```
-
-We use peer dependencies to ensure that the code generator and runtime library are
-compatible with each other. Note that npm installs them automatically, but Yarn
-and pnpm do not.
 
 ## Generating code
 


### PR DESCRIPTION
I've proposed splitting the runtime vs dev dependencies into separate lines as aligned with best practices. Additionally, I've added a default-collapsed section for yarn users.