### PR TITLE
Gracefully handle Number for BigInt fields

### DIFF
--- a/packages/protobuf-test/src/serialization-errors.test.ts
+++ b/packages/protobuf-test/src/serialization-errors.test.ts
@@ -217,6 +217,17 @@ void suite("serialization errors", () => {
         /^cannot encode field spec.ScalarValuesMessage.uint64_field to binary: invalid uint64: -1$/,
     },
     {
+      name: "uint64 field Infinity",
+      val(m) {
+        // @ts-expect-error TS2322: Type number is not assignable to type bigint
+        m.uint64Field = Number.POSITIVE_INFINITY;
+      },
+      jsonErr:
+        /^cannot encode field spec.ScalarValuesMessage.uint64_field to JSON: expected bigint \(uint64\): Infinity out of range/,
+      binaryErr:
+        /^cannot encode field spec.ScalarValuesMessage.uint64_field to binary: The number Infinity cannot be converted to a BigInt because it is not an integer$/,
+    },
+    {
       name: "bytes field true",
       val(m) {
         // @ts-expect-error TS2322

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -369,12 +369,16 @@ function scalarToJson(
     case ScalarType.INT64:
     case ScalarType.SFIXED64:
     case ScalarType.SINT64:
-      if (typeof value != "bigint" && typeof value != "string") {
-        throw new Error(
-          `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-        );
+      if (
+        typeof value == "bigint" ||
+        typeof value == "string" ||
+        (typeof value == "number" && Number.isInteger(value))
+      ) {
+        return value.toString();
       }
-      return value.toString();
+      throw new Error(
+        `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
+      );
 
     // bytes: JSON value will be the data encoded as a string using standard base64 encoding with paddings.
     // Either standard or URL-safe base64 encoding with/without paddings are accepted.


### PR DESCRIPTION
When a Number value is assigned to a BigInt field (e.g. protobuf field int64), `toJson` raises an error. The error message is confusing because the underlying code does support serialization of Number, and does not provide meaningful error details.

This PR relaxes the validation in `toJson` to gracefully handle serialization of integral Number values.

Fixes https://github.com/bufbuild/protobuf-es/issues/1345.