### PR TITLE
Fix message field presence reported by DescField for LEGACY_REQUIRED

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   128,579 b |  66,681 b |   15,401 b |
-| Protobuf-ES         |     4 |   130,768 b |  68,189 b |   16,142 b |
-| Protobuf-ES         |     8 |   133,530 b |  69,960 b |   16,659 b |
-| Protobuf-ES         |    16 |   143,980 b |  77,941 b |   18,987 b |
-| Protobuf-ES         |    32 |   171,771 b |  99,959 b |   24,411 b |
+| Protobuf-ES         |     1 |   128,663 b |  66,739 b |   15,448 b |
+| Protobuf-ES         |     4 |   130,852 b |  68,249 b |   16,165 b |
+| Protobuf-ES         |     8 |   133,614 b |  70,020 b |   16,680 b |
+| Protobuf-ES         |    16 |   144,064 b |  78,001 b |   19,040 b |
+| Protobuf-ES         |    32 |   171,855 b | 100,017 b |   24,425 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.38388671875 140,244.2853515625 280,242.82119140625 420,236.22822265625 560,220.86728515624998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.25078125 140,244.22021484375 280,242.76171875 420,236.078125 560,220.82763671875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.38388671875" r="4" fill="#ffa600"><title>Protobuf-ES 15.04 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.2853515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.76 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.82119140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.27 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.22822265625" r="4" fill="#ffa600"><title>Protobuf-ES 18.54 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.86728515624998" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.25078125" r="4" fill="#ffa600"><title>Protobuf-ES 15.09 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.22021484375" r="4" fill="#ffa600"><title>Protobuf-ES 15.79 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.76171875" r="4" fill="#ffa600"><title>Protobuf-ES 16.29 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.078125" r="4" fill="#ffa600"><title>Protobuf-ES 18.59 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.82763671875" r="4" fill="#ffa600"><title>Protobuf-ES 23.85 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,245.990234375 140,241.980078125 280,238.6326171875 420,217.896484375 560,134.51015625000002">

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -45,8 +45,6 @@ import {
   compileService,
 } from "./helpers.js";
 
