### PR TITLE
Fix optional chaining in Deno check for Int64 support in proto-int64.ts

### DIFF
--- a/packages/protobuf/src/proto-int64.ts
+++ b/packages/protobuf/src/proto-int64.ts
@@ -133,7 +133,7 @@ function makeInt64Support(): Int64Support {
     typeof dv.getBigUint64 === "function" &&
     typeof dv.setBigInt64 === "function" &&
     typeof dv.setBigUint64 === "function" &&
-    (!!(globalThis as { Deno?: unknown }).Deno ||
+    (!!(globalThis as { Deno?: unknown })?.Deno ||
       typeof process != "object" ||
       typeof process.env != "object" ||
       process.env.BUF_BIGINT_DISABLE !== "1");


### PR DESCRIPTION
in < Chrome 71，browser not support globalthis，from:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
