### PR TITLE
Permit google.protobuf.Value.null_value in map values in ProtoJSON

### DIFF
--- a/packages/protobuf-test/src/issue1313.test.ts
+++ b/packages/protobuf-test/src/issue1313.test.ts
@@ -1,0 +1,57 @@
+// Copyright 2021-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test } from "node:test";
+import { compileMessage } from "./helpers.js";
+import { create, fromJson, toJson } from "@bufbuild/protobuf";
+import { NullValue } from "@bufbuild/protobuf/wkt";
+import assert from "node:assert";
+
+void test("issue #1313", async () => {
+  const descMessage = await compileMessage(`
+    syntax="proto3";
+    import "google/protobuf/struct.proto";
+    message M {
+      map<string, google.protobuf.Value> value_map = 1;
+      map<string, google.protobuf.NullValue> null_value_map = 2;
+      repeated google.protobuf.Value value_list = 3;
+      repeated google.protobuf.NullValue null_value_list = 4;
+    }
+  `);
+  const msg = create(descMessage, {
+    valueMap: {
+      val1: {
+        kind: { case: "nullValue", value: NullValue.NULL_VALUE },
+      },
+    },
+    nullValueMap: {
+      val1: NullValue.NULL_VALUE,
+    },
+    valueList: [
+      {
+        kind: { case: "nullValue", value: NullValue.NULL_VALUE },
+      },
+    ],
+    nullValueList: [NullValue.NULL_VALUE],
+  });
+  const json = toJson(descMessage, msg);
+  assert.deepStrictEqual(json, {
+    valueMap: { val1: null },
+    nullValueMap: { val1: null },
+    valueList: [null],
+    nullValueList: [null],
+  });
+  const msg2 = fromJson(descMessage, json);
+  assert.deepStrictEqual(msg2, msg);
+});

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -285,7 +285,7 @@ function readMapField(map: ReflectMap, json: JsonValue, opts: JsonReadOptions) {
     throw new FieldError(field, "expected object, got " + formatVal(json));
   }
   for (const [jsonMapKey, jsonMapValue] of Object.entries(json)) {
-    if (jsonMapValue === null) {
+    if (jsonMapValue === null && !isSafeNullValueInListOrMap(field)) {
       throw new FieldError(field, "map value must not be null");
     }
     let value: unknown;
@@ -328,7 +328,7 @@ function readListField(
     throw new FieldError(field, "expected Array, got " + formatVal(json));
   }
   for (const jsonItem of json) {
-    if (jsonItem === null) {
+    if (jsonItem === null && !isSafeNullValueInListOrMap(field)) {
       throw new FieldError(field, "list item must not be null");
     }
     switch (field.listKind) {
@@ -353,6 +353,15 @@ function readListField(
         break;
     }
   }
+}
+
+function isSafeNullValueInListOrMap(
+  field: DescField & { fieldKind: "map" | "list" },
+): boolean {
+  return (
+    field.message?.typeName == "google.protobuf.Value" ||
+    field.enum?.typeName == "google.protobuf.NullValue"
+  );
 }
 
 function readMessageField(


### PR DESCRIPTION
When parsing ProtoJSON, `fromJson` incorrectly rejects `null` in map values and repeated fields using `google.protobuf.NullValue` and `google.protobuf.Value` (with field `null_value` selected).

To illustrate, consider this Protobuf message:

```proto
syntax="proto3";
import "google/protobuf/struct.proto";
message M {
  map<string, google.protobuf.Value> value_map = 1;
  map<string, google.protobuf.NullValue> null_value_map = 2;
  repeated google.protobuf.Value value_list = 3;
  repeated google.protobuf.NullValue null_value_list = 4;
}
```

The following JSON should parse without error, but does not.

```json
{
    "valueMap": { "val1": null },
    "nullValueMap": { "val1": null },
    "valueList": [null],
    "nullValueList": [null],
}
```

This PR rectifies `fromJson`, but still rejects `null` for other repeated fields and map values.

Fixes https://github.com/bufbuild/protobuf-es/issues/1313