### PR TITLE
Add globalThis to requirements

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    // We target ES2017, but require the Text Encoding API, and optionally
-    // BigInt and AsyncIterable, see below.
+    // We target ES2017, but require the Text Encoding API, globalThis, and
+    // optionally BigInt and AsyncIterable, see below.
     "target": "es2017",
     "lib": [
       "ES2017",


### PR DESCRIPTION
We rely on `globalThis` in the runtime (@bufbuild/protobuf) and in generated code (@bufbuild/protoplugin). The property was defined in ES2020, so we should call this requirement out in tsconfig.base.json, where we set target and lib to ES2017.