### PR TITLE
Update to TypeScript 5.9 and change returns types from `Uint8Array` to `Uint8Array<ArrayBuffer>`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^24.1.0",
         "jest": "^29.7.0",
         "turbo": "^2.5.5",
-        "typescript": "~5.6.3"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=18",
@@ -7027,6 +7027,18 @@
       "resolved": "packages/typescript-compat/v5.5.x",
       "link": true
     },
+    "node_modules/ts5.6": {
+      "resolved": "packages/typescript-compat/v5.6.x",
+      "link": true
+    },
+    "node_modules/ts5.7": {
+      "resolved": "packages/typescript-compat/v5.7.x",
+      "link": true
+    },
+    "node_modules/ts5.8": {
+      "resolved": "packages/typescript-compat/v5.8.x",
+      "link": true
+    },
     "node_modules/tsx": {
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
@@ -7173,9 +7185,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7713,8 +7725,17 @@
       "name": "ts5.2",
       "dependencies": {
         "@bufbuild/protobuf-test": "*",
-        "@types/node": "24.1.0",
+        "@types/node": "24.2.1",
         "typescript": "5.2.x"
+      }
+    },
+    "packages/typescript-compat/v5.2.x/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "packages/typescript-compat/v5.2.x/node_modules/typescript": {
@@ -7729,12 +7750,27 @@
         "node": ">=14.17"
       }
     },
+    "packages/typescript-compat/v5.2.x/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
+    },
     "packages/typescript-compat/v5.3.x": {
       "name": "ts5.3",
       "dependencies": {
         "@bufbuild/protobuf-test": "*",
-        "@types/node": "24.1.0",
+        "@types/node": "24.2.1",
         "typescript": "5.3.x"
+      }
+    },
+    "packages/typescript-compat/v5.3.x/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "packages/typescript-compat/v5.3.x/node_modules/typescript": {
@@ -7749,6 +7785,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "packages/typescript-compat/v5.3.x/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "packages/typescript-compat/v5.4.x": {
       "name": "ts5.4",
