### PR TITLE
Add function usedTypes

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -19,8 +19,8 @@ usually do. We repeat this for an increasing number of files.
 | Protobuf-ES         |     1 |   128,579 b |  66,681 b |   15,401 b |
 | Protobuf-ES         |     4 |   130,768 b |  68,189 b |   16,142 b |
 | Protobuf-ES         |     8 |   133,530 b |  69,960 b |   16,659 b |
-| Protobuf-ES         |    16 |   143,980 b |  77,941 b |   18,987 b |
-| Protobuf-ES         |    32 |   171,771 b |  99,959 b |   24,411 b |
+| Protobuf-ES         |    16 |   143,980 b |  77,941 b |   18,961 b |
+| Protobuf-ES         |    32 |   171,771 b |  99,959 b |   24,465 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.38388671875 140,244.2853515625 280,242.82119140625 420,236.22822265625 560,220.86728515624998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.38388671875 140,244.2853515625 280,242.82119140625 420,236.30185546875 560,220.71435546875">
     <title>Protobuf-ES</title>
   </polyline>
 <circle cx="0" cy="246.38388671875" r="4" fill="#ffa600"><title>Protobuf-ES 15.04 KiB for 1 files</title></circle>
 <circle cx="140" cy="244.2853515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.76 KiB for 4 files</title></circle>
 <circle cx="280" cy="242.82119140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.27 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.22822265625" r="4" fill="#ffa600"><title>Protobuf-ES 18.54 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.86728515624998" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="420" cy="236.30185546875" r="4" fill="#ffa600"><title>Protobuf-ES 18.52 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.71435546875" r="4" fill="#ffa600"><title>Protobuf-ES 23.89 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,245.990234375 140,241.980078125 280,238.6326171875 420,217.896484375 560,134.51015625000002">


### PR DESCRIPTION
This adds the export `usedTypes` to @bufbuild/protobuf/reflect.

The function takes a message descriptor as an argument, and returns an iterator yields every message or enum referenced in the argument.


For example:

```proto
syntax="proto3";

message Example {
  Msg singular = 1;
  repeated Level list = 2;
}

message Msg {}

enum Level {
  LEVEL_UNSPECIFIED = 0;
}
```

The message `Example` references the message `Msg`, and the enum `Level`.