### PR TITLE
Fix upstream-protobuf scripts

### DIFF
--- a/packages/upstream-protobuf/README.md
+++ b/packages/upstream-protobuf/README.md
@@ -1,11 +1,11 @@
 # Upstream protobuf
 
-This package provides `protoc`, `conformance_test_runner`, related proto files, 
-and feature-set defaults for editions via npm "binaries", and via an exported 
+This package provides `protoc`, `conformance_test_runner`, related proto files,
+and feature-set defaults for editions via npm "binaries", and via an exported
 class.
 
-To update this project to use a new version, update the version number in 
-version.txt and run `npx turbo run bootstrap:inject bootstrap:wkt`. This will 
-re-generate the well-known types from the upstream definitions, and seed the 
-edition feature-set defaults. As a result, `@bufbuild/protobuf` may be modified. 
+To update this project to use a new version, update the version number in
+version.txt and run `npx turbo run bootstrap:inject bootstrap:wkt`. This will
+re-generate the well-known types from the upstream definitions, and seed the
+edition feature-set defaults. As a result, `@bufbuild/protobuf` may be modified.
 Run `npx turbo run test` to run all tests with the updated code.

--- a/packages/upstream-protobuf/bin/conformance_test_runner.mjs
+++ b/packages/upstream-protobuf/bin/conformance_test_runner.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/bin/protoc-gen-dumpcodegenreq.mjs
+++ b/packages/upstream-protobuf/bin/protoc-gen-dumpcodegenreq.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/bin/protoc.mjs
+++ b/packages/upstream-protobuf/bin/protoc.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/bin/upstream-files.mjs
+++ b/packages/upstream-protobuf/bin/upstream-files.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/bin/upstream-include.mjs
+++ b/packages/upstream-protobuf/bin/upstream-include.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/bin/upstream-warmup.mjs
+++ b/packages/upstream-protobuf/bin/upstream-warmup.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/index.d.ts
+++ b/packages/upstream-protobuf/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/index.mjs
+++ b/packages/upstream-protobuf/index.mjs
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Buf Technologies, Inc.
+// Copyright 2021-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/upstream-protobuf/package.json
+++ b/packages/upstream-protobuf/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node bin/upstream-warmup.mjs"
+    "build": "node bin/upstream-warmup.mjs",
+    "format": "prettier --write --ignore-unknown '.' '!.tmp'",
+    "license-header": "license-header"
   },
   "bin": {
     "protoc": "bin/protoc.mjs",
@@ -11,10 +13,7 @@
     "conformance_test_runner": "bin/conformance_test_runner.mjs",
     "upstream-files": "bin/upstream-files.mjs",
     "upstream-include": "bin/upstream-include.mjs",
-    "upstream-warmup": "bin/upstream-warmup.mjs",
-    "format": "prettier --write --ignore-unknown '.' '!.tmp'",
-    "license-header": "license-header",
-    "lint": "eslint --max-warnings 0 ."
+    "upstream-warmup": "bin/upstream-warmup.mjs"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
This fixes npm scripts of the internal package `upstream-protobuf`. This is purely cosmetics, and not relevant to any user-facing API.