### PR TITLE
Fix timestampFromMs with negative values

### DIFF
--- a/packages/protobuf-test/src/wkt/timestamp.test.ts
+++ b/packages/protobuf-test/src/wkt/timestamp.test.ts
@@ -64,6 +64,26 @@ describe("timestampFromMs()", () => {
     expect(Number(timestampWithMs.seconds)).toBe(818035920);
     expect(timestampWithMs.nanos).toBe(123000000);
   });
+  test("1000 ms", () => {
+    const ts = timestampFromMs(1000);
+    expect(Number(ts.seconds)).toBe(1);
+    expect(ts.nanos).toBe(0);
+  });
+  test("1020 ms", () => {
+    const ts = timestampFromMs(1020);
+    expect(Number(ts.seconds)).toBe(1);
+    expect(ts.nanos).toBe(20 * 1000000);
+  });
+  test("-1070 ms", () => {
+    const ts = timestampFromMs(-1070);
+    expect(Number(ts.seconds)).toBe(-2);
+    expect(ts.nanos).toBe(930 * 1000000);
+  });
+  test("-1000 ms", () => {
+    const ts = timestampFromMs(-1000);
+    expect(Number(ts.seconds)).toBe(-1);
+    expect(ts.nanos).toBe(0);
+  });
 });
 
 describe("timestampFromDate()", () => {

--- a/packages/protobuf/src/wkt/timestamp.ts
+++ b/packages/protobuf/src/wkt/timestamp.ts
@@ -42,9 +42,10 @@ export function timestampDate(timestamp: Timestamp): Date {
  * Create a google.protobuf.Timestamp message from a Unix timestamp in milliseconds.
  */
 export function timestampFromMs(timestampMs: number): Timestamp {
+  const seconds = Math.floor(timestampMs / 1000);
   return create(TimestampSchema, {
-    seconds: protoInt64.parse(Math.floor(timestampMs / 1000)),
-    nanos: (timestampMs % 1000) * 1000000,
+    seconds: protoInt64.parse(seconds),
+    nanos: (timestampMs - seconds * 1000) * 1000000,
   });
 }
 


### PR DESCRIPTION
`timestampFromMs` from `@bufbuild/protobuf/wkt` creates a `google.protobuf.Timestamp` from the given Unix timestamp in milliseconds.

`Timestamp` supports values before January 1970 - the millisecond value is simply negative. But when such a value is passed to `timestampFromMs`, the `nanos` field of `Timestamp` is set to a negative value, which is invalid and will raise an error when serializing to JSON.

Since `timestampFromDate` uses `timestampFromMs` under the hood, it's also affected, and will return invalid `Timestamp`s for Dates before January 1st 1970.

This fixes the bug and adds tests.