### PR TITLE
Suppress logs of cached build tasks

### DIFF
--- a/packages/bundle-size/turbo.json
+++ b/packages/bundle-size/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "bundle-size": {
-      "dependsOn": ["^build", "generate"]
+      "dependsOn": ["^build", "generate"],
+      "outputLogs": "new-only"
     }
   }
 }

--- a/packages/protobuf-example/turbo.json
+++ b/packages/protobuf-example/turbo.json
@@ -4,7 +4,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "generate"],
-      "outputs": []
+      "outputs": [],
+      "outputLogs": "new-only"
     }
   }
 }

--- a/packages/protobuf-test/turbo.json
+++ b/packages/protobuf-test/turbo.json
@@ -4,15 +4,18 @@
   "tasks": {
     "perf": {
       "dependsOn": ["^build", "generate"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "new-only"
     },
     "profile": {
       "dependsOn": ["^build", "generate"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "new-only"
     },
     "flamegraph": {
       "dependsOn": ["^build", "generate"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "new-only"
     }
   }
 }

--- a/packages/protobuf/turbo.json
+++ b/packages/protobuf/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "bootstrap": {
-      "dependsOn": ["build", "@bufbuild/protoc-gen-es#build"]
+      "dependsOn": ["build", "@bufbuild/protoc-gen-es#build"],
+      "outputLogs": "new-only"
     }
   }
 }

--- a/packages/protoc-gen-es/turbo.json
+++ b/packages/protoc-gen-es/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "bootstrap": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "outputLogs": "new-only"
     }
   }
 }

--- a/packages/protoplugin-example/turbo.json
+++ b/packages/protoplugin-example/turbo.json
@@ -4,7 +4,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "generate"],
-      "outputs": []
+      "outputs": [],
+      "outputLogs": "new-only"
     }
   }
 }

--- a/packages/upstream-protobuf/turbo.json
+++ b/packages/upstream-protobuf/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": [".tmp/**"]
+      "outputs": [".tmp/**"],
+      "outputLogs": "new-only"
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -3,42 +3,55 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "generate"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "outputLogs": "new-only"
     },
     "generate": {
       "dependsOn": ["^build"],
-      "outputs": ["src/gen/**"]
+      "outputs": ["src/gen/**"],
+      "outputLogs": "new-only"
     },
     "test": {
       "dependsOn": ["build"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "new-only"
     },
-    "format": {},
+    "format": {
+      "outputLogs": "new-only"
+    },
     "license-header": {
-      "dependsOn": ["generate"]
+      "dependsOn": ["generate"],
+      "outputLogs": "new-only"
     },
     "lint": {
       "dependsOn": ["format", "^build", "generate"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "new-only"
     },
     "attw": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "outputLogs": "new-only"
     },
     "//#format": {
-      "inputs": ["$TURBO_DEFAULT$", "!packages/**", "package-lock.json"]
+      "inputs": ["$TURBO_DEFAULT$", "!packages/**", "package-lock.json"],
+      "outputLogs": "new-only"
     },
     "//#license-header": {
-      "inputs": ["$TURBO_DEFAULT$", "!packages/**"]
+      "inputs": ["$TURBO_DEFAULT$", "!packages/**"],
+      "outputLogs": "new-only"
     },
     "//#lint": {
       "dependsOn": ["format"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "new-only"
     },
     "@bufbuild/protobuf-conformance#lint": {
-      "dependsOn": ["format", "^build", "generate", "build"]
+      "dependsOn": ["format", "^build", "generate", "build"],
+      "outputLogs": "new-only"
     },
     "@bufbuild/protoc-gen-es#lint": {
-      "dependsOn": ["format", "^build", "generate", "build"]
+      "dependsOn": ["format", "^build", "generate", "build"],
+      "outputLogs": "new-only"
     }
   }
 }


### PR DESCRIPTION
This sets the option `"outputLogs": "new-only"` for all turborepo tasks, removing a lot of clutter on repeated builds.

Documentation: https://turborepo.com/docs/reference/configuration#outputlogs

We're already setting this option in protovalidate-es ([here](https://github.com/bufbuild/protovalidate-es/blob/v1.0.0/turbo.json)), and it's been useful.