### PR TITLE
Remove type RawPluginOptions

### DIFF
--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -30,7 +30,6 @@ import {
 } from "@bufbuild/protoplugin";
 import { fieldJsonType, fieldTypeScriptType, functionCall } from "./util";
 import { version } from "../package.json";
-import { RawPluginOptions } from "@bufbuild/protoplugin/dist/cjs/parameter";
 
 export const protocGenEs = createEcmaScriptPlugin({
   name: "protoc-gen-es",
@@ -45,7 +44,12 @@ type Options = {
   jsonTypes: boolean;
 };
 
-function parseOptions(options: RawPluginOptions): Options {
+function parseOptions(
+  options: {
+    key: string;
+    value: string;
+  }[],
+): Options {
   let jsonTypes = false;
   for (const { key, value } of options) {
     switch (key) {

--- a/packages/protoplugin/src/create-es-plugin.ts
+++ b/packages/protoplugin/src/create-es-plugin.ts
@@ -29,7 +29,6 @@ import type { FileInfo } from "./generated-file.js";
 import type { Plugin } from "./plugin.js";
 import { transpile } from "./transpile.js";
 import { parseParameter } from "./parameter.js";
-import type { RawPluginOptions } from "./parameter.js";
 
 interface PluginInit<Options extends object> {
   /**
@@ -45,8 +44,28 @@ interface PluginInit<Options extends object> {
   /**
    * An optional parsing function which can be used to parse your own plugin
    * options.
+   *
+   * For example, if a plugin is run with the options foo=123,bar,baz=a,baz=b
+   * the raw options are:
+   *
+   * ```ts
+   * [
+   *   { key: "foo", value: "123" },
+   *   { key: "bar", value: "" },
+   *   { key: "baz", value: "a" },
+   *   { key: "baz", value: "b" },
+   * ]
+   * ```
+   *
+   * If your plugin does not recognize an option, it must throw an Error in
+   * parseOptions.
    */
-  parseOptions?: (rawOptions: RawPluginOptions) => Options;
+  parseOptions?: (
+    rawOptions: {
+      key: string;
+      value: string;
+    }[],
+  ) => Options;
 
   /**
    * The earliest edition supported by this plugin. Defaults to the minimum

--- a/packages/protoplugin/src/parameter.ts
+++ b/packages/protoplugin/src/parameter.ts
@@ -76,32 +76,16 @@ export interface ParsedParameter<T> {
   sanitized: string;
 }
 
-/**
- * Raw options to parse.
- *
- * For example, if a plugin is run with the options foo=123,bar,baz=a,baz=b
- * the raw options are:
- *
- * ```ts
- * [
- *   { key: "foo", value: "123" },
- *   { key: "bar", value: "" },
- *   { key: "baz", value: "a" },
- *   { key: "baz", value: "b" },
- * ]
- * ```
- *
- * If your plugin does not recognize an option, it must throw an Error in
- * parseOptions.
- */
-export type RawPluginOptions = {
-  key: string;
-  value: string;
-}[];
-
 export function parseParameter<T extends object>(
   parameter: string,
-  parseExtraOptions: ((rawOptions: RawPluginOptions) => T) | undefined,
+  parseExtraOptions:
+    | ((
+        rawOptions: {
+          key: string;
+          value: string;
+        }[],
+      ) => T)
+    | undefined,
 ): ParsedParameter<T> {
   let targets: Target[] = ["js", "dts"];
   let tsNocheck = false;
@@ -110,7 +94,10 @@ export function parseParameter<T extends object>(
   const rewriteImports: RewriteImports = [];
   let importExtension: ImportExtension = "none";
   let jsImportStyle: "module" | "legacy_commonjs" = "module";
-  const extraParameters: RawPluginOptions = [];
+  const extraParameters: {
+    key: string;
+    value: string;
+  }[] = [];
   const extraParametersRaw: string[] = [];
   const rawParameters: string[] = [];
   for (const { key, value, raw } of splitParameter(parameter)) {


### PR DESCRIPTION
The type `RawPluginOptions` is used for plugins. It defines raw options that are parsed to the `parseOptions` functions given to `createEcmaScriptPlugin`. However, we never exported the type from `@bufbuild/protoplugin`.

This PR removes the type, and replaces the few call-sites with the anonymous typing `{key: string; value: string; }[]`.