### PR TITLE
Emit | undefined for optional fields

### DIFF
--- a/bun/conformance/src/gen/conformance/conformance_pb.ts
+++ b/bun/conformance/src/gen/conformance/conformance_pb.ts
@@ -159,7 +159,7 @@ export type ConformanceRequest = Message<"conformance.ConformanceRequest"> & {
    *
    * @generated from field: conformance.JspbEncodingConfig jspb_encoding_options = 6;
    */
-  jspbEncodingOptions?: JspbEncodingConfig;
+  jspbEncodingOptions?: JspbEncodingConfig | undefined;
 
   /**
    * This can be used in json and text format. If true, testee should print

--- a/bun/conformance/src/gen/google/protobuf/test_messages_edition2023_pb.ts
+++ b/bun/conformance/src/gen/google/protobuf/test_messages_edition2023_pb.ts
@@ -128,12 +128,12 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage optional_nested_message = 18 [features.message_encoding = LENGTH_PREFIXED];
    */
-  optionalNestedMessage?: TestAllTypesEdition2023_NestedMessage;
+  optionalNestedMessage?: TestAllTypesEdition2023_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.ForeignMessageEdition2023 optional_foreign_message = 19 [features.message_encoding = LENGTH_PREFIXED];
    */
-  optionalForeignMessage?: ForeignMessageEdition2023;
+  optionalForeignMessage?: ForeignMessageEdition2023 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.NestedEnum optional_nested_enum = 21;
@@ -158,7 +158,7 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023 recursive_message = 27 [features.message_encoding = LENGTH_PREFIXED];
    */
-  recursiveMessage?: TestAllTypesEdition2023;
+  recursiveMessage?: TestAllTypesEdition2023 | undefined;
 
   /**
    * Repeated
@@ -570,12 +570,12 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType groupliketype = 201;
    */
-  groupliketype?: TestAllTypesEdition2023_GroupLikeType;
+  groupliketype?: TestAllTypesEdition2023_GroupLikeType | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType delimited_field = 202;
    */
-  delimitedField?: TestAllTypesEdition2023_GroupLikeType;
+  delimitedField?: TestAllTypesEdition2023_GroupLikeType | undefined;
 };
 
 /**
@@ -597,7 +597,7 @@ export type TestAllTypesEdition2023_NestedMessage = Message<"protobuf_test_messa
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023 corecursive = 2 [features.message_encoding = LENGTH_PREFIXED];
    */
-  corecursive?: TestAllTypesEdition2023;
+  corecursive?: TestAllTypesEdition2023 | undefined;
 };
 
 /**

--- a/bun/conformance/src/gen/google/protobuf/test_messages_proto2_editions_pb.ts
+++ b/bun/conformance/src/gen/google/protobuf/test_messages_proto2_editions_pb.ts
@@ -123,12 +123,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -153,7 +153,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -575,12 +575,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.Data data = 201 [features.message_encoding = DELIMITED];
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204 [features.message_encoding = DELIMITED];
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -755,7 +755,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -777,7 +777,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1018,12 +1018,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.editions.pro
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: bool optional_bool = 1006;
@@ -1235,12 +1235,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 required_foreign_message = 19 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21 [features.field_presence = LEGACY_REQUIRED];
@@ -1265,17 +1265,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 recursive_message = 27 [features.field_presence = LEGACY_REQUIRED];
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.Data data = 201 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1374,12 +1374,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 corecursive = 2 [features.field_presence = LEGACY_REQUIRED];
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/bun/conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/bun/conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -120,12 +120,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -150,7 +150,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -572,12 +572,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -752,7 +752,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -774,7 +774,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1015,12 +1015,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.proto2.Unkno
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1232,12 +1232,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1262,17 +1262,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1371,12 +1371,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/bun/conformance/src/gen/google/protobuf/test_messages_proto3_editions_pb.ts
+++ b/bun/conformance/src/gen/google/protobuf/test_messages_proto3_editions_pb.ts
@@ -122,12 +122,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -157,7 +157,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -577,47 +577,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -667,32 +667,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -847,7 +847,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/bun/conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/bun/conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -121,12 +121,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -156,7 +156,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -576,47 +576,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -666,32 +666,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -846,7 +846,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/deno/conformance/src/gen/conformance/conformance_pb.ts
+++ b/deno/conformance/src/gen/conformance/conformance_pb.ts
@@ -159,7 +159,7 @@ export type ConformanceRequest = Message<"conformance.ConformanceRequest"> & {
    *
    * @generated from field: conformance.JspbEncodingConfig jspb_encoding_options = 6;
    */
-  jspbEncodingOptions?: JspbEncodingConfig;
+  jspbEncodingOptions?: JspbEncodingConfig | undefined;
 
   /**
    * This can be used in json and text format. If true, testee should print

--- a/deno/conformance/src/gen/google/protobuf/test_messages_edition2023_pb.ts
+++ b/deno/conformance/src/gen/google/protobuf/test_messages_edition2023_pb.ts
@@ -128,12 +128,12 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage optional_nested_message = 18 [features.message_encoding = LENGTH_PREFIXED];
    */
-  optionalNestedMessage?: TestAllTypesEdition2023_NestedMessage;
+  optionalNestedMessage?: TestAllTypesEdition2023_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.ForeignMessageEdition2023 optional_foreign_message = 19 [features.message_encoding = LENGTH_PREFIXED];
    */
-  optionalForeignMessage?: ForeignMessageEdition2023;
+  optionalForeignMessage?: ForeignMessageEdition2023 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.NestedEnum optional_nested_enum = 21;
@@ -158,7 +158,7 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023 recursive_message = 27 [features.message_encoding = LENGTH_PREFIXED];
    */
-  recursiveMessage?: TestAllTypesEdition2023;
+  recursiveMessage?: TestAllTypesEdition2023 | undefined;
 
   /**
    * Repeated
@@ -570,12 +570,12 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType groupliketype = 201;
    */
-  groupliketype?: TestAllTypesEdition2023_GroupLikeType;
+  groupliketype?: TestAllTypesEdition2023_GroupLikeType | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType delimited_field = 202;
    */
-  delimitedField?: TestAllTypesEdition2023_GroupLikeType;
+  delimitedField?: TestAllTypesEdition2023_GroupLikeType | undefined;
 };
 
 /**
@@ -597,7 +597,7 @@ export type TestAllTypesEdition2023_NestedMessage = Message<"protobuf_test_messa
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023 corecursive = 2 [features.message_encoding = LENGTH_PREFIXED];
    */
-  corecursive?: TestAllTypesEdition2023;
+  corecursive?: TestAllTypesEdition2023 | undefined;
 };
 
 /**

--- a/deno/conformance/src/gen/google/protobuf/test_messages_proto2_editions_pb.ts
+++ b/deno/conformance/src/gen/google/protobuf/test_messages_proto2_editions_pb.ts
@@ -123,12 +123,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -153,7 +153,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -575,12 +575,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.Data data = 201 [features.message_encoding = DELIMITED];
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204 [features.message_encoding = DELIMITED];
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -755,7 +755,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -777,7 +777,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1018,12 +1018,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.editions.pro
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: bool optional_bool = 1006;
@@ -1235,12 +1235,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 required_foreign_message = 19 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21 [features.field_presence = LEGACY_REQUIRED];
@@ -1265,17 +1265,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 recursive_message = 27 [features.field_presence = LEGACY_REQUIRED];
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.Data data = 201 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1374,12 +1374,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 corecursive = 2 [features.field_presence = LEGACY_REQUIRED];
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/deno/conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/deno/conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -120,12 +120,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -150,7 +150,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -572,12 +572,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -752,7 +752,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -774,7 +774,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1015,12 +1015,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.proto2.Unkno
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1232,12 +1232,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1262,17 +1262,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1371,12 +1371,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/deno/conformance/src/gen/google/protobuf/test_messages_proto3_editions_pb.ts
+++ b/deno/conformance/src/gen/google/protobuf/test_messages_proto3_editions_pb.ts
@@ -122,12 +122,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -157,7 +157,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -577,47 +577,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -667,32 +667,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -847,7 +847,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/deno/conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/deno/conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -121,12 +121,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -156,7 +156,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -576,47 +576,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -666,32 +666,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -846,7 +846,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/client_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/client_pb.ts
@@ -95,56 +95,56 @@ export type ClientLibrarySettings = Message<"google.api.ClientLibrarySettings"> 
    *
    * @generated from field: google.api.JavaSettings java_settings = 21;
    */
-  javaSettings?: JavaSettings;
+  javaSettings?: JavaSettings | undefined;
 
   /**
    * Settings for C++ client libraries.
    *
    * @generated from field: google.api.CppSettings cpp_settings = 22;
    */
-  cppSettings?: CppSettings;
+  cppSettings?: CppSettings | undefined;
 
   /**
    * Settings for PHP client libraries.
    *
    * @generated from field: google.api.PhpSettings php_settings = 23;
    */
-  phpSettings?: PhpSettings;
+  phpSettings?: PhpSettings | undefined;
 
   /**
    * Settings for Python client libraries.
    *
    * @generated from field: google.api.PythonSettings python_settings = 24;
    */
-  pythonSettings?: PythonSettings;
+  pythonSettings?: PythonSettings | undefined;
 
   /**
    * Settings for Node client libraries.
    *
    * @generated from field: google.api.NodeSettings node_settings = 25;
    */
-  nodeSettings?: NodeSettings;
+  nodeSettings?: NodeSettings | undefined;
 
   /**
    * Settings for .NET client libraries.
    *
    * @generated from field: google.api.DotnetSettings dotnet_settings = 26;
    */
-  dotnetSettings?: DotnetSettings;
+  dotnetSettings?: DotnetSettings | undefined;
 
   /**
    * Settings for Ruby client libraries.
    *
    * @generated from field: google.api.RubySettings ruby_settings = 27;
    */
-  rubySettings?: RubySettings;
+  rubySettings?: RubySettings | undefined;
 
   /**
    * Settings for Go client libraries.
    *
    * @generated from field: google.api.GoSettings go_settings = 28;
    */
-  goSettings?: GoSettings;
+  goSettings?: GoSettings | undefined;
 };
 
 /**
@@ -306,7 +306,7 @@ export type JavaSettings = Message<"google.api.JavaSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 3;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -327,7 +327,7 @@ export type CppSettings = Message<"google.api.CppSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -348,7 +348,7 @@ export type PhpSettings = Message<"google.api.PhpSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -369,7 +369,7 @@ export type PythonSettings = Message<"google.api.PythonSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -390,7 +390,7 @@ export type NodeSettings = Message<"google.api.NodeSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -411,7 +411,7 @@ export type DotnetSettings = Message<"google.api.DotnetSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 
   /**
    * Map from original service names to renamed versions.
@@ -482,7 +482,7 @@ export type RubySettings = Message<"google.api.RubySettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -503,7 +503,7 @@ export type GoSettings = Message<"google.api.GoSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common?: CommonLanguageSettings | undefined;
 };
 
 /**
@@ -548,7 +548,7 @@ export type MethodSettings = Message<"google.api.MethodSettings"> & {
    *
    * @generated from field: google.api.MethodSettings.LongRunning long_running = 2;
    */
-  longRunning?: MethodSettings_LongRunning;
+  longRunning?: MethodSettings_LongRunning | undefined;
 
   /**
    * List of top-level fields of the request message, that should be
@@ -591,7 +591,7 @@ export type MethodSettings_LongRunning = Message<"google.api.MethodSettings.Long
    *
    * @generated from field: google.protobuf.Duration initial_poll_delay = 1;
    */
-  initialPollDelay?: Duration;
+  initialPollDelay?: Duration | undefined;
 
   /**
    * Multiplier to gradually increase delay between subsequent polls until it
@@ -608,7 +608,7 @@ export type MethodSettings_LongRunning = Message<"google.api.MethodSettings.Long
    *
    * @generated from field: google.protobuf.Duration max_poll_delay = 3;
    */
-  maxPollDelay?: Duration;
+  maxPollDelay?: Duration | undefined;
 
   /**
    * Total polling timeout.
@@ -616,7 +616,7 @@ export type MethodSettings_LongRunning = Message<"google.api.MethodSettings.Long
    *
    * @generated from field: google.protobuf.Duration total_poll_timeout = 4;
    */
-  totalPollTimeout?: Duration;
+  totalPollTimeout?: Duration | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/checked_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/checked_pb.ts
@@ -74,7 +74,7 @@ export type CheckedExpr = Message<"google.api.expr.v1alpha1.CheckedExpr"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.SourceInfo source_info = 5;
    */
-  sourceInfo?: SourceInfo;
+  sourceInfo?: SourceInfo | undefined;
 
   /**
    * The expr version indicates the major / minor version number of the `expr`
@@ -95,7 +95,7 @@ export type CheckedExpr = Message<"google.api.expr.v1alpha1.CheckedExpr"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr expr = 4;
    */
-  expr?: Expr;
+  expr?: Expr | undefined;
 };
 
 /**
@@ -255,7 +255,7 @@ export type Type_ListType = Message<"google.api.expr.v1alpha1.Type.ListType"> & 
    *
    * @generated from field: google.api.expr.v1alpha1.Type elem_type = 1;
    */
-  elemType?: Type;
+  elemType?: Type | undefined;
 };
 
 /**
@@ -276,14 +276,14 @@ export type Type_MapType = Message<"google.api.expr.v1alpha1.Type.MapType"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Type key_type = 1;
    */
-  keyType?: Type;
+  keyType?: Type | undefined;
 
   /**
    * The type of the value.
    *
    * @generated from field: google.api.expr.v1alpha1.Type value_type = 2;
    */
-  valueType?: Type;
+  valueType?: Type | undefined;
 };
 
 /**
@@ -304,7 +304,7 @@ export type Type_FunctionType = Message<"google.api.expr.v1alpha1.Type.FunctionT
    *
    * @generated from field: google.api.expr.v1alpha1.Type result_type = 1;
    */
-  resultType?: Type;
+  resultType?: Type | undefined;
 
   /**
    * Argument types of the function.
@@ -534,7 +534,7 @@ export type Decl_IdentDecl = Message<"google.api.expr.v1alpha1.Decl.IdentDecl"> 
    *
    * @generated from field: google.api.expr.v1alpha1.Type type = 1;
    */
-  type?: Type;
+  type?: Type | undefined;
 
   /**
    * The constant value of the identifier. If not specified, the identifier
@@ -542,7 +542,7 @@ export type Decl_IdentDecl = Message<"google.api.expr.v1alpha1.Decl.IdentDecl"> 
    *
    * @generated from field: google.api.expr.v1alpha1.Constant value = 2;
    */
-  value?: Constant;
+  value?: Constant | undefined;
 
   /**
    * Documentation string for the identifier.
@@ -644,7 +644,7 @@ export type Decl_FunctionDecl_Overload = Message<"google.api.expr.v1alpha1.Decl.
    *
    * @generated from field: google.api.expr.v1alpha1.Type result_type = 4;
    */
-  resultType?: Type;
+  resultType?: Type | undefined;
 
   /**
    * Whether the function is to be used in a method call-style `x.f(...)`
@@ -706,7 +706,7 @@ export type Reference = Message<"google.api.expr.v1alpha1.Reference"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Constant value = 4;
    */
-  value?: Constant;
+  value?: Constant | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/syntax_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/syntax_pb.ts
@@ -39,14 +39,14 @@ export type ParsedExpr = Message<"google.api.expr.v1alpha1.ParsedExpr"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr expr = 2;
    */
-  expr?: Expr;
+  expr?: Expr | undefined;
 
   /**
    * The source info derived from input that generated the parsed `expr`.
    *
    * @generated from field: google.api.expr.v1alpha1.SourceInfo source_info = 3;
    */
-  sourceInfo?: SourceInfo;
+  sourceInfo?: SourceInfo | undefined;
 };
 
 /**
@@ -197,7 +197,7 @@ export type Expr_Select = Message<"google.api.expr.v1alpha1.Expr.Select"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr operand = 1;
    */
-  operand?: Expr;
+  operand?: Expr | undefined;
 
   /**
    * Required. The name of the field to select.
@@ -240,7 +240,7 @@ export type Expr_Call = Message<"google.api.expr.v1alpha1.Expr.Call"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr target = 1;
    */
-  target?: Expr;
+  target?: Expr | undefined;
 
   /**
    * Required. The name of the function or method being called.
@@ -380,7 +380,7 @@ export type Expr_CreateStruct_Entry = Message<"google.api.expr.v1alpha1.Expr.Cre
    *
    * @generated from field: google.api.expr.v1alpha1.Expr value = 4;
    */
-  value?: Expr;
+  value?: Expr | undefined;
 
   /**
    * Whether the key-value pair is optional.
@@ -440,7 +440,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr iter_range = 2;
    */
-  iterRange?: Expr;
+  iterRange?: Expr | undefined;
 
   /**
    * The name of the variable used for accumulation of the result.
@@ -454,7 +454,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr accu_init = 4;
    */
-  accuInit?: Expr;
+  accuInit?: Expr | undefined;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -464,7 +464,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr loop_condition = 5;
    */
