### PR TITLE
Provide a strong type name in the generated message schema

### DIFF
--- a/packages/protobuf-test/src/types.test.ts
+++ b/packages/protobuf-test/src/types.test.ts
@@ -51,10 +51,9 @@ describe("type Message", () => {
           throw new Error();
       }
     });
-    test("cannot switch on Message.$typeName against embedded desc's typeName", () => {
+    test("cam switch on Message.$typeName against embedded desc's typeName", () => {
       switch (msg.$typeName) {
         case UserSchema.typeName:
-          // @ts-expect-error TS2339
           expect(msg.firstName).toBeDefined();
           break;
         default:

--- a/packages/protobuf-test/src/types.test.ts
+++ b/packages/protobuf-test/src/types.test.ts
@@ -51,7 +51,7 @@ describe("type Message", () => {
           throw new Error();
       }
     });
-    test("cam switch on Message.$typeName against embedded desc's typeName", () => {
+    test("can switch on Message.$typeName against embedded desc's typeName", () => {
       switch (msg.$typeName) {
         case UserSchema.typeName:
           expect(msg.firstName).toBeDefined();

--- a/packages/protobuf/src/codegenv1/types.ts
+++ b/packages/protobuf/src/codegenv1/types.ts
@@ -42,8 +42,11 @@ export type GenFile = DescFile;
  */
 // biome-ignore format: want this to read well
 export type GenMessage<RuntimeShape extends Message, JsonType = JsonValue> =
-  & Omit<DescMessage, "field">
-  & { field: Record<MessageFieldNames<RuntimeShape>, DescField> }
+  & Omit<DescMessage, "field" | "typeName">
+  & {
+    field: Record<MessageFieldNames<RuntimeShape>, DescField>,
+    typeName: RuntimeShape["$typeName"],
+  }
   & brandv1<RuntimeShape, JsonType>;
 
 /**


### PR DESCRIPTION
This makes the `typeName` property of generated message schemas a literal type.

For example, given this proto:

```proto
syntax = "proto3";
package example;
message User {
  string first_name = 1;
}
```

```ts
import { UserSchema } from "./gen/example_pb";

UserSchema.typeName; // "example.User"
```

Previously, `typeName` was just a `string`.

Closes https://github.com/bufbuild/protobuf-es/issues/1056.