### PR TITLE
Update to protocolbuffers/protobuf v33.1

### DIFF
--- a/deno/conformance/package.json
+++ b/deno/conformance/package.json
@@ -15,6 +15,6 @@
     "@bufbuild/buf": "^1.59.0",
     "@bufbuild/protobuf": "2.10.1",
     "@bufbuild/protoc-gen-es": "2.10.1",
-    "protobuf-conformance": "33.0.0"
+    "protobuf-conformance": "33.1.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@bufbuild/buf": "^1.59.0",
         "@bufbuild/protobuf": "2.10.1",
         "@bufbuild/protoc-gen-es": "2.10.1",
-        "protobuf-conformance": "33.0.0"
+        "protobuf-conformance": "33.1.0"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -3489,9 +3489,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/protobuf-conformance": {
-      "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/protobuf-conformance/-/protobuf-conformance-33.0.0.tgz",
-      "integrity": "sha512-h6BoHrRNtcGoDb6h3islqmXyERZ+TzkWevshH/TXI7I7PMr5xkSiBkGOG+6bI+tnMX8CRomD3QN35JxPMTuQBg==",
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/protobuf-conformance/-/protobuf-conformance-33.1.0.tgz",
+      "integrity": "sha512-vBtaJrGnrCiFGq6xcAX7sagmhKiOZmB/UfgkUe//DuBoLwbdO4d2gwMta2rF6akbHhuywWWeE8Ml2Lf42V8RIA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3503,9 +3503,9 @@
       }
     },
     "node_modules/protoc": {
-      "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/protoc/-/protoc-33.0.0.tgz",
-      "integrity": "sha512-zp1nrPRwXcmxGHlsrhlbBhmAWqAhcsHY4IEsuqZxNsIHqC//ojlAGsSnqfgqw4MqyUAp630XOrVYYEes1NtBgA==",
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/protoc/-/protoc-33.1.0.tgz",
+      "integrity": "sha512-NL8A6wI4RYhli4nDPjC7y2vDb1HSJf8Xl2MSGLoGkLjU4OvFpRf1KEpBe/xY3+aNBEAt4YawcmFw3Y28D3BStA==",
       "license": "Apache-2.0",
       "bin": {
         "protoc": "protoc.cjs"
@@ -5001,7 +5001,7 @@
         "@bufbuild/buf": "^1.59.0",
         "@bufbuild/protobuf": "2.10.1",
         "@bufbuild/protoc-gen-es": "2.10.1",
-        "protobuf-conformance": "33.0.0"
+        "protobuf-conformance": "33.1.0"
       }
     },
     "packages/protobuf-example": {
@@ -5364,7 +5364,7 @@
     "packages/upstream-protobuf": {
       "dependencies": {
         "fflate": "^0.8.1",
-        "protoc": "33.0.0"
+        "protoc": "33.1.0"
       },
       "bin": {
         "protoc-gen-dumpcodegenreq": "bin/protoc-gen-dumpcodegenreq.mjs",

--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -26,6 +26,6 @@
     "@bufbuild/buf": "^1.59.0",
     "@bufbuild/protobuf": "2.10.1",
     "@bufbuild/protoc-gen-es": "2.10.1",
-    "protobuf-conformance": "33.0.0"
+    "protobuf-conformance": "33.1.0"
   }
 }

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -425,7 +425,7 @@ const OPEN: FeatureSet_EnumType.OPEN = 1;
 
 // biome-ignore format: want this to read well
 // bootstrap-inject defaults: EDITION_PROTO2 to EDITION_2024: export const minimumEdition: SupportedEdition = $minimumEdition, maximumEdition: SupportedEdition = $maximumEdition;
-// generated from protoc v33.0
+// generated from protoc v33.1
 export const minimumEdition: SupportedEdition = 998, maximumEdition: SupportedEdition = 1001;
 const featureDefaults = {
   // EDITION_PROTO2

--- a/packages/upstream-protobuf/package.json
+++ b/packages/upstream-protobuf/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "fflate": "^0.8.1",
-    "protoc": "33.0.0"
+    "protoc": "33.1.0"
   }
 }


### PR DESCRIPTION
This updates to the upstream [release v33.1](https://github.com/protocolbuffers/protobuf/releases/tag/v33.1). There are no changes affecting this project.