-  loopCondition?: Expr;
+  loopCondition?: Expr | undefined;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -473,7 +473,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr loop_step = 6;
    */
-  loopStep?: Expr;
+  loopStep?: Expr | undefined;
 
   /**
    * An expression which can contain accu_var.
@@ -482,7 +482,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr result = 7;
    */
-  result?: Expr;
+  result?: Expr | undefined;
 };
 
 /**
@@ -712,7 +712,7 @@ export type SourceInfo_Extension = Message<"google.api.expr.v1alpha1.SourceInfo.
    *
    * @generated from field: google.api.expr.v1alpha1.SourceInfo.Extension.Version version = 3;
    */
-  version?: SourceInfo_Extension_Version;
+  version?: SourceInfo_Extension_Version | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/value_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/value_pb.ts
@@ -241,14 +241,14 @@ export type MapValue_Entry = Message<"google.api.expr.v1alpha1.MapValue.Entry"> 
    *
    * @generated from field: google.api.expr.v1alpha1.Value key = 1;
    */
-  key?: Value;
+  key?: Value | undefined;
 
   /**
    * The value.
    *
    * @generated from field: google.api.expr.v1alpha1.Value value = 2;
    */
-  value?: Value;
+  value?: Value | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/decl_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/decl_pb.ts
@@ -136,14 +136,14 @@ export type IdentDecl = Message<"google.api.expr.v1beta1.IdentDecl"> & {
    *
    * @generated from field: google.api.expr.v1beta1.DeclType type = 3;
    */
-  type?: DeclType;
+  type?: DeclType | undefined;
 
   /**
    * Optional value of the identifier.
    *
    * @generated from field: google.api.expr.v1beta1.Expr value = 4;
    */
-  value?: Expr;
+  value?: Expr | undefined;
 };
 
 /**
@@ -171,7 +171,7 @@ export type FunctionDecl = Message<"google.api.expr.v1beta1.FunctionDecl"> & {
    *
    * @generated from field: google.api.expr.v1beta1.DeclType return_type = 2;
    */
-  returnType?: DeclType;
+  returnType?: DeclType | undefined;
 
   /**
    * If the first argument of the function is the receiver.

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/eval_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/eval_pb.ts
@@ -74,7 +74,7 @@ export type EvalState_Result = Message<"google.api.expr.v1beta1.EvalState.Result
    *
    * @generated from field: google.api.expr.v1beta1.IdRef expr = 1;
    */
-  expr?: IdRef;
+  expr?: IdRef | undefined;
 
   /**
    * The index in `values` of the resulting value.

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/expr_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/expr_pb.ts
@@ -41,14 +41,14 @@ export type ParsedExpr = Message<"google.api.expr.v1beta1.ParsedExpr"> & {
    *
    * @generated from field: google.api.expr.v1beta1.Expr expr = 2;
    */
-  expr?: Expr;
+  expr?: Expr | undefined;
 
   /**
    * The source info derived from input that generated the parsed `expr`.
    *
    * @generated from field: google.api.expr.v1beta1.SourceInfo source_info = 3;
    */
-  sourceInfo?: SourceInfo;
+  sourceInfo?: SourceInfo | undefined;
 
   /**
    * The syntax version of the source, e.g. `cel1`.
@@ -203,7 +203,7 @@ export type Expr_Select = Message<"google.api.expr.v1beta1.Expr.Select"> & {
    *
    * @generated from field: google.api.expr.v1beta1.Expr operand = 1;
    */
-  operand?: Expr;
+  operand?: Expr | undefined;
 
   /**
    * Required. The name of the field to select.
@@ -246,7 +246,7 @@ export type Expr_Call = Message<"google.api.expr.v1beta1.Expr.Call"> & {
    *
    * @generated from field: google.api.expr.v1beta1.Expr target = 1;
    */
-  target?: Expr;
+  target?: Expr | undefined;
 
   /**
    * Required. The name of the function or method being called.
@@ -370,7 +370,7 @@ export type Expr_CreateStruct_Entry = Message<"google.api.expr.v1beta1.Expr.Crea
    *
    * @generated from field: google.api.expr.v1beta1.Expr value = 4;
    */
-  value?: Expr;
+  value?: Expr | undefined;
 };
 
 /**
@@ -423,7 +423,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr iter_range = 2;
    */
-  iterRange?: Expr;
+  iterRange?: Expr | undefined;
 
   /**
    * The name of the variable used for accumulation of the result.
@@ -437,7 +437,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr accu_init = 4;
    */
-  accuInit?: Expr;
+  accuInit?: Expr | undefined;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -447,7 +447,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr loop_condition = 5;
    */
-  loopCondition?: Expr;
+  loopCondition?: Expr | undefined;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -456,7 +456,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr loop_step = 6;
    */
-  loopStep?: Expr;
+  loopStep?: Expr | undefined;
 
   /**
    * An expression which can contain accu_var.
@@ -465,7 +465,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr result = 7;
    */
-  result?: Expr;
+  result?: Expr | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/value_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/value_pb.ts
@@ -241,14 +241,14 @@ export type MapValue_Entry = Message<"google.api.expr.v1beta1.MapValue.Entry"> &
    *
    * @generated from field: google.api.expr.v1beta1.Value key = 1;
    */
-  key?: Value;
+  key?: Value | undefined;
 
   /**
    * The value.
    *
    * @generated from field: google.api.expr.v1beta1.Value value = 2;
    */
-  value?: Value;
+  value?: Value | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/geo/type/viewport_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/geo/type/viewport_pb.ts
@@ -73,14 +73,14 @@ export type Viewport = Message<"google.geo.type.Viewport"> & {
    *
    * @generated from field: google.type.LatLng low = 1;
    */
-  low?: LatLng;
+  low?: LatLng | undefined;
 
   /**
    * Required. The high point of the viewport.
    *
    * @generated from field: google.type.LatLng high = 2;
    */
-  high?: LatLng;
+  high?: LatLng | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
@@ -56,7 +56,7 @@ export type Operation = Message<"google.longrunning.Operation"> & {
    *
    * @generated from field: google.protobuf.Any metadata = 2;
    */
-  metadata?: Any;
+  metadata?: Any | undefined;
 
   /**
    * If the value is `false`, it means the operation is still in progress.
@@ -260,7 +260,7 @@ export type WaitOperationRequest = Message<"google.longrunning.WaitOperationRequ
    *
    * @generated from field: google.protobuf.Duration timeout = 2;
    */
-  timeout?: Duration;
+  timeout?: Duration | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/rpc/context/attribute_context_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/rpc/context/attribute_context_pb.ts
@@ -57,7 +57,7 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Peer origin = 7;
    */
-  origin?: AttributeContext_Peer;
+  origin?: AttributeContext_Peer | undefined;
 
   /**
    * The source of a network activity, such as starting a TCP connection.
@@ -66,7 +66,7 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Peer source = 1;
    */
-  source?: AttributeContext_Peer;
+  source?: AttributeContext_Peer | undefined;
 
   /**
    * The destination of a network activity, such as accepting a TCP connection.
@@ -75,21 +75,21 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Peer destination = 2;
    */
-  destination?: AttributeContext_Peer;
+  destination?: AttributeContext_Peer | undefined;
 
   /**
    * Represents a network request, such as an HTTP request.
    *
    * @generated from field: google.rpc.context.AttributeContext.Request request = 3;
    */
-  request?: AttributeContext_Request;
+  request?: AttributeContext_Request | undefined;
 
   /**
    * Represents a network response, such as an HTTP response.
    *
    * @generated from field: google.rpc.context.AttributeContext.Response response = 4;
    */
-  response?: AttributeContext_Response;
+  response?: AttributeContext_Response | undefined;
 
   /**
    * Represents a target resource that is involved with a network activity.
@@ -98,14 +98,14 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Resource resource = 5;
    */
-  resource?: AttributeContext_Resource;
+  resource?: AttributeContext_Resource | undefined;
 
   /**
    * Represents an API operation that is involved to a network activity.
    *
    * @generated from field: google.rpc.context.AttributeContext.Api api = 6;
    */
-  api?: AttributeContext_Api;
+  api?: AttributeContext_Api | undefined;
 
   /**
    * Supports extensions for advanced use cases, such as logs and metrics.
@@ -296,7 +296,7 @@ export type AttributeContext_Auth = Message<"google.rpc.context.AttributeContext
    *
    * @generated from field: google.protobuf.Struct claims = 4;
    */
-  claims?: JsonObject;
+  claims?: JsonObject | undefined;
 
   /**
    * A list of access level resource names that allow resources to be
@@ -387,7 +387,7 @@ export type AttributeContext_Request = Message<"google.rpc.context.AttributeCont
    *
    * @generated from field: google.protobuf.Timestamp time = 9;
    */
-  time?: Timestamp;
+  time?: Timestamp | undefined;
 
   /**
    * The HTTP request size in bytes. If unknown, it must be -1.
@@ -420,7 +420,7 @@ export type AttributeContext_Request = Message<"google.rpc.context.AttributeCont
    *
    * @generated from field: google.rpc.context.AttributeContext.Auth auth = 13;
    */
-  auth?: AttributeContext_Auth;
+  auth?: AttributeContext_Auth | undefined;
 };
 
 /**
@@ -466,7 +466,7 @@ export type AttributeContext_Response = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp time = 4;
    */
-  time?: Timestamp;
+  time?: Timestamp | undefined;
 
   /**
    * The amount of time it takes the backend service to fully respond to a
@@ -476,7 +476,7 @@ export type AttributeContext_Response = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Duration backend_latency = 5;
    */
-  backendLatency?: Duration;
+  backendLatency?: Duration | undefined;
 };
 
 /**
@@ -575,7 +575,7 @@ export type AttributeContext_Resource = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp create_time = 8;
    */
-  createTime?: Timestamp;
+  createTime?: Timestamp | undefined;
 
   /**
    * Output only. The timestamp when the resource was last updated. Any
@@ -584,7 +584,7 @@ export type AttributeContext_Resource = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp update_time = 9;
    */
-  updateTime?: Timestamp;
+  updateTime?: Timestamp | undefined;
 
   /**
    * Output only. The timestamp when the resource was deleted.
@@ -592,7 +592,7 @@ export type AttributeContext_Resource = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp delete_time = 10;
    */
-  deleteTime?: Timestamp;
+  deleteTime?: Timestamp | undefined;
 
   /**
    * Output only. An opaque value that uniquely identifies a version or

--- a/packages/bundle-size/src/gen/protobuf-es/google/rpc/error_details_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/rpc/error_details_pb.ts
@@ -125,7 +125,7 @@ export type RetryInfo = Message<"google.rpc.RetryInfo"> & {
    *
    * @generated from field: google.protobuf.Duration retry_delay = 1;
    */
-  retryDelay?: Duration;
+  retryDelay?: Duration | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/type/color_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/type/color_pb.ts
@@ -192,7 +192,7 @@ export type Color = Message<"google.type.Color"> & {
    *
    * @generated from field: google.protobuf.FloatValue alpha = 4;
    */
-  alpha?: number;
+  alpha?: number | undefined;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/type/interval_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/type/interval_pb.ts
@@ -47,7 +47,7 @@ export type Interval = Message<"google.type.Interval"> & {
    *
    * @generated from field: google.protobuf.Timestamp start_time = 1;
    */
-  startTime?: Timestamp;
+  startTime?: Timestamp | undefined;
 
   /**
    * Optional. Exclusive end of the interval.
@@ -57,7 +57,7 @@ export type Interval = Message<"google.type.Interval"> & {
    *
    * @generated from field: google.protobuf.Timestamp end_time = 2;
    */
-  endTime?: Timestamp;
+  endTime?: Timestamp | undefined;
 };
 
 /**

--- a/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
+++ b/packages/protobuf-conformance/src/gen/conformance/conformance_pb.ts
@@ -159,7 +159,7 @@ export type ConformanceRequest = Message<"conformance.ConformanceRequest"> & {
    *
    * @generated from field: conformance.JspbEncodingConfig jspb_encoding_options = 6;
    */
-  jspbEncodingOptions?: JspbEncodingConfig;
+  jspbEncodingOptions?: JspbEncodingConfig | undefined;
 
   /**
    * This can be used in json and text format. If true, testee should print

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_edition2023_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_edition2023_pb.ts
@@ -128,12 +128,12 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage optional_nested_message = 18 [features.message_encoding = LENGTH_PREFIXED];
    */
-  optionalNestedMessage?: TestAllTypesEdition2023_NestedMessage;
+  optionalNestedMessage?: TestAllTypesEdition2023_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.ForeignMessageEdition2023 optional_foreign_message = 19 [features.message_encoding = LENGTH_PREFIXED];
    */
-  optionalForeignMessage?: ForeignMessageEdition2023;
+  optionalForeignMessage?: ForeignMessageEdition2023 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.NestedEnum optional_nested_enum = 21;
@@ -158,7 +158,7 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023 recursive_message = 27 [features.message_encoding = LENGTH_PREFIXED];
    */
-  recursiveMessage?: TestAllTypesEdition2023;
+  recursiveMessage?: TestAllTypesEdition2023 | undefined;
 
   /**
    * Repeated
@@ -570,12 +570,12 @@ export type TestAllTypesEdition2023 = Message<"protobuf_test_messages.editions.T
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType groupliketype = 201;
    */
-  groupliketype?: TestAllTypesEdition2023_GroupLikeType;
+  groupliketype?: TestAllTypesEdition2023_GroupLikeType | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType delimited_field = 202;
    */
-  delimitedField?: TestAllTypesEdition2023_GroupLikeType;
+  delimitedField?: TestAllTypesEdition2023_GroupLikeType | undefined;
 };
 
 /**
@@ -597,7 +597,7 @@ export type TestAllTypesEdition2023_NestedMessage = Message<"protobuf_test_messa
   /**
    * @generated from field: protobuf_test_messages.editions.TestAllTypesEdition2023 corecursive = 2 [features.message_encoding = LENGTH_PREFIXED];
    */
-  corecursive?: TestAllTypesEdition2023;
+  corecursive?: TestAllTypesEdition2023 | undefined;
 };
 
 /**

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_editions_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_editions_pb.ts
@@ -123,12 +123,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -153,7 +153,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -575,12 +575,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.Data data = 201 [features.message_encoding = DELIMITED];
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204 [features.message_encoding = DELIMITED];
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -755,7 +755,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.editions.proto2
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -777,7 +777,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1018,12 +1018,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.editions.pro
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: bool optional_bool = 1006;
@@ -1235,12 +1235,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.ForeignMessageProto2 required_foreign_message = 19 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21 [features.field_presence = LEGACY_REQUIRED];
@@ -1265,17 +1265,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 recursive_message = 27 [features.field_presence = LEGACY_REQUIRED];
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.Data data = 201 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1374,12 +1374,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 corecursive = 2 [features.field_presence = LEGACY_REQUIRED];
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto2_pb.ts
@@ -120,12 +120,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -150,7 +150,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -572,12 +572,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -752,7 +752,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -774,7 +774,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1015,12 +1015,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.proto2.Unkno
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1232,12 +1232,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1262,17 +1262,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1371,12 +1371,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_editions_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_editions_pb.ts
@@ -122,12 +122,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -157,7 +157,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -577,47 +577,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -667,32 +667,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -847,7 +847,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-conformance/src/gen/google/protobuf/test_messages_proto3_pb.ts
@@ -121,12 +121,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -156,7 +156,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -576,47 +576,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -666,32 +666,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -846,7 +846,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/protobuf-example/src/gen/example_pb.ts
+++ b/packages/protobuf-example/src/gen/example_pb.ts
@@ -48,7 +48,7 @@ export type User = Message<"example.User"> & {
   /**
    * @generated from field: example.User manager = 4;
    */
-  manager?: User;
+  manager?: User | undefined;
 
   /**
    * @generated from field: repeated string locations = 5;

--- a/packages/protobuf-test/src/gen/js,json_types/extra/json_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js,json_types/extra/json_types_pb.d.ts
@@ -57,42 +57,42 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField?: JsonTypesMessage | undefined;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField?: ListValue | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -102,52 +102,52 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;

--- a/packages/protobuf-test/src/gen/js,valid_types/extra/minimal-validate_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js,valid_types/extra/minimal-validate_pb.d.ts
@@ -115,7 +115,7 @@ export declare type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items?: FieldRules | undefined;
 };
 
 export declare type RepeatedRulesValid = RepeatedRules;
@@ -133,7 +133,7 @@ export declare type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values?: FieldRules | undefined;
 };
 
 export declare type MapRulesValid = MapRules;

--- a/packages/protobuf-test/src/gen/js,valid_types/extra/valid_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js,valid_types/extra/valid_types_pb.d.ts
@@ -36,7 +36,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -45,7 +45,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -54,7 +54,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -63,14 +63,14 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -165,7 +165,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -174,7 +174,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -182,7 +182,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt?: Timestamp | undefined;
 };
 
 /**
@@ -196,7 +196,7 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_OtherValid;
+  msg?: VTypes_OtherValid | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -214,7 +214,7 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -223,14 +223,14 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_OtherValid;
+  msgIgnoreUnpopulated?: VTypes_OtherValid | undefined;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_OtherValid;
+  msgIgnoreDefault?: VTypes_OtherValid | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -342,7 +342,7 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt?: Timestamp | undefined;
 };
 
 /**
@@ -377,7 +377,7 @@ export declare type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg?: VTypes | undefined;
 };
 
 /**
@@ -392,7 +392,7 @@ export declare type VTypes2Valid = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypesValid;
+  msg?: VTypesValid | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/editions/golden/test_messages_proto3_editions_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/editions/golden/test_messages_proto3_editions_pb.d.ts
@@ -119,12 +119,12 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -154,7 +154,7 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -574,47 +574,47 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -664,32 +664,32 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -843,7 +843,7 @@ export declare type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-proto2_pb.d.ts
@@ -48,7 +48,7 @@ export declare type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageFor
   /**
    * @generated from field: optional spec.Proto2MessageForEdition2023.OptionalGroup optionalgroup = 4;
    */