-/* eslint-disable @typescript-eslint/no-unused-expressions -- we use expressions for type tests */
-
 describe("createRegistry()", () => {
   let testReg: FileRegistry;
   let testDescs: {
@@ -800,7 +798,7 @@ describe("DescEnumValue", () => {
 
 describe("DescField", () => {
   describe("presence", () => {
-    test("proto2 optional is EXPLICIT", async () => {
+    test("proto2 optional scalar is EXPLICIT", async () => {
       const field = await compileField(`
         syntax="proto2";
         message M { 
@@ -818,7 +816,7 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
-    test("proto2 required is LEGACY_REQUIRED", async () => {
+    test("proto2 required scalar is LEGACY_REQUIRED", async () => {
       const field = await compileField(`
         syntax="proto2";
         message M { 
@@ -836,7 +834,7 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
     });
-    test("proto2 list is IMPLICIT", async () => {
+    test("proto2 scalar list is IMPLICIT", async () => {
       const field = await compileField(`
         syntax="proto2";
         message M { 
@@ -845,11 +843,29 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
-    test("proto2 map is IMPLICIT", async () => {
+    test("proto2 message list is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto2";
+        message M { 
+          repeated M f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("proto2 scalar map is IMPLICIT", async () => {
       const field = await compileField(`
         syntax="proto2";
         message M { 
           map <int32, int32> f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("proto2 message map is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto2";
+        message M { 
+          map <int32, M> f = 1;
         }
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
@@ -865,7 +881,7 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
-    test("proto3 is IMPLICIT", async () => {
+    test("proto3 scalar is IMPLICIT", async () => {
       const field = await compileField(`
         syntax="proto3";
         message M { 
@@ -874,7 +890,7 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
-    test("proto3 optional is EXPLICIT", async () => {
+    test("proto3 optional scalar is EXPLICIT", async () => {
       const field = await compileField(`
         syntax="proto3";
         message M { 
@@ -883,7 +899,7 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
-    test("proto3 list is IMPLICIT", async () => {
+    test("proto3 scalar list is IMPLICIT", async () => {
       const field = await compileField(`
         syntax="proto3";
         message M { 
@@ -892,11 +908,29 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
     });
-    test("proto3 map is IMPLICIT", async () => {
+    test("proto3 message list is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto3";
+        message M { 
+          repeated M f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("proto3 scalar map is IMPLICIT", async () => {
       const field = await compileField(`
         syntax="proto3";
         message M { 
           map <int32, int32> f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("proto3 message map is IMPLICIT", async () => {
+      const field = await compileField(`
+        syntax="proto3";
+        message M { 
+          map <int32, M> f = 1;
         }
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
@@ -939,7 +973,7 @@ describe("DescField", () => {
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
     });
-    test("edition2023 inherited features.field_presence is IMPLICIT", async () => {
+    test("edition2023 scalar inherits IMPLICIT", async () => {
       const field = await compileField(`
         edition="2023";
         option features.field_presence = IMPLICIT;
@@ -948,6 +982,62 @@ describe("DescField", () => {
         }
       `);
       expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("edition2023 message is EXPLICIT", async () => {
+      const field = await compileField(`
+        edition="2023";
+        option features.field_presence = IMPLICIT;
+        message M { 
+          M f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
+    });
+    test("edition2023 message does not inherit IMPLICIT", async () => {
+      const field = await compileField(`
+        edition="2023";
+        option features.field_presence = IMPLICIT;
+        message M { 
+          M f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.EXPLICIT);
+    });
+    test("edition2023 scalar list is IMPLICIT", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M { 
+          repeated int32 f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("edition2023 message list is IMPLICIT", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M { 
+          repeated M f = 1;
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.IMPLICIT);
+    });
+    test("edition2023 scalar with LEGACY_REQUIRED is LEGACY_REQUIRED", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M { 
+          int32 f = 1 [features.field_presence = LEGACY_REQUIRED];
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
+    });
+    test("edition2023 message with LEGACY_REQUIRED is LEGACY_REQUIRED", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M { 
+          M f = 1 [features.field_presence = LEGACY_REQUIRED];
+        }
+      `);
+      expect(field.presence).toBe(FeatureSet_FieldPresence.LEGACY_REQUIRED);
     });
   });
   describe("delimitedEncoding", () => {

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -1118,7 +1118,10 @@ function getFieldPresence(
     return EXPLICIT;
   }
   const resolved = resolveFeature("fieldPresence", { proto, parent });
-  if (resolved == IMPLICIT && (proto.type == TYPE_MESSAGE || proto.type == TYPE_GROUP)) {
+  if (
+    resolved == IMPLICIT &&
+    (proto.type == TYPE_MESSAGE || proto.type == TYPE_GROUP)
+  ) {
     // singular message field cannot be implicit
     return EXPLICIT;
   }

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -1113,15 +1113,16 @@ function getFieldPresence(
     // oneof is always explicit
     return EXPLICIT;
   }
-  if (proto.type == TYPE_MESSAGE) {
-    // singular message field cannot be implicit
-    return EXPLICIT;
-  }
   if (isExtension) {
     // extensions always track presence
     return EXPLICIT;
   }
-  return resolveFeature("fieldPresence", { proto, parent });
+  const resolved = resolveFeature("fieldPresence", { proto, parent });
+  if (resolved == IMPLICIT && (proto.type == TYPE_MESSAGE || proto.type == TYPE_GROUP)) {
+    // singular message field cannot be implicit
+    return EXPLICIT;
+  }
+  return resolved;
 }
 
 /**


### PR DESCRIPTION
If the `required` label is set for a proto2 message field, `DescField.presence` reports LEGACY_REQUIRED, as expected:

```proto
syntax="proto2";
message Example {
  required Example field = 1; // DescField.presence reports LEGACY_REQUIRED
}
```

But if the equivalent feature in Edition 2023 is set, `DescField.presence` incorrectly reports EXPLICIT:


```proto
edition="2023";
message Example {
  Example field = 1 [features.field_presence = LEGACY_REQUIRED]; // // DescField.presence reports EXPLICIT
}
```

This PR fixes the behavior and adds tests. See the commit messages for details.