### PR TITLE
Fix closed enum parsing

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   131,530 b |  68,233 b |   15,681 b |
-| Protobuf-ES         |     4 |   133,719 b |  69,743 b |   16,342 b |
-| Protobuf-ES         |     8 |   136,481 b |  71,514 b |   16,880 b |
-| Protobuf-ES         |    16 |   146,931 b |  79,495 b |   19,248 b |
-| Protobuf-ES         |    32 |   174,722 b | 101,511 b |   24,714 b |
+| Protobuf-ES         |     1 |   132,069 b |  68,479 b |   15,746 b |
+| Protobuf-ES         |     4 |   134,258 b |  69,989 b |   16,445 b |
+| Protobuf-ES         |     8 |   137,020 b |  71,760 b |   16,938 b |
+| Protobuf-ES         |    16 |   147,470 b |  79,741 b |   19,274 b |
+| Protobuf-ES         |    32 |   175,261 b | 101,759 b |   24,722 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.59091796875 140,243.7189453125 280,242.1953125 420,235.4890625 560,220.00917968750002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.4068359375 140,243.42724609375 280,242.0310546875 420,235.4154296875 560,219.9865234375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.59091796875" r="4" fill="#ffa600"><title>Protobuf-ES 15.31 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.7189453125" r="4" fill="#ffa600"><title>Protobuf-ES 15.96 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.1953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.48 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.4890625" r="4" fill="#ffa600"><title>Protobuf-ES 18.8 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.00917968750002" r="4" fill="#ffa600"><title>Protobuf-ES 24.13 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.4068359375" r="4" fill="#ffa600"><title>Protobuf-ES 15.38 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.42724609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.06 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.0310546875" r="4" fill="#ffa600"><title>Protobuf-ES 16.54 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.4154296875" r="4" fill="#ffa600"><title>Protobuf-ES 18.82 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.9865234375" r="4" fill="#ffa600"><title>Protobuf-ES 24.14 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,245.990234375 140,241.980078125 280,238.6326171875 420,217.896484375 560,134.51015625000002">

--- a/packages/protobuf-test/src/enum-open-closed.test.ts
+++ b/packages/protobuf-test/src/enum-open-closed.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2021-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "@jest/globals";
+import { BinaryWriter, WireType } from "@bufbuild/protobuf/wire";
+import { fromBinary, isFieldSet } from "@bufbuild/protobuf";
+import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
+import * as proto2_ts from "./gen/ts/extra/proto2_pb.js";
+
+describe("open enum", () => {
+  test("from binary sets foreign value", () => {
+    expect(proto3_ts.Proto3EnumSchema.open).toBe(true);
+    const foreignValue = 4;
+    expect(proto3_ts.Proto3Enum[foreignValue]).toBeUndefined();
+    const bytes = new BinaryWriter()
+      .tag(
+        proto3_ts.Proto3MessageSchema.field.singularEnumField.number,
+        WireType.Varint,
+      )
+      .int32(foreignValue)
+      .finish();
+    const msg = fromBinary(proto3_ts.Proto3MessageSchema, bytes);
+    const set = isFieldSet(
+      msg,
+      proto3_ts.Proto3MessageSchema.field.singularEnumField,
+    );
+    expect(set).toBe(true);
+    expect(msg.singularEnumField).toBe(foreignValue);
+    expect(msg.$unknown).toBeUndefined();
+  });
+});
+
+describe("closed enum", () => {
+  test("from binary sets foreign value as unknown field", () => {
+    expect(proto2_ts.Proto2EnumSchema.open).toBe(false);
+    const foreignValue = 4;
+    expect(proto2_ts.Proto2Enum[foreignValue]).toBeUndefined();
+    const bytes = new BinaryWriter()
+      .tag(
+        proto2_ts.Proto2MessageSchema.field.optionalEnumField.number,
+        WireType.Varint,
+      )
+      .int32(foreignValue)
+      .finish();
+    const msg = fromBinary(proto2_ts.Proto2MessageSchema, bytes);
+    const set = isFieldSet(
+      msg,
+      proto2_ts.Proto2MessageSchema.field.optionalEnumField,
+    );
+    expect(set).toBe(false);
+    expect(msg.optionalEnumField).toBe(proto2_ts.Proto2Enum.YES);
+    expect(msg.$unknown).toBeDefined();
+    expect(msg.$unknown?.length).toBe(1);
+    expect(msg.$unknown?.[0].no).toBe(
+      proto2_ts.Proto2MessageSchema.field.optionalEnumField.number,
+    );
+    expect(msg.$unknown?.[0].wireType).toBe(WireType.Varint);
+    expect(msg.$unknown?.[0].data).toStrictEqual(
+      new BinaryWriter().int32(foreignValue).finish(),
+    );
+  });
+});


### PR DESCRIPTION
Protobuf enums are open in proto3, and closed in proto2. An open enum field can contain values not defined in the enum (for example from a future schema change). A closed enum field can only contain values defined in the enum.

The way we handle closed enums when parsing with `fromBinary` is flawed. While we never set an enum field to a value not defined in the enum, we do raise a parse error. The correct behavior is to put the unknown value into the set of unknown fields instead. This PR fixes the behavior.