### PR TITLE
Implement merge function for Protobuf messages

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -18,7 +18,7 @@ usually do. We repeat this for an increasing number of files.
 | ------------------- | ----: | ----------: | --------: | ---------: |
 | Protobuf-ES         |     1 |   128,659 b |  66,739 b |   15,466 b |
 | Protobuf-ES         |     4 |   130,848 b |  68,249 b |   16,099 b |
-| Protobuf-ES         |     8 |   133,610 b |  70,020 b |   16,656 b |
+| Protobuf-ES         |     8 |   133,610 b |  70,020 b |   16,676 b |
 | Protobuf-ES         |    16 |   144,060 b |  78,001 b |   19,012 b |
 | Protobuf-ES         |    32 |   171,851 b | 100,017 b |   24,452 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,12 +43,12 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.1998046875 140,244.40712890625 280,242.8296875 420,236.157421875 560,220.751171875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.1998046875 140,244.40712890625 280,242.773046875 420,236.157421875 560,220.751171875">
     <title>Protobuf-ES</title>
   </polyline>
 <circle cx="0" cy="246.1998046875" r="4" fill="#ffa600"><title>Protobuf-ES 15.1 KiB for 1 files</title></circle>
 <circle cx="140" cy="244.40712890625" r="4" fill="#ffa600"><title>Protobuf-ES 15.72 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.8296875" r="4" fill="#ffa600"><title>Protobuf-ES 16.27 KiB for 8 files</title></circle>
+<circle cx="280" cy="242.773046875" r="4" fill="#ffa600"><title>Protobuf-ES 16.29 KiB for 8 files</title></circle>
 <circle cx="420" cy="236.157421875" r="4" fill="#ffa600"><title>Protobuf-ES 18.57 KiB for 16 files</title></circle>
 <circle cx="560" cy="220.751171875" r="4" fill="#ffa600"><title>Protobuf-ES 23.88 KiB for 32 files</title></circle>
 </g>

--- a/packages/protobuf-test/src/merge.test.ts
+++ b/packages/protobuf-test/src/merge.test.ts
@@ -1,0 +1,147 @@
+// Copyright 2021-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "@jest/globals";
+import { create, merge } from "@bufbuild/protobuf";
+import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
+import { WireType } from "@bufbuild/protobuf/wire";
+
+describe("merge()", () => {
+  test("sets scalar field in target, replacing existing fields", () => {
+    const target = create(proto3_ts.Proto3MessageSchema, {
+      singularMessageField: {
+        singularStringField: "old",
+        singularBytesField: new Uint8Array([0xff, 0xff]),
+        optionalStringField: "old",
+        singularEnumField: proto3_ts.Proto3Enum.NO,
+      },
+    });
+    const source = create(proto3_ts.Proto3MessageSchema, {
+      singularStringField: "abc",
+      singularBytesField: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+      optionalStringField: "abc",
+      singularEnumField: proto3_ts.Proto3Enum.YES,
+      singularMessageField: {
+        singularStringField: "abc",
+        singularBytesField: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        optionalStringField: "abc",
+        singularEnumField: proto3_ts.Proto3Enum.YES,
+      },
+    });
+    merge(proto3_ts.Proto3MessageSchema, target, source);
+    // sets scalar field in target
+    expect(target.singularStringField).toBe("abc");
+    expect(target.optionalStringField).toBe("abc");
+    expect(target.singularBytesField).toBe(source.singularBytesField); // bytes field is copied by reference
+    expect(target.singularEnumField).toBe(proto3_ts.Proto3Enum.YES);
+    // replaces existing fields
+    expect(target.singularMessageField?.singularStringField).toBe("abc");
+    expect(target.singularMessageField?.optionalStringField).toBe("abc");
+    expect(target.singularMessageField?.singularBytesField).toBe(
+      source.singularMessageField?.singularBytesField,
+    ); // bytes field is copied by reference
+    expect(target.singularMessageField?.singularEnumField).toBe(
+      proto3_ts.Proto3Enum.YES,
+    );
+  });
+  test("sets map values in target", () => {
+    const target = create(proto3_ts.Proto3MessageSchema, {
+      mapStringStringField: {
+        a: "A",
+        b: "B",
+      },
+    });
+    const source = create(proto3_ts.Proto3MessageSchema, {
+      mapStringStringField: {
+        b: "beta",
+        c: "C",
+      },
+    });
+    merge(proto3_ts.Proto3MessageSchema, target, source);
+    expect(target.mapStringStringField).toStrictEqual({
+      a: "A",
+      b: "beta",
+      c: "C",
+    });
+  });
+  test("adds repeated items in target", () => {
+    const target = create(proto3_ts.Proto3MessageSchema, {
+      repeatedStringField: ["a", "b"],
+    });
+    const source = create(proto3_ts.Proto3MessageSchema, {
+      repeatedStringField: ["c"],
+      repeatedInt32Field: [1, 2],
+    });
+    merge(proto3_ts.Proto3MessageSchema, target, source);
+    expect(target.repeatedStringField).toStrictEqual(["a", "b", "c"]);
+    expect(target.repeatedInt32Field).toStrictEqual([1, 2]);
+  });
+  test("merges message field with field in target", () => {
+    const target = create(proto3_ts.Proto3MessageSchema, {
+      singularMessageField: {
+        singularStringField: "abc",
+        repeatedInt32Field: [1],
+      },
+    });
+    const source = create(proto3_ts.Proto3MessageSchema, {
+      singularMessageField: {
+        singularStringField: "DEF",
+        repeatedInt32Field: [2],
+      },
+      optionalMessageField: {
+        singularStringField: "foo",
+      },
+    });
+    const targetSingularMessageField = target.singularMessageField;
+    merge(proto3_ts.Proto3MessageSchema, target, source);
+    expect(target.optionalMessageField).toBe(source.optionalMessageField); // message field is copied by reference
+    expect(target.singularMessageField).not.toBe(source.singularMessageField);
+    expect(target.singularMessageField).toBe(targetSingularMessageField); // target message field reference is maintained
+    expect(target.singularMessageField?.singularStringField).toBe("DEF");
+    expect(target.singularMessageField?.repeatedInt32Field).toStrictEqual([
+      1, 2,
+    ]);
+  });
+  test("adds unknown fields to target", () => {
+    const target = create(proto3_ts.Proto3MessageSchema);
+    target.$unknown = [
+      {
+        no: 98,
+        wireType: WireType.Varint,
+        data: new Uint8Array([0xaa]),
+      },
+    ];
+    const source = create(proto3_ts.Proto3MessageSchema);
+    source.$unknown = [
+      {
+        no: 99,
+        wireType: WireType.Varint,
+        data: new Uint8Array([0xbb]),
+      },
+    ];
+    merge(proto3_ts.Proto3MessageSchema, target, source);
+    expect(target.$unknown).toStrictEqual([
+      {
+        no: 98,
+        wireType: WireType.Varint,
+        data: new Uint8Array([0xaa]),
+      },
+      {
+        no: 99,
+        wireType: WireType.Varint,
+        data: new Uint8Array([0xbb]),
+      },
+    ]);
+  });
+});

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -27,6 +27,7 @@ export { fromBinary, mergeFromBinary } from "./from-binary.js";
 export type { BinaryReadOptions } from "./from-binary.js";
 export * from "./to-json.js";
 export * from "./from-json.js";