-  optionalgroup?: Proto2MessageForEdition2023_OptionalGroup;
+  optionalgroup?: Proto2MessageForEdition2023_OptionalGroup | undefined;
 
   /**
    * @generated from field: required bool required_bool_field = 5;
@@ -68,7 +68,7 @@ export declare type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageFor
   /**
    * @generated from field: required spec.Proto2MessageForEdition2023.RequiredGroup requiredgroup = 8;
    */
-  requiredgroup?: Proto2MessageForEdition2023_RequiredGroup;
+  requiredgroup?: Proto2MessageForEdition2023_RequiredGroup | undefined;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-proto3_pb.d.ts
@@ -43,12 +43,12 @@ export declare type Proto3MessageForEdition2023 = Message<"spec.Proto3MessageFor
   /**
    * @generated from field: optional bool explicit_bool_field = 5;
    */
-  explicitBoolField?: boolean;
+  explicitBoolField?: boolean | undefined;
 
   /**
    * @generated from field: optional spec.Proto3EnumForEdition2023 explicit_open_enum_field = 6;
    */
-  explicitOpenEnumField?: Proto3EnumForEdition2023;
+  explicitOpenEnumField?: Proto3EnumForEdition2023 | undefined;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/js/extra/edition2023_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023_pb.d.ts
@@ -84,17 +84,17 @@ export declare type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message explicit_message_field = 311;
    */
-  explicitMessageField?: Edition2023Message;
+  explicitMessageField?: Edition2023Message | undefined;
 
   /**
    * @generated from field: spec.Edition2023Message explicit_message_delimited_field = 312 [features.message_encoding = DELIMITED];
    */
-  explicitMessageDelimitedField?: Edition2023Message;
+  explicitMessageDelimitedField?: Edition2023Message | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value explicit_wrapped_uint32_field = 313;
    */
-  explicitWrappedUint32Field?: number;
+  explicitWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: string implicit_string_field = 201 [features.field_presence = IMPLICIT];
@@ -194,17 +194,17 @@ export declare type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_field = 11 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessageField?: Edition2023Message_Child;
+  requiredMessageField?: Edition2023Message_Child | undefined;
 
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_delimited_field = 12 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  requiredMessageDelimitedField?: Edition2023Message_Child;
+  requiredMessageDelimitedField?: Edition2023Message_Child | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value required_wrapped_uint32_field = 13 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: string required_default_string_field = 101 [default = "hello \" *\/ ", features.field_presence = LEGACY_REQUIRED];
@@ -519,7 +519,7 @@ export declare type Edition2023FromProto2Message = Message<"spec.Edition2023From
   /**
    * @generated from field: spec.Edition2023FromProto2Message.OptionalGroup optionalgroup = 4 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: Edition2023FromProto2Message_OptionalGroup;
+  optionalgroup?: Edition2023FromProto2Message_OptionalGroup | undefined;
 
   /**
    * @generated from field: bool required_bool_field = 5 [features.field_presence = LEGACY_REQUIRED];
@@ -539,7 +539,7 @@ export declare type Edition2023FromProto2Message = Message<"spec.Edition2023From
   /**
    * @generated from field: spec.Edition2023FromProto2Message.RequiredGroup requiredgroup = 8 [features.message_encoding = DELIMITED];
    */
-  requiredgroup?: Edition2023FromProto2Message_RequiredGroup;
+  requiredgroup?: Edition2023FromProto2Message_RequiredGroup | undefined;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [features.repeated_field_encoding = PACKED];

--- a/packages/protobuf-test/src/gen/js/extra/example-service_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/example-service_pb.d.ts
@@ -53,7 +53,7 @@ export declare type CreateUserResponse = Message<"example.CreateUserResponse"> &
   /**
    * @generated from field: example.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/example_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/example_pb.d.ts
@@ -46,7 +46,7 @@ export declare type User = Message<"example.User"> & {
   /**
    * @generated from field: example.User manager = 4;
    */
-  manager?: User;
+  manager?: User | undefined;
 
   /**
    * @generated from field: repeated string locations = 5;

--- a/packages/protobuf-test/src/gen/js/extra/json_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/json_types_pb.d.ts
@@ -57,42 +57,42 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField?: JsonTypesMessage | undefined;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField?: ListValue | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -102,52 +102,52 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;

--- a/packages/protobuf-test/src/gen/js/extra/minimal-validate_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/minimal-validate_pb.d.ts
@@ -109,7 +109,7 @@ export declare type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items?: FieldRules | undefined;
 };
 
 /**
@@ -125,7 +125,7 @@ export declare type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values?: FieldRules | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/msg-message_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-message_pb.d.ts
@@ -31,7 +31,7 @@ export declare type MessageFieldMessage = Message<"spec.MessageFieldMessage"> & 
   /**
    * @generated from field: spec.MessageFieldMessage.TestMessage message_field = 1;
    */
-  messageField?: MessageFieldMessage_TestMessage;
+  messageField?: MessageFieldMessage_TestMessage | undefined;
 
   /**
    * @generated from field: repeated spec.MessageFieldMessage.TestMessage repeated_message_field = 2;

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -36,7 +36,7 @@ export declare type User = Message$1<"spec.User"> & {
    *
    * @generated from field: example.User u = 1;
    */
-  u?: User$1;
+  u?: User$1 | undefined;
 };
 
 /**
@@ -916,7 +916,7 @@ export declare type NoClashOneofADT = Message$1<"spec.NoClashOneofADT"> & {
   /**
    * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  m?: NoClashOneofADT_M;
+  m?: NoClashOneofADT_M | undefined;
 };
 
 /**
@@ -937,7 +937,7 @@ export declare type NoClashOneofADT_M = Message$1<"spec.NoClashOneofADT.M"> & {
   /**
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value?: string | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/perf_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/perf_pb.d.ts
@@ -46,12 +46,12 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: optional int64 int64_field = 3;
    */
-  int64Field?: bigint;
+  int64Field?: bigint | undefined;
 
   /**
    * @generated from field: optional bool bool_field = 4;
    */
-  boolField?: boolean;
+  boolField?: boolean | undefined;
 
   /**
    * @generated from field: string string_field = 5;
@@ -71,7 +71,7 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: perf.v1.PerfMessage small_message_field = 8;
    */
-  smallMessageField?: PerfMessage;
+  smallMessageField?: PerfMessage | undefined;
 
   /**
    * @generated from field: int32 unused_field_1 = 9;

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
@@ -79,17 +79,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_message_field = 8;
    */
-  requiredMessageField?: Proto2Message;
+  requiredMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredGroup requiredgroup = 9;
    */
-  requiredgroup?: Proto2Message_RequiredGroup;
+  requiredgroup?: Proto2Message_RequiredGroup | undefined;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_wrapped_uint32_field = 201;
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: required string required_default_string_field = 10 [default = "hello \" *\/ "];
@@ -139,17 +139,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_default_message_field = 17;
    */
-  requiredDefaultMessageField?: Proto2Message;
+  requiredDefaultMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredDefaultGroup requireddefaultgroup = 18;
    */
-  requireddefaultgroup?: Proto2Message_RequiredDefaultGroup;
+  requireddefaultgroup?: Proto2Message_RequiredDefaultGroup | undefined;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_default_wrapped_uint32_field = 202;
    */
-  requiredDefaultWrappedUint32Field?: number;
+  requiredDefaultWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: optional string optional_string_field = 19;
@@ -199,17 +199,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_message_field = 26;
    */
-  optionalMessageField?: Proto2Message;
+  optionalMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalGroup optionalgroup = 27;
    */
-  optionalgroup?: Proto2Message_OptionalGroup;
+  optionalgroup?: Proto2Message_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 207;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: optional string optional_default_string_field = 28 [default = "hello \" *\/ "];
@@ -259,17 +259,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_default_message_field = 35;
    */
-  optionalDefaultMessageField?: Proto2Message;
+  optionalDefaultMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalDefaultGroup optionaldefaultgroup = 36;
    */
-  optionaldefaultgroup?: Proto2Message_OptionalDefaultGroup;
+  optionaldefaultgroup?: Proto2Message_OptionalDefaultGroup | undefined;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_default_wrapped_uint32_field = 203;
    */
-  optionalDefaultWrappedUint32Field?: number;
+  optionalDefaultWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: repeated string repeated_string_field = 37;

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
@@ -79,77 +79,77 @@ export declare type Proto3Message = Message<"spec.Proto3Message"> & {
   /**
    * @generated from field: spec.Proto3Message singular_message_field = 8;
    */
-  singularMessageField?: Proto3Message;
+  singularMessageField?: Proto3Message | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value singular_wrapped_uint32_field = 211;
    */
-  singularWrappedUint32Field?: number;
+  singularWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct singular_struct_field = 214;
    */
-  singularStructField?: JsonObject;
+  singularStructField?: JsonObject | undefined;
 
   /**
    * @generated from field: optional string optional_string_field = 9;
    */
-  optionalStringField?: string;
+  optionalStringField?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes_field = 10;
    */
-  optionalBytesField?: Uint8Array;
+  optionalBytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_field = 11;
    */
-  optionalInt32Field?: number;
+  optionalInt32Field?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_field = 12;
    */
-  optionalInt64Field?: bigint;
+  optionalInt64Field?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_js_number_field = 106 [jstype = JS_NUMBER];
    */
-  optionalInt64JsNumberField?: bigint;
+  optionalInt64JsNumberField?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_js_string_field = 105 [jstype = JS_STRING];
    */
-  optionalInt64JsStringField?: string;
+  optionalInt64JsStringField?: string | undefined;
 
   /**
    * @generated from field: optional float optional_float_field = 13;
    */
-  optionalFloatField?: number;
+  optionalFloatField?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool_field = 14;
    */
-  optionalBoolField?: boolean;
+  optionalBoolField?: boolean | undefined;
 
   /**
    * @generated from field: optional spec.Proto3Enum optional_enum_field = 15;
    */
-  optionalEnumField?: Proto3Enum;
+  optionalEnumField?: Proto3Enum | undefined;
 
   /**
    * @generated from field: optional spec.Proto3Message optional_message_field = 16;
    */
-  optionalMessageField?: Proto3Message;
+  optionalMessageField?: Proto3Message | undefined;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 212;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.Struct optional_struct_field = 215;
    */
-  optionalStructField?: JsonObject;
+  optionalStructField?: JsonObject | undefined;
 
   /**
    * @generated from field: repeated string repeated_string_field = 17;

--- a/packages/protobuf-test/src/gen/js/extra/ts-types-proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/ts-types-proto2_pb.d.ts
@@ -36,7 +36,7 @@ export declare type TsTypeA = Message<"spec.TsTypeA"> & {
   /**
    * @generated from field: optional spec.TsTypeA child = 2;
    */
-  child?: TsTypeA;
+  child?: TsTypeA | undefined;
 };
 
 /**
@@ -57,7 +57,7 @@ export declare type TsTypeB = Message<"spec.TsTypeB"> & {
   /**
    * @generated from field: optional spec.TsTypeB child = 2;
    */
-  child?: TsTypeB;
+  child?: TsTypeB | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/valid_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/valid_types_pb.d.ts
@@ -36,7 +36,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -45,7 +45,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -54,7 +54,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -63,14 +63,14 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -165,7 +165,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -174,7 +174,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -182,7 +182,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt?: Timestamp | undefined;
 };
 
 /**
@@ -215,7 +215,7 @@ export declare type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg?: VTypes | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
@@ -34,47 +34,47 @@ export declare type WrappersMessage = Message<"spec.WrappersMessage"> & {
   /**
    * @generated from field: google.protobuf.DoubleValue double_value_field = 1;
    */
-  doubleValueField?: number;
+  doubleValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_value_field = 2;
    */
-  boolValueField?: boolean;
+  boolValueField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_value_field = 3;
    */
-  floatValueField?: number;
+  floatValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_value_field = 4;
    */
-  int64ValueField?: bigint;
+  int64ValueField?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_value_field = 5;
    */
-  uint64ValueField?: bigint;
+  uint64ValueField?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_value_field = 6;
    */
-  int32ValueField?: number;
+  int32ValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_value_field = 7;
    */
-  uint32ValueField?: number;
+  uint32ValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue string_value_field = 8;
    */
-  stringValueField?: string;
+  stringValueField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_value_field = 9;
    */
-  bytesValueField?: Uint8Array;
+  bytesValueField?: Uint8Array | undefined;
 
   /**
    * @generated from oneof spec.WrappersMessage.oneof_fields

--- a/packages/protobuf-test/src/gen/js/google/protobuf/map_proto2_unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/map_proto2_unittest_pb.d.ts
@@ -309,7 +309,7 @@ export declare type TestSubmessageMaps = Message<"proto2_unittest.TestSubmessage
   /**
    * @generated from field: optional proto2_unittest.TestMaps m = 1;
    */
-  m?: TestMaps;
+  m?: TestMaps | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
@@ -118,12 +118,12 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -148,7 +148,7 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -570,12 +570,12 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -750,7 +750,7 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -771,7 +771,7 @@ export declare type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -999,12 +999,12 @@ export declare type UnknownToTestAllTypes = Message<"protobuf_test_messages.prot
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1209,12 +1209,12 @@ export declare type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1239,17 +1239,17 @@ export declare type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1347,12 +1347,12 @@ export declare type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
@@ -118,12 +118,12 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -153,7 +153,7 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -573,47 +573,47 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -663,32 +663,32 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -842,7 +842,7 @@ export declare type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.d.ts
@@ -69,7 +69,7 @@ export declare type Type = Message<"google.protobuf.Type"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -404,7 +404,7 @@ export declare type Enum = Message<"google.protobuf.Enum"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -495,7 +495,7 @@ export declare type Option = Message<"google.protobuf.Option"> & {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value?: Any | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -330,7 +330,7 @@ export declare type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionT
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType1 bar = 1;
    */
-  bar?: ComplexOptionType1;
+  bar?: ComplexOptionType1 | undefined;
 
   /**
    * @generated from field: optional int32 baz = 2;
@@ -340,7 +340,7 @@ export declare type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionT
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
    */
-  fred?: ComplexOptionType2_ComplexOptionType4;
+  fred?: ComplexOptionType2_ComplexOptionType4 | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.ComplexOptionType2.ComplexOptionType4 barney = 4;
@@ -387,7 +387,7 @@ export declare type ComplexOptionType3 = Message<"proto2_unittest.ComplexOptionT
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
    */
-  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5;
+  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5 | undefined;
 };
 
 /**
@@ -496,28 +496,28 @@ export declare type Aggregate = Message<"proto2_unittest.Aggregate"> & {
    *
    * @generated from field: optional proto2_unittest.Aggregate sub = 3;
    */
-  sub?: Aggregate;
+  sub?: Aggregate | undefined;
 
   /**
    * To test the parsing of extensions inside aggregate values
    *
    * @generated from field: optional google.protobuf.FileOptions file = 4;
    */
-  file?: FileOptions;
+  file?: FileOptions | undefined;
 
   /**
    * An embedded message set
    *
    * @generated from field: optional proto2_unittest.AggregateMessageSet mset = 5;
    */
-  mset?: AggregateMessageSet;
+  mset?: AggregateMessageSet | undefined;
 
   /**
    * An any
    *
    * @generated from field: optional google.protobuf.Any any = 6;
    */
-  any?: Any;
+  any?: Any | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.d.ts
@@ -41,7 +41,7 @@ export declare type TestEmbedOptimizedForSize = Message<"proto2_unittest.TestEmb
    *
    * @generated from field: optional proto2_unittest.TestOptimizedForSize optional_message = 1;
    */
-  optionalMessage?: TestOptimizedForSize;
+  optionalMessage?: TestOptimizedForSize | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestOptimizedForSize repeated_message = 2;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_extension_set_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_extension_set_pb.d.ts
@@ -51,7 +51,7 @@ export declare type TestExtensionSetContainer = Message<"proto2_unittest.TestExt
   /**
    * @generated from field: optional proto2_unittest.TestExtensionSet extension = 1;
    */
