### PR TITLE
Drop support for Node.js 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, v24.x]
+        node-version: [20.x, 22.x, v24.x]
         bigint-disable: [0, 1]
     name: test ${{ matrix.node-version }} (${{ matrix.bigint-disable && 'fallback' || 'bigint' }})
     steps:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, v24.x]
+        node-version: [20.x, 22.x, v24.x]
         bigint-disable: [0, 1]
     name: conformance ${{ matrix.node-version }} (${{ matrix.bigint-disable && 'fallback' || 'bigint' }})
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "typescript": "~5.6.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=9"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7554,7 +7554,7 @@
         "upstream-protobuf": "*"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "2.6.3"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "type": "module",
   "engineStrict": true,
   "engines": {
-    "node": ">=18",
-    "npm": ">=9"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "packageManager": "npm@10.9.0",
   "licenseHeader": {

--- a/packages/protoc-gen-es/package.json
+++ b/packages/protoc-gen-es/package.json
@@ -19,7 +19,7 @@
     "protoc-gen-es": "bin/protoc-gen-es"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "scripts": {
     "prebuild": "rm -rf ./dist/cjs/*",


### PR DESCRIPTION
This PR removes Node.js 18 from CI. 

Node.js 18 has reached its end of life earlier this year, and does not receive security updates anymore (see the [release schedule](https://nodejs.org/en/about/previous-releases)). 

If you are running Protobuf-ES on Node.js 18, this doesn't mean that it will stop working right away, but we stop testing on  this version of Node.js, and will no longer consider failures a bug. However, we strongly recommend updating to a more recent version (see this [blog post](https://nodejs.org/en/blog/announcements/node-18-eol-support) for more information).