### PR TITLE
Fix protoc-gen-es dependency constraint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7527,7 +7527,7 @@
       "version": "2.6.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.6.1",
+        "@bufbuild/protobuf": "2.6.1",
         "@bufbuild/protoplugin": "2.6.1"
       },
       "bin": {

--- a/packages/protoc-gen-es/package.json
+++ b/packages/protoc-gen-es/package.json
@@ -32,7 +32,7 @@
   },
   "preferUnplugged": true,
   "dependencies": {
-    "@bufbuild/protobuf": "^2.6.1",
+    "@bufbuild/protobuf": "2.6.1",
     "@bufbuild/protoplugin": "2.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
To ensure that @bufbuild/protoc-gen-es runs with the same version of @bufbuild/protobuf, use an exact version (2.6.1) instead of the "compatible with" constraint (^2.6.1).

We already use an exact version for the peer dependency, somehow this extra caret went unnoticed for a long time.

Fixes https://github.com/bufbuild/protobuf-es/issues/1175