-  extension?: TestExtensionSet;
+  extension?: TestExtensionSet | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.d.ts
@@ -36,14 +36,14 @@ export declare type TestLiteImportsNonlite = Message<"proto2_unittest.TestLiteIm
   /**
    * @generated from field: optional proto2_unittest.TestAllTypes message = 1;
    */
-  message?: TestAllTypes;
+  message?: TestAllTypes | undefined;
 
   /**
    * Verifies that transitive required fields generates valid code.
    *
    * @generated from field: optional proto2_unittest.TestRequired message_with_required = 2;
    */
-  messageWithRequired?: TestRequired;
+  messageWithRequired?: TestRequired | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
@@ -39,7 +39,7 @@ export declare type TestMessageSetContainer = Message<"proto2_unittest.TestMessa
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet?: TestMessageSet | undefined;
 };
 
 /**
@@ -55,17 +55,17 @@ export declare type NestedTestMessageSetContainer = Message<"proto2_unittest.Nes
   /**
    * @generated from field: optional proto2_unittest.TestMessageSetContainer container = 1;
    */
-  container?: TestMessageSetContainer;
+  container?: TestMessageSetContainer | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer child = 2;
    */
-  child?: NestedTestMessageSetContainer;
+  child?: NestedTestMessageSetContainer | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer lazy_child = 3;
    */
-  lazyChild?: NestedTestMessageSetContainer;
+  lazyChild?: NestedTestMessageSetContainer | undefined;
 };
 
 /**
@@ -91,7 +91,7 @@ export declare type NestedTestInt = Message<"proto2_unittest.NestedTestInt"> & {
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt child = 2;
    */
-  child?: NestedTestInt;
+  child?: NestedTestInt | undefined;
 };
 
 /**
@@ -112,7 +112,7 @@ export declare type TestMessageSetExtension1 = Message<"proto2_unittest.TestMess
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
    */
-  recursive?: TestMessageSet;
+  recursive?: TestMessageSet | undefined;
 
   /**
    * @generated from field: optional string test_aliasing = 17;
@@ -159,7 +159,7 @@ export declare type TestMessageSetExtension3 = Message<"proto2_unittest.TestMess
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt msg = 35;
    */
-  msg?: NestedTestInt;
+  msg?: NestedTestInt | undefined;
 
   /**
    * @generated from field: required int32 required_int = 36;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.d.ts
@@ -51,7 +51,7 @@ export declare type TestMessageSetWireFormatContainer = Message<"proto2_wireform
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet?: TestMessageSet | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
@@ -43,7 +43,7 @@ export declare type TestOptimizedForSize = Message<"proto2_unittest.TestOptimize
   /**
    * @generated from field: optional proto2_unittest.ForeignMessage msg = 19;
    */
-  msg?: ForeignMessage;
+  msg?: ForeignMessage | undefined;
 
   /**
    * @generated from oneof proto2_unittest.TestOptimizedForSize.foo
@@ -102,7 +102,7 @@ export declare type TestOptionalOptimizedForSize = Message<"proto2_unittest.Test
   /**
    * @generated from field: optional proto2_unittest.TestRequiredOptimizedForSize o = 1;
    */
-  o?: TestRequiredOptimizedForSize;
+  o?: TestRequiredOptimizedForSize | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -128,22 +128,22 @@ export declare type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestAllTypes_OptionalGroup;
+  optionalgroup?: TestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -180,17 +180,17 @@ export declare type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -570,12 +570,12 @@ export declare type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllT
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.NestedTestAllTypes repeated_child = 3;
@@ -585,12 +585,12 @@ export declare type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllT
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes lazy_child = 4;
    */
-  lazyChild?: NestedTestAllTypes;
+  lazyChild?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes eager_child = 5;
    */
-  eagerChild?: TestAllTypes;
+  eagerChild?: TestAllTypes | undefined;
 };
 
 /**
@@ -619,7 +619,7 @@ export declare type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecat
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage deprecated_message = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedMessage?: TestAllTypes_NestedMessage;
+  deprecatedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from oneof proto2_unittest.TestDeprecatedFields.oneof_fields
@@ -636,7 +636,7 @@ export declare type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecat
   /**
    * @generated from field: proto2_unittest.TestDeprecatedFields nested = 5;
    */
-  nested?: TestDeprecatedFields;
+  nested?: TestDeprecatedFields | undefined;
 };
 
 /**
@@ -777,7 +777,7 @@ export declare type TestGroup = Message<"proto2_unittest.TestGroup"> & {
   /**
    * @generated from field: proto2_unittest.TestGroup.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestGroup_OptionalGroup;
+  optionalgroup?: TestGroup_OptionalGroup | undefined;
 
   /**
    * @generated from field: proto2_unittest.ForeignEnum optional_foreign_enum = 22;
@@ -897,7 +897,7 @@ export declare type TestChildExtension = Message<"proto2_unittest.TestChildExten
   /**
    * @generated from field: proto2_unittest.TestAllExtensions optional_extension = 3;
    */
-  optionalExtension?: TestAllExtensions;
+  optionalExtension?: TestAllExtensions | undefined;
 };
 
 /**
@@ -926,7 +926,7 @@ export declare type TestChildExtensionData = Message<"proto2_unittest.TestChildE
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
    */
-  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData;
+  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData | undefined;
 };
 
 /**
@@ -942,7 +942,7 @@ export declare type TestChildExtensionData_NestedTestAllExtensionsData = Message
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData.NestedDynamicExtensions dynamic = 409707008;
    */
-  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
+  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions | undefined;
 };
 
 /**
@@ -984,7 +984,7 @@ export declare type TestNestedChildExtension = Message<"proto2_unittest.TestNest
   /**
    * @generated from field: proto2_unittest.TestChildExtension child = 2;
    */
-  child?: TestChildExtension;
+  child?: TestChildExtension | undefined;
 };
 
 /**
@@ -1008,7 +1008,7 @@ export declare type TestNestedChildExtensionData = Message<"proto2_unittest.Test
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData child = 2;
    */
-  child?: TestChildExtensionData;
+  child?: TestChildExtensionData | undefined;
 };
 
 /**
@@ -1450,7 +1450,7 @@ export declare type TestRequired = Message<"proto2_unittest.TestRequired"> & {
    *
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign = 34;
    */
-  optionalForeign?: ForeignMessage;
+  optionalForeign?: ForeignMessage | undefined;
 
   /**
    * @generated from field: map<string, proto2_unittest.TestRequired> map_field = 35;
@@ -1481,7 +1481,7 @@ export declare type TestRequiredForeign = Message<"proto2_unittest.TestRequiredF
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage?: TestRequired | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1498,7 +1498,7 @@ export declare type TestRequiredForeign = Message<"proto2_unittest.TestRequiredF
    *
    * @generated from field: proto2_unittest.NestedTestAllTypes optional_lazy_message = 4;
    */
-  optionalLazyMessage?: NestedTestAllTypes;
+  optionalLazyMessage?: NestedTestAllTypes | undefined;
 };
 
 /**
@@ -1514,7 +1514,7 @@ export declare type TestRequiredMessage = Message<"proto2_unittest.TestRequiredM
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage?: TestRequired | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1524,7 +1524,7 @@ export declare type TestRequiredMessage = Message<"proto2_unittest.TestRequiredM
   /**
    * @generated from field: proto2_unittest.TestRequired required_message = 3 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessage?: TestRequired;
+  requiredMessage?: TestRequired | undefined;
 };
 
 /**
@@ -1540,12 +1540,12 @@ export declare type TestRequiredLazyMessage = Message<"proto2_unittest.TestRequi
   /**
    * @generated from field: proto2_unittest.TestRequired child = 1;
    */
-  child?: TestRequired;
+  child?: TestRequired | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredLazyMessage recurse = 2;
    */
-  recurse?: TestRequiredLazyMessage;
+  recurse?: TestRequiredLazyMessage | undefined;
 };
 
 /**
@@ -1561,12 +1561,12 @@ export declare type TestNestedRequiredForeign = Message<"proto2_unittest.TestNes
   /**
    * @generated from field: proto2_unittest.TestNestedRequiredForeign child = 1;
    */
-  child?: TestNestedRequiredForeign;
+  child?: TestNestedRequiredForeign | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredForeign payload = 2;
    */
-  payload?: TestRequiredForeign;
+  payload?: TestRequiredForeign | undefined;
 
   /**
    * @generated from field: int32 dummy = 3;
@@ -1578,22 +1578,22 @@ export declare type TestNestedRequiredForeign = Message<"proto2_unittest.TestNes
    *
    * @generated from field: proto2_unittest.TestRequiredEnum required_enum = 5;
    */
-  requiredEnum?: TestRequiredEnum;
+  requiredEnum?: TestRequiredEnum | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask required_enum_no_mask = 6;
    */
-  requiredEnumNoMask?: TestRequiredEnumNoMask;
+  requiredEnumNoMask?: TestRequiredEnumNoMask | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti required_enum_multi = 7;
    */
-  requiredEnumMulti?: TestRequiredEnumMulti;
+  requiredEnumMulti?: TestRequiredEnumMulti | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti required_no_mask = 9;
    */
-  requiredNoMask?: TestRequiredNoMaskMulti;
+  requiredNoMask?: TestRequiredNoMaskMulti | undefined;
 };
 
 /**
@@ -1611,7 +1611,7 @@ export declare type TestForeignNested = Message<"proto2_unittest.TestForeignNest
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage foreign_nested = 1;
    */
-  foreignNested?: TestAllTypes_NestedMessage;
+  foreignNested?: TestAllTypes_NestedMessage | undefined;
 };
 
 /**
@@ -1740,7 +1740,7 @@ export declare type TestRecursiveMessage = Message<"proto2_unittest.TestRecursiv
   /**
    * @generated from field: proto2_unittest.TestRecursiveMessage a = 1;
    */
-  a?: TestRecursiveMessage;
+  a?: TestRecursiveMessage | undefined;
 
   /**
    * @generated from field: int32 i = 2;
@@ -1763,12 +1763,12 @@ export declare type TestMutualRecursionA = Message<"proto2_unittest.TestMutualRe
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB bb = 1;
    */
-  bb?: TestMutualRecursionB;
+  bb?: TestMutualRecursionB | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubGroup subgroup = 2 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestMutualRecursionA_SubGroup;
+  subgroup?: TestMutualRecursionA_SubGroup | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestMutualRecursionA.SubGroupR subgroupr = 5 [features.message_encoding = DELIMITED];
@@ -1789,7 +1789,7 @@ export declare type TestMutualRecursionA_SubMessage = Message<"proto2_unittest.T
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB b = 1;
    */
-  b?: TestMutualRecursionB;
+  b?: TestMutualRecursionB | undefined;
 };
 
 /**
@@ -1807,12 +1807,12 @@ export declare type TestMutualRecursionA_SubGroup = Message<"proto2_unittest.Tes
    *
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubMessage sub_message = 3;
    */
-  subMessage?: TestMutualRecursionA_SubMessage;
+  subMessage?: TestMutualRecursionA_SubMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes not_in_this_scc = 4;
    */
-  notInThisScc?: TestAllTypes;
+  notInThisScc?: TestAllTypes | undefined;
 };
 
 /**
@@ -1828,7 +1828,7 @@ export declare type TestMutualRecursionA_SubGroupR = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 6;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 };
 
 /**
@@ -1844,7 +1844,7 @@ export declare type TestMutualRecursionB = Message<"proto2_unittest.TestMutualRe
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA a = 1;
    */
-  a?: TestMutualRecursionA;
+  a?: TestMutualRecursionA | undefined;
 
   /**
    * @generated from field: int32 optional_int32 = 2;
@@ -1865,7 +1865,7 @@ export declare type TestIsInitialized = Message<"proto2_unittest.TestIsInitializ
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage sub_message = 1;
    */
-  subMessage?: TestIsInitialized_SubMessage;
+  subMessage?: TestIsInitialized_SubMessage | undefined;
 };
 
 /**
@@ -1881,7 +1881,7 @@ export declare type TestIsInitialized_SubMessage = Message<"proto2_unittest.Test
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage.SubGroup subgroup = 1 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestIsInitialized_SubMessage_SubGroup;
+  subgroup?: TestIsInitialized_SubMessage_SubGroup | undefined;
 };
 
 /**
@@ -1929,14 +1929,14 @@ export declare type TestDupFieldNumber = Message<"proto2_unittest.TestDupFieldNu
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Foo foo = 2 [features.message_encoding = DELIMITED];
    */
-  foo?: TestDupFieldNumber_Foo;
+  foo?: TestDupFieldNumber_Foo | undefined;
 
   /**
    * NO_PROTO1
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Bar bar = 3 [features.message_encoding = DELIMITED];
    */
-  bar?: TestDupFieldNumber_Bar;
+  bar?: TestDupFieldNumber_Bar | undefined;
 };
 
 /**
@@ -1994,7 +1994,7 @@ export declare type TestEagerMessage = Message<"proto2_unittest.TestEagerMessage
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage?: TestAllTypes | undefined;
 };
 
 /**
@@ -2010,7 +2010,7 @@ export declare type TestLazyMessage = Message<"proto2_unittest.TestLazyMessage">
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage?: TestAllTypes | undefined;
 };
 
 /**
@@ -2026,27 +2026,27 @@ export declare type TestLazyRequiredEnum = Message<"proto2_unittest.TestLazyRequ
   /**
    * @generated from field: proto2_unittest.TestRequiredOpenEnum optional_required_open_enum = 1;
    */
-  optionalRequiredOpenEnum?: TestRequiredOpenEnum;
+  optionalRequiredOpenEnum?: TestRequiredOpenEnum | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnum optional_required_enum = 2;
    */
-  optionalRequiredEnum?: TestRequiredEnum;
+  optionalRequiredEnum?: TestRequiredEnum | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask optional_required_enum_no_mask = 3;
    */
-  optionalRequiredEnumNoMask?: TestRequiredEnumNoMask;
+  optionalRequiredEnumNoMask?: TestRequiredEnumNoMask | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti optional_required_enum_multi = 4;
    */
-  optionalRequiredEnumMulti?: TestRequiredEnumMulti;
+  optionalRequiredEnumMulti?: TestRequiredEnumMulti | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti optional_required_no_mask = 5;
    */
-  optionalRequiredNoMask?: TestRequiredNoMaskMulti;
+  optionalRequiredNoMask?: TestRequiredNoMaskMulti | undefined;
 };
 
 /**
@@ -2078,17 +2078,17 @@ export declare type TestEagerMaybeLazy = Message<"proto2_unittest.TestEagerMaybe
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_foo = 1;
    */
-  messageFoo?: TestAllTypes;
+  messageFoo?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_bar = 2;
    */
-  messageBar?: TestAllTypes;
+  messageBar?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestEagerMaybeLazy.NestedMessage message_baz = 3;
    */
-  messageBaz?: TestEagerMaybeLazy_NestedMessage;
+  messageBaz?: TestEagerMaybeLazy_NestedMessage | undefined;
 };
 
 /**
@@ -2104,7 +2104,7 @@ export declare type TestEagerMaybeLazy_NestedMessage = Message<"proto2_unittest.
   /**
    * @generated from field: proto2_unittest.TestPackedTypes packed = 1;
    */
-  packed?: TestPackedTypes;
+  packed?: TestPackedTypes | undefined;
 };
 
 /**
@@ -2122,7 +2122,7 @@ export declare type TestNestedMessageHasBits = Message<"proto2_unittest.TestNest
   /**
    * @generated from field: proto2_unittest.TestNestedMessageHasBits.NestedMessage optional_nested_message = 1;
    */
-  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage;
+  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage | undefined;
 };
 
 /**
@@ -2177,7 +2177,7 @@ export declare type TestCamelCaseFieldNames = Message<"proto2_unittest.TestCamel
   /**
    * @generated from field: proto2_unittest.ForeignMessage MessageField = 4;
    */
-  MessageField?: ForeignMessage;
+  MessageField?: ForeignMessage | undefined;
 
   /**
    * @generated from field: string StringPieceField = 5;
@@ -2251,7 +2251,7 @@ export declare type TestFieldOrderings = Message<"proto2_unittest.TestFieldOrder
   /**
    * @generated from field: proto2_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
    */
-  optionalNestedMessage?: TestFieldOrderings_NestedMessage;
+  optionalNestedMessage?: TestFieldOrderings_NestedMessage | undefined;
 };
 
 /**
@@ -2927,12 +2927,12 @@ export declare type TestOneofBackwardsCompatible = Message<"proto2_unittest.Test
   /**
    * @generated from field: proto2_unittest.TestAllTypes foo_message = 3;
    */
-  fooMessage?: TestAllTypes;
+  fooMessage?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestOneofBackwardsCompatible.FooGroup foogroup = 4 [features.message_encoding = DELIMITED];
    */