@@ -7775,8 +7817,17 @@
       "name": "ts5.5",
       "dependencies": {
         "@bufbuild/protobuf-test": "*",
-        "@types/node": "24.1.0",
+        "@types/node": "24.2.1",
         "typescript": "5.5.x"
+      }
+    },
+    "packages/typescript-compat/v5.5.x/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "packages/typescript-compat/v5.5.x/node_modules/typescript": {
@@ -7791,6 +7842,120 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "packages/typescript-compat/v5.5.x/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
+    },
+    "packages/typescript-compat/v5.6.x": {
+      "name": "ts5.6",
+      "dependencies": {
+        "@bufbuild/protobuf-test": "*",
+        "@types/node": "24.2.1",
+        "typescript": "5.6.x"
+      }
+    },
+    "packages/typescript-compat/v5.6.x/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "packages/typescript-compat/v5.6.x/node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/typescript-compat/v5.6.x/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
+    },
+    "packages/typescript-compat/v5.7.x": {
+      "name": "ts5.7",
+      "dependencies": {
+        "@bufbuild/protobuf-test": "*",
+        "@types/node": "24.2.1",
+        "typescript": "5.7.x"
+      }
+    },
+    "packages/typescript-compat/v5.7.x/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "packages/typescript-compat/v5.7.x/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/typescript-compat/v5.7.x/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
+    },
+    "packages/typescript-compat/v5.8.x": {
+      "name": "ts5.8",
+      "dependencies": {
+        "@bufbuild/protobuf-test": "*",
+        "@types/node": "24.2.1",
+        "typescript": "5.8.x"
+      }
+    },
+    "packages/typescript-compat/v5.8.x/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "packages/typescript-compat/v5.8.x/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/typescript-compat/v5.8.x/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "packages/upstream-protobuf": {
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^24.1.0",
     "jest": "^29.7.0",
     "turbo": "^2.5.5",
-    "typescript": "~5.6.3"
+    "typescript": "^5.9.2"
   },
   "//": "avoid hoisting of @typescript/vfs, see packages/protoplugin/src/transpile.ts",
   "dependencies": {

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,159 b |  68,489 b |   15,756 b |
-| Protobuf-ES         |     4 |   134,348 b |  69,996 b |   16,428 b |
-| Protobuf-ES         |     8 |   137,110 b |  71,767 b |   16,932 b |
-| Protobuf-ES         |    16 |   147,560 b |  79,748 b |   19,320 b |
-| Protobuf-ES         |    32 |   175,351 b | 101,766 b |   24,771 b |
+| Protobuf-ES         |     1 |   132,341 b |  68,489 b |   15,756 b |
+| Protobuf-ES         |     4 |   134,530 b |  69,996 b |   16,428 b |
+| Protobuf-ES         |     8 |   137,292 b |  71,767 b |   16,932 b |
+| Protobuf-ES         |    16 |   147,742 b |  79,748 b |   19,320 b |
+| Protobuf-ES         |    32 |   175,533 b | 101,766 b |   24,771 b |
 | protobuf-javascript |     1 |   104,048 b |  70,320 b |   15,540 b |
 | protobuf-javascript |     4 |   130,537 b |  85,672 b |   16,956 b |
 | protobuf-javascript |     8 |   152,429 b |  98,044 b |   18,138 b |

--- a/packages/protobuf-conformance/src/conformance.ts
+++ b/packages/protobuf-conformance/src/conformance.ts
@@ -180,7 +180,10 @@ async function* readMessages<Desc extends DescMessage>(
   messageDesc: Desc,
 ): AsyncIterable<MessageShape<Desc>> {
   // append chunk to buffer, returning updated buffer
-  function append(buffer: Uint8Array, chunk: Uint8Array): Uint8Array {
+  function append(
+    buffer: Uint8Array<ArrayBuffer>,
+    chunk: Uint8Array,
+  ): Uint8Array<ArrayBuffer> {
     const n = new Uint8Array(buffer.byteLength + chunk.byteLength);
     n.set(buffer);
     n.set(chunk, buffer.byteLength);

--- a/packages/protobuf-test/src/wire/text-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/text-encoding.test.ts
@@ -100,7 +100,7 @@ describe("configureTextEncoding()", () => {
     configureTextEncoding({
       checkUtf8: backup.checkUtf8,
       decodeUtf8: backup.decodeUtf8,
-      encodeUtf8(text: string): Uint8Array {
+      encodeUtf8(text: string) {
         arg = text;
         return new Uint8Array(10);
       },

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -54,7 +54,7 @@ export function toBinary<Desc extends DescMessage>(
   schema: Desc,
   message: MessageShape<Desc>,
   options?: Partial<BinaryWriteOptions>,
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   return writeFields(
     new BinaryWriter(),
     makeWriteOptions(options),

--- a/packages/protobuf/src/wire/base64-encoding.ts
+++ b/packages/protobuf/src/wire/base64-encoding.ts
@@ -23,7 +23,7 @@
  *   "_" instead of "/",
  *   no padding
  */
-export function base64Decode(base64Str: string) {
+export function base64Decode(base64Str: string): Uint8Array<ArrayBuffer> {
   const table = getDecodeTable();
   // estimate byte size, not accounting for inner padding and whitespace
   let es = (base64Str.length * 3) / 4;
@@ -39,7 +39,7 @@ export function base64Decode(base64Str: string) {
     b = table[base64Str.charCodeAt(i)];
     if (b === undefined) {
       switch (base64Str[i]) {
-        // @ts-expect-error TS7029: Fallthrough case in switch
+        // @ts-ignore TS7029: Fallthrough case in switch -- ignore instead of expect-error for compiler settings without noFallthroughCasesInSwitch: true
         case "=":
           groupPos = 0; // reset state when padding found
         case "\n":

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -130,7 +130,7 @@ export class BinaryWriter {
   /**
    * Return all bytes written and reset this writer.
    */
-  finish(): Uint8Array {
+  finish(): Uint8Array<ArrayBuffer> {
     if (this.buf.length) {
       this.chunks.push(new Uint8Array(this.buf)); // flush the buffer
       this.buf = [];
@@ -412,7 +412,7 @@ export class BinaryReader {
           // ignore
         }
         break;
-      // @ts-expect-error TS7029: Fallthrough case in switch
+      // @ts-ignore TS7029: Fallthrough case in switch -- ignore instead of expect-error for compiler settings without noFallthroughCasesInSwitch: true
       case WireType.Bit64:
         this.pos += 4;
       case WireType.Bit32:

--- a/packages/protobuf/src/wire/size-delimited.ts
+++ b/packages/protobuf/src/wire/size-delimited.ts
@@ -54,7 +54,10 @@ export async function* sizeDelimitedDecodeStream<Desc extends DescMessage>(
   options?: BinaryReadOptions,
 ): AsyncIterableIterator<MessageShape<Desc>> {
   // append chunk to buffer, returning updated buffer
-  function append(buffer: Uint8Array, chunk: Uint8Array): Uint8Array {
+  function append(
+    buffer: Uint8Array<ArrayBuffer>,
+    chunk: Uint8Array,
+  ): Uint8Array<ArrayBuffer> {
     const n = new Uint8Array(buffer.byteLength + chunk.byteLength);
     n.set(buffer);
     n.set(chunk, buffer.length);

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -22,7 +22,7 @@ interface TextEncoding {
   /**
    * Encode UTF-8 text to binary.
    */
-  encodeUtf8: (text: string) => Uint8Array;
+  encodeUtf8: (text: string) => Uint8Array<ArrayBuffer>;
   /**
    * Decode UTF-8 text from binary.
    */
@@ -51,7 +51,7 @@ export function getTextEncoding() {
       globalThis as unknown as GlobalWithTextEncoderDecoder
     ).TextDecoder();
     (globalThis as GlobalWithTextEncoding)[symbol] = {
-      encodeUtf8(text: string): Uint8Array {
+      encodeUtf8(text: string): Uint8Array<ArrayBuffer> {
         return te.encode(text);
       },
       decodeUtf8(bytes: Uint8Array): string {
@@ -77,7 +77,7 @@ type GlobalWithTextEncoding = {
 type GlobalWithTextEncoderDecoder = {
   TextEncoder: {
     new (): {
-      encode(text: string): Uint8Array;
+      encode(text: string): Uint8Array<ArrayBuffer>;
     };
   };
   TextDecoder: {

--- a/packages/typescript-compat/v4.9.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v4.9.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v4.9.x/tsconfig.json
+++ b/packages/typescript-compat/v4.9.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.0.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.0.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.0.x/tsconfig.json
+++ b/packages/typescript-compat/v5.0.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.1.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.1.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.1.x/tsconfig.json
+++ b/packages/typescript-compat/v5.1.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.2.x/package.json
+++ b/packages/typescript-compat/v5.2.x/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf-test": "*",
-    "@types/node": "24.1.0",
+    "@types/node": "24.2.1",
     "typescript": "5.2.x"
   }
 }

--- a/packages/typescript-compat/v5.2.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.2.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.2.x/tsconfig.json
+++ b/packages/typescript-compat/v5.2.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     "strict": true /* Enable all strict type-checking options. */,
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.3.x/package.json
+++ b/packages/typescript-compat/v5.3.x/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf-test": "*",
-    "@types/node": "24.1.0",
+    "@types/node": "24.2.1",
     "typescript": "5.3.x"
   }
 }

--- a/packages/typescript-compat/v5.3.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.3.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.3.x/tsconfig.json
+++ b/packages/typescript-compat/v5.3.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.4.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.4.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.4.x/tsconfig.json
+++ b/packages/typescript-compat/v5.4.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.5.x/package.json
+++ b/packages/typescript-compat/v5.5.x/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf-test": "*",
-    "@types/node": "24.1.0",
+    "@types/node": "24.2.1",
     "typescript": "5.5.x"
   }
 }

--- a/packages/typescript-compat/v5.5.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.5.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.5.x/tsconfig.json
+++ b/packages/typescript-compat/v5.5.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.6.x/package.json
+++ b/packages/typescript-compat/v5.6.x/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ts5.6",
+  "private": true,
+  "scripts": {
+    "test": "node_modules/.bin/tsc --outDir dist"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf-test": "*",
+    "@types/node": "24.2.1",
+    "typescript": "5.6.x"
+  }
+}

--- a/packages/typescript-compat/v5.6.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.6.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,28 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  return [infer, uint8Arr] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr] as const;
+}
+
+

--- a/packages/typescript-compat/v5.6.x/tsconfig.json
+++ b/packages/typescript-compat/v5.6.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",
@@ -19,9 +20,7 @@
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // To guard against regression and ensure we are remaining backwards
-    // compatible, set the skipLibCheck flag to false explicitly.
-    "skipLibCheck": false,
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
     // Certain errors are only triggered by actually emitting declaration files,
     // see https://github.com/bufbuild/protobuf-es/pull/398
     "declaration": true,

--- a/packages/typescript-compat/v5.6.x/tsconfig.json
+++ b/packages/typescript-compat/v5.6.x/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "include": [
+    "../../protobuf-test/src/types.test.ts",
+    "../../protobuf-test/src/registry.test.ts",
+    "../../protobuf-test/src/json_types.test.ts",
+    "../../protobuf-test/src/is-message.test.ts",
+    "../../protobuf-test/src/generate-code.test.ts",
+    "../../protobuf-test/src/fields.test.ts",
+    "../../protobuf-test/src/create.test.ts",
+    "../../protobuf-test/src/wkt/*.test.ts",
+    "../../protobuf-test/src/gen/**/*",
+    "../../protobuf-test/src/codegenv1/types.test.ts"
+  ],
+  // These are the default compiler options for TypeScript v5.6.x, created
+  // with `tsc --init` (except where noted in comments below)
+  "compilerOptions": {
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // To guard against regression and ensure we are remaining backwards
+    // compatible, set the skipLibCheck flag to false explicitly.
+    "skipLibCheck": false,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/typescript-compat/v5.7.x/package.json
+++ b/packages/typescript-compat/v5.7.x/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ts5.7",
+  "private": true,
+  "scripts": {
+    "test": "node_modules/.bin/tsc --outDir dist"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf-test": "*",
+    "@types/node": "24.2.1",
+    "typescript": "5.7.x"
+  }
+}

--- a/packages/typescript-compat/v5.7.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.7.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,32 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = new BinaryWriter().finish();
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = base64Decode("");
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+

--- a/packages/typescript-compat/v5.7.x/tsconfig.json
+++ b/packages/typescript-compat/v5.7.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",

--- a/packages/typescript-compat/v5.7.x/tsconfig.json
+++ b/packages/typescript-compat/v5.7.x/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "include": [
+    "../../protobuf-test/src/types.test.ts",
+    "../../protobuf-test/src/registry.test.ts",
+    "../../protobuf-test/src/json_types.test.ts",
+    "../../protobuf-test/src/is-message.test.ts",
+    "../../protobuf-test/src/generate-code.test.ts",
+    "../../protobuf-test/src/fields.test.ts",
+    "../../protobuf-test/src/create.test.ts",
+    "../../protobuf-test/src/wkt/*.test.ts",
+    "../../protobuf-test/src/gen/**/*",
+    "../../protobuf-test/src/codegenv1/types.test.ts"
+  ],
+  // These are the default compiler options for TypeScript v5.7.x, created
+  // with `tsc --init` (except where noted in comments below)
+  "compilerOptions": {
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // To guard against regression and ensure we are remaining backwards
+    // compatible, set the skipLibCheck flag to false explicitly.
+    "skipLibCheck": false,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/typescript-compat/v5.8.x/package.json
+++ b/packages/typescript-compat/v5.8.x/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ts5.8",
+  "private": true,
+  "scripts": {
+    "test": "node_modules/.bin/tsc --outDir dist"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf-test": "*",
+    "@types/node": "24.2.1",
+    "typescript": "5.8.x"
+  }
+}

--- a/packages/typescript-compat/v5.8.x/src/uint8array-arraybuffer.ts
+++ b/packages/typescript-compat/v5.8.x/src/uint8array-arraybuffer.ts
@@ -1,0 +1,32 @@
+import {BinaryWriter, base64Decode, getTextEncoding} from "@bufbuild/protobuf/wire";
+import {DescMessage, type Message, toBinary} from "@bufbuild/protobuf";
+
+export function testBinaryWriterFinish() {
+  const infer = new BinaryWriter().finish();
+  const uint8Arr: Uint8Array = new BinaryWriter().finish();
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = new BinaryWriter().finish();
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+export function testBase64Decode() {
+  const infer = base64Decode("");
+  const uint8Arr: Uint8Array = base64Decode("");
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = base64Decode("");
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+export function testEncodeUtf8() {
+  const infer = getTextEncoding().encodeUtf8("");
+  const uint8Arr: Uint8Array = getTextEncoding().encodeUtf8("");
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = getTextEncoding().encodeUtf8("");
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+export function testToBinary() {
+  const infer = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8Arr: Uint8Array = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  const uint8ArrBuff: Uint8Array<ArrayBuffer> = toBinary(null as unknown as DescMessage, null as unknown as Message);
+  return [infer, uint8Arr, uint8ArrBuff] as const;
+}
+
+

--- a/packages/typescript-compat/v5.8.x/tsconfig.json
+++ b/packages/typescript-compat/v5.8.x/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "./src/**/*.ts",
     "../../protobuf-test/src/types.test.ts",
     "../../protobuf-test/src/registry.test.ts",
     "../../protobuf-test/src/json_types.test.ts",

--- a/packages/typescript-compat/v5.8.x/tsconfig.json
+++ b/packages/typescript-compat/v5.8.x/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "include": [
+    "../../protobuf-test/src/types.test.ts",
+    "../../protobuf-test/src/registry.test.ts",
+    "../../protobuf-test/src/json_types.test.ts",
+    "../../protobuf-test/src/is-message.test.ts",
+    "../../protobuf-test/src/generate-code.test.ts",
+    "../../protobuf-test/src/fields.test.ts",
+    "../../protobuf-test/src/create.test.ts",
+    "../../protobuf-test/src/wkt/*.test.ts",
+    "../../protobuf-test/src/gen/**/*",
+    "../../protobuf-test/src/codegenv1/types.test.ts"
+  ],
+  // These are the default compiler options for TypeScript v5.8.x, created
+  // with `tsc --init` (except where noted in comments below)
+  "compilerOptions": {
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // To guard against regression and ensure we are remaining backwards
+    // compatible, set the skipLibCheck flag to false explicitly.
+    "skipLibCheck": false,
+    // Certain errors are only triggered by actually emitting declaration files,
+    // see https://github.com/bufbuild/protobuf-es/pull/398
+    "declaration": true,
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
This PR updates the repository from TypeScript 5.6 to 5.9.

> [!IMPORTANT]
> 
> TypeScript 5.9 includes [breaking changes to lib.d.ts](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#notable-behavioral-changes), forcing us to change return types for some functions from `Uint8Array` to `Uint8Array<ArrayBuffer>`, most notably `toBinary()`.

If you are on TypeScript 5.7 or later, you will not see any issues, because it already [ships with the new type parameter](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html#support-for---target-es2024-and---lib-es2024).

If you are on TypeScript 5.6 and earlier, you will be affected by this change: The return type of `toBinary()` will become `any`, because the compiler does not understand the `Uint8Array<ArrayBuffer>` type.

If you see a compiler error `TS2315: Type 'Uint8Array' is not generic` originating from `@bufbuild/protobuf`, make sure to set `skipLibCheck": true` in your tsconfig.json.

The rationale for this change in TypeScript is explained in https://github.com/microsoft/TypeScript/pull/59417: Some APIs accept typed arrays backed by a `SharedArrayBuffer`, while others only accept `ArrayBuffer`, and the new version of TypeScript checks the types. For example:

```ts
// Invalid because fetch requires an ArrayBuffer. Compile-time error with TS v5.9
fetch("http://example.com", {
  method: "POST",
  body: new Uint8Array(new SharedArrayBuffer(0)),
});

// Valid
fetch("http://example.com", {
  method: "POST",
  body: new Uint8Array(new ArrayBuffer(0)),
});
```

Because of this interoperability with other APIs, it's necessary that we change our return types. 