### PR TITLE
Add experimental options to equals() to include extensions and others

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   126,585 b |  65,684 b |   15,268 b |
-| Protobuf-ES         |     4 |   128,774 b |  67,192 b |   15,925 b |
-| Protobuf-ES         |     8 |   131,536 b |  68,963 b |   16,458 b |
-| Protobuf-ES         |    16 |   141,986 b |  76,944 b |   18,756 b |
-| Protobuf-ES         |    32 |   169,777 b |  98,962 b |   24,290 b |
+| Protobuf-ES         |     1 |   126,585 b |  65,684 b |   15,250 b |
+| Protobuf-ES         |     4 |   128,774 b |  67,192 b |   15,939 b |
+| Protobuf-ES         |     8 |   131,536 b |  68,963 b |   16,469 b |
+| Protobuf-ES         |    16 |   141,986 b |  76,944 b |   18,784 b |
+| Protobuf-ES         |    32 |   169,777 b |  98,962 b |   24,247 b |
 | protobuf-javascript |     1 |   104,048 b |  70,318 b |   15,474 b |
 | protobuf-javascript |     4 |   130,537 b |  85,670 b |   16,986 b |
 | protobuf-javascript |     8 |   152,429 b |  98,042 b |   18,111 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.760546875 140,244.89990234375 280,243.3904296875 420,236.882421875 560,221.2099609375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.8115234375 140,244.86025390625 280,243.35927734375 420,236.803125 560,221.33173828125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.760546875" r="4" fill="#ffa600"><title>Protobuf-ES 14.91 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.89990234375" r="4" fill="#ffa600"><title>Protobuf-ES 15.55 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.3904296875" r="4" fill="#ffa600"><title>Protobuf-ES 16.07 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.882421875" r="4" fill="#ffa600"><title>Protobuf-ES 18.32 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.2099609375" r="4" fill="#ffa600"><title>Protobuf-ES 23.72 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.8115234375" r="4" fill="#ffa600"><title>Protobuf-ES 14.89 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.86025390625" r="4" fill="#ffa600"><title>Protobuf-ES 15.57 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.35927734375" r="4" fill="#ffa600"><title>Protobuf-ES 16.08 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.803125" r="4" fill="#ffa600"><title>Protobuf-ES 18.34 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.33173828125" r="4" fill="#ffa600"><title>Protobuf-ES 23.68 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,246.1771484375 140,241.8951171875 280,238.70908203125 420,217.77187500000002 560,134.34306640625">

--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -19,12 +19,19 @@ import {
   equals,
   type Message,
   type DescMessage,
+  createRegistry,
+  type Registry,
+  setExtension,
+  type UnknownField,
 } from "@bufbuild/protobuf";
 import { reflect } from "@bufbuild/protobuf/reflect";
 import { WireType } from "@bufbuild/protobuf/wire";
+import { type Any, anyPack, AnySchema } from "@bufbuild/protobuf/wkt";
 import * as proto2_ts from "./gen/ts/extra/proto2_pb.js";
 import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
 import * as edition2023_ts from "./gen/ts/extra/edition2023_pb.js";
+import * as test_messages_proto3 from "./gen/ts/google/protobuf/test_messages_proto3_pb.js";
+import * as extensions_proto2 from "./gen/ts/extra/extensions-proto2_pb.js";
 import { UserSchema } from "./gen/ts/extra/example_pb.js";
 import { fillProto3Message } from "./helpers-proto3.js";
 import { fillProto2Message } from "./helpers-proto2.js";
