### PR TITLE
Fix regression in DescEnumValue.deprecated

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   128,579 b |  66,681 b |   15,401 b |
-| Protobuf-ES         |     4 |   130,768 b |  68,189 b |   16,142 b |
-| Protobuf-ES         |     8 |   133,530 b |  69,960 b |   16,659 b |
-| Protobuf-ES         |    16 |   143,980 b |  77,941 b |   18,987 b |
-| Protobuf-ES         |    32 |   171,771 b |  99,959 b |   24,411 b |
+| Protobuf-ES         |     1 |   128,575 b |  66,681 b |   15,415 b |
+| Protobuf-ES         |     4 |   130,764 b |  68,189 b |   16,139 b |
+| Protobuf-ES         |     8 |   133,526 b |  69,960 b |   16,602 b |
+| Protobuf-ES         |    16 |   143,976 b |  77,941 b |   18,983 b |
+| Protobuf-ES         |    32 |   171,767 b |  99,959 b |   24,432 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.38388671875 140,244.2853515625 280,242.82119140625 420,236.22822265625 560,220.86728515624998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.34423828125 140,244.29384765625 280,242.9826171875 420,236.23955078125 560,220.8078125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.38388671875" r="4" fill="#ffa600"><title>Protobuf-ES 15.04 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.2853515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.76 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.82119140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.27 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.22822265625" r="4" fill="#ffa600"><title>Protobuf-ES 18.54 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.86728515624998" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.34423828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.05 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.29384765625" r="4" fill="#ffa600"><title>Protobuf-ES 15.76 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.9826171875" r="4" fill="#ffa600"><title>Protobuf-ES 16.21 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.23955078125" r="4" fill="#ffa600"><title>Protobuf-ES 18.54 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.8078125" r="4" fill="#ffa600"><title>Protobuf-ES 23.86 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,245.990234375 140,241.980078125 280,238.6326171875 420,217.896484375 560,134.51015625000002">

--- a/packages/protobuf-test/src/gen/js/extra/comments_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/comments_pb.d.ts
@@ -201,13 +201,11 @@ export declare const EnumWithCommentsSchema: GenEnum<EnumWithComments>;
 export enum DeprecatedEnumWithComment {
   /**
    * @generated from enum value: DEPRECATED_ENUM_WITH_COMMENT_A = 0;
-   * @deprecated
    */
   A = 0,
 
   /**
    * @generated from enum value: DEPRECATED_ENUM_WITH_COMMENT_B = 1;
-   * @deprecated
    */
   B = 1,
 }
@@ -225,13 +223,11 @@ export declare const DeprecatedEnumWithCommentSchema: GenEnum<DeprecatedEnumWith
 export enum DeprecatedEnumNoComment {
   /**
    * @generated from enum value: DEPRECATED_ENUM_NO_COMMENT_A = 0;
-   * @deprecated
    */
   A = 0,
 
   /**
    * @generated from enum value: DEPRECATED_ENUM_NO_COMMENT_B = 1;
-   * @deprecated
    */
   B = 1,
 }

--- a/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/deprecation-explicit_pb.d.ts
@@ -82,13 +82,11 @@ export declare const DeprecatedFieldMessageSchema: GenMessage<DeprecatedFieldMes
 export enum DeprecatedEnum {
   /**
    * @generated from enum value: DEPRECATED_ENUM_A = 0;
-   * @deprecated
    */
   A = 0,
 
   /**
    * @generated from enum value: DEPRECATED_ENUM_B = 1;
-   * @deprecated
    */
   B = 1,
 }
@@ -112,6 +110,7 @@ export enum DeprecatedValueEnum {
 
   /**
    * @generated from enum value: DEPRECATED_VALUE_ENUM_DEPRECATED_VALUE = 1 [deprecated = true];
+   * @deprecated
    */
   DEPRECATED_VALUE = 1,
 }

--- a/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
@@ -207,13 +207,11 @@ export const EnumWithCommentsSchema: GenEnum<EnumWithComments> = /*@__PURE__*/
 export enum DeprecatedEnumWithComment {
   /**
    * @generated from enum value: DEPRECATED_ENUM_WITH_COMMENT_A = 0;
-   * @deprecated
    */
   A = 0,
 
   /**
    * @generated from enum value: DEPRECATED_ENUM_WITH_COMMENT_B = 1;
-   * @deprecated
    */
   B = 1,
 }
