### PR TITLE
Avoid duplicate work for some extensions in to json

### DIFF
--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -212,6 +212,7 @@ function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
       if (tagSeen.has(uf.no)) {
         continue;
       }
+      tagSeen.add(uf.no);
       const extension = opts.registry.getExtensionFor(msg.desc, uf.no);
       if (!extension) {
         continue;

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -206,22 +206,21 @@ function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
   }
   if (opts.registry) {
     const tagSeen = new Set<number>();
-    for (const uf of msg.getUnknown() ?? []) {
+    for (const { no } of msg.getUnknown() ?? []) {
       // Same tag can appear multiple times, so we
       // keep track and skip identical ones.
-      if (tagSeen.has(uf.no)) {
-        continue;
-      }
-      tagSeen.add(uf.no);
-      const extension = opts.registry.getExtensionFor(msg.desc, uf.no);
-      if (!extension) {
-        continue;
-      }
-      const value = getExtension(msg.message, extension);
-      const [container, field] = createExtensionContainer(extension, value);
-      const jsonValue = fieldToJson(field, container.get(field), opts);
-      if (jsonValue !== undefined) {
-        json[extension.jsonName] = jsonValue;
+      if (!tagSeen.has(no)) {
+        tagSeen.add(no);
+        const extension = opts.registry.getExtensionFor(msg.desc, no);
+        if (!extension) {
+          continue;
+        }
+        const value = getExtension(msg.message, extension);
+        const [container, field] = createExtensionContainer(extension, value);
+        const jsonValue = fieldToJson(field, container.get(field), opts);
+        if (jsonValue !== undefined) {
+          json[extension.jsonName] = jsonValue;
+        }
       }
     }
   }


### PR DESCRIPTION
When serializing to JSON, some extension values are serialized to JSON multiple times. The result is correct, we're just doing unnecessary extra work. This change avoids the extra work.

See https://github.com/bufbuild/protobuf-es/commit/caaff92170171d413b4c420d9bb28c8ed5fb749c. The rest is a refactor for readability.