### PR TITLE
Optimize bundle-size impact of fix to closed enum parsing

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,088 b |  68,483 b |   15,718 b |
-| Protobuf-ES         |     4 |   134,277 b |  69,993 b |   16,450 b |
-| Protobuf-ES         |     8 |   137,039 b |  71,764 b |   16,974 b |
-| Protobuf-ES         |    16 |   147,489 b |  79,745 b |   19,317 b |
-| Protobuf-ES         |    32 |   175,280 b | 101,763 b |   24,760 b |
+| Protobuf-ES         |     1 |   132,159 b |  68,489 b |   15,756 b |
+| Protobuf-ES         |     4 |   134,348 b |  69,996 b |   16,428 b |
+| Protobuf-ES         |     8 |   137,110 b |  71,767 b |   16,932 b |
+| Protobuf-ES         |    16 |   147,560 b |  79,748 b |   19,320 b |
+| Protobuf-ES         |    32 |   175,351 b | 101,766 b |   24,771 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.4861328125 140,243.4130859375 280,241.9291015625 420,235.29365234375 560,219.87890625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.378515625 140,243.475390625 280,242.048046875 420,235.28515625 560,219.84775390624998">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.4861328125" r="4" fill="#ffa600"><title>Protobuf-ES 15.35 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.4130859375" r="4" fill="#ffa600"><title>Protobuf-ES 16.06 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.9291015625" r="4" fill="#ffa600"><title>Protobuf-ES 16.58 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.29365234375" r="4" fill="#ffa600"><title>Protobuf-ES 18.86 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.87890625" r="4" fill="#ffa600"><title>Protobuf-ES 24.18 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.378515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.39 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.475390625" r="4" fill="#ffa600"><title>Protobuf-ES 16.04 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.048046875" r="4" fill="#ffa600"><title>Protobuf-ES 16.54 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.28515625" r="4" fill="#ffa600"><title>Protobuf-ES 18.87 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.84775390624998" r="4" fill="#ffa600"><title>Protobuf-ES 24.19 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,245.990234375 140,241.980078125 280,238.6326171875 420,217.896484375 560,134.51015625000002">


### PR DESCRIPTION
https://github.com/bufbuild/protobuf-es/pull/1170 fixed a bug with parsing unknown values for closed enum fields. 

The fix pulls in `BinaryWriter` to `fromBinary`, which affects bundle size for consumers that only care about _reading_ from binary. 

This PR optimizes for bundle size by importing just `varint32write` instead of `BinaryWriter`.