### PR TITLE
Fix nanos sign in durationFromMs()

### DIFF
--- a/packages/protobuf-test/src/wkt/duration.test.ts
+++ b/packages/protobuf-test/src/wkt/duration.test.ts
@@ -53,6 +53,11 @@ void suite("durationFromMs()", () => {
     assert.strictEqual(Number(durationWithMs.seconds), 818035920);
     assert.strictEqual(durationWithMs.nanos, 123000000);
   });
+  void test("70 ms", () => {
+    const ts = durationFromMs(70);
+    assert.strictEqual(Number(ts.seconds), 0);
+    assert.strictEqual(ts.nanos, 70_000_000);
+  });
   void test("1000 ms", () => {
     const ts = durationFromMs(1000);
     assert.strictEqual(Number(ts.seconds), 1);
@@ -61,16 +66,36 @@ void suite("durationFromMs()", () => {
   void test("1020 ms", () => {
     const ts = durationFromMs(1020);
     assert.strictEqual(Number(ts.seconds), 1);
-    assert.strictEqual(ts.nanos, 20 * 1000000);
+    assert.strictEqual(ts.nanos, 20_000_000);
   });
-  void test("-1070 ms", () => {
-    const ts = durationFromMs(-1070);
-    assert.strictEqual(Number(ts.seconds), -2);
-    assert.strictEqual(ts.nanos, 930 * 1000000);
+  void test("1800 ms", () => {
+    const ts = durationFromMs(1800);
+    assert.strictEqual(Number(ts.seconds), 1);
+    assert.strictEqual(ts.nanos, 800_000_000);
+  });
+  void test("-0 ms", () => {
+    const ts = durationFromMs(-0);
+    assert.strictEqual(Number(ts.seconds), 0);
+    assert.strictEqual(ts.nanos, 0);
+  });
+  void test("-70 ms", () => {
+    const ts = durationFromMs(-70);
+    assert.strictEqual(Number(ts.seconds), 0);
+    assert.strictEqual(ts.nanos, -70_000_000);
   });
   void test("-1000 ms", () => {
     const ts = durationFromMs(-1000);
     assert.strictEqual(Number(ts.seconds), -1);
     assert.strictEqual(ts.nanos, 0);
+  });
+  void test("-1070 ms", () => {
+    const ts = durationFromMs(-1070);
+    assert.strictEqual(Number(ts.seconds), -1);
+    assert.strictEqual(ts.nanos, -70_000_000);
+  });
+  void test("-1800 ms", () => {
+    const ts = durationFromMs(-1800);
+    assert.strictEqual(Number(ts.seconds), -1);
+    assert.strictEqual(ts.nanos, -800_000_000);
   });
 });

--- a/packages/protobuf/src/wkt/duration.ts
+++ b/packages/protobuf/src/wkt/duration.ts
@@ -21,10 +21,13 @@ import { protoInt64 } from "../proto-int64.js";
  * Create a google.protobuf.Duration message from a Unix timestamp in milliseconds.
  */
 export function durationFromMs(durationMs: number): Duration {
-  const seconds = Math.floor(durationMs / 1000);
+  const sign = durationMs < 0 ? -1 : 1;
+  const absDurationMs = Math.abs(durationMs);
+  const absSeconds = Math.floor(absDurationMs / 1000);
+  const absNanos = (absDurationMs - absSeconds * 1000) * 1000000;
   return create(DurationSchema, {
-    seconds: protoInt64.parse(seconds),
-    nanos: (durationMs - seconds * 1000) * 1000000,
+    seconds: protoInt64.parse(absSeconds * sign),
+    nanos: absNanos === 0 ? 0 : (absNanos * sign), // deliberately avoid signed 0 - it does not serialize
   });
 }
 

--- a/packages/protobuf/src/wkt/duration.ts
+++ b/packages/protobuf/src/wkt/duration.ts
@@ -27,7 +27,7 @@ export function durationFromMs(durationMs: number): Duration {
   const absNanos = (absDurationMs - absSeconds * 1000) * 1000000;
   return create(DurationSchema, {
     seconds: protoInt64.parse(absSeconds * sign),
-    nanos: absNanos === 0 ? 0 : (absNanos * sign), // deliberately avoid signed 0 - it does not serialize
+    nanos: absNanos === 0 ? 0 : absNanos * sign, // deliberately avoid signed 0 - it does not serialize
   });
 }
 


### PR DESCRIPTION
The well-known type `Duration` has the [following comment](https://github.com/protocolbuffers/protobuf/blob/v32.1/src/google/protobuf/duration.proto#L108):

> For durations of one second or more, a non-zero value for the `nanos` field must be  of the same sign as the `seconds` field.

This PR fixes the behavior of `durationFromMs()` from `@bufbuild/protobuf/wkt` (added in #1244, unreleased) accordingly.