-  foogroup?: TestOneofBackwardsCompatible_FooGroup;
+  foogroup?: TestOneofBackwardsCompatible_FooGroup | undefined;
 };
 
 /**
@@ -3151,7 +3151,7 @@ export declare type TestOneof2_NestedMessage = Message<"proto2_unittest.TestOneo
   /**
    * @generated from field: proto2_unittest.TestOneof2.NestedMessage child = 3;
    */
-  child?: TestOneof2_NestedMessage;
+  child?: TestOneof2_NestedMessage | undefined;
 };
 
 /**
@@ -3456,12 +3456,12 @@ export declare type TestDynamicExtensions = Message<"proto2_unittest.TestDynamic
   /**
    * @generated from field: proto2_unittest.ForeignMessage message_extension = 2003;
    */
-  messageExtension?: ForeignMessage;
+  messageExtension?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestDynamicExtensions.DynamicMessageType dynamic_message_extension = 2004;
    */
-  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType;
+  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType | undefined;
 
   /**
    * @generated from field: repeated string repeated_extension = 2005;
@@ -3613,12 +3613,12 @@ export declare type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge
   /**
    * @generated from field: proto2_unittest.TestAllTypes required_all_types = 1 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredAllTypes?: TestAllTypes;
+  requiredAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 2;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 3;
@@ -3628,7 +3628,7 @@ export declare type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge
   /**
    * @generated from field: proto2_unittest.TestParsingMerge.OptionalGroup optionalgroup = 10 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestParsingMerge_OptionalGroup;
+  optionalgroup?: TestParsingMerge_OptionalGroup | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestParsingMerge.RepeatedGroup repeatedgroup = 20 [features.message_encoding = DELIMITED];
@@ -3701,7 +3701,7 @@ export declare type TestParsingMerge_RepeatedFieldsGenerator_Group1 = Message<"p
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 11;
    */
-  field1?: TestAllTypes;
+  field1?: TestAllTypes | undefined;
 };
 
 /**
@@ -3717,7 +3717,7 @@ export declare type TestParsingMerge_RepeatedFieldsGenerator_Group2 = Message<"p
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 21;
    */
-  field1?: TestAllTypes;
+  field1?: TestAllTypes | undefined;
 };
 
 /**
@@ -3733,7 +3733,7 @@ export declare type TestParsingMerge_OptionalGroup = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_group_all_types = 11;
    */
-  optionalGroupAllTypes?: TestAllTypes;
+  optionalGroupAllTypes?: TestAllTypes | undefined;
 };
 
 /**
@@ -3749,7 +3749,7 @@ export declare type TestParsingMerge_RepeatedGroup = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes repeated_group_all_types = 21;
    */
-  repeatedGroupAllTypes?: TestAllTypes;
+  repeatedGroupAllTypes?: TestAllTypes | undefined;
 };
 
 /**
@@ -3778,7 +3778,7 @@ export declare type TestMergeException = Message<"proto2_unittest.TestMergeExcep
   /**
    * @generated from field: proto2_unittest.TestAllExtensions all_extensions = 1;
    */
-  allExtensions?: TestAllExtensions;
+  allExtensions?: TestAllExtensions | undefined;
 };
 
 /**
@@ -3920,7 +3920,7 @@ export declare type TestEagerlyVerifiedLazyMessage = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestEagerlyVerifiedLazyMessage.LazyMessage lazy_message = 1;
    */
-  lazyMessage?: TestEagerlyVerifiedLazyMessage_LazyMessage;
+  lazyMessage?: TestEagerlyVerifiedLazyMessage_LazyMessage | undefined;
 };
 
 /**
@@ -4107,12 +4107,12 @@ export declare type TestHugeFieldNumbers = Message<"proto2_unittest.TestHugeFiel
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_message = 536870007;
    */
-  optionalMessage?: ForeignMessage;
+  optionalMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestHugeFieldNumbers.OptionalGroup optionalgroup = 536870008 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestHugeFieldNumbers_OptionalGroup;
+  optionalgroup?: TestHugeFieldNumbers_OptionalGroup | undefined;
 
   /**
    * @generated from field: map<string, string> string_string_map = 536870010;
@@ -4271,7 +4271,7 @@ export declare type TestNestedGroupExtensionOuter = Message<"proto2_unittest.Tes
   /**
    * @generated from field: proto2_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup layer1optionalgroup = 1 [features.message_encoding = DELIMITED];
    */
-  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
+  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup | undefined;
 };
 
 /**
@@ -4463,7 +4463,7 @@ export declare type TestVerifyInt32 = Message<"proto2_unittest.TestVerifyInt32">
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4519,7 +4519,7 @@ export declare type TestVerifyMostlyInt32 = Message<"proto2_unittest.TestVerifyM
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4580,7 +4580,7 @@ export declare type TestVerifyMostlyInt32BigFieldNumber = Message<"proto2_unitte
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4652,7 +4652,7 @@ export declare type TestVerifyUint32 = Message<"proto2_unittest.TestVerifyUint32
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4693,7 +4693,7 @@ export declare type TestVerifyOneUint32 = Message<"proto2_unittest.TestVerifyOne
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4739,7 +4739,7 @@ export declare type TestVerifyOneInt32BigFieldNumber = Message<"proto2_unittest.
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4790,7 +4790,7 @@ export declare type TestVerifyInt32BigFieldNumber = Message<"proto2_unittest.Tes
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4841,7 +4841,7 @@ export declare type TestVerifyUint32BigFieldNumber = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4862,7 +4862,7 @@ export declare type TestVerifyBigFieldNumberUint32 = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested | undefined;
 };
 
 /**
@@ -4918,7 +4918,7 @@ export declare type TestVerifyBigFieldNumberUint32_Nested = Message<"proto2_unit
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;
@@ -5677,7 +5677,7 @@ export declare type InlinedStringIdxRegressionProto = Message<"proto2_unittest.I
    *
    * @generated from field: proto2_unittest.InlinedStringIdxRegressionProto sub = 2;
    */
-  sub?: InlinedStringIdxRegressionProto;
+  sub?: InlinedStringIdxRegressionProto | undefined;
 
   /**
    * aux_idx == 3, inlined_string_idx == 2
@@ -5820,12 +5820,12 @@ export declare type RedactedFields = Message<"proto2_unittest.RedactedFields"> &
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_redacted_message = 5;
    */
-  optionalRedactedMessage?: TestNestedMessageRedaction;
+  optionalRedactedMessage?: TestNestedMessageRedaction | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_unredacted_message = 6;
    */
-  optionalUnredactedMessage?: TestNestedMessageRedaction;
+  optionalUnredactedMessage?: TestNestedMessageRedaction | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestNestedMessageRedaction repeated_redacted_message = 7;
@@ -6414,7 +6414,7 @@ export declare type MessageCreatorZeroInit = Message<"proto2_unittest.MessageCre
   /**
    * @generated from field: proto2_unittest.MessageCreatorZeroInit m = 3;
    */
-  m?: MessageCreatorZeroInit;
+  m?: MessageCreatorZeroInit | undefined;
 
   /**
    * @generated from oneof proto2_unittest.MessageCreatorZeroInit.one
@@ -6469,7 +6469,7 @@ export declare type MessageCreatorMemcpy = Message<"proto2_unittest.MessageCreat
   /**
    * @generated from field: proto2_unittest.MessageCreatorMemcpy m = 3;
    */
-  m?: MessageCreatorMemcpy;
+  m?: MessageCreatorMemcpy | undefined;
 
   /**
    * @generated from field: map<int32, int32> m2 = 4;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
@@ -34,97 +34,97 @@ export declare type TestProto3Optional = Message<"proto2_unittest.TestProto3Opti
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 16;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestProto3Optional_NestedMessage;
+  optionalNestedMessage?: TestProto3Optional_NestedMessage | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage lazy_nested_message = 19;
    */
-  lazyNestedMessage?: TestProto3Optional_NestedMessage;
+  lazyNestedMessage?: TestProto3Optional_NestedMessage | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestProto3Optional_NestedEnum;
+  optionalNestedEnum?: TestProto3Optional_NestedEnum | undefined;
 
   /**
    * Add some non-optional fields to verify we can mix them.
@@ -156,7 +156,7 @@ export declare type TestProto3Optional_NestedMessage = Message<"proto2_unittest.
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 };
 
 /**
@@ -209,12 +209,12 @@ export declare type TestProto3OptionalMessage = Message<"proto2_unittest.TestPro
   /**
    * @generated from field: proto2_unittest.TestProto3OptionalMessage.NestedMessage nested_message = 1;
    */
-  nestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  nestedMessage?: TestProto3OptionalMessage_NestedMessage | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3OptionalMessage.NestedMessage optional_nested_message = 2;
    */
-  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
@@ -113,17 +113,17 @@ export declare type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
   /**
    * @generated from field: optional proto3_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -150,22 +150,22 @@ export declare type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
-  optionalLazyImportMessage?: ImportMessage;
+  optionalLazyImportMessage?: ImportMessage | undefined;
 
   /**
    * Repeated
@@ -550,12 +550,12 @@ export declare type NestedTestAllTypes = Message<"proto3_unittest.NestedTestAllT
   /**
    * @generated from field: proto3_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 };
 
 /**
@@ -1029,7 +1029,7 @@ export declare type TestHasbits = Message<"proto3_unittest.TestHasbits"> & {
   /**
    * @generated from field: proto3_unittest.TestAllTypes child = 100;
    */
-  child?: TestAllTypes;
+  child?: TestAllTypes | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_redaction_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_redaction_pb.d.ts
@@ -89,7 +89,7 @@ export declare type TestNestedMessageEnum = Message<"proto2_unittest.TestNestedM
   /**
    * @generated from field: proto2_unittest.TestMessageEnum nested_enum = 2;
    */
-  nestedEnum?: TestMessageEnum;
+  nestedEnum?: TestMessageEnum | undefined;
 
   /**
    * @generated from field: string redacted_string = 3;
@@ -136,7 +136,7 @@ export declare type TestRedactedMessage = Message<"proto2_unittest.TestRedactedM
   /**
    * @generated from field: google.protobuf.Any any_field = 18;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: string redactable_false = 19;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.d.ts
@@ -37,99 +37,99 @@ export declare type TestWellKnownTypes = Message<"proto2_unittest.TestWellKnownT
   /**
    * @generated from field: google.protobuf.Any any_field = 1;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Api api_field = 2;
    */
-  apiField?: Api;
+  apiField?: Api | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 3;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 4;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 5;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.SourceContext source_context_field = 6;
    */
-  sourceContextField?: SourceContext;
+  sourceContextField?: SourceContext | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 7;
    */
-  structField?: JsonObject;
+  structField?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 8;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.Type type_field = 9;
    */
-  typeField?: Type;
+  typeField?: Type | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue double_field = 10;
    */
-  doubleField?: number;
+  doubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_field = 11;
    */
-  floatField?: number;
+  floatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_field = 12;
    */
-  int64Field?: bigint;
+  int64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_field = 13;
    */
-  uint64Field?: bigint;
+  uint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_field = 14;
    */
-  int32Field?: number;
+  int32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_field = 15;
    */
-  uint32Field?: number;
+  uint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_field = 16;
    */
-  boolField?: boolean;
+  boolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue string_field = 17;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_field = 18;
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * Part of struct, but useful to be able to test separately
    *
    * @generated from field: google.protobuf.Value value_field = 19;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts,json_types/extra/json_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts,json_types/extra/json_types_pb.ts
@@ -60,42 +60,42 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField?: JsonTypesMessage | undefined;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField?: ListValue | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -105,52 +105,52 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;

--- a/packages/protobuf-test/src/gen/ts,valid_types/extra/minimal-validate_pb.ts
+++ b/packages/protobuf-test/src/gen/ts,valid_types/extra/minimal-validate_pb.ts
@@ -121,7 +121,7 @@ export type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items?: FieldRules | undefined;
 };
 
 export type RepeatedRulesValid = RepeatedRules;
@@ -140,7 +140,7 @@ export type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values?: FieldRules | undefined;
 };
 
 export type MapRulesValid = MapRules;

--- a/packages/protobuf-test/src/gen/ts,valid_types/extra/valid_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts,valid_types/extra/valid_types_pb.ts
@@ -40,7 +40,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -49,7 +49,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -58,7 +58,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -67,14 +67,14 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -169,7 +169,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -178,7 +178,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -186,7 +186,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt?: Timestamp | undefined;
 };
 
 /**
@@ -200,7 +200,7 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_OtherValid;
+  msg?: VTypes_OtherValid | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -218,7 +218,7 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -227,14 +227,14 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_OtherValid;
+  msgIgnoreUnpopulated?: VTypes_OtherValid | undefined;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_OtherValid;
+  msgIgnoreDefault?: VTypes_OtherValid | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -346,7 +346,7 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt?: Timestamp | undefined;
 };
 
 /**
@@ -383,7 +383,7 @@ export type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg?: VTypes | undefined;
 };
 
 /**
@@ -398,7 +398,7 @@ export type VTypes2Valid = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypesValid;
+  msg?: VTypesValid | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/editions/golden/test_messages_proto3_editions_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/editions/golden/test_messages_proto3_editions_pb.ts
@@ -122,12 +122,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -157,7 +157,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -577,47 +577,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -667,32 +667,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -847,7 +847,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023-proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023-proto2_pb.ts
@@ -50,7 +50,7 @@ export type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageForEdition2
   /**
    * @generated from field: optional spec.Proto2MessageForEdition2023.OptionalGroup optionalgroup = 4;
    */
-  optionalgroup?: Proto2MessageForEdition2023_OptionalGroup;
+  optionalgroup?: Proto2MessageForEdition2023_OptionalGroup | undefined;
 
   /**
    * @generated from field: required bool required_bool_field = 5;
@@ -70,7 +70,7 @@ export type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageForEdition2
   /**
    * @generated from field: required spec.Proto2MessageForEdition2023.RequiredGroup requiredgroup = 8;
    */
-  requiredgroup?: Proto2MessageForEdition2023_RequiredGroup;
+  requiredgroup?: Proto2MessageForEdition2023_RequiredGroup | undefined;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023-proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023-proto3_pb.ts
@@ -45,12 +45,12 @@ export type Proto3MessageForEdition2023 = Message<"spec.Proto3MessageForEdition2
   /**
    * @generated from field: optional bool explicit_bool_field = 5;
    */
-  explicitBoolField?: boolean;
+  explicitBoolField?: boolean | undefined;
 
   /**
    * @generated from field: optional spec.Proto3EnumForEdition2023 explicit_open_enum_field = 6;
    */
-  explicitOpenEnumField?: Proto3EnumForEdition2023;
+  explicitOpenEnumField?: Proto3EnumForEdition2023 | undefined;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023_pb.ts
@@ -87,17 +87,17 @@ export type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message explicit_message_field = 311;
    */
-  explicitMessageField?: Edition2023Message;
+  explicitMessageField?: Edition2023Message | undefined;
 
   /**
    * @generated from field: spec.Edition2023Message explicit_message_delimited_field = 312 [features.message_encoding = DELIMITED];
    */
-  explicitMessageDelimitedField?: Edition2023Message;
+  explicitMessageDelimitedField?: Edition2023Message | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value explicit_wrapped_uint32_field = 313;
    */
-  explicitWrappedUint32Field?: number;
+  explicitWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: string implicit_string_field = 201 [features.field_presence = IMPLICIT];
@@ -197,17 +197,17 @@ export type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_field = 11 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessageField?: Edition2023Message_Child;
+  requiredMessageField?: Edition2023Message_Child | undefined;
 
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_delimited_field = 12 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  requiredMessageDelimitedField?: Edition2023Message_Child;
+  requiredMessageDelimitedField?: Edition2023Message_Child | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value required_wrapped_uint32_field = 13 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: string required_default_string_field = 101 [default = "hello \" *\/ ", features.field_presence = LEGACY_REQUIRED];
@@ -524,7 +524,7 @@ export type Edition2023FromProto2Message = Message<"spec.Edition2023FromProto2Me
   /**
    * @generated from field: spec.Edition2023FromProto2Message.OptionalGroup optionalgroup = 4 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: Edition2023FromProto2Message_OptionalGroup;
+  optionalgroup?: Edition2023FromProto2Message_OptionalGroup | undefined;
 
   /**
    * @generated from field: bool required_bool_field = 5 [features.field_presence = LEGACY_REQUIRED];
@@ -544,7 +544,7 @@ export type Edition2023FromProto2Message = Message<"spec.Edition2023FromProto2Me
   /**
    * @generated from field: spec.Edition2023FromProto2Message.RequiredGroup requiredgroup = 8 [features.message_encoding = DELIMITED];
    */
-  requiredgroup?: Edition2023FromProto2Message_RequiredGroup;
+  requiredgroup?: Edition2023FromProto2Message_RequiredGroup | undefined;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [features.repeated_field_encoding = PACKED];