@@ -232,13 +230,11 @@ export const DeprecatedEnumWithCommentSchema: GenEnum<DeprecatedEnumWithComment>
 export enum DeprecatedEnumNoComment {
   /**
    * @generated from enum value: DEPRECATED_ENUM_NO_COMMENT_A = 0;
-   * @deprecated
    */
   A = 0,
 
   /**
    * @generated from enum value: DEPRECATED_ENUM_NO_COMMENT_B = 1;
-   * @deprecated
    */
   B = 1,
 }

--- a/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/deprecation-explicit_pb.ts
@@ -87,13 +87,11 @@ export const DeprecatedFieldMessageSchema: GenMessage<DeprecatedFieldMessage> = 
 export enum DeprecatedEnum {
   /**
    * @generated from enum value: DEPRECATED_ENUM_A = 0;
-   * @deprecated
    */
   A = 0,
 
   /**
    * @generated from enum value: DEPRECATED_ENUM_B = 1;
-   * @deprecated
    */
   B = 1,
 }
@@ -118,6 +116,7 @@ export enum DeprecatedValueEnum {
 
   /**
    * @generated from enum value: DEPRECATED_VALUE_ENUM_DEPRECATED_VALUE = 1 [deprecated = true];
+   * @deprecated
    */
   DEPRECATED_VALUE = 1,
 }

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -732,6 +732,37 @@ describe("DescEnum", () => {
       expect(descEnum.sharedPrefix).toBeUndefined();
     });
   });
+  describe("deprecated", () => {
+    test("not deprecated by default", async () => {
+      const descEnum = await compileEnum(`
+        syntax="proto3";
+        enum E {
+          A = 0;
+        }
+      `);
+      expect(descEnum.deprecated).toBe(false);
+    });
+    test("deprecated is deprecated", async () => {
+      const descEnum = await compileEnum(`
+        syntax="proto3";
+        enum E {
+          option deprecated = true;
+          A = 0;
+        }
+      `);
+      expect(descEnum.deprecated).toBe(true);
+    });
+    test("deprecated file is not deprecated", async () => {
+      const descEnum = await compileEnum(`
+        syntax="proto3";
+        option deprecated = true;
+        enum E {
+          A = 0;
+        }
+      `);
+      expect(descEnum.deprecated).toBe(false);
+    });
+  });
 });
 
 describe("DescEnumValue", () => {
@@ -794,6 +825,54 @@ describe("DescEnumValue", () => {
       `)
       ).values[0];
       expect(value.localName).toBe("constructor$");
+    });
+  });
+  describe("deprecated", () => {
+    test("not deprecated by default", async () => {
+      const value = (
+        await compileEnum(`
+        syntax="proto3";
+        enum E {
+          A = 0;
+        }
+      `)
+      ).values[0];
+      expect(value.deprecated).toBe(false);
+    });
+    test("deprecated is deprecated", async () => {
+      const value = (
+        await compileEnum(`
+        syntax="proto3";
+        enum E {
+          A = 0 [deprecated = true];
+        }
+      `)
+      ).values[0];
+      expect(value.deprecated).toBe(true);
+    });
+    test("deprecated enum is not deprecated", async () => {
+      const value = (
+        await compileEnum(`
+        syntax="proto3";
+        enum E {
+        option deprecated = true;
+          A = 0;
+        }
+      `)
+      ).values[0];
+      expect(value.deprecated).toBe(false);
+    });
+    test("deprecated file is not deprecated", async () => {
+      const value = (
+        await compileEnum(`
+        syntax="proto3";
+        option deprecated = true;
+        enum E {
+          A = 0;
+        }
+      `)
+      ).values[0];
+      expect(value.deprecated).toBe(false);
     });
   });
 });

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -619,7 +619,7 @@ function addEnum(
       (desc.value[p.number] = {
         kind: "enum_value" as const,
         proto: p,
-        deprecated: proto.options?.deprecated ?? false,
+        deprecated: p.options?.deprecated ?? false,
         parent: desc,
         name,
         localName: safeObjectProperty(


### PR DESCRIPTION
`DescEnumValue` is a descriptor for values of a Protobuf enum. It's `deprecated` property reports whether the value was marked deprecated in the source.  For example:

```
syntax="proto3";
enum Example {
  EXAMPLE_UNSPECIFIED = 0;
  EXAMPLE_FOO = 1 [deprecated = true];
}
```

The latest release v2.3.0 includes an unwanted change to the property: Instead of reporting whether the enum value is marked deprecated, it reports whether the containing enum is deprecated.

This adds tests and fixes the bug.