### PR TITLE
Rely on Desc*.toString for serialization error messages

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   128,611 b |  66,711 b |   15,442 b |
-| Protobuf-ES         |     4 |   130,800 b |  68,219 b |   16,119 b |
-| Protobuf-ES         |     8 |   133,562 b |  69,990 b |   16,653 b |
-| Protobuf-ES         |    16 |   144,012 b |  77,971 b |   18,995 b |
-| Protobuf-ES         |    32 |   171,803 b |  99,989 b |   24,448 b |
+| Protobuf-ES         |     1 |   128,579 b |  66,681 b |   15,401 b |
+| Protobuf-ES         |     4 |   130,768 b |  68,189 b |   16,142 b |
+| Protobuf-ES         |     8 |   133,530 b |  69,960 b |   16,659 b |
+| Protobuf-ES         |    16 |   143,980 b |  77,941 b |   18,987 b |
+| Protobuf-ES         |    32 |   171,771 b |  99,959 b |   24,411 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.2677734375 140,244.35048828125 280,242.83818359375 420,236.20556640625 560,220.7625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.38388671875 140,244.2853515625 280,242.82119140625 420,236.22822265625 560,220.86728515624998">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.2677734375" r="4" fill="#ffa600"><title>Protobuf-ES 15.08 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.35048828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.74 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.83818359375" r="4" fill="#ffa600"><title>Protobuf-ES 16.26 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.20556640625" r="4" fill="#ffa600"><title>Protobuf-ES 18.55 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.7625" r="4" fill="#ffa600"><title>Protobuf-ES 23.88 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.38388671875" r="4" fill="#ffa600"><title>Protobuf-ES 15.04 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.2853515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.76 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.82119140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.27 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.22822265625" r="4" fill="#ffa600"><title>Protobuf-ES 18.54 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.86728515624998" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,245.990234375 140,241.980078125 280,238.6326171875 420,217.896484375 560,134.51015625000002">

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -178,9 +178,7 @@ export function enumFromJson<Desc extends DescEnum>(
 ): EnumShape<Desc> {
   const val = readEnum(descEnum, json, false, false);
   if (val === tokenIgnoredUnknownEnum) {
-    throw new Error(
-      `cannot decode ${String(descEnum)} from JSON: ${formatVal(json)}`,
-    );
+    throw new Error(`cannot decode ${descEnum} from JSON: ${formatVal(json)}`);
   }
   return val as EnumShape<Desc>;
 }

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -70,9 +70,7 @@ function writeFields(
   for (const f of msg.sortedFields) {
     if (!msg.isSet(f)) {
       if (f.presence == LEGACY_REQUIRED) {
-        throw new Error(
-          `cannot encode field ${msg.desc.typeName}.${f.name} to binary: required field not set`,
-        );
+        throw new Error(`cannot encode ${f} to binary: required field not set`);
       }
       continue;
     }

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -176,9 +176,7 @@ export function enumToJson<Desc extends DescEnum>(
   }
   const name = (descEnum.value[value] as DescEnumValue | undefined)?.name;
   if (name === undefined) {
-    throw new Error(
-      `${String(value)} is not a value in ${descEnum.toString()}`,
-    );
+    throw new Error(`${value} is not a value in ${descEnum}`);
   }
   return name as EnumJsonType<Desc>;
 }
@@ -190,9 +188,7 @@ function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
   for (const f of msg.sortedFields) {
     if (!msg.isSet(f)) {
       if (f.presence == LEGACY_REQUIRED) {
-        throw new Error(
-          `cannot encode field ${msg.desc.typeName}.${f.name} to JSON: required field not set`,
-        );
+        throw new Error(`cannot encode ${f} to JSON: required field not set`);
       }
       if (!opts.alwaysEmitImplicit || f.presence !== IMPLICIT) {
         // Fields with implicit presence omit zero values (e.g. empty string) by default


### PR DESCRIPTION
This is a small code quality improvement with a very minor improvement for bundle sizes:

In serialization errors, we construct a qualified name for the offending field, for example:

```ts
`cannot encode field ${msg.desc.typeName}.${f.name} to JSON: required field not set`
```

But field descriptors already return "field " + qualified name from their `toString` method. So the expression can be shortened to:

```ts
`cannot encode ${f} to JSON: required field not set`
```