--- a/packages/protobuf-test/src/gen/ts/extra/example-service_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example-service_pb.ts
@@ -57,7 +57,7 @@ export type CreateUserResponse = Message<"example.CreateUserResponse"> & {
   /**
    * @generated from field: example.User user = 1;
    */
-  user?: User;
+  user?: User | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
@@ -48,7 +48,7 @@ export type User = Message<"example.User"> & {
   /**
    * @generated from field: example.User manager = 4;
    */
-  manager?: User;
+  manager?: User | undefined;
 
   /**
    * @generated from field: repeated string locations = 5;

--- a/packages/protobuf-test/src/gen/ts/extra/json_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/json_types_pb.ts
@@ -60,42 +60,42 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField?: JsonTypesMessage | undefined;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField?: ListValue | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -105,52 +105,52 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;

--- a/packages/protobuf-test/src/gen/ts/extra/minimal-validate_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/minimal-validate_pb.ts
@@ -115,7 +115,7 @@ export type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items?: FieldRules | undefined;
 };
 
 /**
@@ -132,7 +132,7 @@ export type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values?: FieldRules | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
@@ -33,7 +33,7 @@ export type MessageFieldMessage = Message<"spec.MessageFieldMessage"> & {
   /**
    * @generated from field: spec.MessageFieldMessage.TestMessage message_field = 1;
    */
-  messageField?: MessageFieldMessage_TestMessage;
+  messageField?: MessageFieldMessage_TestMessage | undefined;
 
   /**
    * @generated from field: repeated spec.MessageFieldMessage.TestMessage repeated_message_field = 2;

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -39,7 +39,7 @@ export type User = Message$1<"spec.User"> & {
    *
    * @generated from field: example.User u = 1;
    */
-  u?: User$1;
+  u?: User$1 | undefined;
 };
 
 /**
@@ -958,7 +958,7 @@ export type NoClashOneofADT = Message$1<"spec.NoClashOneofADT"> & {
   /**
    * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  m?: NoClashOneofADT_M;
+  m?: NoClashOneofADT_M | undefined;
 };
 
 /**
@@ -980,7 +980,7 @@ export type NoClashOneofADT_M = Message$1<"spec.NoClashOneofADT.M"> & {
   /**
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value?: string | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/perf_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/perf_pb.ts
@@ -48,12 +48,12 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: optional int64 int64_field = 3;
    */
-  int64Field?: bigint;
+  int64Field?: bigint | undefined;
 
   /**
    * @generated from field: optional bool bool_field = 4;
    */
-  boolField?: boolean;
+  boolField?: boolean | undefined;
 
   /**
    * @generated from field: string string_field = 5;
@@ -73,7 +73,7 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: perf.v1.PerfMessage small_message_field = 8;
    */
-  smallMessageField?: PerfMessage;
+  smallMessageField?: PerfMessage | undefined;
 
   /**
    * @generated from field: int32 unused_field_1 = 9;

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -82,17 +82,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_message_field = 8;
    */
-  requiredMessageField?: Proto2Message;
+  requiredMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredGroup requiredgroup = 9;
    */
-  requiredgroup?: Proto2Message_RequiredGroup;
+  requiredgroup?: Proto2Message_RequiredGroup | undefined;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_wrapped_uint32_field = 201;
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: required string required_default_string_field = 10 [default = "hello \" *\/ "];
@@ -142,17 +142,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_default_message_field = 17;
    */
-  requiredDefaultMessageField?: Proto2Message;
+  requiredDefaultMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredDefaultGroup requireddefaultgroup = 18;
    */
-  requireddefaultgroup?: Proto2Message_RequiredDefaultGroup;
+  requireddefaultgroup?: Proto2Message_RequiredDefaultGroup | undefined;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_default_wrapped_uint32_field = 202;
    */
-  requiredDefaultWrappedUint32Field?: number;
+  requiredDefaultWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: optional string optional_string_field = 19;
@@ -202,17 +202,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_message_field = 26;
    */
-  optionalMessageField?: Proto2Message;
+  optionalMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalGroup optionalgroup = 27;
    */
-  optionalgroup?: Proto2Message_OptionalGroup;
+  optionalgroup?: Proto2Message_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 207;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: optional string optional_default_string_field = 28 [default = "hello \" *\/ "];
@@ -262,17 +262,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_default_message_field = 35;
    */
-  optionalDefaultMessageField?: Proto2Message;
+  optionalDefaultMessageField?: Proto2Message | undefined;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalDefaultGroup optionaldefaultgroup = 36;
    */
-  optionaldefaultgroup?: Proto2Message_OptionalDefaultGroup;
+  optionaldefaultgroup?: Proto2Message_OptionalDefaultGroup | undefined;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_default_wrapped_uint32_field = 203;
    */
-  optionalDefaultWrappedUint32Field?: number;
+  optionalDefaultWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: repeated string repeated_string_field = 37;

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -82,77 +82,77 @@ export type Proto3Message = Message<"spec.Proto3Message"> & {
   /**
    * @generated from field: spec.Proto3Message singular_message_field = 8;
    */
-  singularMessageField?: Proto3Message;
+  singularMessageField?: Proto3Message | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value singular_wrapped_uint32_field = 211;
    */
-  singularWrappedUint32Field?: number;
+  singularWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct singular_struct_field = 214;
    */
-  singularStructField?: JsonObject;
+  singularStructField?: JsonObject | undefined;
 
   /**
    * @generated from field: optional string optional_string_field = 9;
    */
-  optionalStringField?: string;
+  optionalStringField?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes_field = 10;
    */
-  optionalBytesField?: Uint8Array;
+  optionalBytesField?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional int32 optional_int32_field = 11;
    */
-  optionalInt32Field?: number;
+  optionalInt32Field?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_field = 12;
    */
-  optionalInt64Field?: bigint;
+  optionalInt64Field?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_js_number_field = 106 [jstype = JS_NUMBER];
    */
-  optionalInt64JsNumberField?: bigint;
+  optionalInt64JsNumberField?: bigint | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64_js_string_field = 105 [jstype = JS_STRING];
    */
-  optionalInt64JsStringField?: string;
+  optionalInt64JsStringField?: string | undefined;
 
   /**
    * @generated from field: optional float optional_float_field = 13;
    */
-  optionalFloatField?: number;
+  optionalFloatField?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool_field = 14;
    */
-  optionalBoolField?: boolean;
+  optionalBoolField?: boolean | undefined;
 
   /**
    * @generated from field: optional spec.Proto3Enum optional_enum_field = 15;
    */
-  optionalEnumField?: Proto3Enum;
+  optionalEnumField?: Proto3Enum | undefined;
 
   /**
    * @generated from field: optional spec.Proto3Message optional_message_field = 16;
    */
-  optionalMessageField?: Proto3Message;
+  optionalMessageField?: Proto3Message | undefined;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 212;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field?: number | undefined;
 
   /**
    * @generated from field: optional google.protobuf.Struct optional_struct_field = 215;
    */
-  optionalStructField?: JsonObject;
+  optionalStructField?: JsonObject | undefined;
 
   /**
    * @generated from field: repeated string repeated_string_field = 17;

--- a/packages/protobuf-test/src/gen/ts/extra/ts-types-proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/ts-types-proto2_pb.ts
@@ -38,7 +38,7 @@ export type TsTypeA = Message<"spec.TsTypeA"> & {
   /**
    * @generated from field: optional spec.TsTypeA child = 2;
    */
-  child?: TsTypeA;
+  child?: TsTypeA | undefined;
 };
 
 /**
@@ -60,7 +60,7 @@ export type TsTypeB = Message<"spec.TsTypeB"> & {
   /**
    * @generated from field: optional spec.TsTypeB child = 2;
    */
-  child?: TsTypeB;
+  child?: TsTypeB | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/valid_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/valid_types_pb.ts
@@ -40,7 +40,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -49,7 +49,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -58,7 +58,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -67,14 +67,14 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -169,7 +169,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should:
@@ -178,7 +178,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways?: VTypes_Other | undefined;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -186,7 +186,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt?: Timestamp | undefined;
 };
 
 /**
@@ -221,7 +221,7 @@ export type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg?: VTypes | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
@@ -37,47 +37,47 @@ export type WrappersMessage = Message<"spec.WrappersMessage"> & {
   /**
    * @generated from field: google.protobuf.DoubleValue double_value_field = 1;
    */
-  doubleValueField?: number;
+  doubleValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_value_field = 2;
    */
-  boolValueField?: boolean;
+  boolValueField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_value_field = 3;
    */
-  floatValueField?: number;
+  floatValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_value_field = 4;
    */
-  int64ValueField?: bigint;
+  int64ValueField?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_value_field = 5;
    */
-  uint64ValueField?: bigint;
+  uint64ValueField?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_value_field = 6;
    */
-  int32ValueField?: number;
+  int32ValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_value_field = 7;
    */
-  uint32ValueField?: number;
+  uint32ValueField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue string_value_field = 8;
    */
-  stringValueField?: string;
+  stringValueField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_value_field = 9;
    */
-  bytesValueField?: Uint8Array;
+  bytesValueField?: Uint8Array | undefined;
 
   /**
    * @generated from oneof spec.WrappersMessage.oneof_fields

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/map_proto2_unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/map_proto2_unittest_pb.ts
@@ -317,7 +317,7 @@ export type TestSubmessageMaps = Message<"proto2_unittest.TestSubmessageMaps"> &
   /**
    * @generated from field: optional proto2_unittest.TestMaps m = 1;
    */
-  m?: TestMaps;
+  m?: TestMaps | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
@@ -120,12 +120,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -150,7 +150,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage?: TestAllTypesProto2 | undefined;
 
   /**
    * Repeated
@@ -572,12 +572,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data?: TestAllTypesProto2_Data | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField | undefined;
 
   /**
    * default values
@@ -752,7 +752,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect | undefined;
 };
 
 /**
@@ -774,7 +774,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive?: TestAllTypesProto2 | undefined;
 };
 
 /**
@@ -1015,12 +1015,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.proto2.Unkno
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup?: UnknownToTestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1232,12 +1232,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage?: ForeignMessageProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1262,17 +1262,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data?: TestAllRequiredTypesProto2_Data | undefined;
 
   /**
    * default values
@@ -1371,12 +1371,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive?: TestAllRequiredTypesProto2 | undefined;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive?: TestAllRequiredTypesProto2 | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
@@ -121,12 +121,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage?: TestAllTypesProto3_NestedMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -156,7 +156,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage?: TestAllTypesProto3 | undefined;
 
   /**
    * Repeated
@@ -576,47 +576,47 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper?: Uint8Array | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -666,32 +666,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue?: Value | undefined;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -846,7 +846,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive?: TestAllTypesProto3 | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
@@ -72,7 +72,7 @@ export type Type = Message<"google.protobuf.Type"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -411,7 +411,7 @@ export type Enum = Message<"google.protobuf.Enum"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -504,7 +504,7 @@ export type Option = Message<"google.protobuf.Option"> & {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value?: Any | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -352,7 +352,7 @@ export type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionType2"> &
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType1 bar = 1;
    */
-  bar?: ComplexOptionType1;
+  bar?: ComplexOptionType1 | undefined;
 
   /**
    * @generated from field: optional int32 baz = 2;
@@ -362,7 +362,7 @@ export type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionType2"> &
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
    */
-  fred?: ComplexOptionType2_ComplexOptionType4;
+  fred?: ComplexOptionType2_ComplexOptionType4 | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.ComplexOptionType2.ComplexOptionType4 barney = 4;
@@ -412,7 +412,7 @@ export type ComplexOptionType3 = Message<"proto2_unittest.ComplexOptionType3"> &
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
    */
-  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5;
+  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5 | undefined;
 };
 
 /**
@@ -528,28 +528,28 @@ export type Aggregate = Message<"proto2_unittest.Aggregate"> & {
    *
    * @generated from field: optional proto2_unittest.Aggregate sub = 3;
    */
-  sub?: Aggregate;
+  sub?: Aggregate | undefined;
 
   /**
    * To test the parsing of extensions inside aggregate values
    *
    * @generated from field: optional google.protobuf.FileOptions file = 4;
    */
-  file?: FileOptions;
+  file?: FileOptions | undefined;
 
   /**
    * An embedded message set
    *
    * @generated from field: optional proto2_unittest.AggregateMessageSet mset = 5;
    */
-  mset?: AggregateMessageSet;
+  mset?: AggregateMessageSet | undefined;
 
   /**
    * An any
    *
    * @generated from field: optional google.protobuf.Any any = 6;
    */
-  any?: Any;
+  any?: Any | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
@@ -44,7 +44,7 @@ export type TestEmbedOptimizedForSize = Message<"proto2_unittest.TestEmbedOptimi
    *
    * @generated from field: optional proto2_unittest.TestOptimizedForSize optional_message = 1;
    */
-  optionalMessage?: TestOptimizedForSize;
+  optionalMessage?: TestOptimizedForSize | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestOptimizedForSize repeated_message = 2;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_extension_set_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_extension_set_pb.ts
@@ -54,7 +54,7 @@ export type TestExtensionSetContainer = Message<"proto2_unittest.TestExtensionSe
   /**
    * @generated from field: optional proto2_unittest.TestExtensionSet extension = 1;
    */
-  extension?: TestExtensionSet;
+  extension?: TestExtensionSet | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
@@ -39,14 +39,14 @@ export type TestLiteImportsNonlite = Message<"proto2_unittest.TestLiteImportsNon
   /**
    * @generated from field: optional proto2_unittest.TestAllTypes message = 1;
    */
-  message?: TestAllTypes;
+  message?: TestAllTypes | undefined;
 
   /**
    * Verifies that transitive required fields generates valid code.
    *
    * @generated from field: optional proto2_unittest.TestRequired message_with_required = 2;
    */
-  messageWithRequired?: TestRequired;
+  messageWithRequired?: TestRequired | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
@@ -42,7 +42,7 @@ export type TestMessageSetContainer = Message<"proto2_unittest.TestMessageSetCon
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet?: TestMessageSet | undefined;
 };
 
 /**
@@ -59,17 +59,17 @@ export type NestedTestMessageSetContainer = Message<"proto2_unittest.NestedTestM
   /**
    * @generated from field: optional proto2_unittest.TestMessageSetContainer container = 1;
    */
-  container?: TestMessageSetContainer;
+  container?: TestMessageSetContainer | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer child = 2;
    */
-  child?: NestedTestMessageSetContainer;
+  child?: NestedTestMessageSetContainer | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer lazy_child = 3;
    */
-  lazyChild?: NestedTestMessageSetContainer;
+  lazyChild?: NestedTestMessageSetContainer | undefined;
 };
 
 /**
@@ -96,7 +96,7 @@ export type NestedTestInt = Message<"proto2_unittest.NestedTestInt"> & {
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt child = 2;
    */
-  child?: NestedTestInt;
+  child?: NestedTestInt | undefined;
 };
 
 /**
@@ -118,7 +118,7 @@ export type TestMessageSetExtension1 = Message<"proto2_unittest.TestMessageSetEx
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
    */
-  recursive?: TestMessageSet;
+  recursive?: TestMessageSet | undefined;
 
   /**
    * @generated from field: optional string test_aliasing = 17;
@@ -169,7 +169,7 @@ export type TestMessageSetExtension3 = Message<"proto2_unittest.TestMessageSetEx
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt msg = 35;
    */
-  msg?: NestedTestInt;
+  msg?: NestedTestInt | undefined;
 
   /**
    * @generated from field: required int32 required_int = 36;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
@@ -54,7 +54,7 @@ export type TestMessageSetWireFormatContainer = Message<"proto2_wireformat_unitt
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet?: TestMessageSet | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
@@ -46,7 +46,7 @@ export type TestOptimizedForSize = Message<"proto2_unittest.TestOptimizedForSize
   /**
    * @generated from field: optional proto2_unittest.ForeignMessage msg = 19;
    */
-  msg?: ForeignMessage;
+  msg?: ForeignMessage | undefined;
 
   /**
    * @generated from oneof proto2_unittest.TestOptimizedForSize.foo
@@ -109,7 +109,7 @@ export type TestOptionalOptimizedForSize = Message<"proto2_unittest.TestOptional
   /**
    * @generated from field: optional proto2_unittest.TestRequiredOptimizedForSize o = 1;
    */
-  o?: TestRequiredOptimizedForSize;
+  o?: TestRequiredOptimizedForSize | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -131,22 +131,22 @@ export type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestAllTypes_OptionalGroup;
+  optionalgroup?: TestAllTypes_OptionalGroup | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -183,17 +183,17 @@ export type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * Repeated
@@ -578,12 +578,12 @@ export type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllTypes"> &
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.NestedTestAllTypes repeated_child = 3;
@@ -593,12 +593,12 @@ export type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllTypes"> &
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes lazy_child = 4;
    */
-  lazyChild?: NestedTestAllTypes;
+  lazyChild?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes eager_child = 5;
    */
-  eagerChild?: TestAllTypes;
+  eagerChild?: TestAllTypes | undefined;
 };
 
 /**
@@ -628,7 +628,7 @@ export type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecatedFields
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage deprecated_message = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedMessage?: TestAllTypes_NestedMessage;
+  deprecatedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from oneof proto2_unittest.TestDeprecatedFields.oneof_fields
@@ -645,7 +645,7 @@ export type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecatedFields
   /**
    * @generated from field: proto2_unittest.TestDeprecatedFields nested = 5;
    */
