### PR TITLE
Fix custom plugin option initialization

### DIFF
--- a/packages/protoplugin-test/src/parse-option.test.ts
+++ b/packages/protoplugin-test/src/parse-option.test.ts
@@ -79,6 +79,18 @@ describe("parse custom plugin option", () => {
       }),
     );
   });
+  test("custom option is initialized to default if no plugin option is provided", () => {
+    runPlugin(
+      (options) => {
+        expect(options.foo).toBeUndefined();
+        expect(options.bar).toBe(false);
+        expect(options.baz).toStrictEqual([]);
+      },
+      create(CodeGeneratorRequestSchema, {
+        parameter: "",
+      }),
+    );
+  });
   test("error from parseOption is wrapped", () => {
     expect(() =>
       runPlugin(

--- a/packages/protoplugin/src/parameter.ts
+++ b/packages/protoplugin/src/parameter.ts
@@ -235,7 +235,7 @@ export function parseParameter<T extends object>(
     jsImportStyle,
     keepEmptyFiles,
   };
-  if (parseExtraOptions === undefined || extraParameters.length === 0) {
+  if (parseExtraOptions === undefined) {
     return {
       parsed: ecmaScriptPluginOptions as T & EcmaScriptPluginOptions,
       sanitized: sanitizedParameters,


### PR DESCRIPTION
A plugin can support custom plugin options via a `parseOptions` function. The type it returns is automatically added to `Schema.options`. See [the manual](https://github.com/bufbuild/protobuf-es/blob/v2.2.5/MANUAL.md#parsing-plugin-options).

However, if no plugin option is passed, `parseOptions` is never invoked, and the default values it may return are not merged into the standard plugin options. As a result, `Schema.options` may promise properties that do not exist. 

This changes the behavior to always invoke `parseOptions`.