### PR TITLE
Add functions durationFromMS and durationMs

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -19,8 +19,8 @@ usually do. We repeat this for an increasing number of files.
 | Protobuf-ES         |     1 |   132,844 b |  68,698 b |   15,784 b |
 | Protobuf-ES         |     4 |   135,033 b |  70,205 b |   16,463 b |
 | Protobuf-ES         |     8 |   137,795 b |  71,976 b |   16,969 b |
-| Protobuf-ES         |    16 |   148,245 b |  79,957 b |   19,342 b |
-| Protobuf-ES         |    32 |   176,036 b | 101,975 b |   24,801 b |
+| Protobuf-ES         |    16 |   148,245 b |  79,957 b |   19,319 b |
+| Protobuf-ES         |    32 |   176,036 b | 101,975 b |   24,775 b |
 | protobuf-javascript |     1 |   304,940 b | 235,014 b |   35,843 b |
 | protobuf-javascript |     4 |   330,957 b | 249,986 b |   37,225 b |
 | protobuf-javascript |     8 |   351,751 b | 261,563 b |   38,385 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.29921875 140,243.37626953125 280,241.94326171875 420,235.2228515625 560,219.76279296875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.29921875 140,243.37626953125 280,241.94326171875 420,235.28798828125 560,219.83642578125">
     <title>Protobuf-ES</title>
   </polyline>
 <circle cx="0" cy="245.29921875" r="4" fill="#ffa600"><title>Protobuf-ES 15.41 KiB for 1 files</title></circle>
 <circle cx="140" cy="243.37626953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.08 KiB for 4 files</title></circle>
 <circle cx="280" cy="241.94326171875" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.2228515625" r="4" fill="#ffa600"><title>Protobuf-ES 18.89 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.76279296875" r="4" fill="#ffa600"><title>Protobuf-ES 24.22 KiB for 32 files</title></circle>
+<circle cx="420" cy="235.28798828125" r="4" fill="#ffa600"><title>Protobuf-ES 18.87 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.83642578125" r="4" fill="#ffa600"><title>Protobuf-ES 24.19 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.49150390625 140,184.57763671875 280,181.29248046875 420,160.86220703125 560,76.77353515625">

--- a/packages/protobuf-test/src/wkt/duration.test.ts
+++ b/packages/protobuf-test/src/wkt/duration.test.ts
@@ -1,0 +1,76 @@
+// Copyright 2021-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { suite, test } from "node:test";
+import * as assert from "node:assert";
+import {
+  durationFromMs,
+  durationMs,
+  DurationSchema,
+} from "@bufbuild/protobuf/wkt";
+import { create, protoInt64 } from "@bufbuild/protobuf";
+
+void suite("durationMs()", () => {
+  void test("converts Duration to unix duration with milliseconds", () => {
+    assert.strictEqual(
+      durationMs(
+        create(DurationSchema, {
+          seconds: protoInt64.zero,
+          nanos: 0,
+        }),
+      ),
+      0,
+    );
+    assert.strictEqual(
+      durationMs(
+        create(DurationSchema, {
+          seconds: protoInt64.parse(818035920),
+          nanos: 123456789,
+        }),
+      ),
+      818035920123,
+    );
+  });
+});
+
+void suite("durationFromMs()", () => {
+  void test("converts unix duration with milliseconds to Duration", () => {
+    const durationZero = durationFromMs(0);
+    assert.strictEqual(Number(durationZero.seconds), 0);
+    assert.strictEqual(durationZero.nanos, 0);
+    const durationWithMs = durationFromMs(818035920123);
+    assert.strictEqual(Number(durationWithMs.seconds), 818035920);
+    assert.strictEqual(durationWithMs.nanos, 123000000);
+  });
+  void test("1000 ms", () => {
+    const ts = durationFromMs(1000);
+    assert.strictEqual(Number(ts.seconds), 1);
+    assert.strictEqual(ts.nanos, 0);
+  });
+  void test("1020 ms", () => {
+    const ts = durationFromMs(1020);
+    assert.strictEqual(Number(ts.seconds), 1);
+    assert.strictEqual(ts.nanos, 20 * 1000000);
+  });
+  void test("-1070 ms", () => {
+    const ts = durationFromMs(-1070);
+    assert.strictEqual(Number(ts.seconds), -2);
+    assert.strictEqual(ts.nanos, 930 * 1000000);
+  });
+  void test("-1000 ms", () => {
+    const ts = durationFromMs(-1000);
+    assert.strictEqual(Number(ts.seconds), -1);
+    assert.strictEqual(ts.nanos, 0);
+  });
+});

--- a/packages/protobuf/src/wkt/duration.ts
+++ b/packages/protobuf/src/wkt/duration.ts
@@ -1,0 +1,36 @@
+// Copyright 2021-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Duration } from "./gen/google/protobuf/duration_pb.js";
+import { DurationSchema } from "./gen/google/protobuf/duration_pb.js";
+import { create } from "../create.js";
+import { protoInt64 } from "../proto-int64.js";
+
+/**
+ * Create a google.protobuf.Duration message from a Unix timestamp in milliseconds.
+ */
+export function durationFromMs(durationMs: number): Duration {
+  const seconds = Math.floor(durationMs / 1000);
+  return create(DurationSchema, {
+    seconds: protoInt64.parse(seconds),
+    nanos: (durationMs - seconds * 1000) * 1000000,
+  });
+}
+
+/**
+ * Convert a google.protobuf.Duration to a Unix timestamp in milliseconds.
+ */
+export function durationMs(duration: Duration): number {
+  return Number(duration.seconds) * 1000 + Math.round(duration.nanos / 1000000);
+}

--- a/packages/protobuf/src/wkt/index.ts
+++ b/packages/protobuf/src/wkt/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 export * from "./timestamp.js";
+export * from "./duration.js";
 export * from "./any.js";
 export * from "./wrappers.js";
 export * from "./gen/google/protobuf/any_pb.js";


### PR DESCRIPTION
Adds two methods to `@bufbuild/protobuf/wkt`: `durationFromMs` and `durationMs`, equivalent to their `Timestamp` counterparts.

Closes https://github.com/bufbuild/protobuf-es/issues/1239