-  nested?: TestDeprecatedFields;
+  nested?: TestDeprecatedFields | undefined;
 };
 
 /**
@@ -796,7 +796,7 @@ export type TestGroup = Message<"proto2_unittest.TestGroup"> & {
   /**
    * @generated from field: proto2_unittest.TestGroup.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestGroup_OptionalGroup;
+  optionalgroup?: TestGroup_OptionalGroup | undefined;
 
   /**
    * @generated from field: proto2_unittest.ForeignEnum optional_foreign_enum = 22;
@@ -925,7 +925,7 @@ export type TestChildExtension = Message<"proto2_unittest.TestChildExtension"> &
   /**
    * @generated from field: proto2_unittest.TestAllExtensions optional_extension = 3;
    */
-  optionalExtension?: TestAllExtensions;
+  optionalExtension?: TestAllExtensions | undefined;
 };
 
 /**
@@ -955,7 +955,7 @@ export type TestChildExtensionData = Message<"proto2_unittest.TestChildExtension
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
    */
-  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData;
+  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData | undefined;
 };
 
 /**
@@ -972,7 +972,7 @@ export type TestChildExtensionData_NestedTestAllExtensionsData = Message<"proto2
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData.NestedDynamicExtensions dynamic = 409707008;
    */
-  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
+  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions | undefined;
 };
 
 /**
@@ -1016,7 +1016,7 @@ export type TestNestedChildExtension = Message<"proto2_unittest.TestNestedChildE
   /**
    * @generated from field: proto2_unittest.TestChildExtension child = 2;
    */
-  child?: TestChildExtension;
+  child?: TestChildExtension | undefined;
 };
 
 /**
@@ -1041,7 +1041,7 @@ export type TestNestedChildExtensionData = Message<"proto2_unittest.TestNestedCh
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData child = 2;
    */
-  child?: TestChildExtensionData;
+  child?: TestChildExtensionData | undefined;
 };
 
 /**
@@ -1492,7 +1492,7 @@ export type TestRequired = Message<"proto2_unittest.TestRequired"> & {
    *
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign = 34;
    */
-  optionalForeign?: ForeignMessage;
+  optionalForeign?: ForeignMessage | undefined;
 
   /**
    * @generated from field: map<string, proto2_unittest.TestRequired> map_field = 35;
@@ -1526,7 +1526,7 @@ export type TestRequiredForeign = Message<"proto2_unittest.TestRequiredForeign">
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage?: TestRequired | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1543,7 +1543,7 @@ export type TestRequiredForeign = Message<"proto2_unittest.TestRequiredForeign">
    *
    * @generated from field: proto2_unittest.NestedTestAllTypes optional_lazy_message = 4;
    */
-  optionalLazyMessage?: NestedTestAllTypes;
+  optionalLazyMessage?: NestedTestAllTypes | undefined;
 };
 
 /**
@@ -1560,7 +1560,7 @@ export type TestRequiredMessage = Message<"proto2_unittest.TestRequiredMessage">
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage?: TestRequired | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1570,7 +1570,7 @@ export type TestRequiredMessage = Message<"proto2_unittest.TestRequiredMessage">
   /**
    * @generated from field: proto2_unittest.TestRequired required_message = 3 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessage?: TestRequired;
+  requiredMessage?: TestRequired | undefined;
 };
 
 /**
@@ -1587,12 +1587,12 @@ export type TestRequiredLazyMessage = Message<"proto2_unittest.TestRequiredLazyM
   /**
    * @generated from field: proto2_unittest.TestRequired child = 1;
    */
-  child?: TestRequired;
+  child?: TestRequired | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredLazyMessage recurse = 2;
    */
-  recurse?: TestRequiredLazyMessage;
+  recurse?: TestRequiredLazyMessage | undefined;
 };
 
 /**
@@ -1609,12 +1609,12 @@ export type TestNestedRequiredForeign = Message<"proto2_unittest.TestNestedRequi
   /**
    * @generated from field: proto2_unittest.TestNestedRequiredForeign child = 1;
    */
-  child?: TestNestedRequiredForeign;
+  child?: TestNestedRequiredForeign | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredForeign payload = 2;
    */
-  payload?: TestRequiredForeign;
+  payload?: TestRequiredForeign | undefined;
 
   /**
    * @generated from field: int32 dummy = 3;
@@ -1626,22 +1626,22 @@ export type TestNestedRequiredForeign = Message<"proto2_unittest.TestNestedRequi
    *
    * @generated from field: proto2_unittest.TestRequiredEnum required_enum = 5;
    */
-  requiredEnum?: TestRequiredEnum;
+  requiredEnum?: TestRequiredEnum | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask required_enum_no_mask = 6;
    */
-  requiredEnumNoMask?: TestRequiredEnumNoMask;
+  requiredEnumNoMask?: TestRequiredEnumNoMask | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti required_enum_multi = 7;
    */
-  requiredEnumMulti?: TestRequiredEnumMulti;
+  requiredEnumMulti?: TestRequiredEnumMulti | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti required_no_mask = 9;
    */
-  requiredNoMask?: TestRequiredNoMaskMulti;
+  requiredNoMask?: TestRequiredNoMaskMulti | undefined;
 };
 
 /**
@@ -1660,7 +1660,7 @@ export type TestForeignNested = Message<"proto2_unittest.TestForeignNested"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage foreign_nested = 1;
    */
-  foreignNested?: TestAllTypes_NestedMessage;
+  foreignNested?: TestAllTypes_NestedMessage | undefined;
 };
 
 /**
@@ -1797,7 +1797,7 @@ export type TestRecursiveMessage = Message<"proto2_unittest.TestRecursiveMessage
   /**
    * @generated from field: proto2_unittest.TestRecursiveMessage a = 1;
    */
-  a?: TestRecursiveMessage;
+  a?: TestRecursiveMessage | undefined;
 
   /**
    * @generated from field: int32 i = 2;
@@ -1821,12 +1821,12 @@ export type TestMutualRecursionA = Message<"proto2_unittest.TestMutualRecursionA
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB bb = 1;
    */
-  bb?: TestMutualRecursionB;
+  bb?: TestMutualRecursionB | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubGroup subgroup = 2 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestMutualRecursionA_SubGroup;
+  subgroup?: TestMutualRecursionA_SubGroup | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestMutualRecursionA.SubGroupR subgroupr = 5 [features.message_encoding = DELIMITED];
@@ -1848,7 +1848,7 @@ export type TestMutualRecursionA_SubMessage = Message<"proto2_unittest.TestMutua
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB b = 1;
    */
-  b?: TestMutualRecursionB;
+  b?: TestMutualRecursionB | undefined;
 };
 
 /**
@@ -1867,12 +1867,12 @@ export type TestMutualRecursionA_SubGroup = Message<"proto2_unittest.TestMutualR
    *
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubMessage sub_message = 3;
    */
-  subMessage?: TestMutualRecursionA_SubMessage;
+  subMessage?: TestMutualRecursionA_SubMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes not_in_this_scc = 4;
    */
-  notInThisScc?: TestAllTypes;
+  notInThisScc?: TestAllTypes | undefined;
 };
 
 /**
@@ -1889,7 +1889,7 @@ export type TestMutualRecursionA_SubGroupR = Message<"proto2_unittest.TestMutual
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 6;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 };
 
 /**
@@ -1906,7 +1906,7 @@ export type TestMutualRecursionB = Message<"proto2_unittest.TestMutualRecursionB
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA a = 1;
    */
-  a?: TestMutualRecursionA;
+  a?: TestMutualRecursionA | undefined;
 
   /**
    * @generated from field: int32 optional_int32 = 2;
@@ -1928,7 +1928,7 @@ export type TestIsInitialized = Message<"proto2_unittest.TestIsInitialized"> & {
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage sub_message = 1;
    */
-  subMessage?: TestIsInitialized_SubMessage;
+  subMessage?: TestIsInitialized_SubMessage | undefined;
 };
 
 /**
@@ -1945,7 +1945,7 @@ export type TestIsInitialized_SubMessage = Message<"proto2_unittest.TestIsInitia
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage.SubGroup subgroup = 1 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestIsInitialized_SubMessage_SubGroup;
+  subgroup?: TestIsInitialized_SubMessage_SubGroup | undefined;
 };
 
 /**
@@ -1995,14 +1995,14 @@ export type TestDupFieldNumber = Message<"proto2_unittest.TestDupFieldNumber"> &
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Foo foo = 2 [features.message_encoding = DELIMITED];
    */
-  foo?: TestDupFieldNumber_Foo;
+  foo?: TestDupFieldNumber_Foo | undefined;
 
   /**
    * NO_PROTO1
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Bar bar = 3 [features.message_encoding = DELIMITED];
    */
-  bar?: TestDupFieldNumber_Bar;
+  bar?: TestDupFieldNumber_Bar | undefined;
 };
 
 /**
@@ -2063,7 +2063,7 @@ export type TestEagerMessage = Message<"proto2_unittest.TestEagerMessage"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage?: TestAllTypes | undefined;
 };
 
 /**
@@ -2080,7 +2080,7 @@ export type TestLazyMessage = Message<"proto2_unittest.TestLazyMessage"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage?: TestAllTypes | undefined;
 };
 
 /**
@@ -2097,27 +2097,27 @@ export type TestLazyRequiredEnum = Message<"proto2_unittest.TestLazyRequiredEnum
   /**
    * @generated from field: proto2_unittest.TestRequiredOpenEnum optional_required_open_enum = 1;
    */
-  optionalRequiredOpenEnum?: TestRequiredOpenEnum;
+  optionalRequiredOpenEnum?: TestRequiredOpenEnum | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnum optional_required_enum = 2;
    */
-  optionalRequiredEnum?: TestRequiredEnum;
+  optionalRequiredEnum?: TestRequiredEnum | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask optional_required_enum_no_mask = 3;
    */
-  optionalRequiredEnumNoMask?: TestRequiredEnumNoMask;
+  optionalRequiredEnumNoMask?: TestRequiredEnumNoMask | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti optional_required_enum_multi = 4;
    */
-  optionalRequiredEnumMulti?: TestRequiredEnumMulti;
+  optionalRequiredEnumMulti?: TestRequiredEnumMulti | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti optional_required_no_mask = 5;
    */
-  optionalRequiredNoMask?: TestRequiredNoMaskMulti;
+  optionalRequiredNoMask?: TestRequiredNoMaskMulti | undefined;
 };
 
 /**
@@ -2151,17 +2151,17 @@ export type TestEagerMaybeLazy = Message<"proto2_unittest.TestEagerMaybeLazy"> &
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_foo = 1;
    */
-  messageFoo?: TestAllTypes;
+  messageFoo?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_bar = 2;
    */
-  messageBar?: TestAllTypes;
+  messageBar?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestEagerMaybeLazy.NestedMessage message_baz = 3;
    */
-  messageBaz?: TestEagerMaybeLazy_NestedMessage;
+  messageBaz?: TestEagerMaybeLazy_NestedMessage | undefined;
 };
 
 /**
@@ -2178,7 +2178,7 @@ export type TestEagerMaybeLazy_NestedMessage = Message<"proto2_unittest.TestEage
   /**
    * @generated from field: proto2_unittest.TestPackedTypes packed = 1;
    */
-  packed?: TestPackedTypes;
+  packed?: TestPackedTypes | undefined;
 };
 
 /**
@@ -2197,7 +2197,7 @@ export type TestNestedMessageHasBits = Message<"proto2_unittest.TestNestedMessag
   /**
    * @generated from field: proto2_unittest.TestNestedMessageHasBits.NestedMessage optional_nested_message = 1;
    */
-  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage;
+  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage | undefined;
 };
 
 /**
@@ -2254,7 +2254,7 @@ export type TestCamelCaseFieldNames = Message<"proto2_unittest.TestCamelCaseFiel
   /**
    * @generated from field: proto2_unittest.ForeignMessage MessageField = 4;
    */
-  MessageField?: ForeignMessage;
+  MessageField?: ForeignMessage | undefined;
 
   /**
    * @generated from field: string StringPieceField = 5;
@@ -2329,7 +2329,7 @@ export type TestFieldOrderings = Message<"proto2_unittest.TestFieldOrderings"> &
   /**
    * @generated from field: proto2_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
    */
-  optionalNestedMessage?: TestFieldOrderings_NestedMessage;
+  optionalNestedMessage?: TestFieldOrderings_NestedMessage | undefined;
 };
 
 /**
@@ -3027,12 +3027,12 @@ export type TestOneofBackwardsCompatible = Message<"proto2_unittest.TestOneofBac
   /**
    * @generated from field: proto2_unittest.TestAllTypes foo_message = 3;
    */
-  fooMessage?: TestAllTypes;
+  fooMessage?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestOneofBackwardsCompatible.FooGroup foogroup = 4 [features.message_encoding = DELIMITED];
    */
-  foogroup?: TestOneofBackwardsCompatible_FooGroup;
+  foogroup?: TestOneofBackwardsCompatible_FooGroup | undefined;
 };
 
 /**
@@ -3255,7 +3255,7 @@ export type TestOneof2_NestedMessage = Message<"proto2_unittest.TestOneof2.Neste
   /**
    * @generated from field: proto2_unittest.TestOneof2.NestedMessage child = 3;
    */
-  child?: TestOneof2_NestedMessage;
+  child?: TestOneof2_NestedMessage | undefined;
 };
 
 /**
@@ -3568,12 +3568,12 @@ export type TestDynamicExtensions = Message<"proto2_unittest.TestDynamicExtensio
   /**
    * @generated from field: proto2_unittest.ForeignMessage message_extension = 2003;
    */
-  messageExtension?: ForeignMessage;
+  messageExtension?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestDynamicExtensions.DynamicMessageType dynamic_message_extension = 2004;
    */
-  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType;
+  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType | undefined;
 
   /**
    * @generated from field: repeated string repeated_extension = 2005;
@@ -3730,12 +3730,12 @@ export type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes required_all_types = 1 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredAllTypes?: TestAllTypes;
+  requiredAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 2;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 3;
@@ -3745,7 +3745,7 @@ export type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge"> & {
   /**
    * @generated from field: proto2_unittest.TestParsingMerge.OptionalGroup optionalgroup = 10 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestParsingMerge_OptionalGroup;
+  optionalgroup?: TestParsingMerge_OptionalGroup | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestParsingMerge.RepeatedGroup repeatedgroup = 20 [features.message_encoding = DELIMITED];
@@ -3820,7 +3820,7 @@ export type TestParsingMerge_RepeatedFieldsGenerator_Group1 = Message<"proto2_un
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 11;
    */
-  field1?: TestAllTypes;
+  field1?: TestAllTypes | undefined;
 };
 
 /**
@@ -3837,7 +3837,7 @@ export type TestParsingMerge_RepeatedFieldsGenerator_Group2 = Message<"proto2_un
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 21;
    */
-  field1?: TestAllTypes;
+  field1?: TestAllTypes | undefined;
 };
 
 /**
@@ -3854,7 +3854,7 @@ export type TestParsingMerge_OptionalGroup = Message<"proto2_unittest.TestParsin
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_group_all_types = 11;
    */
-  optionalGroupAllTypes?: TestAllTypes;
+  optionalGroupAllTypes?: TestAllTypes | undefined;
 };
 
 /**
@@ -3871,7 +3871,7 @@ export type TestParsingMerge_RepeatedGroup = Message<"proto2_unittest.TestParsin
   /**
    * @generated from field: proto2_unittest.TestAllTypes repeated_group_all_types = 21;
    */
-  repeatedGroupAllTypes?: TestAllTypes;
+  repeatedGroupAllTypes?: TestAllTypes | undefined;
 };
 
 /**
@@ -3903,7 +3903,7 @@ export type TestMergeException = Message<"proto2_unittest.TestMergeException"> &
   /**
    * @generated from field: proto2_unittest.TestAllExtensions all_extensions = 1;
    */
-  allExtensions?: TestAllExtensions;
+  allExtensions?: TestAllExtensions | undefined;
 };
 
 /**
@@ -4050,7 +4050,7 @@ export type TestEagerlyVerifiedLazyMessage = Message<"proto2_unittest.TestEagerl
   /**
    * @generated from field: proto2_unittest.TestEagerlyVerifiedLazyMessage.LazyMessage lazy_message = 1;
    */
-  lazyMessage?: TestEagerlyVerifiedLazyMessage_LazyMessage;
+  lazyMessage?: TestEagerlyVerifiedLazyMessage_LazyMessage | undefined;
 };
 
 /**
@@ -4246,12 +4246,12 @@ export type TestHugeFieldNumbers = Message<"proto2_unittest.TestHugeFieldNumbers
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_message = 536870007;
    */
