### PR TITLE
Mention Deno in package README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/bufbuild/protobuf-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/protobuf/latest?color=green&label=%40bufbuild%2Fprotobuf)](https://www.npmjs.com/package/@bufbuild/protobuf) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/protoplugin/latest?color=green&label=%40bufbuild%2Fprotoplugin)](https://www.npmjs.com/package/@bufbuild/protoplugin) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/protoc-gen-es/latest?color=green&label=%40bufbuild%2Fprotoc-gen-es)](https://www.npmjs.com/package/@bufbuild/protoc-gen-es)
 
 A complete implementation of [Protocol Buffers](https://protobuf.dev/) in TypeScript,
-suitable for web browsers, Node.js and Deno, created by [Buf](https://buf.build).
+suitable for web browsers, Node.js, and Deno, created by [Buf](https://buf.build).
 
 Protobuf-ES is the only fully-compliant JavaScript Protobuf library that passes the
 Protobuf conformance tests—[read more on our blog][blog-post].

--- a/packages/protobuf/README.md
+++ b/packages/protobuf/README.md
@@ -6,7 +6,7 @@ code generator plugin.
 ## Protocol Buffers for ECMAScript
 
 A complete implementation of [Protocol Buffers](https://protobuf.dev/) in TypeScript,
-suitable for web browsers and Node.js, created by [Buf](https://buf.build).
+suitable for web browsers, Node.js, and Deno, created by [Buf](https://buf.build).
 
 **Protobuf-ES** is a solid, modern alternative to existing Protobuf implementations for the JavaScript ecosystem. It's
 the first project in this space to provide a comprehensive plugin framework and decouple the base types from RPC

--- a/packages/protoplugin/README.md
+++ b/packages/protoplugin/README.md
@@ -3,8 +3,7 @@
 This package helps you create your own code generator plugin using the
 Protobuf-ES plugin framework.
 
-**Protobuf-ES** is a complete implementation of [Protocol Buffers](https://protobuf.dev) in TypeScript, suitable for
-web browsers and Node.js.
+**Protobuf-ES** is a complete implementation of [Protocol Buffers](https://protobuf.dev) in TypeScript, suitable for web browsers, Node.js, and Deno.
 
 In addition to a full Protobuf runtime library, it provides the [`protoc-gen-es`](https://www.npmjs.com/package/@bufbuild/protoc-gen-es)
 code generator, which uses a plugin framework to generate base types from


### PR DESCRIPTION
In https://github.com/bufbuild/protobuf-es/pull/1233, we added Deno to the repository README.md and MANUAL.md. 

This adds the same reference to the README.md files for the packages [@bufbuild/protobuf](https://www.npmjs.com/package/@bufbuild/protobuf) and [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin).