### PR TITLE
Add strict option to v1

### DIFF
--- a/packages/protobuf/src/codegen-info.ts
+++ b/packages/protobuf/src/codegen-info.ts
@@ -47,11 +47,11 @@ interface CodegenInfo {
       | DescOneof
       | DescField
       | DescService
-      | DescMethod
+      | DescMethod,
   ) => string;
   readonly symbols: Record<RuntimeSymbolName, RuntimeSymbolInfo>;
   readonly getUnwrappedFieldType: (
-    field: DescField | DescExtension
+    field: DescField | DescExtension,
   ) => ScalarType | undefined;
   readonly wktSourceFiles: readonly string[];
   /**
@@ -60,7 +60,7 @@ interface CodegenInfo {
   readonly scalarDefaultValue: (type: ScalarType, longType: LongType) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
   readonly scalarZeroValue: <T extends ScalarType, L extends LongType>(
     type: T,
-    longType: L
+    longType: L,
   ) => ScalarValue<T, L>;
   /**
    * @deprecated please use reifyWkt from @bufbuild/protoplugin/ecmascript instead

--- a/packages/protobuf/src/codegen-info.ts
+++ b/packages/protobuf/src/codegen-info.ts
@@ -47,11 +47,11 @@ interface CodegenInfo {
       | DescOneof
       | DescField
       | DescService
-      | DescMethod,
+      | DescMethod
   ) => string;
   readonly symbols: Record<RuntimeSymbolName, RuntimeSymbolInfo>;
   readonly getUnwrappedFieldType: (
-    field: DescField | DescExtension,
+    field: DescField | DescExtension
   ) => ScalarType | undefined;
   readonly wktSourceFiles: readonly string[];
   /**
@@ -60,7 +60,7 @@ interface CodegenInfo {
   readonly scalarDefaultValue: (type: ScalarType, longType: LongType) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
   readonly scalarZeroValue: <T extends ScalarType, L extends LongType>(
     type: T,
-    longType: L,
+    longType: L
   ) => ScalarValue<T, L>;
   /**
    * @deprecated please use reifyWkt from @bufbuild/protoplugin/ecmascript instead
@@ -75,6 +75,7 @@ type RuntimeSymbolName =
   | "proto3"
   | "Message"
   | "PartialMessage"
+  | "PartialStrictMessage"
   | "PlainMessage"
   | "FieldList"
   | "MessageType"
@@ -116,6 +117,7 @@ export const codegenInfo: CodegenInfo = {
     proto3:               {typeOnly: false, privateImportPath: "./proto3.js",        publicImportPath: packageName},
     Message:              {typeOnly: false, privateImportPath: "./message.js",       publicImportPath: packageName},
     PartialMessage:       {typeOnly: true,  privateImportPath: "./message.js",       publicImportPath: packageName},
+    PartialStrictMessage: {typeOnly: true,  privateImportPath: "./message.js",       publicImportPath: packageName},
     PlainMessage:         {typeOnly: true,  privateImportPath: "./message.js",       publicImportPath: packageName},
     FieldList:            {typeOnly: true,  privateImportPath: "./field-list.js",    publicImportPath: packageName},
     MessageType:          {typeOnly: true,  privateImportPath: "./message-type.js",  publicImportPath: packageName},

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -21,7 +21,12 @@ export { protoDelimited } from "./proto-delimited.js";
 export { codegenInfo } from "./codegen-info.js";
 
 export { Message } from "./message.js";
-export type { AnyMessage, PartialMessage, PlainMessage } from "./message.js";
+export type {
+  AnyMessage,
+  PartialMessage,
+  PartialStrictMessage,
+  PlainMessage,
+} from "./message.js";
 export { isMessage } from "./is-message.js";
 
 export type { FieldInfo, OneofInfo } from "./field.js";

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -46,7 +46,7 @@ export class Message<T extends Message<T> = AnyMessage> {
     return this.getType().runtime.util.equals(
       this.getType(),
       this as unknown as T,
-      other,
+      other
     );
   }
 
@@ -96,7 +96,7 @@ export class Message<T extends Message<T> = AnyMessage> {
       throw new Error(
         `cannot decode ${this.getType().typeName} from JSON: ${
           e instanceof Error ? e.message : String(e)
-        }`,
+        }`
       );
     }
     return this.fromJson(json, options);
@@ -203,6 +203,22 @@ export type PartialMessage<T extends Message<T>> = {
   // eslint-disable-next-line @typescript-eslint/ban-types -- we use `Function` to identify methods
   [P in keyof T as T[P] extends Function ? never : P]?: PartialField<T[P]>;
 };
+
+export type PartialStrictMessage<T extends Message<T>> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types -- we use `Function` to identify methods
+  [P in keyof T as T[P] extends Function ? never : P]: PartialStrictField<T[P]>;
+};
+
+// prettier-ignore
+type PartialStrictField<F> =
+  F extends (Date | Uint8Array | bigint | boolean | string | number) ? F
+  : F extends Array<infer U> ? Array<PartialField<U>>
+  : F extends ReadonlyArray<infer U> ? ReadonlyArray<PartialField<U>>
+  : F extends Message<infer U> ? PartialStrictMessage<U>
+  : F extends OneofSelectedMessage<infer C, infer V> ? {case: C; value: PartialStrictMessage<V>}
+  : F extends { case: string | undefined; value?: unknown; } ? F
+  : F extends {[key: string|number]: Message<infer U>} ? {[key: string|number]: PartialStrictMessage<U>}
+  : F ;
 
 // prettier-ignore
 type PartialField<F> =

--- a/packages/protobuf/src/message.ts
+++ b/packages/protobuf/src/message.ts
@@ -46,7 +46,7 @@ export class Message<T extends Message<T> = AnyMessage> {
     return this.getType().runtime.util.equals(
       this.getType(),
       this as unknown as T,
-      other
+      other,
     );
   }
 
@@ -96,7 +96,7 @@ export class Message<T extends Message<T> = AnyMessage> {
       throw new Error(
         `cannot decode ${this.getType().typeName} from JSON: ${
           e instanceof Error ? e.message : String(e)
-        }`
+        }`,
       );
     }
     return this.fromJson(json, options);

--- a/packages/protoc-gen-es/src/declaration.ts
+++ b/packages/protoc-gen-es/src/declaration.ts
@@ -87,7 +87,6 @@ function generateMessage(schema: Schema, f: GeneratedFile, message: DescMessage)
     }
     f.print();
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   f.print("  constructor(data?: ", schema.strict ? PartialStrictMessage : PartialMessage, "<", m, ">);");
   f.print();
   generateWktMethods(schema, f, message);

--- a/packages/protoc-gen-es/src/util.ts
+++ b/packages/protoc-gen-es/src/util.ts
@@ -25,7 +25,10 @@ import {
 import type { Printable } from "@bufbuild/protoplugin/ecmascript";
 import { localName } from "@bufbuild/protoplugin/ecmascript";
 
-export function getFieldTypeInfo(field: DescField | DescExtension): {
+export function getFieldTypeInfo(
+  field: DescField | DescExtension,
+  strict: boolean
+): {
   typing: Printable;
   optional: boolean;
   typingInferrableFromZeroValue: boolean;
@@ -38,7 +41,7 @@ export function getFieldTypeInfo(field: DescField | DescExtension): {
       typing.push(scalarTypeScriptType(field.scalar, field.longType));
       optional =
         field.optional ||
-        field.proto.label === FieldDescriptorProto_Label.REQUIRED;
+        (!strict && field.proto.label === FieldDescriptorProto_Label.REQUIRED);
       typingInferrableFromZeroValue = true;
       break;
     case "message": {
@@ -64,7 +67,7 @@ export function getFieldTypeInfo(field: DescField | DescExtension): {
       });
       optional =
         field.optional ||
-        field.proto.label === FieldDescriptorProto_Label.REQUIRED;
+        (!strict && field.proto.label === FieldDescriptorProto_Label.REQUIRED);
       typingInferrableFromZeroValue = true;
       break;
     case "map": {
@@ -86,7 +89,7 @@ export function getFieldTypeInfo(field: DescField | DescExtension): {
         case "scalar":
           valueType = scalarTypeScriptType(
             field.mapValue.scalar,
-            LongType.BIGINT,
+            LongType.BIGINT
           );
           break;
         case "message":
@@ -127,7 +130,7 @@ export function getFieldDefaultValueExpression(
   enumAs:
     | "enum_value_as_is"
     | "enum_value_as_integer"
-    | "enum_value_as_cast_integer" = "enum_value_as_is",
+    | "enum_value_as_cast_integer" = "enum_value_as_is"
 ): Printable | undefined {
   if (field.repeated) {
     return undefined;
@@ -142,11 +145,11 @@ export function getFieldDefaultValueExpression(
   switch (field.fieldKind) {
     case "enum": {
       const enumValue = field.enum.values.find(
-        (value) => value.number === defaultValue,
+        (value) => value.number === defaultValue
       );
       if (enumValue === undefined) {
         throw new Error(
-          `invalid enum default value: ${String(defaultValue)} for ${enumValue}`,
+          `invalid enum default value: ${String(defaultValue)} for ${enumValue}`
         );
       }
       return literalEnumValue(enumValue, enumAs);
@@ -171,7 +174,7 @@ export function getFieldZeroValueExpression(
   enumAs:
     | "enum_value_as_is"
     | "enum_value_as_integer"
-    | "enum_value_as_cast_integer" = "enum_value_as_is",
+    | "enum_value_as_cast_integer" = "enum_value_as_is"
 ): Printable | undefined {
   if (field.repeated) {
     return "[]";
@@ -193,7 +196,7 @@ export function getFieldZeroValueExpression(
     case "scalar": {
       const defaultValue = codegenInfo.scalarZeroValue(
         field.scalar,
-        field.longType,
+        field.longType
       );
       return literalScalarValue(defaultValue, field);
     }
@@ -202,7 +205,7 @@ export function getFieldZeroValueExpression(
 
 function literalScalarValue(
   value: ScalarValue,
-  field: (DescField | DescExtension) & { fieldKind: "scalar" },
+  field: (DescField | DescExtension) & { fieldKind: "scalar" }
 ): Printable {
   switch (field.scalar) {
     case ScalarType.DOUBLE:
@@ -214,28 +217,28 @@ function literalScalarValue(
     case ScalarType.SINT32:
       if (typeof value != "number") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
         );
       }
       return value;
     case ScalarType.BOOL:
       if (typeof value != "boolean") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
         );
       }
       return value;
     case ScalarType.STRING:
       if (typeof value != "string") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
         );
       }
       return { kind: "es_string", value };
     case ScalarType.BYTES:
       if (!(value instanceof Uint8Array)) {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
         );
       }
       return value;
@@ -246,7 +249,7 @@ function literalScalarValue(
     case ScalarType.FIXED64:
       if (typeof value != "bigint" && typeof value != "string") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
         );
       }
       return {
@@ -263,7 +266,7 @@ function literalEnumValue(
   enumAs:
     | "enum_value_as_is"
     | "enum_value_as_integer"
-    | "enum_value_as_cast_integer",
+    | "enum_value_as_cast_integer"
 ): Printable {
   switch (enumAs) {
     case "enum_value_as_is":

--- a/packages/protoc-gen-es/src/util.ts
+++ b/packages/protoc-gen-es/src/util.ts
@@ -27,7 +27,7 @@ import { localName } from "@bufbuild/protoplugin/ecmascript";
 
 export function getFieldTypeInfo(
   field: DescField | DescExtension,
-  strict: boolean
+  strict: boolean,
 ): {
   typing: Printable;
   optional: boolean;
@@ -89,7 +89,7 @@ export function getFieldTypeInfo(
         case "scalar":
           valueType = scalarTypeScriptType(
             field.mapValue.scalar,
-            LongType.BIGINT
+            LongType.BIGINT,
           );
           break;
         case "message":
@@ -130,7 +130,7 @@ export function getFieldDefaultValueExpression(
   enumAs:
     | "enum_value_as_is"
     | "enum_value_as_integer"
-    | "enum_value_as_cast_integer" = "enum_value_as_is"
+    | "enum_value_as_cast_integer" = "enum_value_as_is",
 ): Printable | undefined {
   if (field.repeated) {
     return undefined;
@@ -145,11 +145,11 @@ export function getFieldDefaultValueExpression(
   switch (field.fieldKind) {
     case "enum": {
       const enumValue = field.enum.values.find(
-        (value) => value.number === defaultValue
+        (value) => value.number === defaultValue,
       );
       if (enumValue === undefined) {
         throw new Error(
-          `invalid enum default value: ${String(defaultValue)} for ${enumValue}`
+          `invalid enum default value: ${String(defaultValue)} for ${enumValue}`,
         );
       }
       return literalEnumValue(enumValue, enumAs);
@@ -174,7 +174,7 @@ export function getFieldZeroValueExpression(
   enumAs:
     | "enum_value_as_is"
     | "enum_value_as_integer"
-    | "enum_value_as_cast_integer" = "enum_value_as_is"
+    | "enum_value_as_cast_integer" = "enum_value_as_is",
 ): Printable | undefined {
   if (field.repeated) {
     return "[]";
@@ -196,7 +196,7 @@ export function getFieldZeroValueExpression(
     case "scalar": {
       const defaultValue = codegenInfo.scalarZeroValue(
         field.scalar,
-        field.longType
+        field.longType,
       );
       return literalScalarValue(defaultValue, field);
     }
@@ -205,7 +205,7 @@ export function getFieldZeroValueExpression(
 
 function literalScalarValue(
   value: ScalarValue,
-  field: (DescField | DescExtension) & { fieldKind: "scalar" }
+  field: (DescField | DescExtension) & { fieldKind: "scalar" },
 ): Printable {
   switch (field.scalar) {
     case ScalarType.DOUBLE:
@@ -217,28 +217,28 @@ function literalScalarValue(
     case ScalarType.SINT32:
       if (typeof value != "number") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
         );
       }
       return value;
     case ScalarType.BOOL:
       if (typeof value != "boolean") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
         );
       }
       return value;
     case ScalarType.STRING:
       if (typeof value != "string") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
         );
       }
       return { kind: "es_string", value };
     case ScalarType.BYTES:
       if (!(value instanceof Uint8Array)) {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
         );
       }
       return value;
@@ -249,7 +249,7 @@ function literalScalarValue(
     case ScalarType.FIXED64:
       if (typeof value != "bigint" && typeof value != "string") {
         throw new Error(
-          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`
+          `Unexpected value for ${ScalarType[field.scalar]} ${field.toString()}: ${String(value)}`,
         );
       }
       return {
@@ -266,7 +266,7 @@ function literalEnumValue(
   enumAs:
     | "enum_value_as_is"
     | "enum_value_as_integer"
-    | "enum_value_as_cast_integer"
+    | "enum_value_as_cast_integer",
 ): Printable {
   switch (enumAs) {
     case "enum_value_as_is":

--- a/packages/protoplugin/src/ecmascript/parameter.ts
+++ b/packages/protoplugin/src/ecmascript/parameter.ts
@@ -30,7 +30,7 @@ export interface ParsedParameter {
 
 export function parseParameter(
   parameter: string | undefined,
-  parseExtraOption: ((key: string, value: string) => void) | undefined
+  parseExtraOption: ((key: string, value: string) => void) | undefined,
 ): ParsedParameter {
   let targets: Target[] = ["js", "dts"];
   let tsNocheck = true;
@@ -96,7 +96,7 @@ export function parseParameter(
         if (parts.length !== 2) {
           throw new PluginOptionError(
             raw,
-            "must be in the form of <pattern>:<target>"
+            "must be in the form of <pattern>:<target>",
           );
         }
         const [pattern, target] = parts;
@@ -184,7 +184,7 @@ export function parseParameter(
 }
 
 function splitParameter(
-  parameter: string | undefined
+  parameter: string | undefined,
 ): { key: string; value: string; raw: string }[] {
   if (parameter == undefined) {
     return [];

--- a/packages/protoplugin/src/ecmascript/parameter.ts
+++ b/packages/protoplugin/src/ecmascript/parameter.ts
@@ -25,11 +25,12 @@ export interface ParsedParameter {
   importExtension: string;
   jsImportStyle: "module" | "legacy_commonjs";
   sanitizedParameter: string;
+  strict: boolean;
 }
 
 export function parseParameter(
   parameter: string | undefined,
-  parseExtraOption: ((key: string, value: string) => void) | undefined,
+  parseExtraOption: ((key: string, value: string) => void) | undefined
 ): ParsedParameter {
   let targets: Target[] = ["js", "dts"];
   let tsNocheck = true;
@@ -38,6 +39,7 @@ export function parseParameter(
   const rewriteImports: RewriteImports = [];
   let importExtension = ".js";
   let jsImportStyle: "module" | "legacy_commonjs" = "module";
+  let strict = false;
   const rawParameters: string[] = [];
   for (const { key, value, raw } of splitParameter(parameter)) {
     // Whether this key/value plugin parameter pair should be
@@ -94,7 +96,7 @@ export function parseParameter(
         if (parts.length !== 2) {
           throw new PluginOptionError(
             raw,
-            "must be in the form of <pattern>:<target>",
+            "must be in the form of <pattern>:<target>"
           );
         }
         const [pattern, target] = parts;
@@ -135,6 +137,21 @@ export function parseParameter(
         }
         break;
       }
+      case "strict": {
+        switch (value) {
+          case "true":
+          case "1":
+            strict = true;
+            break;
+          case "false":
+          case "0":
+            strict = false;
+            break;
+          default:
+            throw new PluginOptionError(raw);
+        }
+        break;
+      }
       default:
         if (parseExtraOption === undefined) {
           throw new PluginOptionError(raw);
@@ -154,6 +171,7 @@ export function parseParameter(
   const sanitizedParameter = rawParameters.join(",");
 
   return {
+    strict,
     targets,
     tsNocheck,
     bootstrapWkt,
@@ -166,7 +184,7 @@ export function parseParameter(
 }
 
 function splitParameter(
-  parameter: string | undefined,
+  parameter: string | undefined
 ): { key: string; value: string; raw: string }[] {
   if (parameter == undefined) {
     return [];

--- a/packages/protoplugin/src/ecmascript/runtime-imports.ts
+++ b/packages/protoplugin/src/ecmascript/runtime-imports.ts
@@ -71,12 +71,12 @@ export function createRuntimeImports(bootstrapWkt: boolean): RuntimeImports {
 
 function infoToSymbol(
   name: keyof typeof codegenInfo.symbols,
-  bootstrapWkt: boolean
+  bootstrapWkt: boolean,
 ): ImportSymbol {
   const info = codegenInfo.symbols[name];
   const symbol = createImportSymbol(
     name,
-    bootstrapWkt ? info.privateImportPath : info.publicImportPath
+    bootstrapWkt ? info.privateImportPath : info.publicImportPath,
   );
   return info.typeOnly ? symbol.toTypeOnly() : symbol;
 }

--- a/packages/protoplugin/src/ecmascript/runtime-imports.ts
+++ b/packages/protoplugin/src/ecmascript/runtime-imports.ts
@@ -21,6 +21,7 @@ export interface RuntimeImports {
   proto3: ImportSymbol;
   Message: ImportSymbol;
   PartialMessage: ImportSymbol;
+  PartialStrictMessage: ImportSymbol;
   PlainMessage: ImportSymbol;
   FieldList: ImportSymbol;
   MessageType: ImportSymbol;
@@ -47,6 +48,7 @@ export function createRuntimeImports(bootstrapWkt: boolean): RuntimeImports {
     proto3:                infoToSymbol("proto3",               bootstrapWkt),
     Message:               infoToSymbol("Message",              bootstrapWkt),
     PartialMessage:        infoToSymbol("PartialMessage",       bootstrapWkt),
+    PartialStrictMessage:  infoToSymbol("PartialStrictMessage", bootstrapWkt),
     PlainMessage:          infoToSymbol("PlainMessage",         bootstrapWkt),
     FieldList:             infoToSymbol("FieldList",            bootstrapWkt),
     MessageType:           infoToSymbol("MessageType",          bootstrapWkt),
@@ -69,12 +71,12 @@ export function createRuntimeImports(bootstrapWkt: boolean): RuntimeImports {
 
 function infoToSymbol(
   name: keyof typeof codegenInfo.symbols,
-  bootstrapWkt: boolean,
+  bootstrapWkt: boolean
 ): ImportSymbol {
   const info = codegenInfo.symbols[name];
   const symbol = createImportSymbol(
     name,
-    bootstrapWkt ? info.privateImportPath : info.publicImportPath,
+    bootstrapWkt ? info.privateImportPath : info.publicImportPath
   );
   return info.typeOnly ? symbol.toTypeOnly() : symbol;
 }

--- a/packages/protoplugin/src/ecmascript/schema.ts
+++ b/packages/protoplugin/src/ecmascript/schema.ts
@@ -78,6 +78,11 @@ export interface Schema {
    * The original google.protobuf.compiler.CodeGeneratorRequest.
    */
   readonly proto: CodeGeneratorRequest;