-  optionalMessage?: ForeignMessage;
+  optionalMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestHugeFieldNumbers.OptionalGroup optionalgroup = 536870008 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestHugeFieldNumbers_OptionalGroup;
+  optionalgroup?: TestHugeFieldNumbers_OptionalGroup | undefined;
 
   /**
    * @generated from field: map<string, string> string_string_map = 536870010;
@@ -4413,7 +4413,7 @@ export type TestNestedGroupExtensionOuter = Message<"proto2_unittest.TestNestedG
   /**
    * @generated from field: proto2_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup layer1optionalgroup = 1 [features.message_encoding = DELIMITED];
    */
-  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
+  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup | undefined;
 };
 
 /**
@@ -4617,7 +4617,7 @@ export type TestVerifyInt32 = Message<"proto2_unittest.TestVerifyInt32"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4674,7 +4674,7 @@ export type TestVerifyMostlyInt32 = Message<"proto2_unittest.TestVerifyMostlyInt
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4736,7 +4736,7 @@ export type TestVerifyMostlyInt32BigFieldNumber = Message<"proto2_unittest.TestV
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4810,7 +4810,7 @@ export type TestVerifyUint32 = Message<"proto2_unittest.TestVerifyUint32"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4852,7 +4852,7 @@ export type TestVerifyOneUint32 = Message<"proto2_unittest.TestVerifyOneUint32">
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4899,7 +4899,7 @@ export type TestVerifyOneInt32BigFieldNumber = Message<"proto2_unittest.TestVeri
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4951,7 +4951,7 @@ export type TestVerifyInt32BigFieldNumber = Message<"proto2_unittest.TestVerifyI
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -5003,7 +5003,7 @@ export type TestVerifyUint32BigFieldNumber = Message<"proto2_unittest.TestVerify
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes?: TestAllTypes | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -5025,7 +5025,7 @@ export type TestVerifyBigFieldNumberUint32 = Message<"proto2_unittest.TestVerify
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested | undefined;
 };
 
 /**
@@ -5082,7 +5082,7 @@ export type TestVerifyBigFieldNumberUint32_Nested = Message<"proto2_unittest.Tes
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested?: TestVerifyBigFieldNumberUint32_Nested | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;
@@ -5862,7 +5862,7 @@ export type InlinedStringIdxRegressionProto = Message<"proto2_unittest.InlinedSt
    *
    * @generated from field: proto2_unittest.InlinedStringIdxRegressionProto sub = 2;
    */
-  sub?: InlinedStringIdxRegressionProto;
+  sub?: InlinedStringIdxRegressionProto | undefined;
 
   /**
    * aux_idx == 3, inlined_string_idx == 2
@@ -6011,12 +6011,12 @@ export type RedactedFields = Message<"proto2_unittest.RedactedFields"> & {
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_redacted_message = 5;
    */
-  optionalRedactedMessage?: TestNestedMessageRedaction;
+  optionalRedactedMessage?: TestNestedMessageRedaction | undefined;
 
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_unredacted_message = 6;
    */
-  optionalUnredactedMessage?: TestNestedMessageRedaction;
+  optionalUnredactedMessage?: TestNestedMessageRedaction | undefined;
 
   /**
    * @generated from field: repeated proto2_unittest.TestNestedMessageRedaction repeated_redacted_message = 7;
@@ -6615,7 +6615,7 @@ export type MessageCreatorZeroInit = Message<"proto2_unittest.MessageCreatorZero
   /**
    * @generated from field: proto2_unittest.MessageCreatorZeroInit m = 3;
    */
-  m?: MessageCreatorZeroInit;
+  m?: MessageCreatorZeroInit | undefined;
 
   /**
    * @generated from oneof proto2_unittest.MessageCreatorZeroInit.one
@@ -6671,7 +6671,7 @@ export type MessageCreatorMemcpy = Message<"proto2_unittest.MessageCreatorMemcpy
   /**
    * @generated from field: proto2_unittest.MessageCreatorMemcpy m = 3;
    */
-  m?: MessageCreatorMemcpy;
+  m?: MessageCreatorMemcpy | undefined;
 
   /**
    * @generated from field: map<int32, int32> m2 = 4;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
@@ -37,97 +37,97 @@ export type TestProto3Optional = Message<"proto2_unittest.TestProto3Optional"> &
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32?: number | undefined;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64?: bigint | undefined;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32?: number | undefined;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64?: bigint | undefined;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32?: number | undefined;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64?: bigint | undefined;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32?: number | undefined;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32?: number | undefined;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64?: bigint | undefined;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat?: number | undefined;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble?: number | undefined;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool?: boolean | undefined;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString?: string | undefined;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes?: Uint8Array | undefined;
 
   /**
    * @generated from field: optional string optional_cord = 16;
    */
-  optionalCord?: string;
+  optionalCord?: string | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestProto3Optional_NestedMessage;
+  optionalNestedMessage?: TestProto3Optional_NestedMessage | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage lazy_nested_message = 19;
    */
-  lazyNestedMessage?: TestProto3Optional_NestedMessage;
+  lazyNestedMessage?: TestProto3Optional_NestedMessage | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestProto3Optional_NestedEnum;
+  optionalNestedEnum?: TestProto3Optional_NestedEnum | undefined;
 
   /**
    * Add some non-optional fields to verify we can mix them.
@@ -160,7 +160,7 @@ export type TestProto3Optional_NestedMessage = Message<"proto2_unittest.TestProt
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb?: number | undefined;
 };
 
 /**
@@ -215,12 +215,12 @@ export type TestProto3OptionalMessage = Message<"proto2_unittest.TestProto3Optio
   /**
    * @generated from field: proto2_unittest.TestProto3OptionalMessage.NestedMessage nested_message = 1;
    */
-  nestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  nestedMessage?: TestProto3OptionalMessage_NestedMessage | undefined;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3OptionalMessage.NestedMessage optional_nested_message = 2;
    */
-  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
@@ -116,17 +116,17 @@ export type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
   /**
    * @generated from field: optional proto3_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage?: ForeignMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage?: ImportMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -153,22 +153,22 @@ export type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage?: PublicImportMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage | undefined;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
-  optionalLazyImportMessage?: ImportMessage;
+  optionalLazyImportMessage?: ImportMessage | undefined;
 
   /**
    * Repeated
@@ -558,12 +558,12 @@ export type NestedTestAllTypes = Message<"proto3_unittest.NestedTestAllTypes"> &
   /**
    * @generated from field: proto3_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child?: NestedTestAllTypes | undefined;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload?: TestAllTypes | undefined;
 };
 
 /**
@@ -1043,7 +1043,7 @@ export type TestHasbits = Message<"proto3_unittest.TestHasbits"> & {
   /**
    * @generated from field: proto3_unittest.TestAllTypes child = 100;
    */
-  child?: TestAllTypes;
+  child?: TestAllTypes | undefined;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_redaction_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_redaction_pb.ts
@@ -95,7 +95,7 @@ export type TestNestedMessageEnum = Message<"proto2_unittest.TestNestedMessageEn
   /**
    * @generated from field: proto2_unittest.TestMessageEnum nested_enum = 2;
    */
-  nestedEnum?: TestMessageEnum;
+  nestedEnum?: TestMessageEnum | undefined;
 
   /**
    * @generated from field: string redacted_string = 3;
@@ -143,7 +143,7 @@ export type TestRedactedMessage = Message<"proto2_unittest.TestRedactedMessage">
   /**
    * @generated from field: google.protobuf.Any any_field = 18;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: string redactable_false = 19;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
@@ -41,99 +41,99 @@ export type TestWellKnownTypes = Message<"proto2_unittest.TestWellKnownTypes"> &
   /**
    * @generated from field: google.protobuf.Any any_field = 1;
    */
-  anyField?: Any;
+  anyField?: Any | undefined;
 
   /**
    * @generated from field: google.protobuf.Api api_field = 2;
    */
-  apiField?: Api;
+  apiField?: Api | undefined;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 3;
    */
-  durationField?: Duration;
+  durationField?: Duration | undefined;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 4;
    */
-  emptyField?: Empty;
+  emptyField?: Empty | undefined;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 5;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField?: FieldMask | undefined;
 
   /**
    * @generated from field: google.protobuf.SourceContext source_context_field = 6;
    */
-  sourceContextField?: SourceContext;
+  sourceContextField?: SourceContext | undefined;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 7;
    */
-  structField?: JsonObject;
+  structField?: JsonObject | undefined;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 8;
    */
-  timestampField?: Timestamp;
+  timestampField?: Timestamp | undefined;
 
   /**
    * @generated from field: google.protobuf.Type type_field = 9;
    */
-  typeField?: Type;
+  typeField?: Type | undefined;
 
   /**
    * @generated from field: google.protobuf.DoubleValue double_field = 10;
    */
-  doubleField?: number;
+  doubleField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_field = 11;
    */
-  floatField?: number;
+  floatField?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_field = 12;
    */
-  int64Field?: bigint;
+  int64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_field = 13;
    */
-  uint64Field?: bigint;
+  uint64Field?: bigint | undefined;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_field = 14;
    */
-  int32Field?: number;
+  int32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_field = 15;
    */
-  uint32Field?: number;
+  uint32Field?: number | undefined;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_field = 16;
    */
-  boolField?: boolean;
+  boolField?: boolean | undefined;
 
   /**
    * @generated from field: google.protobuf.StringValue string_field = 17;
    */
-  stringField?: string;
+  stringField?: string | undefined;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_field = 18;
    */
-  bytesField?: Uint8Array;
+  bytesField?: Uint8Array | undefined;
 
   /**
    * Part of struct, but useful to be able to test separately
    *
    * @generated from field: google.protobuf.Value value_field = 19;
    */
-  valueField?: Value;
+  valueField?: Value | undefined;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/api_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/api_pb.ts
@@ -104,7 +104,7 @@ export type Api = Message<"google.protobuf.Api"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * Included interfaces. See [Mixin][].

--- a/packages/protobuf/src/wkt/gen/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/compiler/plugin_pb.ts
@@ -171,7 +171,7 @@ export type CodeGeneratorRequest = Message<"google.protobuf.compiler.CodeGenerat
    *
    * @generated from field: optional google.protobuf.compiler.Version compiler_version = 3;
    */
-  compilerVersion?: Version;
+  compilerVersion?: Version | undefined;
 };
 
 /**
@@ -440,7 +440,7 @@ export type CodeGeneratorResponse_File = Message<"google.protobuf.compiler.CodeG
    *
    * @generated from field: optional google.protobuf.GeneratedCodeInfo generated_code_info = 16;
    */
-  generatedCodeInfo?: GeneratedCodeInfo;
+  generatedCodeInfo?: GeneratedCodeInfo | undefined;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/descriptor_pb.ts
@@ -144,7 +144,7 @@ export type FileDescriptorProto = Message<"google.protobuf.FileDescriptorProto">
   /**
    * @generated from field: optional google.protobuf.FileOptions options = 8;
    */
-  options?: FileOptions;
+  options?: FileOptions | undefined;
 
   /**
    * This field contains optional information about the original source code.
@@ -154,7 +154,7 @@ export type FileDescriptorProto = Message<"google.protobuf.FileDescriptorProto">
    *
    * @generated from field: optional google.protobuf.SourceCodeInfo source_code_info = 9;
    */
-  sourceCodeInfo?: SourceCodeInfo;
+  sourceCodeInfo?: SourceCodeInfo | undefined;
 
   /**
    * The syntax of the proto file.
@@ -342,7 +342,7 @@ export type DescriptorProto = Message<"google.protobuf.DescriptorProto"> & {
   /**
    * @generated from field: optional google.protobuf.MessageOptions options = 7;
    */
-  options?: MessageOptions;
+  options?: MessageOptions | undefined;
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9;
@@ -460,7 +460,7 @@ export type DescriptorProto_ExtensionRange = Message<"google.protobuf.Descriptor
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
    */
-  options?: ExtensionRangeOptions;
+  options?: ExtensionRangeOptions | undefined;
 };
 
 /**
@@ -572,7 +572,7 @@ export type ExtensionRangeOptions = Message<"google.protobuf.ExtensionRangeOptio
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 50;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * The verification state of the range.
@@ -838,7 +838,7 @@ export type FieldDescriptorProto = Message<"google.protobuf.FieldDescriptorProto
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
    */
-  options?: FieldOptions;
+  options?: FieldOptions | undefined;
 
   /**
    * If true, this is a proto3 "optional". When a proto3 field is optional, it
@@ -1164,7 +1164,7 @@ export type OneofDescriptorProto = Message<"google.protobuf.OneofDescriptorProto
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
    */
-  options?: OneofOptions;
+  options?: OneofOptions | undefined;
 };
 
 /**
@@ -1210,7 +1210,7 @@ export type EnumDescriptorProto = Message<"google.protobuf.EnumDescriptorProto">
   /**
    * @generated from field: optional google.protobuf.EnumOptions options = 3;
    */
-  options?: EnumOptions;
+  options?: EnumOptions | undefined;
 
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
@@ -1368,7 +1368,7 @@ export type EnumValueDescriptorProto = Message<"google.protobuf.EnumValueDescrip
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
    */
-  options?: EnumValueOptions;
+  options?: EnumValueOptions | undefined;
 };
 
 /**
@@ -1419,7 +1419,7 @@ export type ServiceDescriptorProto = Message<"google.protobuf.ServiceDescriptorP
   /**
    * @generated from field: optional google.protobuf.ServiceOptions options = 3;
    */
-  options?: ServiceOptions;
+  options?: ServiceOptions | undefined;
 };
 
 /**
@@ -1478,7 +1478,7 @@ export type MethodDescriptorProto = Message<"google.protobuf.MethodDescriptorPro
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
    */
-  options?: MethodOptions;
+  options?: MethodOptions | undefined;
 
   /**
    * Identifies if client streams multiple client messages
@@ -1735,7 +1735,7 @@ export type FileOptions = Message<"google.protobuf.FileOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 50;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * The parser stores options it doesn't recognize here.
@@ -2095,7 +2095,7 @@ export type MessageOptions = Message<"google.protobuf.MessageOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 12;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2355,12 +2355,12 @@ export type FieldOptions = Message<"google.protobuf.FieldOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 21;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 22;
    */
-  featureSupport?: FieldOptions_FeatureSupport;
+  featureSupport?: FieldOptions_FeatureSupport | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2854,7 +2854,7 @@ export type OneofOptions = Message<"google.protobuf.OneofOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 1;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2936,7 +2936,7 @@ export type EnumOptions = Message<"google.protobuf.EnumOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 7;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -3028,7 +3028,7 @@ export type EnumValueOptions = Message<"google.protobuf.EnumValueOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 2;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * Indicate that fields annotated with this enum value should not be printed
@@ -3044,7 +3044,7 @@ export type EnumValueOptions = Message<"google.protobuf.EnumValueOptions"> & {
    *
    * @generated from field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 4;
    */
-  featureSupport?: FieldOptions_FeatureSupport;
+  featureSupport?: FieldOptions_FeatureSupport | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -3121,7 +3121,7 @@ export type ServiceOptions = Message<"google.protobuf.ServiceOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 34;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * Is this service deprecated?
@@ -3207,7 +3207,7 @@ export type MethodOptions = Message<"google.protobuf.MethodOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 35;
    */
-  features?: FeatureSet;
+  features?: FeatureSet | undefined;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -3951,14 +3951,14 @@ export type FeatureSetDefaults_FeatureSetEditionDefault = Message<"google.protob
    *
    * @generated from field: optional google.protobuf.FeatureSet overridable_features = 4;
    */
-  overridableFeatures?: FeatureSet;
+  overridableFeatures?: FeatureSet | undefined;
 
   /**
    * Defaults of features that can't be overridden in this edition.
    *
    * @generated from field: optional google.protobuf.FeatureSet fixed_features = 5;
    */
-  fixedFeatures?: FeatureSet;
+  fixedFeatures?: FeatureSet | undefined;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/type_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/type_pb.ts
@@ -76,7 +76,7 @@ export type Type = Message<"google.protobuf.Type"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -574,7 +574,7 @@ export type Enum = Message<"google.protobuf.Enum"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext?: SourceContext | undefined;
 
   /**
    * The source syntax.
@@ -754,7 +754,7 @@ export type Option = Message<"google.protobuf.Option"> & {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value?: Any | undefined;
 };
 
 /**

--- a/packages/protoc-gen-es/src/gen/minimal-validate_pb.ts
+++ b/packages/protoc-gen-es/src/gen/minimal-validate_pb.ts
@@ -95,7 +95,7 @@ export type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items?: FieldRules | undefined;
 };
 
 /**
@@ -112,7 +112,7 @@ export type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values?: FieldRules | undefined;
 };
 
 /**

--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -489,7 +489,7 @@ function generateMessageShapeMember(f: GeneratedFile, member: DescField | DescOn
         }
       }
       if (optional) {
-        f.print("  ", member.localName, "?: ", typing, ";");
+        f.print("  ", member.localName, "?: ", typing, " | undefined;");
       } else {
         f.print("  ", member.localName, ": ", typing, ";");
       }


### PR DESCRIPTION
marking types as `?:` (optional) does not let them be assigned undefined in stricter environments like with https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes