### PR TITLE
Support strict UTF-8 decoding

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,844 b |  68,698 b |   15,784 b |
-| Protobuf-ES         |     4 |   135,033 b |  70,205 b |   16,463 b |
-| Protobuf-ES         |     8 |   137,795 b |  71,976 b |   16,969 b |
-| Protobuf-ES         |    16 |   148,245 b |  79,957 b |   19,319 b |
-| Protobuf-ES         |    32 |   176,036 b | 101,975 b |   24,775 b |
+| Protobuf-ES         |     1 |   132,946 b |  68,756 b |   15,807 b |
+| Protobuf-ES         |     4 |   135,135 b |  70,263 b |   16,491 b |
+| Protobuf-ES         |     8 |   137,897 b |  72,034 b |   17,016 b |
+| Protobuf-ES         |    16 |   148,347 b |  80,015 b |   19,359 b |
+| Protobuf-ES         |    32 |   176,138 b | 102,033 b |   24,779 b |
 | protobuf-javascript |     1 |   304,940 b | 235,014 b |   35,843 b |
 | protobuf-javascript |     4 |   330,957 b | 249,986 b |   37,225 b |
 | protobuf-javascript |     8 |   351,751 b | 261,563 b |   38,385 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.29921875 140,243.37626953125 280,241.94326171875 420,235.28798828125 560,219.83642578125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.23408203125 140,243.29697265625 280,241.81015625 420,235.17470703125 560,219.82509765625002">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.29921875" r="4" fill="#ffa600"><title>Protobuf-ES 15.41 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.37626953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.08 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.94326171875" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.28798828125" r="4" fill="#ffa600"><title>Protobuf-ES 18.87 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.83642578125" r="4" fill="#ffa600"><title>Protobuf-ES 24.19 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.23408203125" r="4" fill="#ffa600"><title>Protobuf-ES 15.44 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.29697265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.1 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.81015625" r="4" fill="#ffa600"><title>Protobuf-ES 16.62 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.17470703125" r="4" fill="#ffa600"><title>Protobuf-ES 18.91 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.82509765625002" r="4" fill="#ffa600"><title>Protobuf-ES 24.2 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.49150390625 140,184.57763671875 280,181.29248046875 420,160.86220703125 560,76.77353515625">

--- a/packages/protobuf-test/src/wire/text-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/text-encoding.test.ts
@@ -45,6 +45,25 @@ void suite("getTextEncoding()", () => {
       );
       assert.strictEqual(text, "hello 🌍");
     });
+    void test("decodes errors as U+FFFD", () => {
+      const text = getTextEncoding().decodeUtf8(
+        new Uint8Array([104, 101, 108, 108, 111, 32, 240]),
+      );
+      assert.strictEqual(text, "hello \uFFFD");
+    });
+    void test("throws TypeError for errors, if strict is true", () => {
+      assert.throws(
+        () => {
+          getTextEncoding().decodeUtf8(
+            new Uint8Array([104, 101, 108, 108, 111, 32, 240]),
+            true,
+          );
+        },
+        {
+          name: "TypeError",
+        },
+      );
+    });
   });
   void suite("checkUtf8()", () => {
     void test("returns true for valid", () => {


### PR DESCRIPTION
I'd rather not have to replicate what `protobuf-es` does for text encoding and decoding in `cel-es`, but CEL casting needs support for strict decoding.