### PR TITLE
Add test for equals comparing two empty Any

### DIFF
--- a/packages/protobuf-test/src/equals.test.ts
+++ b/packages/protobuf-test/src/equals.test.ts
@@ -360,5 +360,11 @@ void suite("equals()", () => {
       b.value.set(a.value, a.value.byteLength);
       assert.strictEqual(anyEq(a, b, reg), true);
     });
+    test("empty Any equals empty Any", () => {
+      const reg = createRegistry();
+      const a = create(AnySchema);
+      const b = create(AnySchema);
+      assert.strictEqual(anyEq(a, b, reg), true);
+    });
   });
 });


### PR DESCRIPTION
This adds a test for the edge case behavior of `equals()` comparing two empty Any messages with the the `unpackAny` option.