+
+  /**
+   * strict mode with `required` support
+   */
+  readonly strict: boolean;
 }
 
 interface SchemaController extends Schema {
@@ -90,7 +95,7 @@ export function createSchema(
   parameter: ParsedParameter,
   pluginName: string,
   pluginVersion: string,
-  featureSetDefaults: FeatureSetDefaults | undefined,
+  featureSetDefaults: FeatureSetDefaults | undefined
 ): SchemaController {
   const descriptorSet = createDescriptorSet(request.protoFile, {
     featureSetDefaults,
@@ -98,13 +103,13 @@ export function createSchema(
   const filesToGenerate = findFilesToGenerate(descriptorSet, request);
   const runtime = createRuntimeImports(parameter.bootstrapWkt);
   const createTypeImport = (
-    desc: DescMessage | DescEnum | DescExtension,
+    desc: DescMessage | DescEnum | DescExtension
   ): ImportSymbol => {
     const name = codegenInfo.localName(desc);
     const from = makeImportPath(
       desc.file,
       parameter.bootstrapWkt,
-      filesToGenerate,
+      filesToGenerate
     );
     return createImportSymbol(name, from);
   };
@@ -114,12 +119,13 @@ export function createSchema(
       pluginName,
       pluginVersion,
       parameter.sanitizedParameter,
-      parameter.tsNocheck,
+      parameter.tsNocheck
     );
   let target: Target | undefined;
   const generatedFiles: GeneratedFileController[] = [];
   return {
     targets: parameter.targets,
+    strict: parameter.strict,
     runtime,
     proto: request,
     files: filesToGenerate,
@@ -127,7 +133,7 @@ export function createSchema(
     generateFile(name) {
       if (target === undefined) {
         throw new Error(
-          "prepareGenerate() must be called before generateFile()",
+          "prepareGenerate() must be called before generateFile()"
         );
       }
       const genFile = createGeneratedFile(
@@ -138,11 +144,11 @@ export function createSchema(
           rewriteImportPath(
             importPath,
             parameter.rewriteImports,
-            parameter.importExtension,
+            parameter.importExtension
           ),
         createTypeImport,
         runtime,
-        createPreamble,
+        createPreamble
       );
       generatedFiles.push(genFile);
       return genFile;
@@ -160,17 +166,15 @@ export function createSchema(
 
 function findFilesToGenerate(
   descriptorSet: DescriptorSet,
-  request: CodeGeneratorRequest,
+  request: CodeGeneratorRequest
 ) {
   const missing = request.fileToGenerate.filter((fileToGenerate) =>
-    descriptorSet.files.every(
-      (file) => fileToGenerate !== file.name + ".proto",
-    ),
+    descriptorSet.files.every((file) => fileToGenerate !== file.name + ".proto")
   );
   if (missing.length) {
     throw `files_to_generate missing in the request: ${missing.join(", ")}`;
   }
   return descriptorSet.files.filter((file) =>
-    request.fileToGenerate.includes(file.name + ".proto"),
+    request.fileToGenerate.includes(file.name + ".proto")
   );
 }

--- a/packages/protoplugin/src/ecmascript/schema.ts
+++ b/packages/protoplugin/src/ecmascript/schema.ts
@@ -95,7 +95,7 @@ export function createSchema(
   parameter: ParsedParameter,
   pluginName: string,
   pluginVersion: string,
-  featureSetDefaults: FeatureSetDefaults | undefined
+  featureSetDefaults: FeatureSetDefaults | undefined,
 ): SchemaController {
   const descriptorSet = createDescriptorSet(request.protoFile, {
     featureSetDefaults,
@@ -103,13 +103,13 @@ export function createSchema(
   const filesToGenerate = findFilesToGenerate(descriptorSet, request);
   const runtime = createRuntimeImports(parameter.bootstrapWkt);
   const createTypeImport = (
-    desc: DescMessage | DescEnum | DescExtension
+    desc: DescMessage | DescEnum | DescExtension,
   ): ImportSymbol => {
     const name = codegenInfo.localName(desc);
     const from = makeImportPath(
       desc.file,
       parameter.bootstrapWkt,
-      filesToGenerate
+      filesToGenerate,
     );
     return createImportSymbol(name, from);
   };
@@ -119,7 +119,7 @@ export function createSchema(
       pluginName,
       pluginVersion,
       parameter.sanitizedParameter,
-      parameter.tsNocheck
+      parameter.tsNocheck,
     );
   let target: Target | undefined;
   const generatedFiles: GeneratedFileController[] = [];
@@ -133,7 +133,7 @@ export function createSchema(
     generateFile(name) {
       if (target === undefined) {
         throw new Error(
-          "prepareGenerate() must be called before generateFile()"
+          "prepareGenerate() must be called before generateFile()",
         );
       }
       const genFile = createGeneratedFile(
@@ -144,11 +144,11 @@ export function createSchema(
           rewriteImportPath(
             importPath,
             parameter.rewriteImports,
-            parameter.importExtension
+            parameter.importExtension,
           ),
         createTypeImport,
         runtime,
-        createPreamble
+        createPreamble,
       );
       generatedFiles.push(genFile);
       return genFile;
@@ -166,15 +166,17 @@ export function createSchema(
 
 function findFilesToGenerate(
   descriptorSet: DescriptorSet,
-  request: CodeGeneratorRequest
+  request: CodeGeneratorRequest,
 ) {
   const missing = request.fileToGenerate.filter((fileToGenerate) =>
-    descriptorSet.files.every((file) => fileToGenerate !== file.name + ".proto")
+    descriptorSet.files.every(
+      (file) => fileToGenerate !== file.name + ".proto",
+    ),
   );
   if (missing.length) {
     throw `files_to_generate missing in the request: ${missing.join(", ")}`;
   }
   return descriptorSet.files.filter((file) =>
-    request.fileToGenerate.includes(file.name + ".proto")
+    request.fileToGenerate.includes(file.name + ".proto"),
   );
 }


### PR DESCRIPTION
addresses https://github.com/bufbuild/protobuf-es/issues/414

This PR adds a `strict` option to protoc-gen-es v1 to allow for `required` labels in proto2 syntax to be reflected as actually required fields. 

All current tests pass with `strict=0` (which is of course the default), so there should be no breaking changes. 

In order to facilitate type checking for strict mode there's a new `PartialStrictMessage` type that enforces required fields to be part of the initial message constructor.

Would highly appreciate if you considered adding this option. I tried to make it non breaking and as useful as possible for others. 