@@ -174,6 +181,182 @@ describe("equals()", () => {
     test("mapInt32MessageField is not equal", () => {
       b.mapInt32MessageField[123].singularStringField = "modified";
       expect(equals(proto3_ts.Proto3MessageSchema, a, b)).toBe(false);
+    });
+  });
+
+  describe("with extensions enabled", () => {
+    const schema = extensions_proto2.Proto2ExtendeeSchema;
+    const ext = extensions_proto2.uint32_ext;
+    function unknownEq(
+      msgA: extensions_proto2.Proto2Extendee,
+      msgB: extensions_proto2.Proto2Extendee,
+      registry: Registry,
+    ) {
+      return equals(schema, msgA, msgB, {
+        registry,
+        extensions: true,
+      });
+    }
+    test("same extensions are equal", () => {
+      const a = create(schema, {});
+      setExtension(a, ext, 123);
+      const b = create(schema, {});
+      setExtension(b, ext, 123);
+      const reg = createRegistry(ext);
+      expect(unknownEq(a, b, reg)).toBe(true);
+    });
+    test("different extension values are equal", () => {
+      const a = create(schema, {});
+      setExtension(a, ext, 123);
+      const b = create(schema, {});
+      setExtension(b, ext, 456);
+      const reg = createRegistry(ext);
+      expect(unknownEq(a, b, reg)).toBe(false);
+    });
+    test("unset extension value is not equal set extension value", () => {
+      const a = create(schema, {});
+      setExtension(a, ext, 123);
+      const b = create(schema, {});
+      const reg = createRegistry(ext);
+      expect(unknownEq(a, b, reg)).toBe(false);
+    });
+    test("compares extension value instead of unknown field", () => {
+      const a = create(schema, {});
+      setExtension(a, ext, 123);
+      const b = create(schema, {});
+      b.$unknown = [...(a.$unknown ?? []), ...(a.$unknown ?? [])];
+      const reg = createRegistry(ext);
+      expect(unknownEq(a, b, reg)).toBe(true);
+    });
+  });
+
+  describe("with unknown enabled", () => {
+    function unknownEq(
+      unknownA: UnknownField[] | undefined,
+      unknownB: UnknownField[] | undefined,
+    ) {
+      const a = create(UserSchema, {});
+      a.$unknown = unknownA;
+      const b = create(UserSchema, {});
+      b.$unknown = unknownB;
+      return equals(UserSchema, a, b, {
+        registry: createRegistry(),
+        unknown: true,
+        extensions: false,
+      });
+    }
+    test("same unknown fields are equal", () => {
+      const a = [
+        { no: 10100, wireType: WireType.Varint, data: new Uint8Array([0]) },
+      ];
+      const b = [
+        { no: 10100, wireType: WireType.Varint, data: new Uint8Array([0]) },
+      ];
+      expect(unknownEq(a, b)).toBe(true);
+    });
+    test("different unknown fields are not equal", () => {
+      const a = [
+        { no: 10100, wireType: WireType.Varint, data: new Uint8Array([0]) },
+      ];
+      const b = [
+        {
+          no: 10100,
+          wireType: WireType.LengthDelimited,
+          data: new Uint8Array([0]),
+        },
+      ];
+      expect(unknownEq(a, b)).toBe(false);
+    });
+  });
+
+  describe("with unpackAny enabled", () => {
+    function anyEq(anyA: Any, anyB: Any, registry: Registry) {
+      const hostSchema = test_messages_proto3.TestAllTypesProto3Schema;
+      const hostA = create(hostSchema, {
+        optionalAny: anyA,
+      });
+      const hostB = create(hostSchema, {
+        optionalAny: anyB,
+      });
+      return equals(hostSchema, hostA, hostB, {
+        registry,
+        unpackAny: true,
+      });
+    }
+    test("equal packed Any are equal", () => {
+      const reg = createRegistry(UserSchema);
+      const a = anyPack(UserSchema, create(UserSchema, { active: true }));
+      const b = anyPack(UserSchema, create(UserSchema, { active: true }));
+      expect(anyEq(a, b, reg)).toBe(true);
+    });
+    test("different packed Any are not equal", () => {
+      const reg = createRegistry(UserSchema);
+      const a = anyPack(UserSchema, create(UserSchema, { active: true }));
+      const b = anyPack(UserSchema, create(UserSchema, { active: false }));
+      expect(anyEq(a, b, reg)).toBe(false);
+    });
+    test("requires Any.typeUrl to be exactly the same", () => {
+      const reg = createRegistry(UserSchema);
+      const a = anyPack(UserSchema, create(UserSchema, { active: true }));
+      a.typeUrl = `type.googleapis.com/${UserSchema.typeName}`;
+      const b = anyPack(UserSchema, create(UserSchema, { active: true }));
+      b.typeUrl = `example.com/${UserSchema.typeName}`;
+      expect(anyEq(a, b, reg)).toBe(false);
+    });
+    test("compares unpacked instead of Any.value bytes", () => {
+      const reg = createRegistry(UserSchema);
+      const a = anyPack(
+        UserSchema,
+        create(UserSchema, {
+          active: true,
+        }),
+      );
+      const b = anyPack(
+        UserSchema,
+        create(UserSchema, {
+          active: true,
+        }),
+      );
+      b.value = new Uint8Array(a.value.byteLength * 2);
+      b.value.set(a.value, 0);
+      b.value.set(a.value, a.value.byteLength);
+      expect(a.value).not.toStrictEqual(b.value);
+      expect(anyEq(a, b, reg)).toBe(true);
+    });
+    test("compares Any.value bytes if message not in registry", () => {
+      const reg = createRegistry();
+      const a = anyPack(
+        UserSchema,
+        create(UserSchema, {
+          active: true,
+        }),
+      );
+      const b = anyPack(
+        UserSchema,
+        create(UserSchema, {
+          active: true,
+        }),
+      );
+      b.value = new Uint8Array(a.value.byteLength * 2);
+      b.value.set(a.value, 0);
+      b.value.set(a.value, a.value.byteLength);
+      expect(a.value).not.toStrictEqual(b.value);
+      expect(anyEq(a, b, reg)).toBe(false);
+    });
+    test("Any in Any", () => {
+      const reg = createRegistry(UserSchema, AnySchema);
+      const a = anyPack(
+        AnySchema,
+        anyPack(UserSchema, create(UserSchema, { active: true })),
+      );
+      const b = anyPack(
+        AnySchema,
+        anyPack(UserSchema, create(UserSchema, { active: true })),
+      );
+      b.value = new Uint8Array(a.value.byteLength * 2);
+      b.value.set(a.value, 0);
+      b.value.set(a.value, a.value.byteLength);
+      expect(anyEq(a, b, reg)).toBe(true);
     });
   });
 });

