### PR TITLE
Remove dev dependency on @types/lz-string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1980,16 +1980,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-s84fKOrzqqNCAPljhVyC5TjAo6BH4jKHw9NRNFNiRUY5QSgZCmVm5XILlWbisiKl+0OcS7eWihmKGS5akc2iQw==",
-      "deprecated": "This is a stub types definition. lz-string provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "lz-string": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
@@ -5245,15 +5235,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.23.2.tgz",
@@ -7558,6 +7539,9 @@
       "bin": {
         "protoc-gen-es": "bin/protoc-gen-es"
       },
+      "devDependencies": {
+        "upstream-protobuf": "*"
+      },
       "engines": {
         "node": ">=14"
       },
@@ -7578,9 +7562,6 @@
         "@bufbuild/protobuf": "2.5.0",
         "@typescript/vfs": "^1.5.2",
         "typescript": "5.4.5"
-      },
-      "devDependencies": {
-        "@types/lz-string": "^1.5.0"
       }
     },
     "packages/protoplugin-example": {

--- a/packages/protoplugin/package.json
+++ b/packages/protoplugin/package.json
@@ -39,8 +39,5 @@
     "@typescript/vfs": "^1.5.2",
     "typescript": "5.4.5"
   },
-  "files": ["dist/**"],
-  "devDependencies": {
-    "@types/lz-string": "^1.5.0"
-  }
+  "files": ["dist/**"]
 }


### PR DESCRIPTION
The dev dependency was added to `@bufbuild/protoplugin` in https://github.com/bufbuild/protobuf-es/pull/228.

Currently, `npm` warns:

```
npm warn deprecated @types/lz-string@1.5.0: This is a stub types definition. lz-string provides its own type definitions, so you do not need this installed.
```

Removing the dev dependency does not yield any error. It looks like we've since updated dependencies, so that we no longer transitively depend on lz-string.