+export * from "./merge.js";
 export {
   hasExtension,
   getExtension,

--- a/packages/protobuf/src/merge.ts
+++ b/packages/protobuf/src/merge.ts
@@ -1,0 +1,74 @@
+// Copyright 2021-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { MessageShape } from "./types.js";
+import type { DescMessage } from "./descriptors.js";
+import { reflect } from "./reflect/reflect.js";
+import type { ReflectMessage } from "./reflect/reflect-types.js";
+
+/**
+ * Merge message `source` into message `target`, following Protobuf semantics.
+ *
+ * This is the same as serializing the source message, then deserializing it
+ * into the target message via `mergeFromBinary()`, with one difference:
+ * While serialization will create a copy of all values, `merge()` will copy
+ * the reference for `bytes` and messages.
+ *
+ * Also see https://protobuf.com/docs/language-spec#merging-protobuf-messages
+ */
+export function merge<Desc extends DescMessage>(
+  schema: Desc,
+  target: MessageShape<Desc>,
+  source: MessageShape<Desc>,
+): void {
+  reflectMerge(reflect(schema, target), reflect(schema, source));
+}
+
+function reflectMerge(target: ReflectMessage, source: ReflectMessage): void {
+  const sourceUnknown = source.message.$unknown;
+  if (sourceUnknown !== undefined && sourceUnknown.length > 0) {
+    target.message.$unknown ??= [];
+    target.message.$unknown.push(...sourceUnknown);
+  }
+  for (const f of target.fields) {
+    if (!source.isSet(f)) {
+      continue;
+    }
+    switch (f.fieldKind) {
+      case "scalar":
+      case "enum":
+        target.set(f, source.get(f));
+        break;
+      case "message":
+        if (target.isSet(f)) {
+          reflectMerge(target.get(f), source.get(f));
+        } else {
+          target.set(f, source.get(f));
+        }
+        break;
+      case "list":
+        const list = target.get(f);
+        for (const e of source.get(f)) {
+          list.add(e);
+        }
+        break;
+      case "map":
+        const map = target.get(f);
+        for (const [k, v] of source.get(f)) {
+          map.set(k, v);
+        }
+        break;
+    }
+  }
+}


### PR DESCRIPTION
This adds the function `merge()`, to merge message `source` into message `target`, following Protobuf semantics.

See https://protobuf.com/docs/language-spec#merging-protobuf-messages

Closes #315.