--- a/packages/protobuf/src/equals.ts
+++ b/packages/protobuf/src/equals.ts
@@ -255,7 +255,7 @@ function extensionsEquals(
   ): DescExtension[] {
     return (msg.getUnknown() ?? [])
       .map((uf) => registry.getExtensionFor(msg.desc, uf.no))
-      .filter((e) => !!e)
+      .filter((e) => e != undefined)
       .filter((e, index, arr) => arr.indexOf(e) === index);
   }
   const extensionsA = getSetExtensions(a, opts.registry);

--- a/packages/protobuf/src/equals.ts
+++ b/packages/protobuf/src/equals.ts
@@ -15,8 +15,47 @@
 import type { MessageShape } from "./types.js";
 import { scalarEquals, type ScalarValue } from "./reflect/scalar.js";
 import { reflect } from "./reflect/reflect.js";
-import type { DescField, DescMessage } from "./descriptors.js";
+import {
+  type DescExtension,
+  type DescField,
+  type DescMessage,
+  ScalarType,
+} from "./descriptors.js";
 import type { ReflectMessage } from "./reflect/index.js";
+import type { Registry } from "./registry.js";
+import { type Any, anyUnpack } from "./wkt/index.js";
+import { createExtensionContainer, getExtension } from "./extensions.js";
+
+export interface EqualsOptions {
+  /**
+   * A registry to look up extensions, and messages packed in Any.
+   *
+   * @private Experimental API, does not follow semantic versioning.
+   */
+  registry: Registry;
+  /**
+   * Unpack google.protobuf.Any before comparing.
+   * If a type is not in the registry, comparison falls back to comparing the
+   * fields of Any.
+   *
+   * @private Experimental API, does not follow semantic versioning.
+   */
+  unpackAny?: boolean;
+  /**
+   * Consider extensions when comparing.
+   *
+   * @private Experimental API, does not follow semantic versioning.
+   */
+  extensions?: boolean;
+  /**
+   * Consider unknown fields when comparing.
+   * The registry is used to distinguish between extensions, and unknown fields
+   * caused by schema changes.
+   *
+   * @private Experimental API, does not follow semantic versioning.
+   */
+  unknown?: boolean;
+}
 
 /**
  * Compare two messages of the same type.
@@ -28,6 +67,7 @@ export function equals<Desc extends DescMessage>(
   schema: Desc,
   a: MessageShape<Desc>,
   b: MessageShape<Desc>,
+  options?: EqualsOptions,
 ): boolean {
   if (a.$typeName != schema.typeName || b.$typeName != schema.typeName) {
     return false;
@@ -35,14 +75,27 @@ export function equals<Desc extends DescMessage>(
   if (a === b) {
     return true;
   }
-  return reflectEquals(reflect(schema, a), reflect(schema, b));
+  return reflectEquals(reflect(schema, a), reflect(schema, b), options);
 }
 
-function reflectEquals(a: ReflectMessage, b: ReflectMessage): boolean {
+function reflectEquals(
+  a: ReflectMessage,
+  b: ReflectMessage,
+  opts?: EqualsOptions,
+): boolean {
+  if (a.desc.typeName === "google.protobuf.Any" && opts?.unpackAny == true) {
+    return anyUnpackedEquals(a.message as Any, b.message as Any, opts);
+  }
   for (const f of a.fields) {
-    if (!fieldEquals(f, a, b)) {
+    if (!fieldEquals(f, a, b, opts)) {
       return false;
     }
+  }
+  if (opts?.unknown == true && !unknownEquals(a, b, opts.registry)) {
+    return false;
+  }
+  if (opts?.extensions == true && !extensionsEquals(a, b, opts)) {
+    return false;
   }
   return true;
 }
@@ -51,6 +104,7 @@ function fieldEquals(
   f: DescField,
   a: ReflectMessage,
   b: ReflectMessage,
+  opts: EqualsOptions | undefined,
 ): boolean {
   if (!a.isSet(f) && !b.isSet(f)) {
     return true;
@@ -64,25 +118,25 @@ function fieldEquals(
     case "enum":
       return a.get(f) === b.get(f);
     case "message":
-      return reflectEquals(a.get(f), b.get(f));
+      return reflectEquals(a.get(f), b.get(f), opts);
     case "map": {
-      const ma = a.get(f);
-      const mb = b.get(f);
-      const keysA: unknown[] = [];
-      for (const k of ma.keys()) {
-        if (!mb.has(k)) {
+      const mapA = a.get(f);
+      const mapB = b.get(f);
+      const keys: unknown[] = [];
+      for (const k of mapA.keys()) {
+        if (!mapB.has(k)) {
           return false;
         }
-        keysA.push(k);
+        keys.push(k);
       }
-      for (const k of mb.keys()) {
-        if (!ma.has(k)) {
+      for (const k of mapB.keys()) {
+        if (!mapA.has(k)) {
           return false;
         }
       }
-      for (const key of keysA) {
-        const va = ma.get(key);
-        const vb = mb.get(key);
+      for (const key of keys) {
+        const va = mapA.get(key);
+        const vb = mapB.get(key);
         if (va === vb) {
           continue;
         }
@@ -90,7 +144,9 @@ function fieldEquals(
           case "enum":
             return false;
           case "message":
-            if (!reflectEquals(va as ReflectMessage, vb as ReflectMessage)) {
+            if (
+              !reflectEquals(va as ReflectMessage, vb as ReflectMessage, opts)
+            ) {
               return false;
             }
             break;
@@ -104,14 +160,14 @@ function fieldEquals(
       break;
     }
     case "list": {
-      const la = a.get(f);
-      const lb = b.get(f);
-      if (la.size != lb.size) {
+      const listA = a.get(f);
+      const listB = b.get(f);
+      if (listA.size != listB.size) {
         return false;
       }
-      for (let i = 0; i < la.size; i++) {
-        const va = la.get(i);
-        const vb = lb.get(i);
+      for (let i = 0; i < listA.size; i++) {
+        const va = listA.get(i);
+        const vb = listB.get(i);
         if (va === vb) {
           continue;
         }
@@ -119,7 +175,9 @@ function fieldEquals(
           case "enum":
             return false;
           case "message":
-            if (!reflectEquals(va as ReflectMessage, vb as ReflectMessage)) {
+            if (
+              !reflectEquals(va as ReflectMessage, vb as ReflectMessage, opts)
+            ) {
               return false;
             }
             break;
@@ -131,6 +189,94 @@ function fieldEquals(
         }
       }
       break;
+    }
+  }
+  return true;
+}
+
+function anyUnpackedEquals(a: Any, b: Any, opts: EqualsOptions): boolean {
+  if (a.typeUrl !== b.typeUrl) {
+    return false;
+  }
+  const unpackedA = anyUnpack(a, opts.registry);
+  const unpackedB = anyUnpack(b, opts.registry);
+  if (unpackedA && unpackedB) {
+    const schema = opts.registry.getMessage(unpackedA.$typeName);
+    if (schema) {
+      return equals(schema, unpackedA, unpackedB, opts);
+    }
+  }
+  return scalarEquals(ScalarType.BYTES, a.value, b.value);
+}
+
+function unknownEquals(
+  a: ReflectMessage,
+  b: ReflectMessage,
+  registry: Registry | undefined,
+) {
+  function getTrulyUnknown(
+    msg: ReflectMessage,
+    registry: Registry | undefined,
+  ) {
+    const u = msg.getUnknown() ?? [];
+    return registry
+      ? u.filter((uf) => !registry.getExtensionFor(msg.desc, uf.no))
+      : u;
+  }
+  const unknownA = getTrulyUnknown(a, registry);
+  const unknownB = getTrulyUnknown(b, registry);
+  if (unknownA.length != unknownB.length) {
+    return false;
+  }
+  for (let i = 0; i < unknownA.length; i++) {
+    const a = unknownA[i],
+      b = unknownB[i];
+    if (a.no != b.no) {
+      return false;
+    }
+    if (a.wireType != b.wireType) {
+      return false;
+    }
+    if (!scalarEquals(ScalarType.BYTES, a.data, b.data)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function extensionsEquals(
+  a: ReflectMessage,
+  b: ReflectMessage,
+  opts: EqualsOptions,
+) {
+  function getSetExtensions(
+    msg: ReflectMessage,
+    registry: Registry,
+  ): DescExtension[] {
+    return (msg.getUnknown() ?? [])
+      .map((uf) => registry.getExtensionFor(msg.desc, uf.no))
+      .filter((e) => !!e)
+      .filter((e, index, arr) => arr.indexOf(e) === index);
+  }
+  const extensionsA = getSetExtensions(a, opts.registry);
+  const extensionsB = getSetExtensions(b, opts.registry);
+  if (
+    extensionsA.length != extensionsB.length ||
+    extensionsA.some((e) => !extensionsB.includes(e))
+  ) {
+    return false;
+  }
+  for (const extension of extensionsA) {
+    const [containerA, field] = createExtensionContainer(
+      extension,
+      getExtension(a.message, extension),
+    );
+    const [containerB] = createExtensionContainer(
+      extension,
+      getExtension(b.message, extension),
+    );
+    if (!fieldEquals(field, containerA, containerB, opts)) {
+      return false;
     }
   }
   return true;

--- a/packages/protobuf/src/equals.ts
+++ b/packages/protobuf/src/equals.ts
@@ -120,6 +120,7 @@ function fieldEquals(
     case "message":
       return reflectEquals(a.get(f), b.get(f), opts);
     case "map": {
+      // TODO(tstamm) can't we compare sizes first?
       const mapA = a.get(f);
       const mapB = b.get(f);
       const keys: unknown[] = [];

--- a/packages/protobuf/src/equals.ts
+++ b/packages/protobuf/src/equals.ts
@@ -26,7 +26,7 @@ import type { Registry } from "./registry.js";
 import { type Any, anyUnpack } from "./wkt/index.js";
 import { createExtensionContainer, getExtension } from "./extensions.js";
 
-export interface EqualsOptions {
+interface EqualsOptions {
   /**
    * A registry to look up extensions, and messages packed in Any.
    *

--- a/packages/protobuf/src/equals.ts
+++ b/packages/protobuf/src/equals.ts
@@ -100,6 +100,7 @@ function reflectEquals(
   return true;
 }
 
+// TODO(tstamm) add an option to consider NaN equal to NaN?
 function fieldEquals(
   f: DescField,
   a: ReflectMessage,


### PR DESCRIPTION
The function `equals` from `@bufbuild/protobuf` compares two messages of the same type. 

This PR adds an options argument to enable comparison of extensions, unknown fields, and semantic comparison of `google.protobuf.Any`:

```ts
interface EqualsOptions {
  /**
   * A registry to look up extensions, and messages packed in Any.
   *
   * @private Experimental API, does not follow semantic versioning.
   */
  registry: Registry;
  /**
   * Unpack google.protobuf.Any before comparing.
   * If a type is not in the registry, comparison falls back to comparing the
   * fields of Any.
   *
   * @private Experimental API, does not follow semantic versioning.
   */
  unpackAny?: boolean;
  /**
   * Consider extensions when comparing.
   *
   * @private Experimental API, does not follow semantic versioning.
   */
  extensions?: boolean;
  /**
   * Consider unknown fields when comparing.
   * The registry is used to distinguish between extensions, and unknown fields
   * caused by schema changes.
   *
   * @private Experimental API, does not follow semantic versioning.
   */
  unknown?: boolean;
}
```

For now, the feature is an experimental API, and it's marked `@private`. This means it's possible to use the API, but at your own risk: It is possible that we change the API, or remove it again.
