### PR TITLE
Add undefined type to optional properties in protoc-gen-es TypeScript

### DIFF
--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -420,7 +420,7 @@ function generateMessageShape(f: GeneratedFile, message: DescMessage, target: Ex
         f.print(f.jsDoc(member, "  "));
         const { typing, optional } = fieldTypeScriptType(member, f.runtime);
         if (optional) {
-          f.print("  ", member.localName, "?: ", typing, ";");
+          f.print("  ", member.localName, "?: ", typing, " | undefined;");
         } else {
           f.print("  ", member.localName, ": ", typing, ";");
         }


### PR DESCRIPTION
Hey :smiley: 

On TypeScript generated code, this generates fields marked with the `optional` label in proto as `name?: typing | undefined` instead of `name?: typing`.

This would allow to work with the [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) rule enabled so optional properties are explicitly possibly undefined.