### PR TITLE
Remove support for non-default typescript settings

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -464,7 +464,7 @@ Protobuf-ES generates the following property:
 result:
   | { case: "number";  value: number }
   | { case: "error";   value: string }
-  | { case: undefined; value?: undefined } = { case: undefined };
+  | { case: "" };
 ```
 
 The entire `oneof` group is turned into an object `result` with two properties:
@@ -472,10 +472,9 @@ The entire `oneof` group is turned into an object `result` with two properties:
 - `case`: The name of the selected field
 - `value`: The value of the selected field
 
-This property is always defined on the message—similar to the way map or repeated fields are always defined. By default,
-it's `{case: undefined}`.
+This property is always defined on the message—similar to the way map or repeated fields are always defined.
 
-In our example, `result.case` can be either `"number"`, `"error"`, or `undefined`. If a field is selected, the
+In our example, `result.case` can be either `"number"`, `"error"`, or `""`. If a field is selected, the
 property `result.value` contains the value of the
 selected field.
 
@@ -483,7 +482,7 @@ To select a field, simply replace the `result` object:
 
 ```typescript
 user.result = { case: "number", value: 123 };
-user.result = { case: undefined };
+user.result = { case: "" };
 ```
 
 To query a `oneof` group, you can use if blocks:
@@ -512,8 +511,7 @@ switch statements above tell the compiler the type of the `value` property.
 
 > [!TIP]
 >
-> This feature requires the TypeScript compiler option `strictNullChecks` to be enabled.
-> This option is automatically enabled with the option `strict`. See the [documentation][strictNullChecks] for details.
+> Oneof types use an empty-string discriminator for the unset case, and are intended for projects using non-strict null checking.
 
 ### Proto2 group fields
 
@@ -2865,7 +2863,6 @@ Serialization to JSON and binary is deterministic within a version of protobuf-e
 [src/wkt/UninterpretedOption_NamePart]: ./packages/protobuf/src/wkt/gen/google/protobuf/descriptor_pb.ts
 [src/wkt/Value]: ./packages/protobuf/src/wkt/gen/google/protobuf/struct_pb.ts
 [src/wkt/Version]: ./packages/protobuf/src/wkt/gen/google/protobuf/compiler/plugin_pb.ts
-[strictNullChecks]: https://www.typescriptlang.org/tsconfig#strictNullChecks
 [Text Encoding API]: https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API
 [ts-enums]: https://www.typescriptlang.org/docs/handbook/enums.html
 [ts-5.0-enum-overhaul]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#enum-overhaul

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/client_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/client_pb.ts
@@ -95,56 +95,56 @@ export type ClientLibrarySettings = Message<"google.api.ClientLibrarySettings"> 
    *
    * @generated from field: google.api.JavaSettings java_settings = 21;
    */
-  javaSettings?: JavaSettings;
+  javaSettings: JavaSettings;
 
   /**
    * Settings for C++ client libraries.
    *
    * @generated from field: google.api.CppSettings cpp_settings = 22;
    */
-  cppSettings?: CppSettings;
+  cppSettings: CppSettings;
 
   /**
    * Settings for PHP client libraries.
    *
    * @generated from field: google.api.PhpSettings php_settings = 23;
    */
-  phpSettings?: PhpSettings;
+  phpSettings: PhpSettings;
 
   /**
    * Settings for Python client libraries.
    *
    * @generated from field: google.api.PythonSettings python_settings = 24;
    */
-  pythonSettings?: PythonSettings;
+  pythonSettings: PythonSettings;
 
   /**
    * Settings for Node client libraries.
    *
    * @generated from field: google.api.NodeSettings node_settings = 25;
    */
-  nodeSettings?: NodeSettings;
+  nodeSettings: NodeSettings;
 
   /**
    * Settings for .NET client libraries.
    *
    * @generated from field: google.api.DotnetSettings dotnet_settings = 26;
    */
-  dotnetSettings?: DotnetSettings;
+  dotnetSettings: DotnetSettings;
 
   /**
    * Settings for Ruby client libraries.
    *
    * @generated from field: google.api.RubySettings ruby_settings = 27;
    */
-  rubySettings?: RubySettings;
+  rubySettings: RubySettings;
 
   /**
    * Settings for Go client libraries.
    *
    * @generated from field: google.api.GoSettings go_settings = 28;
    */
-  goSettings?: GoSettings;
+  goSettings: GoSettings;
 };
 
 /**
@@ -306,7 +306,7 @@ export type JavaSettings = Message<"google.api.JavaSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 3;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -327,7 +327,7 @@ export type CppSettings = Message<"google.api.CppSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -348,7 +348,7 @@ export type PhpSettings = Message<"google.api.PhpSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -369,7 +369,7 @@ export type PythonSettings = Message<"google.api.PythonSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -390,7 +390,7 @@ export type NodeSettings = Message<"google.api.NodeSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -411,7 +411,7 @@ export type DotnetSettings = Message<"google.api.DotnetSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 
   /**
    * Map from original service names to renamed versions.
@@ -482,7 +482,7 @@ export type RubySettings = Message<"google.api.RubySettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -503,7 +503,7 @@ export type GoSettings = Message<"google.api.GoSettings"> & {
    *
    * @generated from field: google.api.CommonLanguageSettings common = 1;
    */
-  common?: CommonLanguageSettings;
+  common: CommonLanguageSettings;
 };
 
 /**
@@ -548,7 +548,7 @@ export type MethodSettings = Message<"google.api.MethodSettings"> & {
    *
    * @generated from field: google.api.MethodSettings.LongRunning long_running = 2;
    */
-  longRunning?: MethodSettings_LongRunning;
+  longRunning: MethodSettings_LongRunning;
 
   /**
    * List of top-level fields of the request message, that should be
@@ -591,7 +591,7 @@ export type MethodSettings_LongRunning = Message<"google.api.MethodSettings.Long
    *
    * @generated from field: google.protobuf.Duration initial_poll_delay = 1;
    */
-  initialPollDelay?: Duration;
+  initialPollDelay: Duration;
 
   /**
    * Multiplier to gradually increase delay between subsequent polls until it
@@ -608,7 +608,7 @@ export type MethodSettings_LongRunning = Message<"google.api.MethodSettings.Long
    *
    * @generated from field: google.protobuf.Duration max_poll_delay = 3;
    */
-  maxPollDelay?: Duration;
+  maxPollDelay: Duration;
 
   /**
    * Total polling timeout.
@@ -616,7 +616,7 @@ export type MethodSettings_LongRunning = Message<"google.api.MethodSettings.Long
    *
    * @generated from field: google.protobuf.Duration total_poll_timeout = 4;
    */
-  totalPollTimeout?: Duration;
+  totalPollTimeout: Duration;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/checked_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/checked_pb.ts
@@ -74,7 +74,7 @@ export type CheckedExpr = Message<"google.api.expr.v1alpha1.CheckedExpr"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.SourceInfo source_info = 5;
    */
-  sourceInfo?: SourceInfo;
+  sourceInfo: SourceInfo;
 
   /**
    * The expr version indicates the major / minor version number of the `expr`
@@ -95,7 +95,7 @@ export type CheckedExpr = Message<"google.api.expr.v1alpha1.CheckedExpr"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr expr = 4;
    */
-  expr?: Expr;
+  expr: Expr;
 };
 
 /**
@@ -234,7 +234,7 @@ export type Type = Message<"google.api.expr.v1alpha1.Type"> & {
      */
     value: Type_AbstractType;
     case: "abstractType";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -255,7 +255,7 @@ export type Type_ListType = Message<"google.api.expr.v1alpha1.Type.ListType"> & 
    *
    * @generated from field: google.api.expr.v1alpha1.Type elem_type = 1;
    */
-  elemType?: Type;
+  elemType: Type;
 };
 
 /**
@@ -276,14 +276,14 @@ export type Type_MapType = Message<"google.api.expr.v1alpha1.Type.MapType"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Type key_type = 1;
    */
-  keyType?: Type;
+  keyType: Type;
 
   /**
    * The type of the value.
    *
    * @generated from field: google.api.expr.v1alpha1.Type value_type = 2;
    */
-  valueType?: Type;
+  valueType: Type;
 };
 
 /**
@@ -304,7 +304,7 @@ export type Type_FunctionType = Message<"google.api.expr.v1alpha1.Type.FunctionT
    *
    * @generated from field: google.api.expr.v1alpha1.Type result_type = 1;
    */
-  resultType?: Type;
+  resultType: Type;
 
   /**
    * Argument types of the function.
@@ -508,7 +508,7 @@ export type Decl = Message<"google.api.expr.v1alpha1.Decl"> & {
      */
     value: Decl_FunctionDecl;
     case: "function";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -534,7 +534,7 @@ export type Decl_IdentDecl = Message<"google.api.expr.v1alpha1.Decl.IdentDecl"> 
    *
    * @generated from field: google.api.expr.v1alpha1.Type type = 1;
    */
-  type?: Type;
+  type: Type;
 
   /**
    * The constant value of the identifier. If not specified, the identifier
@@ -542,7 +542,7 @@ export type Decl_IdentDecl = Message<"google.api.expr.v1alpha1.Decl.IdentDecl"> 
    *
    * @generated from field: google.api.expr.v1alpha1.Constant value = 2;
    */
-  value?: Constant;
+  value: Constant;
 
   /**
    * Documentation string for the identifier.
@@ -644,7 +644,7 @@ export type Decl_FunctionDecl_Overload = Message<"google.api.expr.v1alpha1.Decl.
    *
    * @generated from field: google.api.expr.v1alpha1.Type result_type = 4;
    */
-  resultType?: Type;
+  resultType: Type;
 
   /**
    * Whether the function is to be used in a method call-style `x.f(...)`
@@ -706,7 +706,7 @@ export type Reference = Message<"google.api.expr.v1alpha1.Reference"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Constant value = 4;
    */
-  value?: Constant;
+  value: Constant;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/eval_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/eval_pb.ts
@@ -164,7 +164,7 @@ export type ExprValue = Message<"google.api.expr.v1alpha1.ExprValue"> & {
      */
     value: UnknownSet;
     case: "unknown";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/syntax_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/syntax_pb.ts
@@ -39,14 +39,14 @@ export type ParsedExpr = Message<"google.api.expr.v1alpha1.ParsedExpr"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr expr = 2;
    */
-  expr?: Expr;
+  expr: Expr;
 
   /**
    * The source info derived from input that generated the parsed `expr`.
    *
    * @generated from field: google.api.expr.v1alpha1.SourceInfo source_info = 3;
    */
-  sourceInfo?: SourceInfo;
+  sourceInfo: SourceInfo;
 };
 
 /**
@@ -148,7 +148,7 @@ export type Expr = Message<"google.api.expr.v1alpha1.Expr"> & {
      */
     value: Expr_Comprehension;
     case: "comprehensionExpr";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -197,7 +197,7 @@ export type Expr_Select = Message<"google.api.expr.v1alpha1.Expr.Select"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr operand = 1;
    */
-  operand?: Expr;
+  operand: Expr;
 
   /**
    * Required. The name of the field to select.
@@ -240,7 +240,7 @@ export type Expr_Call = Message<"google.api.expr.v1alpha1.Expr.Call"> & {
    *
    * @generated from field: google.api.expr.v1alpha1.Expr target = 1;
    */
-  target?: Expr;
+  target: Expr;
 
   /**
    * Required. The name of the function or method being called.
@@ -369,7 +369,7 @@ export type Expr_CreateStruct_Entry = Message<"google.api.expr.v1alpha1.Expr.Cre
      */
     value: Expr;
     case: "mapKey";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * Required. The value assigned to the key.
@@ -380,7 +380,7 @@ export type Expr_CreateStruct_Entry = Message<"google.api.expr.v1alpha1.Expr.Cre
    *
    * @generated from field: google.api.expr.v1alpha1.Expr value = 4;
    */
-  value?: Expr;
+  value: Expr;
 
   /**
    * Whether the key-value pair is optional.
@@ -440,7 +440,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr iter_range = 2;
    */
-  iterRange?: Expr;
+  iterRange: Expr;
 
   /**
    * The name of the variable used for accumulation of the result.
@@ -454,7 +454,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr accu_init = 4;
    */
-  accuInit?: Expr;
+  accuInit: Expr;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -464,7 +464,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr loop_condition = 5;
    */
-  loopCondition?: Expr;
+  loopCondition: Expr;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -473,7 +473,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr loop_step = 6;
    */
-  loopStep?: Expr;
+  loopStep: Expr;
 
   /**
    * An expression which can contain accu_var.
@@ -482,7 +482,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1alpha1.Expr.Comprehe
    *
    * @generated from field: google.api.expr.v1alpha1.Expr result = 7;
    */
-  result?: Expr;
+  result: Expr;
 };
 
 /**
@@ -594,7 +594,7 @@ export type Constant = Message<"google.api.expr.v1alpha1.Constant"> & {
      */
     value: Timestamp;
     case: "timestampValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -712,7 +712,7 @@ export type SourceInfo_Extension = Message<"google.api.expr.v1alpha1.SourceInfo.
    *
    * @generated from field: google.api.expr.v1alpha1.SourceInfo.Extension.Version version = 3;
    */
-  version?: SourceInfo_Extension_Version;
+  version: SourceInfo_Extension_Version;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/value_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1alpha1/value_pb.ts
@@ -138,7 +138,7 @@ export type Value = Message<"google.api.expr.v1alpha1.Value"> & {
      */
     value: string;
     case: "typeValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -241,14 +241,14 @@ export type MapValue_Entry = Message<"google.api.expr.v1alpha1.MapValue.Entry"> 
    *
    * @generated from field: google.api.expr.v1alpha1.Value key = 1;
    */
-  key?: Value;
+  key: Value;
 
   /**
    * The value.
    *
    * @generated from field: google.api.expr.v1alpha1.Value value = 2;
    */
-  value?: Value;
+  value: Value;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/decl_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/decl_pb.ts
@@ -76,7 +76,7 @@ export type Decl = Message<"google.api.expr.v1beta1.Decl"> & {
      */
     value: FunctionDecl;
     case: "function";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -136,14 +136,14 @@ export type IdentDecl = Message<"google.api.expr.v1beta1.IdentDecl"> & {
    *
    * @generated from field: google.api.expr.v1beta1.DeclType type = 3;
    */
-  type?: DeclType;
+  type: DeclType;
 
   /**
    * Optional value of the identifier.
    *
    * @generated from field: google.api.expr.v1beta1.Expr value = 4;
    */
-  value?: Expr;
+  value: Expr;
 };
 
 /**
@@ -171,7 +171,7 @@ export type FunctionDecl = Message<"google.api.expr.v1beta1.FunctionDecl"> & {
    *
    * @generated from field: google.api.expr.v1beta1.DeclType return_type = 2;
    */
-  returnType?: DeclType;
+  returnType: DeclType;
 
   /**
    * If the first argument of the function is the receiver.

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/eval_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/eval_pb.ts
@@ -74,7 +74,7 @@ export type EvalState_Result = Message<"google.api.expr.v1beta1.EvalState.Result
    *
    * @generated from field: google.api.expr.v1beta1.IdRef expr = 1;
    */
-  expr?: IdRef;
+  expr: IdRef;
 
   /**
    * The index in `values` of the resulting value.
@@ -164,7 +164,7 @@ export type ExprValue = Message<"google.api.expr.v1beta1.ExprValue"> & {
      */
     value: UnknownSet;
     case: "unknown";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/expr_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/expr_pb.ts
@@ -41,14 +41,14 @@ export type ParsedExpr = Message<"google.api.expr.v1beta1.ParsedExpr"> & {
    *
    * @generated from field: google.api.expr.v1beta1.Expr expr = 2;
    */
-  expr?: Expr;
+  expr: Expr;
 
   /**
    * The source info derived from input that generated the parsed `expr`.
    *
    * @generated from field: google.api.expr.v1beta1.SourceInfo source_info = 3;
    */
-  sourceInfo?: SourceInfo;
+  sourceInfo: SourceInfo;
 
   /**
    * The syntax version of the source, e.g. `cel1`.
@@ -155,7 +155,7 @@ export type Expr = Message<"google.api.expr.v1beta1.Expr"> & {
      */
     value: Expr_Comprehension;
     case: "comprehensionExpr";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -203,7 +203,7 @@ export type Expr_Select = Message<"google.api.expr.v1beta1.Expr.Select"> & {
    *
    * @generated from field: google.api.expr.v1beta1.Expr operand = 1;
    */
-  operand?: Expr;
+  operand: Expr;
 
   /**
    * Required. The name of the field to select.
@@ -246,7 +246,7 @@ export type Expr_Call = Message<"google.api.expr.v1beta1.Expr.Call"> & {
    *
    * @generated from field: google.api.expr.v1beta1.Expr target = 1;
    */
-  target?: Expr;
+  target: Expr;
 
   /**
    * Required. The name of the function or method being called.
@@ -363,14 +363,14 @@ export type Expr_CreateStruct_Entry = Message<"google.api.expr.v1beta1.Expr.Crea
      */
     value: Expr;
     case: "mapKey";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * Required. The value assigned to the key.
    *
    * @generated from field: google.api.expr.v1beta1.Expr value = 4;
    */
-  value?: Expr;
+  value: Expr;
 };
 
 /**
@@ -423,7 +423,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr iter_range = 2;
    */
-  iterRange?: Expr;
+  iterRange: Expr;
 
   /**
    * The name of the variable used for accumulation of the result.
@@ -437,7 +437,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr accu_init = 4;
    */
-  accuInit?: Expr;
+  accuInit: Expr;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -447,7 +447,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr loop_condition = 5;
    */
-  loopCondition?: Expr;
+  loopCondition: Expr;
 
   /**
    * An expression which can contain iter_var and accu_var.
@@ -456,7 +456,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr loop_step = 6;
    */
-  loopStep?: Expr;
+  loopStep: Expr;
 
   /**
    * An expression which can contain accu_var.
@@ -465,7 +465,7 @@ export type Expr_Comprehension = Message<"google.api.expr.v1beta1.Expr.Comprehen
    *
    * @generated from field: google.api.expr.v1beta1.Expr result = 7;
    */
-  result?: Expr;
+  result: Expr;
 };
 
 /**
@@ -552,7 +552,7 @@ export type Literal = Message<"google.api.expr.v1beta1.Literal"> & {
      */
     value: Uint8Array;
     case: "bytesValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/value_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/expr/v1beta1/value_pb.ts
@@ -138,7 +138,7 @@ export type Value = Message<"google.api.expr.v1beta1.Value"> & {
      */
     value: string;
     case: "typeValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -241,14 +241,14 @@ export type MapValue_Entry = Message<"google.api.expr.v1beta1.MapValue.Entry"> &
    *
    * @generated from field: google.api.expr.v1beta1.Value key = 1;
    */
-  key?: Value;
+  key: Value;
 
   /**
    * The value.
    *
    * @generated from field: google.api.expr.v1beta1.Value value = 2;
    */
-  value?: Value;
+  value: Value;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/api/http_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/api/http_pb.ts
@@ -409,7 +409,7 @@ export type HttpRule = Message<"google.api.HttpRule"> & {
      */
     value: CustomHttpPattern;
     case: "custom";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * The name of the request field whose value is mapped to the HTTP request

--- a/packages/bundle-size/src/gen/protobuf-es/google/geo/type/viewport_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/geo/type/viewport_pb.ts
@@ -73,14 +73,14 @@ export type Viewport = Message<"google.geo.type.Viewport"> & {
    *
    * @generated from field: google.type.LatLng low = 1;
    */
-  low?: LatLng;
+  low: LatLng;
 
   /**
    * Required. The high point of the viewport.
    *
    * @generated from field: google.type.LatLng high = 2;
    */
-  high?: LatLng;
+  high: LatLng;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/longrunning/operations_pb.ts
@@ -56,7 +56,7 @@ export type Operation = Message<"google.longrunning.Operation"> & {
    *
    * @generated from field: google.protobuf.Any metadata = 2;
    */
-  metadata?: Any;
+  metadata: Any;
 
   /**
    * If the value is `false`, it means the operation is still in progress.
@@ -97,7 +97,7 @@ export type Operation = Message<"google.longrunning.Operation"> & {
      */
     value: Any;
     case: "response";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -260,7 +260,7 @@ export type WaitOperationRequest = Message<"google.longrunning.WaitOperationRequ
    *
    * @generated from field: google.protobuf.Duration timeout = 2;
    */
-  timeout?: Duration;
+  timeout: Duration;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/rpc/context/attribute_context_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/rpc/context/attribute_context_pb.ts
@@ -57,7 +57,7 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Peer origin = 7;
    */
-  origin?: AttributeContext_Peer;
+  origin: AttributeContext_Peer;
 
   /**
    * The source of a network activity, such as starting a TCP connection.
@@ -66,7 +66,7 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Peer source = 1;
    */
-  source?: AttributeContext_Peer;
+  source: AttributeContext_Peer;
 
   /**
    * The destination of a network activity, such as accepting a TCP connection.
@@ -75,21 +75,21 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Peer destination = 2;
    */
-  destination?: AttributeContext_Peer;
+  destination: AttributeContext_Peer;
 
   /**
    * Represents a network request, such as an HTTP request.
    *
    * @generated from field: google.rpc.context.AttributeContext.Request request = 3;
    */
-  request?: AttributeContext_Request;
+  request: AttributeContext_Request;
 
   /**
    * Represents a network response, such as an HTTP response.
    *
    * @generated from field: google.rpc.context.AttributeContext.Response response = 4;
    */
-  response?: AttributeContext_Response;
+  response: AttributeContext_Response;
 
   /**
    * Represents a target resource that is involved with a network activity.
@@ -98,14 +98,14 @@ export type AttributeContext = Message<"google.rpc.context.AttributeContext"> & 
    *
    * @generated from field: google.rpc.context.AttributeContext.Resource resource = 5;
    */
-  resource?: AttributeContext_Resource;
+  resource: AttributeContext_Resource;
 
   /**
    * Represents an API operation that is involved to a network activity.
    *
    * @generated from field: google.rpc.context.AttributeContext.Api api = 6;
    */
-  api?: AttributeContext_Api;
+  api: AttributeContext_Api;
 
   /**
    * Supports extensions for advanced use cases, such as logs and metrics.
@@ -296,7 +296,7 @@ export type AttributeContext_Auth = Message<"google.rpc.context.AttributeContext
    *
    * @generated from field: google.protobuf.Struct claims = 4;
    */
-  claims?: JsonObject;
+  claims: JsonObject;
 
   /**
    * A list of access level resource names that allow resources to be
@@ -387,7 +387,7 @@ export type AttributeContext_Request = Message<"google.rpc.context.AttributeCont
    *
    * @generated from field: google.protobuf.Timestamp time = 9;
    */
-  time?: Timestamp;
+  time: Timestamp;
 
   /**
    * The HTTP request size in bytes. If unknown, it must be -1.
@@ -420,7 +420,7 @@ export type AttributeContext_Request = Message<"google.rpc.context.AttributeCont
    *
    * @generated from field: google.rpc.context.AttributeContext.Auth auth = 13;
    */
-  auth?: AttributeContext_Auth;
+  auth: AttributeContext_Auth;
 };
 
 /**
@@ -466,7 +466,7 @@ export type AttributeContext_Response = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp time = 4;
    */
-  time?: Timestamp;
+  time: Timestamp;
 
   /**
    * The amount of time it takes the backend service to fully respond to a
@@ -476,7 +476,7 @@ export type AttributeContext_Response = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Duration backend_latency = 5;
    */
-  backendLatency?: Duration;
+  backendLatency: Duration;
 };
 
 /**
@@ -575,7 +575,7 @@ export type AttributeContext_Resource = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp create_time = 8;
    */
-  createTime?: Timestamp;
+  createTime: Timestamp;
 
   /**
    * Output only. The timestamp when the resource was last updated. Any
@@ -584,7 +584,7 @@ export type AttributeContext_Resource = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp update_time = 9;
    */
-  updateTime?: Timestamp;
+  updateTime: Timestamp;
 
   /**
    * Output only. The timestamp when the resource was deleted.
@@ -592,7 +592,7 @@ export type AttributeContext_Resource = Message<"google.rpc.context.AttributeCon
    *
    * @generated from field: google.protobuf.Timestamp delete_time = 10;
    */
-  deleteTime?: Timestamp;
+  deleteTime: Timestamp;
 
   /**
    * Output only. An opaque value that uniquely identifies a version or

--- a/packages/bundle-size/src/gen/protobuf-es/google/rpc/error_details_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/rpc/error_details_pb.ts
@@ -125,7 +125,7 @@ export type RetryInfo = Message<"google.rpc.RetryInfo"> & {
    *
    * @generated from field: google.protobuf.Duration retry_delay = 1;
    */
-  retryDelay?: Duration;
+  retryDelay: Duration;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/type/color_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/type/color_pb.ts
@@ -192,7 +192,7 @@ export type Color = Message<"google.type.Color"> & {
    *
    * @generated from field: google.protobuf.FloatValue alpha = 4;
    */
-  alpha?: number;
+  alpha: number;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/type/datetime_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/type/datetime_pb.ts
@@ -139,7 +139,7 @@ export type DateTime = Message<"google.type.DateTime"> & {
      */
     value: TimeZone;
     case: "timeZone";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/type/interval_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/type/interval_pb.ts
@@ -47,7 +47,7 @@ export type Interval = Message<"google.type.Interval"> & {
    *
    * @generated from field: google.protobuf.Timestamp start_time = 1;
    */
-  startTime?: Timestamp;
+  startTime: Timestamp;
 
   /**
    * Optional. Exclusive end of the interval.
@@ -57,7 +57,7 @@ export type Interval = Message<"google.type.Interval"> & {
    *
    * @generated from field: google.protobuf.Timestamp end_time = 2;
    */
-  endTime?: Timestamp;
+  endTime: Timestamp;
 };
 
 /**

--- a/packages/bundle-size/src/gen/protobuf-es/google/type/phone_number_pb.ts
+++ b/packages/bundle-size/src/gen/protobuf-es/google/type/phone_number_pb.ts
@@ -97,7 +97,7 @@ export type PhoneNumber = Message<"google.type.PhoneNumber"> & {
      */
     value: PhoneNumber_ShortCode;
     case: "shortCode";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * The phone number's extension. The extension is not standardized in ITU

--- a/packages/protobuf-test/src/binary.test.ts
+++ b/packages/protobuf-test/src/binary.test.ts
@@ -144,8 +144,8 @@ void suite(`binary serialization`, () => {
         toggle: false,
       },
     },
-    scalar: { case: undefined },
-    enum: { case: undefined },
+    scalar: { case: "" },
+    enum: { case: "" },
   });
   testBinary(JsonNamesMessageSchema, {
     a: "a",

--- a/packages/protobuf-test/src/create.test.ts
+++ b/packages/protobuf-test/src/create.test.ts
@@ -144,7 +144,7 @@ void suite("create()", () => {
         assert.strictEqual(hasOwn("optionalWrappedUint32Field"), false);
 
         // oneof
-        assert.deepStrictEqual(msg.either, { case: undefined });
+        assert.deepStrictEqual(msg.either, { case: "" });
         assert.strictEqual(hasOwn("either"), true);
 
         // map
@@ -337,7 +337,7 @@ void suite("create()", () => {
         assert.strictEqual(hasOwn("optionalWrappedUint32Field"), false);
 
         // oneof
-        assert.deepStrictEqual(msg.either, { case: undefined });
+        assert.deepStrictEqual(msg.either, { case: "" });
         assert.strictEqual(hasOwn("either"), true);
 
         // map
@@ -536,7 +536,7 @@ void suite("create()", () => {
         assert.strictEqual(hasOwn("repeatedWrappedUint32Field"), true);
 
         // oneof
-        assert.deepStrictEqual(msg.either, { case: undefined });
+        assert.deepStrictEqual(msg.either, { case: "" });
         assert.strictEqual(hasOwn("either"), true);
 
         // map

--- a/packages/protobuf-test/src/gen/js,json_types/extra/json_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js,json_types/extra/json_types_pb.d.ts
@@ -57,42 +57,42 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField: JsonTypesMessage;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField: Duration;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField: Empty;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField: Value;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField: ListValue;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -102,52 +102,52 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField: Timestamp;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField: number;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField: boolean;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField: Uint8Array;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;
@@ -174,7 +174,7 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
      */
     value: string;
     case: "oneofBoolField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: bool json_name_ok = 29 [json_name = "Foo123_bar$"];
@@ -225,183 +225,183 @@ export declare type JsonTypesMessageJson = {
   /**
    * @generated from field: bool bool_field = 1 [json_name = "booleanFieldWithCustomName"];
    */
-  booleanFieldWithCustomName?: boolean;
+  booleanFieldWithCustomName: boolean;
 
   /**
    * @generated from field: double double_field = 2;
    */
-  doubleField?: number | "NaN" | "Infinity" | "-Infinity";
+  doubleField: number | "NaN" | "Infinity" | "-Infinity";
 
   /**
    * @generated from field: bytes bytes_field = 3;
    */
-  bytesField?: string;
+  bytesField: string;
 
   /**
    * @generated from field: int64 int64_field = 4;
    */
-  int64Field?: string;
+  int64Field: string;
 
   /**
    * @generated from field: spec.JsonTypeEnum enum_field = 5;
    */
-  enumField?: JsonTypeEnumJson;
+  enumField: JsonTypeEnumJson;
 
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessageJson;
+  messageField: JsonTypesMessageJson;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: AnyJson;
+  anyField: AnyJson;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: DurationJson;
+  durationField: DurationJson;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: EmptyJson;
+  emptyField: EmptyJson;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMaskJson;
+  fieldMaskField: FieldMaskJson;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: StructJson;
+  structField: StructJson;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: ValueJson;
+  valueField: ValueJson;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValueJson;
+  listValueField: ListValueJson;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
    */
-  nullValueField?: NullValueJson;
+  nullValueField: NullValueJson;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: TimestampJson;
+  timestampField: TimestampJson;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: DoubleValueJson;
+  wrappedDoubleField: DoubleValueJson;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: FloatValueJson;
+  wrappedFloatField: FloatValueJson;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: Int64ValueJson;
+  wrappedInt64Field: Int64ValueJson;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: UInt64ValueJson;
+  wrappedUint64Field: UInt64ValueJson;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: Int32ValueJson;
+  wrappedInt32Field: Int32ValueJson;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: UInt32ValueJson;
+  wrappedUint32Field: UInt32ValueJson;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: BoolValueJson;
+  wrappedBoolField: BoolValueJson;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: StringValueJson;
+  wrappedStringField: StringValueJson;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: BytesValueJson;
+  wrappedBytesField: BytesValueJson;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;
    */
-  repeatedEnumField?: JsonTypeEnumJson[];
+  repeatedEnumField: JsonTypeEnumJson[];
 
   /**
    * @generated from field: map<bool, spec.JsonTypeEnum> map_bool_enum_field = 26;
    */
-  mapBoolEnumField?: { [key: string]: JsonTypeEnumJson };
+  mapBoolEnumField: { [key: string]: JsonTypeEnumJson };
 
   /**
    * @generated from field: string oneof_string_field = 27;
    */
-  oneofStringField?: string;
+  oneofStringField: string;
 
   /**
    * @generated from field: string oneof_bool_field = 28;
    */
-  oneofBoolField?: string;
+  oneofBoolField: string;
 
   /**
    * @generated from field: bool json_name_ok = 29 [json_name = "Foo123_bar$"];
    */
-  Foo123_bar$?: boolean;
+  Foo123_bar$: boolean;
 
   /**
    * @generated from field: bool json_name_at = 30 [json_name = "foo@"];
    */
-  "foo@"?: boolean;
+  "foo@": boolean;
 
   /**
    * @generated from field: bool json_name_hyphen = 31 [json_name = "foo-bar"];
    */
-  "foo-bar"?: boolean;
+  "foo-bar": boolean;
 
   /**
    * @generated from field: bool json_name_start_with_digit = 32 [json_name = "1foo"];
    */
-  "1foo"?: boolean;
+  "1foo": boolean;
 
   /**
    * @generated from field: bool json_name_space = 33 [json_name = "foo bar"];
    */
-  "foo bar"?: boolean;
+  "foo bar": boolean;
 
   /**
    * @generated from field: bool json_name_tab = 34 [json_name = "foo	bar"];
    */
-  "foo	bar"?: boolean;
+  "foo	bar": boolean;
 
   /**
    * @generated from field: bool json_name_non_ascii = 35 [json_name = "你好"];
    */
-  "你好"?: boolean;
+  "你好": boolean;
 
   /**
    * @generated from field: bool json_name_escape = 36 [json_name = "foo
    * bar\n"];
    */
-  "foo\nbar\\n"?: boolean;
+  "foo\nbar\\n": boolean;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js,valid_types/extra/minimal-validate_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js,valid_types/extra/minimal-validate_pb.d.ts
@@ -97,7 +97,7 @@ export declare type FieldRules = Message<"buf.validate.FieldRules"> & {
      */
     value: MapRules;
     case: "map";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 export declare type FieldRulesValid = FieldRules;
@@ -115,7 +115,7 @@ export declare type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items: FieldRules;
 };
 
 export declare type RepeatedRulesValid = RepeatedRules;
@@ -133,7 +133,7 @@ export declare type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values: FieldRules;
 };
 
 export declare type MapRulesValid = MapRules;

--- a/packages/protobuf-test/src/gen/js,valid_types/extra/valid_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js,valid_types/extra/valid_types_pb.d.ts
@@ -36,7 +36,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -45,7 +45,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -54,7 +54,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -63,14 +63,14 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated: VTypes_Other;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -165,7 +165,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -174,7 +174,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -182,7 +182,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt: Timestamp;
 };
 
 /**
@@ -196,7 +196,7 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_OtherValid;
+  msg: VTypes_OtherValid;
 
   /**
    * In the generated valid type, this property should:
@@ -214,7 +214,7 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -223,14 +223,14 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_OtherValid;
+  msgIgnoreUnpopulated: VTypes_OtherValid;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_OtherValid;
+  msgIgnoreDefault: VTypes_OtherValid;
 
   /**
    * In the generated valid type, this property should:
@@ -342,7 +342,7 @@ export declare type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt: Timestamp;
 };
 
 /**
@@ -377,7 +377,7 @@ export declare type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg: VTypes;
 };
 
 /**
@@ -392,7 +392,7 @@ export declare type VTypes2Valid = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypesValid;
+  msg: VTypesValid;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/editions/golden/test_messages_proto3_editions_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/editions/golden/test_messages_proto3_editions_pb.d.ts
@@ -119,12 +119,12 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage: TestAllTypesProto3_NestedMessage;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -154,7 +154,7 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage: TestAllTypesProto3;
 
   /**
    * Repeated
@@ -567,54 +567,54 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
      */
     value: NullValue;
     case: "oneofNullValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * Well-known types
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper: boolean;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper: number;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper: number;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper: Uint8Array;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -664,32 +664,32 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.edition
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration: Duration;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp: Timestamp;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny: Any;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue: Value;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -843,7 +843,7 @@ export declare type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive: TestAllTypesProto3;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/comments_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/comments_pb.d.ts
@@ -74,7 +74,7 @@ export declare type MessageWithComments = Message<"spec.MessageWithComments"> & 
      */
     value: string;
     case: "error";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: string this_field_has_an_empty_comment = 4;

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-proto2_pb.d.ts
@@ -48,7 +48,7 @@ export declare type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageFor
   /**
    * @generated from field: optional spec.Proto2MessageForEdition2023.OptionalGroup optionalgroup = 4;
    */
-  optionalgroup?: Proto2MessageForEdition2023_OptionalGroup;
+  optionalgroup: Proto2MessageForEdition2023_OptionalGroup;
 
   /**
    * @generated from field: required bool required_bool_field = 5;
@@ -68,7 +68,7 @@ export declare type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageFor
   /**
    * @generated from field: required spec.Proto2MessageForEdition2023.RequiredGroup requiredgroup = 8;
    */
-  requiredgroup?: Proto2MessageForEdition2023_RequiredGroup;
+  requiredgroup: Proto2MessageForEdition2023_RequiredGroup;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/js/extra/edition2023-proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023-proto3_pb.d.ts
@@ -43,12 +43,12 @@ export declare type Proto3MessageForEdition2023 = Message<"spec.Proto3MessageFor
   /**
    * @generated from field: optional bool explicit_bool_field = 5;
    */
-  explicitBoolField?: boolean;
+  explicitBoolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto3EnumForEdition2023 explicit_open_enum_field = 6;
    */
-  explicitOpenEnumField?: Proto3EnumForEdition2023;
+  explicitOpenEnumField: Proto3EnumForEdition2023;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/js/extra/edition2023_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/edition2023_pb.d.ts
@@ -84,17 +84,17 @@ export declare type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message explicit_message_field = 311;
    */
-  explicitMessageField?: Edition2023Message;
+  explicitMessageField: Edition2023Message;
 
   /**
    * @generated from field: spec.Edition2023Message explicit_message_delimited_field = 312 [features.message_encoding = DELIMITED];
    */
-  explicitMessageDelimitedField?: Edition2023Message;
+  explicitMessageDelimitedField: Edition2023Message;
 
   /**
    * @generated from field: google.protobuf.UInt32Value explicit_wrapped_uint32_field = 313;
    */
-  explicitWrappedUint32Field?: number;
+  explicitWrappedUint32Field: number;
 
   /**
    * @generated from field: string implicit_string_field = 201 [features.field_presence = IMPLICIT];
@@ -194,17 +194,17 @@ export declare type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_field = 11 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessageField?: Edition2023Message_Child;
+  requiredMessageField: Edition2023Message_Child;
 
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_delimited_field = 12 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  requiredMessageDelimitedField?: Edition2023Message_Child;
+  requiredMessageDelimitedField: Edition2023Message_Child;
 
   /**
    * @generated from field: google.protobuf.UInt32Value required_wrapped_uint32_field = 13 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field: number;
 
   /**
    * @generated from field: string required_default_string_field = 101 [default = "hello \" *\/ ", features.field_presence = LEGACY_REQUIRED];
@@ -432,7 +432,7 @@ export declare type Edition2023Message = Message<"spec.Edition2023Message"> & {
      */
     value: UInt32Value;
     case: "oneofWrappedUint32Field";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_string_string_field = 601;
@@ -519,7 +519,7 @@ export declare type Edition2023FromProto2Message = Message<"spec.Edition2023From
   /**
    * @generated from field: spec.Edition2023FromProto2Message.OptionalGroup optionalgroup = 4 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: Edition2023FromProto2Message_OptionalGroup;
+  optionalgroup: Edition2023FromProto2Message_OptionalGroup;
 
   /**
    * @generated from field: bool required_bool_field = 5 [features.field_presence = LEGACY_REQUIRED];
@@ -539,7 +539,7 @@ export declare type Edition2023FromProto2Message = Message<"spec.Edition2023From
   /**
    * @generated from field: spec.Edition2023FromProto2Message.RequiredGroup requiredgroup = 8 [features.message_encoding = DELIMITED];
    */
-  requiredgroup?: Edition2023FromProto2Message_RequiredGroup;
+  requiredgroup: Edition2023FromProto2Message_RequiredGroup;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [features.repeated_field_encoding = PACKED];

--- a/packages/protobuf-test/src/gen/js/extra/example-service_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/example-service_pb.d.ts
@@ -53,7 +53,7 @@ export declare type CreateUserResponse = Message<"example.CreateUserResponse"> &
   /**
    * @generated from field: example.User user = 1;
    */
-  user?: User;
+  user: User;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/example_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/example_pb.d.ts
@@ -46,7 +46,7 @@ export declare type User = Message<"example.User"> & {
   /**
    * @generated from field: example.User manager = 4;
    */
-  manager?: User;
+  manager: User;
 
   /**
    * @generated from field: repeated string locations = 5;

--- a/packages/protobuf-test/src/gen/js/extra/json_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/json_types_pb.d.ts
@@ -57,42 +57,42 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField: JsonTypesMessage;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField: Duration;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField: Empty;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField: Value;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField: ListValue;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -102,52 +102,52 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField: Timestamp;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField: number;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField: boolean;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField: Uint8Array;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;
@@ -174,7 +174,7 @@ export declare type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
      */
     value: string;
     case: "oneofBoolField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: bool json_name_ok = 29 [json_name = "Foo123_bar$"];

--- a/packages/protobuf-test/src/gen/js/extra/minimal-validate_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/minimal-validate_pb.d.ts
@@ -93,7 +93,7 @@ export declare type FieldRules = Message<"buf.validate.FieldRules"> & {
      */
     value: MapRules;
     case: "map";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -109,7 +109,7 @@ export declare type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items: FieldRules;
 };
 
 /**
@@ -125,7 +125,7 @@ export declare type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values: FieldRules;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/msg-message_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-message_pb.d.ts
@@ -31,7 +31,7 @@ export declare type MessageFieldMessage = Message<"spec.MessageFieldMessage"> & 
   /**
    * @generated from field: spec.MessageFieldMessage.TestMessage message_field = 1;
    */
-  messageField?: MessageFieldMessage_TestMessage;
+  messageField: MessageFieldMessage_TestMessage;
 
   /**
    * @generated from field: repeated spec.MessageFieldMessage.TestMessage repeated_message_field = 2;

--- a/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/msg-oneof_pb.d.ts
@@ -49,7 +49,7 @@ export declare type OneofMessage = Message<"spec.OneofMessage"> & {
      */
     value: Uint8Array;
     case: "bytes";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof spec.OneofMessage.message
@@ -72,7 +72,7 @@ export declare type OneofMessage = Message<"spec.OneofMessage"> & {
      */
     value: OneofMessageBar;
     case: "baz";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof spec.OneofMessage.enum
@@ -83,7 +83,7 @@ export declare type OneofMessage = Message<"spec.OneofMessage"> & {
      */
     value: OneofEnum;
     case: "e";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/name-clash_pb.d.ts
@@ -36,7 +36,7 @@ export declare type User = Message$1<"spec.User"> & {
    *
    * @generated from field: example.User u = 1;
    */
-  u?: User$1;
+  u: User$1;
 };
 
 /**
@@ -201,7 +201,7 @@ export declare type ReservedPropertyNames_OneofBultIn = Message$1<"spec.Reserved
      */
     value: string;
     case: "valueOf";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -271,7 +271,7 @@ export declare type ReservedPropertyNames_OneofRuntime = Message$1<"spec.Reserve
      */
     value: string;
     case: "toJsonString";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -900,7 +900,7 @@ export declare type NoClashOneof = Message$1<"spec.NoClashOneof"> & {
      */
     value: string;
     case: "return";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -916,7 +916,7 @@ export declare type NoClashOneofADT = Message$1<"spec.NoClashOneofADT"> & {
   /**
    * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  m?: NoClashOneofADT_M;
+  m: NoClashOneofADT_M;
 };
 
 /**
@@ -937,7 +937,7 @@ export declare type NoClashOneofADT_M = Message$1<"spec.NoClashOneofADT.M"> & {
   /**
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value: string;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/option-usage_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/option-usage_pb.d.ts
@@ -42,7 +42,7 @@ export declare type MessageWithOptions = Message<"spec.MessageWithOptions"> & {
      */
     value: number;
     case: "oneofField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/perf_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/perf_pb.d.ts
@@ -46,12 +46,12 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: optional int64 int64_field = 3;
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional bool bool_field = 4;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: string string_field = 5;
@@ -71,7 +71,7 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: perf.v1.PerfMessage small_message_field = 8;
    */
-  smallMessageField?: PerfMessage;
+  smallMessageField: PerfMessage;
 
   /**
    * @generated from field: int32 unused_field_1 = 9;
@@ -208,7 +208,7 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
      */
     value: PerfEnum;
     case: "oneofEnumCromulent";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof perf.v1.PerfMessage.oneof_message
@@ -225,7 +225,7 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
      */
     value: PerfMessage;
     case: "oneofSmallMessageField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof perf.v1.PerfMessage.oneof_scalar
@@ -242,7 +242,7 @@ export declare type PerfMessage = Message<"perf.v1.PerfMessage"> & {
      */
     value: boolean;
     case: "oneofBoolField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: uint32 id = 40;

--- a/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto2_pb.d.ts
@@ -79,17 +79,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_message_field = 8;
    */
-  requiredMessageField?: Proto2Message;
+  requiredMessageField: Proto2Message;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredGroup requiredgroup = 9;
    */
-  requiredgroup?: Proto2Message_RequiredGroup;
+  requiredgroup: Proto2Message_RequiredGroup;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_wrapped_uint32_field = 201;
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field: number;
 
   /**
    * @generated from field: required string required_default_string_field = 10 [default = "hello \" *\/ "];
@@ -139,17 +139,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_default_message_field = 17;
    */
-  requiredDefaultMessageField?: Proto2Message;
+  requiredDefaultMessageField: Proto2Message;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredDefaultGroup requireddefaultgroup = 18;
    */
-  requireddefaultgroup?: Proto2Message_RequiredDefaultGroup;
+  requireddefaultgroup: Proto2Message_RequiredDefaultGroup;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_default_wrapped_uint32_field = 202;
    */
-  requiredDefaultWrappedUint32Field?: number;
+  requiredDefaultWrappedUint32Field: number;
 
   /**
    * @generated from field: optional string optional_string_field = 19;
@@ -199,17 +199,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_message_field = 26;
    */
-  optionalMessageField?: Proto2Message;
+  optionalMessageField: Proto2Message;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalGroup optionalgroup = 27;
    */
-  optionalgroup?: Proto2Message_OptionalGroup;
+  optionalgroup: Proto2Message_OptionalGroup;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 207;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field: number;
 
   /**
    * @generated from field: optional string optional_default_string_field = 28 [default = "hello \" *\/ "];
@@ -259,17 +259,17 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_default_message_field = 35;
    */
-  optionalDefaultMessageField?: Proto2Message;
+  optionalDefaultMessageField: Proto2Message;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalDefaultGroup optionaldefaultgroup = 36;
    */
-  optionaldefaultgroup?: Proto2Message_OptionalDefaultGroup;
+  optionaldefaultgroup: Proto2Message_OptionalDefaultGroup;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_default_wrapped_uint32_field = 203;
    */
-  optionalDefaultWrappedUint32Field?: number;
+  optionalDefaultWrappedUint32Field: number;
 
   /**
    * @generated from field: repeated string repeated_string_field = 37;
@@ -436,7 +436,7 @@ export declare type Proto2Message = Message<"spec.Proto2Message"> & {
      */
     value: UInt32Value;
     case: "oneofWrappedUint32Field";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_string_string_field = 70;

--- a/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/proto3_pb.d.ts
@@ -79,77 +79,77 @@ export declare type Proto3Message = Message<"spec.Proto3Message"> & {
   /**
    * @generated from field: spec.Proto3Message singular_message_field = 8;
    */
-  singularMessageField?: Proto3Message;
+  singularMessageField: Proto3Message;
 
   /**
    * @generated from field: google.protobuf.UInt32Value singular_wrapped_uint32_field = 211;
    */
-  singularWrappedUint32Field?: number;
+  singularWrappedUint32Field: number;
 
   /**
    * @generated from field: google.protobuf.Struct singular_struct_field = 214;
    */
-  singularStructField?: JsonObject;
+  singularStructField: JsonObject;
 
   /**
    * @generated from field: optional string optional_string_field = 9;
    */
-  optionalStringField?: string;
+  optionalStringField: string;
 
   /**
    * @generated from field: optional bytes optional_bytes_field = 10;
    */
-  optionalBytesField?: Uint8Array;
+  optionalBytesField: Uint8Array;
 
   /**
    * @generated from field: optional int32 optional_int32_field = 11;
    */
-  optionalInt32Field?: number;
+  optionalInt32Field: number;
 
   /**
    * @generated from field: optional int64 optional_int64_field = 12;
    */
-  optionalInt64Field?: bigint;
+  optionalInt64Field: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_js_number_field = 106 [jstype = JS_NUMBER];
    */
-  optionalInt64JsNumberField?: bigint;
+  optionalInt64JsNumberField: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_js_string_field = 105 [jstype = JS_STRING];
    */
-  optionalInt64JsStringField?: string;
+  optionalInt64JsStringField: string;
 
   /**
    * @generated from field: optional float optional_float_field = 13;
    */
-  optionalFloatField?: number;
+  optionalFloatField: number;
 
   /**
    * @generated from field: optional bool optional_bool_field = 14;
    */
-  optionalBoolField?: boolean;
+  optionalBoolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto3Enum optional_enum_field = 15;
    */
-  optionalEnumField?: Proto3Enum;
+  optionalEnumField: Proto3Enum;
 
   /**
    * @generated from field: optional spec.Proto3Message optional_message_field = 16;
    */
-  optionalMessageField?: Proto3Message;
+  optionalMessageField: Proto3Message;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 212;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field: number;
 
   /**
    * @generated from field: optional google.protobuf.Struct optional_struct_field = 215;
    */
-  optionalStructField?: JsonObject;
+  optionalStructField: JsonObject;
 
   /**
    * @generated from field: repeated string repeated_string_field = 17;
@@ -316,7 +316,7 @@ export declare type Proto3Message = Message<"spec.Proto3Message"> & {
      */
     value: JsonObject;
     case: "oneofStructField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_string_string_field = 39;

--- a/packages/protobuf-test/src/gen/js/extra/ts-types-proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/ts-types-proto2_pb.d.ts
@@ -36,7 +36,7 @@ export declare type TsTypeA = Message<"spec.TsTypeA"> & {
   /**
    * @generated from field: optional spec.TsTypeA child = 2;
    */
-  child?: TsTypeA;
+  child: TsTypeA;
 };
 
 /**
@@ -57,7 +57,7 @@ export declare type TsTypeB = Message<"spec.TsTypeB"> & {
   /**
    * @generated from field: optional spec.TsTypeB child = 2;
    */
-  child?: TsTypeB;
+  child: TsTypeB;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/valid_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/valid_types_pb.d.ts
@@ -36,7 +36,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -45,7 +45,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -54,7 +54,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -63,14 +63,14 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated: VTypes_Other;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -165,7 +165,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -174,7 +174,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -182,7 +182,7 @@ export declare type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt: Timestamp;
 };
 
 /**
@@ -215,7 +215,7 @@ export declare type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg: VTypes;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/extra/wkt-wrappers_pb.d.ts
@@ -34,47 +34,47 @@ export declare type WrappersMessage = Message<"spec.WrappersMessage"> & {
   /**
    * @generated from field: google.protobuf.DoubleValue double_value_field = 1;
    */
-  doubleValueField?: number;
+  doubleValueField: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_value_field = 2;
    */
-  boolValueField?: boolean;
+  boolValueField: boolean;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_value_field = 3;
    */
-  floatValueField?: number;
+  floatValueField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_value_field = 4;
    */
-  int64ValueField?: bigint;
+  int64ValueField: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_value_field = 5;
    */
-  uint64ValueField?: bigint;
+  uint64ValueField: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_value_field = 6;
    */
-  int32ValueField?: number;
+  int32ValueField: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_value_field = 7;
    */
-  uint32ValueField?: number;
+  uint32ValueField: number;
 
   /**
    * @generated from field: google.protobuf.StringValue string_value_field = 8;
    */
-  stringValueField?: string;
+  stringValueField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_value_field = 9;
    */
-  bytesValueField?: Uint8Array;
+  bytesValueField: Uint8Array;
 
   /**
    * @generated from oneof spec.WrappersMessage.oneof_fields
@@ -134,7 +134,7 @@ export declare type WrappersMessage = Message<"spec.WrappersMessage"> & {
      */
     value: BytesValue;
     case: "oneofBytesValueField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: repeated google.protobuf.DoubleValue repeated_double_value_field = 21;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/map_proto2_unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/map_proto2_unittest_pb.d.ts
@@ -309,7 +309,7 @@ export declare type TestSubmessageMaps = Message<"proto2_unittest.TestSubmessage
   /**
    * @generated from field: optional proto2_unittest.TestMaps m = 1;
    */
-  m?: TestMaps;
+  m: TestMaps;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto2_pb.d.ts
@@ -118,12 +118,12 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage: TestAllTypesProto2_NestedMessage;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage: ForeignMessageProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -148,7 +148,7 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage: TestAllTypesProto2;
 
   /**
    * Repeated
@@ -565,17 +565,17 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
      */
     value: TestAllTypesProto2_NestedEnum;
     case: "oneofEnum";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data: TestAllTypesProto2_Data;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield: TestAllTypesProto2_MultiWordGroupField;
 
   /**
    * default values
@@ -750,7 +750,7 @@ export declare type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect: TestAllTypesProto2_MessageSetCorrect;
 };
 
 /**
@@ -771,7 +771,7 @@ export declare type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive: TestAllTypesProto2;
 };
 
 /**
@@ -899,7 +899,7 @@ export declare type TestAllTypesProto2_ExtensionWithOneof = Message<"protobuf_te
      */
     value: number;
     case: "b";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -999,12 +999,12 @@ export declare type UnknownToTestAllTypes = Message<"protobuf_test_messages.prot
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage: ForeignMessageProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup: UnknownToTestAllTypes_OptionalGroup;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1209,12 +1209,12 @@ export declare type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage: TestAllRequiredTypesProto2_NestedMessage;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage: ForeignMessageProto2;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1239,17 +1239,17 @@ export declare type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage: TestAllRequiredTypesProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage: TestAllRequiredTypesProto2;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data: TestAllRequiredTypesProto2_Data;
 
   /**
    * default values
@@ -1347,12 +1347,12 @@ export declare type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive: TestAllRequiredTypesProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive: TestAllRequiredTypesProto2;
 };
 
 /**
@@ -1509,7 +1509,7 @@ export declare type TestLargeOneof = Message<"protobuf_test_messages.proto2.Test
      */
     value: TestLargeOneof_A5;
     case: "a5";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/test_messages_proto3_pb.d.ts
@@ -118,12 +118,12 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage: TestAllTypesProto3_NestedMessage;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -153,7 +153,7 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage: TestAllTypesProto3;
 
   /**
    * Repeated
@@ -566,54 +566,54 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
      */
     value: NullValue;
     case: "oneofNullValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * Well-known types
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper: boolean;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper: number;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper: number;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper: Uint8Array;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -663,32 +663,32 @@ export declare type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration: Duration;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp: Timestamp;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny: Any;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue: Value;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -842,7 +842,7 @@ export declare type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive: TestAllTypesProto3;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/type_pb.d.ts
@@ -69,7 +69,7 @@ export declare type Type = Message<"google.protobuf.Type"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * The source syntax.
@@ -404,7 +404,7 @@ export declare type Enum = Message<"google.protobuf.Enum"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * The source syntax.
@@ -495,7 +495,7 @@ export declare type Option = Message<"google.protobuf.Option"> & {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value: Any;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_custom_options_pb.d.ts
@@ -55,7 +55,7 @@ export declare type TestMessageWithCustomOptions = Message<"proto2_unittest.Test
      */
     value: number;
     case: "oneofField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_field = 3;
@@ -330,7 +330,7 @@ export declare type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionT
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType1 bar = 1;
    */
-  bar?: ComplexOptionType1;
+  bar: ComplexOptionType1;
 
   /**
    * @generated from field: optional int32 baz = 2;
@@ -340,7 +340,7 @@ export declare type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionT
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
    */
-  fred?: ComplexOptionType2_ComplexOptionType4;
+  fred: ComplexOptionType2_ComplexOptionType4;
 
   /**
    * @generated from field: repeated proto2_unittest.ComplexOptionType2.ComplexOptionType4 barney = 4;
@@ -387,7 +387,7 @@ export declare type ComplexOptionType3 = Message<"proto2_unittest.ComplexOptionT
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
    */
-  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5;
+  complexoptiontype5: ComplexOptionType3_ComplexOptionType5;
 };
 
 /**
@@ -496,28 +496,28 @@ export declare type Aggregate = Message<"proto2_unittest.Aggregate"> & {
    *
    * @generated from field: optional proto2_unittest.Aggregate sub = 3;
    */
-  sub?: Aggregate;
+  sub: Aggregate;
 
   /**
    * To test the parsing of extensions inside aggregate values
    *
    * @generated from field: optional google.protobuf.FileOptions file = 4;
    */
-  file?: FileOptions;
+  file: FileOptions;
 
   /**
    * An embedded message set
    *
    * @generated from field: optional proto2_unittest.AggregateMessageSet mset = 5;
    */
-  mset?: AggregateMessageSet;
+  mset: AggregateMessageSet;
 
   /**
    * An any
    *
    * @generated from field: optional google.protobuf.Any any = 6;
    */
-  any?: Any;
+  any: Any;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_embed_optimize_for_pb.d.ts
@@ -41,7 +41,7 @@ export declare type TestEmbedOptimizedForSize = Message<"proto2_unittest.TestEmb
    *
    * @generated from field: optional proto2_unittest.TestOptimizedForSize optional_message = 1;
    */
-  optionalMessage?: TestOptimizedForSize;
+  optionalMessage: TestOptimizedForSize;
 
   /**
    * @generated from field: repeated proto2_unittest.TestOptimizedForSize repeated_message = 2;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_extension_set_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_extension_set_pb.d.ts
@@ -51,7 +51,7 @@ export declare type TestExtensionSetContainer = Message<"proto2_unittest.TestExt
   /**
    * @generated from field: optional proto2_unittest.TestExtensionSet extension = 1;
    */
-  extension?: TestExtensionSet;
+  extension: TestExtensionSet;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_lite_imports_nonlite_pb.d.ts
@@ -36,14 +36,14 @@ export declare type TestLiteImportsNonlite = Message<"proto2_unittest.TestLiteIm
   /**
    * @generated from field: optional proto2_unittest.TestAllTypes message = 1;
    */
-  message?: TestAllTypes;
+  message: TestAllTypes;
 
   /**
    * Verifies that transitive required fields generates valid code.
    *
    * @generated from field: optional proto2_unittest.TestRequired message_with_required = 2;
    */
-  messageWithRequired?: TestRequired;
+  messageWithRequired: TestRequired;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_pb.d.ts
@@ -39,7 +39,7 @@ export declare type TestMessageSetContainer = Message<"proto2_unittest.TestMessa
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet: TestMessageSet;
 };
 
 /**
@@ -55,17 +55,17 @@ export declare type NestedTestMessageSetContainer = Message<"proto2_unittest.Nes
   /**
    * @generated from field: optional proto2_unittest.TestMessageSetContainer container = 1;
    */
-  container?: TestMessageSetContainer;
+  container: TestMessageSetContainer;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer child = 2;
    */
-  child?: NestedTestMessageSetContainer;
+  child: NestedTestMessageSetContainer;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer lazy_child = 3;
    */
-  lazyChild?: NestedTestMessageSetContainer;
+  lazyChild: NestedTestMessageSetContainer;
 };
 
 /**
@@ -91,7 +91,7 @@ export declare type NestedTestInt = Message<"proto2_unittest.NestedTestInt"> & {
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt child = 2;
    */
-  child?: NestedTestInt;
+  child: NestedTestInt;
 };
 
 /**
@@ -112,7 +112,7 @@ export declare type TestMessageSetExtension1 = Message<"proto2_unittest.TestMess
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
    */
-  recursive?: TestMessageSet;
+  recursive: TestMessageSet;
 
   /**
    * @generated from field: optional string test_aliasing = 17;
@@ -159,7 +159,7 @@ export declare type TestMessageSetExtension3 = Message<"proto2_unittest.TestMess
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt msg = 35;
    */
-  msg?: NestedTestInt;
+  msg: NestedTestInt;
 
   /**
    * @generated from field: required int32 required_int = 36;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_mset_wire_format_pb.d.ts
@@ -51,7 +51,7 @@ export declare type TestMessageSetWireFormatContainer = Message<"proto2_wireform
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet: TestMessageSet;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_optimize_for_pb.d.ts
@@ -43,7 +43,7 @@ export declare type TestOptimizedForSize = Message<"proto2_unittest.TestOptimize
   /**
    * @generated from field: optional proto2_unittest.ForeignMessage msg = 19;
    */
-  msg?: ForeignMessage;
+  msg: ForeignMessage;
 
   /**
    * @generated from oneof proto2_unittest.TestOptimizedForSize.foo
@@ -60,7 +60,7 @@ export declare type TestOptimizedForSize = Message<"proto2_unittest.TestOptimize
      */
     value: string;
     case: "stringField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -102,7 +102,7 @@ export declare type TestOptionalOptimizedForSize = Message<"proto2_unittest.Test
   /**
    * @generated from field: optional proto2_unittest.TestRequiredOptimizedForSize o = 1;
    */
-  o?: TestRequiredOptimizedForSize;
+  o: TestRequiredOptimizedForSize;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_pb.d.ts
@@ -128,22 +128,22 @@ export declare type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestAllTypes_OptionalGroup;
+  optionalgroup: TestAllTypes_OptionalGroup;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage: ImportMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -180,17 +180,17 @@ export declare type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage: PublicImportMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * Repeated
@@ -468,7 +468,7 @@ export declare type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
      */
     value: TestAllTypes_NestedMessage;
     case: "oneofLazyNestedMessage";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -570,12 +570,12 @@ export declare type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllT
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child: NestedTestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.NestedTestAllTypes repeated_child = 3;
@@ -585,12 +585,12 @@ export declare type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllT
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes lazy_child = 4;
    */
-  lazyChild?: NestedTestAllTypes;
+  lazyChild: NestedTestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes eager_child = 5;
    */
-  eagerChild?: TestAllTypes;
+  eagerChild: TestAllTypes;
 };
 
 /**
@@ -619,7 +619,7 @@ export declare type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecat
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage deprecated_message = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedMessage?: TestAllTypes_NestedMessage;
+  deprecatedMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from oneof proto2_unittest.TestDeprecatedFields.oneof_fields
@@ -631,12 +631,12 @@ export declare type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecat
      */
     value: number;
     case: "deprecatedInt32InOneof";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: proto2_unittest.TestDeprecatedFields nested = 5;
    */
-  nested?: TestDeprecatedFields;
+  nested: TestDeprecatedFields;
 };
 
 /**
@@ -777,7 +777,7 @@ export declare type TestGroup = Message<"proto2_unittest.TestGroup"> & {
   /**
    * @generated from field: proto2_unittest.TestGroup.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestGroup_OptionalGroup;
+  optionalgroup: TestGroup_OptionalGroup;
 
   /**
    * @generated from field: proto2_unittest.ForeignEnum optional_foreign_enum = 22;
@@ -897,7 +897,7 @@ export declare type TestChildExtension = Message<"proto2_unittest.TestChildExten
   /**
    * @generated from field: proto2_unittest.TestAllExtensions optional_extension = 3;
    */
-  optionalExtension?: TestAllExtensions;
+  optionalExtension: TestAllExtensions;
 };
 
 /**
@@ -926,7 +926,7 @@ export declare type TestChildExtensionData = Message<"proto2_unittest.TestChildE
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
    */
-  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData;
+  optionalExtension: TestChildExtensionData_NestedTestAllExtensionsData;
 };
 
 /**
@@ -942,7 +942,7 @@ export declare type TestChildExtensionData_NestedTestAllExtensionsData = Message
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData.NestedDynamicExtensions dynamic = 409707008;
    */
-  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
+  dynamic: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
 };
 
 /**
@@ -984,7 +984,7 @@ export declare type TestNestedChildExtension = Message<"proto2_unittest.TestNest
   /**
    * @generated from field: proto2_unittest.TestChildExtension child = 2;
    */
-  child?: TestChildExtension;
+  child: TestChildExtension;
 };
 
 /**
@@ -1008,7 +1008,7 @@ export declare type TestNestedChildExtensionData = Message<"proto2_unittest.Test
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData child = 2;
    */
-  child?: TestChildExtensionData;
+  child: TestChildExtensionData;
 };
 
 /**
@@ -1450,7 +1450,7 @@ export declare type TestRequired = Message<"proto2_unittest.TestRequired"> & {
    *
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign = 34;
    */
-  optionalForeign?: ForeignMessage;
+  optionalForeign: ForeignMessage;
 
   /**
    * @generated from field: map<string, proto2_unittest.TestRequired> map_field = 35;
@@ -1481,7 +1481,7 @@ export declare type TestRequiredForeign = Message<"proto2_unittest.TestRequiredF
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage: TestRequired;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1498,7 +1498,7 @@ export declare type TestRequiredForeign = Message<"proto2_unittest.TestRequiredF
    *
    * @generated from field: proto2_unittest.NestedTestAllTypes optional_lazy_message = 4;
    */
-  optionalLazyMessage?: NestedTestAllTypes;
+  optionalLazyMessage: NestedTestAllTypes;
 };
 
 /**
@@ -1514,7 +1514,7 @@ export declare type TestRequiredMessage = Message<"proto2_unittest.TestRequiredM
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage: TestRequired;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1524,7 +1524,7 @@ export declare type TestRequiredMessage = Message<"proto2_unittest.TestRequiredM
   /**
    * @generated from field: proto2_unittest.TestRequired required_message = 3 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessage?: TestRequired;
+  requiredMessage: TestRequired;
 };
 
 /**
@@ -1540,12 +1540,12 @@ export declare type TestRequiredLazyMessage = Message<"proto2_unittest.TestRequi
   /**
    * @generated from field: proto2_unittest.TestRequired child = 1;
    */
-  child?: TestRequired;
+  child: TestRequired;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredLazyMessage recurse = 2;
    */
-  recurse?: TestRequiredLazyMessage;
+  recurse: TestRequiredLazyMessage;
 };
 
 /**
@@ -1561,12 +1561,12 @@ export declare type TestNestedRequiredForeign = Message<"proto2_unittest.TestNes
   /**
    * @generated from field: proto2_unittest.TestNestedRequiredForeign child = 1;
    */
-  child?: TestNestedRequiredForeign;
+  child: TestNestedRequiredForeign;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredForeign payload = 2;
    */
-  payload?: TestRequiredForeign;
+  payload: TestRequiredForeign;
 
   /**
    * @generated from field: int32 dummy = 3;
@@ -1578,22 +1578,22 @@ export declare type TestNestedRequiredForeign = Message<"proto2_unittest.TestNes
    *
    * @generated from field: proto2_unittest.TestRequiredEnum required_enum = 5;
    */
-  requiredEnum?: TestRequiredEnum;
+  requiredEnum: TestRequiredEnum;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask required_enum_no_mask = 6;
    */
-  requiredEnumNoMask?: TestRequiredEnumNoMask;
+  requiredEnumNoMask: TestRequiredEnumNoMask;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti required_enum_multi = 7;
    */
-  requiredEnumMulti?: TestRequiredEnumMulti;
+  requiredEnumMulti: TestRequiredEnumMulti;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti required_no_mask = 9;
    */
-  requiredNoMask?: TestRequiredNoMaskMulti;
+  requiredNoMask: TestRequiredNoMaskMulti;
 };
 
 /**
@@ -1611,7 +1611,7 @@ export declare type TestForeignNested = Message<"proto2_unittest.TestForeignNest
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage foreign_nested = 1;
    */
-  foreignNested?: TestAllTypes_NestedMessage;
+  foreignNested: TestAllTypes_NestedMessage;
 };
 
 /**
@@ -1740,7 +1740,7 @@ export declare type TestRecursiveMessage = Message<"proto2_unittest.TestRecursiv
   /**
    * @generated from field: proto2_unittest.TestRecursiveMessage a = 1;
    */
-  a?: TestRecursiveMessage;
+  a: TestRecursiveMessage;
 
   /**
    * @generated from field: int32 i = 2;
@@ -1763,12 +1763,12 @@ export declare type TestMutualRecursionA = Message<"proto2_unittest.TestMutualRe
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB bb = 1;
    */
-  bb?: TestMutualRecursionB;
+  bb: TestMutualRecursionB;
 
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubGroup subgroup = 2 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestMutualRecursionA_SubGroup;
+  subgroup: TestMutualRecursionA_SubGroup;
 
   /**
    * @generated from field: repeated proto2_unittest.TestMutualRecursionA.SubGroupR subgroupr = 5 [features.message_encoding = DELIMITED];
@@ -1789,7 +1789,7 @@ export declare type TestMutualRecursionA_SubMessage = Message<"proto2_unittest.T
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB b = 1;
    */
-  b?: TestMutualRecursionB;
+  b: TestMutualRecursionB;
 };
 
 /**
@@ -1807,12 +1807,12 @@ export declare type TestMutualRecursionA_SubGroup = Message<"proto2_unittest.Tes
    *
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubMessage sub_message = 3;
    */
-  subMessage?: TestMutualRecursionA_SubMessage;
+  subMessage: TestMutualRecursionA_SubMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes not_in_this_scc = 4;
    */
-  notInThisScc?: TestAllTypes;
+  notInThisScc: TestAllTypes;
 };
 
 /**
@@ -1828,7 +1828,7 @@ export declare type TestMutualRecursionA_SubGroupR = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 6;
    */
-  payload?: TestAllTypes;
+  payload: TestAllTypes;
 };
 
 /**
@@ -1844,7 +1844,7 @@ export declare type TestMutualRecursionB = Message<"proto2_unittest.TestMutualRe
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA a = 1;
    */
-  a?: TestMutualRecursionA;
+  a: TestMutualRecursionA;
 
   /**
    * @generated from field: int32 optional_int32 = 2;
@@ -1865,7 +1865,7 @@ export declare type TestIsInitialized = Message<"proto2_unittest.TestIsInitializ
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage sub_message = 1;
    */
-  subMessage?: TestIsInitialized_SubMessage;
+  subMessage: TestIsInitialized_SubMessage;
 };
 
 /**
@@ -1881,7 +1881,7 @@ export declare type TestIsInitialized_SubMessage = Message<"proto2_unittest.Test
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage.SubGroup subgroup = 1 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestIsInitialized_SubMessage_SubGroup;
+  subgroup: TestIsInitialized_SubMessage_SubGroup;
 };
 
 /**
@@ -1929,14 +1929,14 @@ export declare type TestDupFieldNumber = Message<"proto2_unittest.TestDupFieldNu
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Foo foo = 2 [features.message_encoding = DELIMITED];
    */
-  foo?: TestDupFieldNumber_Foo;
+  foo: TestDupFieldNumber_Foo;
 
   /**
    * NO_PROTO1
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Bar bar = 3 [features.message_encoding = DELIMITED];
    */
-  bar?: TestDupFieldNumber_Bar;
+  bar: TestDupFieldNumber_Bar;
 };
 
 /**
@@ -1994,7 +1994,7 @@ export declare type TestEagerMessage = Message<"proto2_unittest.TestEagerMessage
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage: TestAllTypes;
 };
 
 /**
@@ -2010,7 +2010,7 @@ export declare type TestLazyMessage = Message<"proto2_unittest.TestLazyMessage">
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage: TestAllTypes;
 };
 
 /**
@@ -2026,27 +2026,27 @@ export declare type TestLazyRequiredEnum = Message<"proto2_unittest.TestLazyRequ
   /**
    * @generated from field: proto2_unittest.TestRequiredOpenEnum optional_required_open_enum = 1;
    */
-  optionalRequiredOpenEnum?: TestRequiredOpenEnum;
+  optionalRequiredOpenEnum: TestRequiredOpenEnum;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnum optional_required_enum = 2;
    */
-  optionalRequiredEnum?: TestRequiredEnum;
+  optionalRequiredEnum: TestRequiredEnum;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask optional_required_enum_no_mask = 3;
    */
-  optionalRequiredEnumNoMask?: TestRequiredEnumNoMask;
+  optionalRequiredEnumNoMask: TestRequiredEnumNoMask;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti optional_required_enum_multi = 4;
    */
-  optionalRequiredEnumMulti?: TestRequiredEnumMulti;
+  optionalRequiredEnumMulti: TestRequiredEnumMulti;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti optional_required_no_mask = 5;
    */
-  optionalRequiredNoMask?: TestRequiredNoMaskMulti;
+  optionalRequiredNoMask: TestRequiredNoMaskMulti;
 };
 
 /**
@@ -2078,17 +2078,17 @@ export declare type TestEagerMaybeLazy = Message<"proto2_unittest.TestEagerMaybe
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_foo = 1;
    */
-  messageFoo?: TestAllTypes;
+  messageFoo: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_bar = 2;
    */
-  messageBar?: TestAllTypes;
+  messageBar: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestEagerMaybeLazy.NestedMessage message_baz = 3;
    */
-  messageBaz?: TestEagerMaybeLazy_NestedMessage;
+  messageBaz: TestEagerMaybeLazy_NestedMessage;
 };
 
 /**
@@ -2104,7 +2104,7 @@ export declare type TestEagerMaybeLazy_NestedMessage = Message<"proto2_unittest.
   /**
    * @generated from field: proto2_unittest.TestPackedTypes packed = 1;
    */
-  packed?: TestPackedTypes;
+  packed: TestPackedTypes;
 };
 
 /**
@@ -2122,7 +2122,7 @@ export declare type TestNestedMessageHasBits = Message<"proto2_unittest.TestNest
   /**
    * @generated from field: proto2_unittest.TestNestedMessageHasBits.NestedMessage optional_nested_message = 1;
    */
-  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage;
+  optionalNestedMessage: TestNestedMessageHasBits_NestedMessage;
 };
 
 /**
@@ -2177,7 +2177,7 @@ export declare type TestCamelCaseFieldNames = Message<"proto2_unittest.TestCamel
   /**
    * @generated from field: proto2_unittest.ForeignMessage MessageField = 4;
    */
-  MessageField?: ForeignMessage;
+  MessageField: ForeignMessage;
 
   /**
    * @generated from field: string StringPieceField = 5;
@@ -2251,7 +2251,7 @@ export declare type TestFieldOrderings = Message<"proto2_unittest.TestFieldOrder
   /**
    * @generated from field: proto2_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
    */
-  optionalNestedMessage?: TestFieldOrderings_NestedMessage;
+  optionalNestedMessage: TestFieldOrderings_NestedMessage;
 };
 
 /**
@@ -2880,7 +2880,7 @@ export declare type TestOneof = Message<"proto2_unittest.TestOneof"> & {
      */
     value: TestOneof_FooGroup;
     case: "foogroup";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -2927,12 +2927,12 @@ export declare type TestOneofBackwardsCompatible = Message<"proto2_unittest.Test
   /**
    * @generated from field: proto2_unittest.TestAllTypes foo_message = 3;
    */
-  fooMessage?: TestAllTypes;
+  fooMessage: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestOneofBackwardsCompatible.FooGroup foogroup = 4 [features.message_encoding = DELIMITED];
    */
-  foogroup?: TestOneofBackwardsCompatible_FooGroup;
+  foogroup: TestOneofBackwardsCompatible_FooGroup;
 };
 
 /**
@@ -3029,7 +3029,7 @@ export declare type TestOneof2 = Message<"proto2_unittest.TestOneof2"> & {
      */
     value: Uint8Array;
     case: "fooBytesCord";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof proto2_unittest.TestOneof2.bar
@@ -3094,7 +3094,7 @@ export declare type TestOneof2 = Message<"proto2_unittest.TestOneof2"> & {
      */
     value: Uint8Array;
     case: "barBytesWithEmptyDefault";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: int32 baz_int = 18;
@@ -3151,7 +3151,7 @@ export declare type TestOneof2_NestedMessage = Message<"proto2_unittest.TestOneo
   /**
    * @generated from field: proto2_unittest.TestOneof2.NestedMessage child = 3;
    */
-  child?: TestOneof2_NestedMessage;
+  child: TestOneof2_NestedMessage;
 };
 
 /**
@@ -3216,7 +3216,7 @@ export declare type TestRequiredOneof = Message<"proto2_unittest.TestRequiredOne
      */
     value: TestRequiredOneof_NestedMessage;
     case: "fooLazyMessage";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -3456,12 +3456,12 @@ export declare type TestDynamicExtensions = Message<"proto2_unittest.TestDynamic
   /**
    * @generated from field: proto2_unittest.ForeignMessage message_extension = 2003;
    */
-  messageExtension?: ForeignMessage;
+  messageExtension: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest.TestDynamicExtensions.DynamicMessageType dynamic_message_extension = 2004;
    */
-  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType;
+  dynamicMessageExtension: TestDynamicExtensions_DynamicMessageType;
 
   /**
    * @generated from field: repeated string repeated_extension = 2005;
@@ -3613,12 +3613,12 @@ export declare type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge
   /**
    * @generated from field: proto2_unittest.TestAllTypes required_all_types = 1 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredAllTypes?: TestAllTypes;
+  requiredAllTypes: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 2;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 3;
@@ -3628,7 +3628,7 @@ export declare type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge
   /**
    * @generated from field: proto2_unittest.TestParsingMerge.OptionalGroup optionalgroup = 10 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestParsingMerge_OptionalGroup;
+  optionalgroup: TestParsingMerge_OptionalGroup;
 
   /**
    * @generated from field: repeated proto2_unittest.TestParsingMerge.RepeatedGroup repeatedgroup = 20 [features.message_encoding = DELIMITED];
@@ -3701,7 +3701,7 @@ export declare type TestParsingMerge_RepeatedFieldsGenerator_Group1 = Message<"p
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 11;
    */
-  field1?: TestAllTypes;
+  field1: TestAllTypes;
 };
 
 /**
@@ -3717,7 +3717,7 @@ export declare type TestParsingMerge_RepeatedFieldsGenerator_Group2 = Message<"p
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 21;
    */
-  field1?: TestAllTypes;
+  field1: TestAllTypes;
 };
 
 /**
@@ -3733,7 +3733,7 @@ export declare type TestParsingMerge_OptionalGroup = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_group_all_types = 11;
    */
-  optionalGroupAllTypes?: TestAllTypes;
+  optionalGroupAllTypes: TestAllTypes;
 };
 
 /**
@@ -3749,7 +3749,7 @@ export declare type TestParsingMerge_RepeatedGroup = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes repeated_group_all_types = 21;
    */
-  repeatedGroupAllTypes?: TestAllTypes;
+  repeatedGroupAllTypes: TestAllTypes;
 };
 
 /**
@@ -3778,7 +3778,7 @@ export declare type TestMergeException = Message<"proto2_unittest.TestMergeExcep
   /**
    * @generated from field: proto2_unittest.TestAllExtensions all_extensions = 1;
    */
-  allExtensions?: TestAllExtensions;
+  allExtensions: TestAllExtensions;
 };
 
 /**
@@ -3920,7 +3920,7 @@ export declare type TestEagerlyVerifiedLazyMessage = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestEagerlyVerifiedLazyMessage.LazyMessage lazy_message = 1;
    */
-  lazyMessage?: TestEagerlyVerifiedLazyMessage_LazyMessage;
+  lazyMessage: TestEagerlyVerifiedLazyMessage_LazyMessage;
 };
 
 /**
@@ -4107,12 +4107,12 @@ export declare type TestHugeFieldNumbers = Message<"proto2_unittest.TestHugeFiel
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_message = 536870007;
    */
-  optionalMessage?: ForeignMessage;
+  optionalMessage: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest.TestHugeFieldNumbers.OptionalGroup optionalgroup = 536870008 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestHugeFieldNumbers_OptionalGroup;
+  optionalgroup: TestHugeFieldNumbers_OptionalGroup;
 
   /**
    * @generated from field: map<string, string> string_string_map = 536870010;
@@ -4146,7 +4146,7 @@ export declare type TestHugeFieldNumbers = Message<"proto2_unittest.TestHugeFiel
      */
     value: Uint8Array;
     case: "oneofBytes";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: bool optional_bool = 536870015;
@@ -4271,7 +4271,7 @@ export declare type TestNestedGroupExtensionOuter = Message<"proto2_unittest.Tes
   /**
    * @generated from field: proto2_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup layer1optionalgroup = 1 [features.message_encoding = DELIMITED];
    */
-  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
+  layer1optionalgroup: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
 };
 
 /**
@@ -4463,7 +4463,7 @@ export declare type TestVerifyInt32 = Message<"proto2_unittest.TestVerifyInt32">
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4519,7 +4519,7 @@ export declare type TestVerifyMostlyInt32 = Message<"proto2_unittest.TestVerifyM
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4580,7 +4580,7 @@ export declare type TestVerifyMostlyInt32BigFieldNumber = Message<"proto2_unitte
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4652,7 +4652,7 @@ export declare type TestVerifyUint32 = Message<"proto2_unittest.TestVerifyUint32
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4693,7 +4693,7 @@ export declare type TestVerifyOneUint32 = Message<"proto2_unittest.TestVerifyOne
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4739,7 +4739,7 @@ export declare type TestVerifyOneInt32BigFieldNumber = Message<"proto2_unittest.
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4790,7 +4790,7 @@ export declare type TestVerifyInt32BigFieldNumber = Message<"proto2_unittest.Tes
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4841,7 +4841,7 @@ export declare type TestVerifyUint32BigFieldNumber = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4862,7 +4862,7 @@ export declare type TestVerifyBigFieldNumberUint32 = Message<"proto2_unittest.Te
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested: TestVerifyBigFieldNumberUint32_Nested;
 };
 
 /**
@@ -4918,7 +4918,7 @@ export declare type TestVerifyBigFieldNumberUint32_Nested = Message<"proto2_unit
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested: TestVerifyBigFieldNumberUint32_Nested;
 
   /**
    * @generated from field: repeated proto2_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;
@@ -5677,7 +5677,7 @@ export declare type InlinedStringIdxRegressionProto = Message<"proto2_unittest.I
    *
    * @generated from field: proto2_unittest.InlinedStringIdxRegressionProto sub = 2;
    */
-  sub?: InlinedStringIdxRegressionProto;
+  sub: InlinedStringIdxRegressionProto;
 
   /**
    * aux_idx == 3, inlined_string_idx == 2
@@ -5820,12 +5820,12 @@ export declare type RedactedFields = Message<"proto2_unittest.RedactedFields"> &
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_redacted_message = 5;
    */
-  optionalRedactedMessage?: TestNestedMessageRedaction;
+  optionalRedactedMessage: TestNestedMessageRedaction;
 
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_unredacted_message = 6;
    */
-  optionalUnredactedMessage?: TestNestedMessageRedaction;
+  optionalUnredactedMessage: TestNestedMessageRedaction;
 
   /**
    * @generated from field: repeated proto2_unittest.TestNestedMessageRedaction repeated_redacted_message = 7;
@@ -6414,7 +6414,7 @@ export declare type MessageCreatorZeroInit = Message<"proto2_unittest.MessageCre
   /**
    * @generated from field: proto2_unittest.MessageCreatorZeroInit m = 3;
    */
-  m?: MessageCreatorZeroInit;
+  m: MessageCreatorZeroInit;
 
   /**
    * @generated from oneof proto2_unittest.MessageCreatorZeroInit.one
@@ -6443,7 +6443,7 @@ export declare type MessageCreatorZeroInit = Message<"proto2_unittest.MessageCre
      */
     value: MessageCreatorZeroInit;
     case: "ol";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -6469,7 +6469,7 @@ export declare type MessageCreatorMemcpy = Message<"proto2_unittest.MessageCreat
   /**
    * @generated from field: proto2_unittest.MessageCreatorMemcpy m = 3;
    */
-  m?: MessageCreatorMemcpy;
+  m: MessageCreatorMemcpy;
 
   /**
    * @generated from field: map<int32, int32> m2 = 4;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_optional_pb.d.ts
@@ -34,97 +34,97 @@ export declare type TestProto3Optional = Message<"proto2_unittest.TestProto3Opti
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional string optional_cord = 16;
    */
-  optionalCord?: string;
+  optionalCord: string;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestProto3Optional_NestedMessage;
+  optionalNestedMessage: TestProto3Optional_NestedMessage;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage lazy_nested_message = 19;
    */
-  lazyNestedMessage?: TestProto3Optional_NestedMessage;
+  lazyNestedMessage: TestProto3Optional_NestedMessage;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestProto3Optional_NestedEnum;
+  optionalNestedEnum: TestProto3Optional_NestedEnum;
 
   /**
    * Add some non-optional fields to verify we can mix them.
@@ -156,7 +156,7 @@ export declare type TestProto3Optional_NestedMessage = Message<"proto2_unittest.
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb: number;
 };
 
 /**
@@ -209,12 +209,12 @@ export declare type TestProto3OptionalMessage = Message<"proto2_unittest.TestPro
   /**
    * @generated from field: proto2_unittest.TestProto3OptionalMessage.NestedMessage nested_message = 1;
    */
-  nestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  nestedMessage: TestProto3OptionalMessage_NestedMessage;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3OptionalMessage.NestedMessage optional_nested_message = 2;
    */
-  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  optionalNestedMessage: TestProto3OptionalMessage_NestedMessage;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_proto3_pb.d.ts
@@ -113,17 +113,17 @@ export declare type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
   /**
    * @generated from field: optional proto3_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto3_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage: ImportMessage;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -150,22 +150,22 @@ export declare type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage: PublicImportMessage;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
-  optionalLazyImportMessage?: ImportMessage;
+  optionalLazyImportMessage: ImportMessage;
 
   /**
    * Repeated
@@ -311,7 +311,7 @@ export declare type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
      */
     value: Uint8Array;
     case: "oneofBytes";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -550,12 +550,12 @@ export declare type NestedTestAllTypes = Message<"proto3_unittest.NestedTestAllT
   /**
    * @generated from field: proto3_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child: NestedTestAllTypes;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload: TestAllTypes;
 };
 
 /**
@@ -634,7 +634,7 @@ export declare type TestOneof2 = Message<"proto3_unittest.TestOneof2"> & {
      */
     value: TestOneof2_NestedEnum;
     case: "fooEnum";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -1029,7 +1029,7 @@ export declare type TestHasbits = Message<"proto3_unittest.TestHasbits"> & {
   /**
    * @generated from field: proto3_unittest.TestAllTypes child = 100;
    */
-  child?: TestAllTypes;
+  child: TestAllTypes;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_redaction_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_redaction_pb.d.ts
@@ -89,7 +89,7 @@ export declare type TestNestedMessageEnum = Message<"proto2_unittest.TestNestedM
   /**
    * @generated from field: proto2_unittest.TestMessageEnum nested_enum = 2;
    */
-  nestedEnum?: TestMessageEnum;
+  nestedEnum: TestMessageEnum;
 
   /**
    * @generated from field: string redacted_string = 3;
@@ -136,7 +136,7 @@ export declare type TestRedactedMessage = Message<"proto2_unittest.TestRedactedM
   /**
    * @generated from field: google.protobuf.Any any_field = 18;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: string redactable_false = 19;

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_retention_pb.d.ts
@@ -83,7 +83,7 @@ export declare type TopLevelMessage = Message<"proto2_unittest.TopLevelMessage">
      */
     value: bigint;
     case: "i";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.d.ts
+++ b/packages/protobuf-test/src/gen/js/google/protobuf/unittest_well_known_types_pb.d.ts
@@ -37,99 +37,99 @@ export declare type TestWellKnownTypes = Message<"proto2_unittest.TestWellKnownT
   /**
    * @generated from field: google.protobuf.Any any_field = 1;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: google.protobuf.Api api_field = 2;
    */
-  apiField?: Api;
+  apiField: Api;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 3;
    */
-  durationField?: Duration;
+  durationField: Duration;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 4;
    */
-  emptyField?: Empty;
+  emptyField: Empty;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 5;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField: FieldMask;
 
   /**
    * @generated from field: google.protobuf.SourceContext source_context_field = 6;
    */
-  sourceContextField?: SourceContext;
+  sourceContextField: SourceContext;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 7;
    */
-  structField?: JsonObject;
+  structField: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 8;
    */
-  timestampField?: Timestamp;
+  timestampField: Timestamp;
 
   /**
    * @generated from field: google.protobuf.Type type_field = 9;
    */
-  typeField?: Type;
+  typeField: Type;
 
   /**
    * @generated from field: google.protobuf.DoubleValue double_field = 10;
    */
-  doubleField?: number;
+  doubleField: number;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_field = 11;
    */
-  floatField?: number;
+  floatField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_field = 12;
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_field = 13;
    */
-  uint64Field?: bigint;
+  uint64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_field = 14;
    */
-  int32Field?: number;
+  int32Field: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_field = 15;
    */
-  uint32Field?: number;
+  uint32Field: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_field = 16;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: google.protobuf.StringValue string_field = 17;
    */
-  stringField?: string;
+  stringField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_field = 18;
    */
-  bytesField?: Uint8Array;
+  bytesField: Uint8Array;
 
   /**
    * Part of struct, but useful to be able to test separately
    *
    * @generated from field: google.protobuf.Value value_field = 19;
    */
-  valueField?: Value;
+  valueField: Value;
 };
 
 /**
@@ -358,7 +358,7 @@ export declare type OneofWellKnownTypes = Message<"proto2_unittest.OneofWellKnow
      */
     value: BytesValue;
     case: "bytesField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts,json_types/extra/json_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts,json_types/extra/json_types_pb.ts
@@ -60,42 +60,42 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField: JsonTypesMessage;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField: Duration;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField: Empty;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField: Value;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField: ListValue;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -105,52 +105,52 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField: Timestamp;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField: number;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField: boolean;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField: Uint8Array;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;
@@ -177,7 +177,7 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
      */
     value: string;
     case: "oneofBoolField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: bool json_name_ok = 29 [json_name = "Foo123_bar$"];
@@ -228,183 +228,183 @@ export type JsonTypesMessageJson = {
   /**
    * @generated from field: bool bool_field = 1 [json_name = "booleanFieldWithCustomName"];
    */
-  booleanFieldWithCustomName?: boolean;
+  booleanFieldWithCustomName: boolean;
 
   /**
    * @generated from field: double double_field = 2;
    */
-  doubleField?: number | "NaN" | "Infinity" | "-Infinity";
+  doubleField: number | "NaN" | "Infinity" | "-Infinity";
 
   /**
    * @generated from field: bytes bytes_field = 3;
    */
-  bytesField?: string;
+  bytesField: string;
 
   /**
    * @generated from field: int64 int64_field = 4;
    */
-  int64Field?: string;
+  int64Field: string;
 
   /**
    * @generated from field: spec.JsonTypeEnum enum_field = 5;
    */
-  enumField?: JsonTypeEnumJson;
+  enumField: JsonTypeEnumJson;
 
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessageJson;
+  messageField: JsonTypesMessageJson;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: AnyJson;
+  anyField: AnyJson;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: DurationJson;
+  durationField: DurationJson;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: EmptyJson;
+  emptyField: EmptyJson;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMaskJson;
+  fieldMaskField: FieldMaskJson;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: StructJson;
+  structField: StructJson;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: ValueJson;
+  valueField: ValueJson;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValueJson;
+  listValueField: ListValueJson;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
    */
-  nullValueField?: NullValueJson;
+  nullValueField: NullValueJson;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: TimestampJson;
+  timestampField: TimestampJson;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: DoubleValueJson;
+  wrappedDoubleField: DoubleValueJson;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: FloatValueJson;
+  wrappedFloatField: FloatValueJson;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: Int64ValueJson;
+  wrappedInt64Field: Int64ValueJson;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: UInt64ValueJson;
+  wrappedUint64Field: UInt64ValueJson;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: Int32ValueJson;
+  wrappedInt32Field: Int32ValueJson;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: UInt32ValueJson;
+  wrappedUint32Field: UInt32ValueJson;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: BoolValueJson;
+  wrappedBoolField: BoolValueJson;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: StringValueJson;
+  wrappedStringField: StringValueJson;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: BytesValueJson;
+  wrappedBytesField: BytesValueJson;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;
    */
-  repeatedEnumField?: JsonTypeEnumJson[];
+  repeatedEnumField: JsonTypeEnumJson[];
 
   /**
    * @generated from field: map<bool, spec.JsonTypeEnum> map_bool_enum_field = 26;
    */
-  mapBoolEnumField?: { [key: string]: JsonTypeEnumJson };
+  mapBoolEnumField: { [key: string]: JsonTypeEnumJson };
 
   /**
    * @generated from field: string oneof_string_field = 27;
    */
-  oneofStringField?: string;
+  oneofStringField: string;
 
   /**
    * @generated from field: string oneof_bool_field = 28;
    */
-  oneofBoolField?: string;
+  oneofBoolField: string;
 
   /**
    * @generated from field: bool json_name_ok = 29 [json_name = "Foo123_bar$"];
    */
-  Foo123_bar$?: boolean;
+  Foo123_bar$: boolean;
 
   /**
    * @generated from field: bool json_name_at = 30 [json_name = "foo@"];
    */
-  "foo@"?: boolean;
+  "foo@": boolean;
 
   /**
    * @generated from field: bool json_name_hyphen = 31 [json_name = "foo-bar"];
    */
-  "foo-bar"?: boolean;
+  "foo-bar": boolean;
 
   /**
    * @generated from field: bool json_name_start_with_digit = 32 [json_name = "1foo"];
    */
-  "1foo"?: boolean;
+  "1foo": boolean;
 
   /**
    * @generated from field: bool json_name_space = 33 [json_name = "foo bar"];
    */
-  "foo bar"?: boolean;
+  "foo bar": boolean;
 
   /**
    * @generated from field: bool json_name_tab = 34 [json_name = "foo	bar"];
    */
-  "foo	bar"?: boolean;
+  "foo	bar": boolean;
 
   /**
    * @generated from field: bool json_name_non_ascii = 35 [json_name = "你好"];
    */
-  "你好"?: boolean;
+  "你好": boolean;
 
   /**
    * @generated from field: bool json_name_escape = 36 [json_name = "foo
    * bar\n"];
    */
-  "foo\nbar\\n"?: boolean;
+  "foo\nbar\\n": boolean;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts,valid_types/extra/minimal-validate_pb.ts
+++ b/packages/protobuf-test/src/gen/ts,valid_types/extra/minimal-validate_pb.ts
@@ -102,7 +102,7 @@ export type FieldRules = Message<"buf.validate.FieldRules"> & {
      */
     value: MapRules;
     case: "map";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 export type FieldRulesValid = FieldRules;
@@ -121,7 +121,7 @@ export type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items: FieldRules;
 };
 
 export type RepeatedRulesValid = RepeatedRules;
@@ -140,7 +140,7 @@ export type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values: FieldRules;
 };
 
 export type MapRulesValid = MapRules;

--- a/packages/protobuf-test/src/gen/ts,valid_types/extra/valid_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts,valid_types/extra/valid_types_pb.ts
@@ -40,7 +40,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -49,7 +49,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -58,7 +58,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -67,14 +67,14 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated: VTypes_Other;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -169,7 +169,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -178,7 +178,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -186,7 +186,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt: Timestamp;
 };
 
 /**
@@ -200,7 +200,7 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_OtherValid;
+  msg: VTypes_OtherValid;
 
   /**
    * In the generated valid type, this property should:
@@ -218,7 +218,7 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -227,14 +227,14 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_OtherValid;
+  msgIgnoreUnpopulated: VTypes_OtherValid;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_OtherValid;
+  msgIgnoreDefault: VTypes_OtherValid;
 
   /**
    * In the generated valid type, this property should:
@@ -346,7 +346,7 @@ export type VTypesValid = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt: Timestamp;
 };
 
 /**
@@ -383,7 +383,7 @@ export type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg: VTypes;
 };
 
 /**
@@ -398,7 +398,7 @@ export type VTypes2Valid = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypesValid;
+  msg: VTypesValid;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/editions/golden/test_messages_proto3_editions_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/editions/golden/test_messages_proto3_editions_pb.ts
@@ -122,12 +122,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage: TestAllTypesProto3_NestedMessage;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -157,7 +157,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage: TestAllTypesProto3;
 
   /**
    * Repeated
@@ -570,54 +570,54 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
      */
     value: NullValue;
     case: "oneofNullValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * Well-known types
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper: boolean;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper: number;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper: number;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper: Uint8Array;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -667,32 +667,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.editions.proto3
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration: Duration;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp: Timestamp;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny: Any;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue: Value;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -847,7 +847,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.e
   /**
    * @generated from field: protobuf_test_messages.editions.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive: TestAllTypesProto3;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/comments_pb.ts
@@ -76,7 +76,7 @@ export type MessageWithComments = Message<"spec.MessageWithComments"> & {
      */
     value: string;
     case: "error";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: string this_field_has_an_empty_comment = 4;

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023-proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023-proto2_pb.ts
@@ -50,7 +50,7 @@ export type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageForEdition2
   /**
    * @generated from field: optional spec.Proto2MessageForEdition2023.OptionalGroup optionalgroup = 4;
    */
-  optionalgroup?: Proto2MessageForEdition2023_OptionalGroup;
+  optionalgroup: Proto2MessageForEdition2023_OptionalGroup;
 
   /**
    * @generated from field: required bool required_bool_field = 5;
@@ -70,7 +70,7 @@ export type Proto2MessageForEdition2023 = Message<"spec.Proto2MessageForEdition2
   /**
    * @generated from field: required spec.Proto2MessageForEdition2023.RequiredGroup requiredgroup = 8;
    */
-  requiredgroup?: Proto2MessageForEdition2023_RequiredGroup;
+  requiredgroup: Proto2MessageForEdition2023_RequiredGroup;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023-proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023-proto3_pb.ts
@@ -45,12 +45,12 @@ export type Proto3MessageForEdition2023 = Message<"spec.Proto3MessageForEdition2
   /**
    * @generated from field: optional bool explicit_bool_field = 5;
    */
-  explicitBoolField?: boolean;
+  explicitBoolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto3EnumForEdition2023 explicit_open_enum_field = 6;
    */
-  explicitOpenEnumField?: Proto3EnumForEdition2023;
+  explicitOpenEnumField: Proto3EnumForEdition2023;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [packed = true];

--- a/packages/protobuf-test/src/gen/ts/extra/edition2023_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/edition2023_pb.ts
@@ -87,17 +87,17 @@ export type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message explicit_message_field = 311;
    */
-  explicitMessageField?: Edition2023Message;
+  explicitMessageField: Edition2023Message;
 
   /**
    * @generated from field: spec.Edition2023Message explicit_message_delimited_field = 312 [features.message_encoding = DELIMITED];
    */
-  explicitMessageDelimitedField?: Edition2023Message;
+  explicitMessageDelimitedField: Edition2023Message;
 
   /**
    * @generated from field: google.protobuf.UInt32Value explicit_wrapped_uint32_field = 313;
    */
-  explicitWrappedUint32Field?: number;
+  explicitWrappedUint32Field: number;
 
   /**
    * @generated from field: string implicit_string_field = 201 [features.field_presence = IMPLICIT];
@@ -197,17 +197,17 @@ export type Edition2023Message = Message<"spec.Edition2023Message"> & {
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_field = 11 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessageField?: Edition2023Message_Child;
+  requiredMessageField: Edition2023Message_Child;
 
   /**
    * @generated from field: spec.Edition2023Message.Child required_message_delimited_field = 12 [features.field_presence = LEGACY_REQUIRED, features.message_encoding = DELIMITED];
    */
-  requiredMessageDelimitedField?: Edition2023Message_Child;
+  requiredMessageDelimitedField: Edition2023Message_Child;
 
   /**
    * @generated from field: google.protobuf.UInt32Value required_wrapped_uint32_field = 13 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field: number;
 
   /**
    * @generated from field: string required_default_string_field = 101 [default = "hello \" *\/ ", features.field_presence = LEGACY_REQUIRED];
@@ -435,7 +435,7 @@ export type Edition2023Message = Message<"spec.Edition2023Message"> & {
      */
     value: UInt32Value;
     case: "oneofWrappedUint32Field";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_string_string_field = 601;
@@ -524,7 +524,7 @@ export type Edition2023FromProto2Message = Message<"spec.Edition2023FromProto2Me
   /**
    * @generated from field: spec.Edition2023FromProto2Message.OptionalGroup optionalgroup = 4 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: Edition2023FromProto2Message_OptionalGroup;
+  optionalgroup: Edition2023FromProto2Message_OptionalGroup;
 
   /**
    * @generated from field: bool required_bool_field = 5 [features.field_presence = LEGACY_REQUIRED];
@@ -544,7 +544,7 @@ export type Edition2023FromProto2Message = Message<"spec.Edition2023FromProto2Me
   /**
    * @generated from field: spec.Edition2023FromProto2Message.RequiredGroup requiredgroup = 8 [features.message_encoding = DELIMITED];
    */
-  requiredgroup?: Edition2023FromProto2Message_RequiredGroup;
+  requiredgroup: Edition2023FromProto2Message_RequiredGroup;
 
   /**
    * @generated from field: repeated double packed_double_field = 9 [features.repeated_field_encoding = PACKED];

--- a/packages/protobuf-test/src/gen/ts/extra/example-service_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example-service_pb.ts
@@ -57,7 +57,7 @@ export type CreateUserResponse = Message<"example.CreateUserResponse"> & {
   /**
    * @generated from field: example.User user = 1;
    */
-  user?: User;
+  user: User;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/example_pb.ts
@@ -48,7 +48,7 @@ export type User = Message<"example.User"> & {
   /**
    * @generated from field: example.User manager = 4;
    */
-  manager?: User;
+  manager: User;
 
   /**
    * @generated from field: repeated string locations = 5;

--- a/packages/protobuf-test/src/gen/ts/extra/json_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/json_types_pb.ts
@@ -60,42 +60,42 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: spec.JsonTypesMessage message_field = 6;
    */
-  messageField?: JsonTypesMessage;
+  messageField: JsonTypesMessage;
 
   /**
    * @generated from field: google.protobuf.Any any_field = 7;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 8;
    */
-  durationField?: Duration;
+  durationField: Duration;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 9;
    */
-  emptyField?: Empty;
+  emptyField: Empty;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 10;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 11;
    */
-  structField?: JsonObject;
+  structField: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Value value_field = 12;
    */
-  valueField?: Value;
+  valueField: Value;
 
   /**
    * @generated from field: google.protobuf.ListValue list_value_field = 13;
    */
-  listValueField?: ListValue;
+  listValueField: ListValue;
 
   /**
    * @generated from field: google.protobuf.NullValue null_value_field = 14;
@@ -105,52 +105,52 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 15;
    */
-  timestampField?: Timestamp;
+  timestampField: Timestamp;
 
   /**
    * @generated from field: google.protobuf.DoubleValue wrapped_double_field = 16;
    */
-  wrappedDoubleField?: number;
+  wrappedDoubleField: number;
 
   /**
    * @generated from field: google.protobuf.FloatValue wrapped_float_field = 17;
    */
-  wrappedFloatField?: number;
+  wrappedFloatField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value wrapped_int64_field = 18;
    */
-  wrappedInt64Field?: bigint;
+  wrappedInt64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value wrapped_uint64_field = 19;
    */
-  wrappedUint64Field?: bigint;
+  wrappedUint64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value wrapped_int32_field = 20;
    */
-  wrappedInt32Field?: number;
+  wrappedInt32Field: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value wrapped_uint32_field = 21;
    */
-  wrappedUint32Field?: number;
+  wrappedUint32Field: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue wrapped_bool_field = 22;
    */
-  wrappedBoolField?: boolean;
+  wrappedBoolField: boolean;
 
   /**
    * @generated from field: google.protobuf.StringValue wrapped_string_field = 23;
    */
-  wrappedStringField?: string;
+  wrappedStringField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue wrapped_bytes_field = 24;
    */
-  wrappedBytesField?: Uint8Array;
+  wrappedBytesField: Uint8Array;
 
   /**
    * @generated from field: repeated spec.JsonTypeEnum repeated_enum_field = 25;
@@ -177,7 +177,7 @@ export type JsonTypesMessage = Message<"spec.JsonTypesMessage"> & {
      */
     value: string;
     case: "oneofBoolField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: bool json_name_ok = 29 [json_name = "Foo123_bar$"];

--- a/packages/protobuf-test/src/gen/ts/extra/minimal-validate_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/minimal-validate_pb.ts
@@ -98,7 +98,7 @@ export type FieldRules = Message<"buf.validate.FieldRules"> & {
      */
     value: MapRules;
     case: "map";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -115,7 +115,7 @@ export type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items: FieldRules;
 };
 
 /**
@@ -132,7 +132,7 @@ export type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values: FieldRules;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-message_pb.ts
@@ -33,7 +33,7 @@ export type MessageFieldMessage = Message<"spec.MessageFieldMessage"> & {
   /**
    * @generated from field: spec.MessageFieldMessage.TestMessage message_field = 1;
    */
-  messageField?: MessageFieldMessage_TestMessage;
+  messageField: MessageFieldMessage_TestMessage;
 
   /**
    * @generated from field: repeated spec.MessageFieldMessage.TestMessage repeated_message_field = 2;

--- a/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/msg-oneof_pb.ts
@@ -51,7 +51,7 @@ export type OneofMessage = Message<"spec.OneofMessage"> & {
      */
     value: Uint8Array;
     case: "bytes";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof spec.OneofMessage.message
@@ -74,7 +74,7 @@ export type OneofMessage = Message<"spec.OneofMessage"> & {
      */
     value: OneofMessageBar;
     case: "baz";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof spec.OneofMessage.enum
@@ -85,7 +85,7 @@ export type OneofMessage = Message<"spec.OneofMessage"> & {
      */
     value: OneofEnum;
     case: "e";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/name-clash_pb.ts
@@ -39,7 +39,7 @@ export type User = Message$1<"spec.User"> & {
    *
    * @generated from field: example.User u = 1;
    */
-  u?: User$1;
+  u: User$1;
 };
 
 /**
@@ -208,7 +208,7 @@ export type ReservedPropertyNames_OneofBultIn = Message$1<"spec.ReservedProperty
      */
     value: string;
     case: "valueOf";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -279,7 +279,7 @@ export type ReservedPropertyNames_OneofRuntime = Message$1<"spec.ReservedPropert
      */
     value: string;
     case: "toJsonString";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -941,7 +941,7 @@ export type NoClashOneof = Message$1<"spec.NoClashOneof"> & {
      */
     value: string;
     case: "return";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -958,7 +958,7 @@ export type NoClashOneofADT = Message$1<"spec.NoClashOneofADT"> & {
   /**
    * @generated from field: spec.NoClashOneofADT.M m = 1;
    */
-  m?: NoClashOneofADT_M;
+  m: NoClashOneofADT_M;
 };
 
 /**
@@ -980,7 +980,7 @@ export type NoClashOneofADT_M = Message$1<"spec.NoClashOneofADT.M"> & {
   /**
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value: string;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/option-usage_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/option-usage_pb.ts
@@ -45,7 +45,7 @@ export type MessageWithOptions = Message<"spec.MessageWithOptions"> & {
      */
     value: number;
     case: "oneofField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/perf_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/perf_pb.ts
@@ -48,12 +48,12 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: optional int64 int64_field = 3;
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: optional bool bool_field = 4;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: string string_field = 5;
@@ -73,7 +73,7 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
   /**
    * @generated from field: perf.v1.PerfMessage small_message_field = 8;
    */
-  smallMessageField?: PerfMessage;
+  smallMessageField: PerfMessage;
 
   /**
    * @generated from field: int32 unused_field_1 = 9;
@@ -210,7 +210,7 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
      */
     value: PerfEnum;
     case: "oneofEnumCromulent";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof perf.v1.PerfMessage.oneof_message
@@ -227,7 +227,7 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
      */
     value: PerfMessage;
     case: "oneofSmallMessageField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof perf.v1.PerfMessage.oneof_scalar
@@ -244,7 +244,7 @@ export type PerfMessage = Message<"perf.v1.PerfMessage"> & {
      */
     value: boolean;
     case: "oneofBoolField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: uint32 id = 40;

--- a/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto2_pb.ts
@@ -82,17 +82,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_message_field = 8;
    */
-  requiredMessageField?: Proto2Message;
+  requiredMessageField: Proto2Message;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredGroup requiredgroup = 9;
    */
-  requiredgroup?: Proto2Message_RequiredGroup;
+  requiredgroup: Proto2Message_RequiredGroup;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_wrapped_uint32_field = 201;
    */
-  requiredWrappedUint32Field?: number;
+  requiredWrappedUint32Field: number;
 
   /**
    * @generated from field: required string required_default_string_field = 10 [default = "hello \" *\/ "];
@@ -142,17 +142,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: required spec.Proto2Message required_default_message_field = 17;
    */
-  requiredDefaultMessageField?: Proto2Message;
+  requiredDefaultMessageField: Proto2Message;
 
   /**
    * @generated from field: required spec.Proto2Message.RequiredDefaultGroup requireddefaultgroup = 18;
    */
-  requireddefaultgroup?: Proto2Message_RequiredDefaultGroup;
+  requireddefaultgroup: Proto2Message_RequiredDefaultGroup;
 
   /**
    * @generated from field: required google.protobuf.UInt32Value required_default_wrapped_uint32_field = 202;
    */
-  requiredDefaultWrappedUint32Field?: number;
+  requiredDefaultWrappedUint32Field: number;
 
   /**
    * @generated from field: optional string optional_string_field = 19;
@@ -202,17 +202,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_message_field = 26;
    */
-  optionalMessageField?: Proto2Message;
+  optionalMessageField: Proto2Message;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalGroup optionalgroup = 27;
    */
-  optionalgroup?: Proto2Message_OptionalGroup;
+  optionalgroup: Proto2Message_OptionalGroup;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 207;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field: number;
 
   /**
    * @generated from field: optional string optional_default_string_field = 28 [default = "hello \" *\/ "];
@@ -262,17 +262,17 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
   /**
    * @generated from field: optional spec.Proto2Message optional_default_message_field = 35;
    */
-  optionalDefaultMessageField?: Proto2Message;
+  optionalDefaultMessageField: Proto2Message;
 
   /**
    * @generated from field: optional spec.Proto2Message.OptionalDefaultGroup optionaldefaultgroup = 36;
    */
-  optionaldefaultgroup?: Proto2Message_OptionalDefaultGroup;
+  optionaldefaultgroup: Proto2Message_OptionalDefaultGroup;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_default_wrapped_uint32_field = 203;
    */
-  optionalDefaultWrappedUint32Field?: number;
+  optionalDefaultWrappedUint32Field: number;
 
   /**
    * @generated from field: repeated string repeated_string_field = 37;
@@ -439,7 +439,7 @@ export type Proto2Message = Message<"spec.Proto2Message"> & {
      */
     value: UInt32Value;
     case: "oneofWrappedUint32Field";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_string_string_field = 70;

--- a/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/proto3_pb.ts
@@ -82,77 +82,77 @@ export type Proto3Message = Message<"spec.Proto3Message"> & {
   /**
    * @generated from field: spec.Proto3Message singular_message_field = 8;
    */
-  singularMessageField?: Proto3Message;
+  singularMessageField: Proto3Message;
 
   /**
    * @generated from field: google.protobuf.UInt32Value singular_wrapped_uint32_field = 211;
    */
-  singularWrappedUint32Field?: number;
+  singularWrappedUint32Field: number;
 
   /**
    * @generated from field: google.protobuf.Struct singular_struct_field = 214;
    */
-  singularStructField?: JsonObject;
+  singularStructField: JsonObject;
 
   /**
    * @generated from field: optional string optional_string_field = 9;
    */
-  optionalStringField?: string;
+  optionalStringField: string;
 
   /**
    * @generated from field: optional bytes optional_bytes_field = 10;
    */
-  optionalBytesField?: Uint8Array;
+  optionalBytesField: Uint8Array;
 
   /**
    * @generated from field: optional int32 optional_int32_field = 11;
    */
-  optionalInt32Field?: number;
+  optionalInt32Field: number;
 
   /**
    * @generated from field: optional int64 optional_int64_field = 12;
    */
-  optionalInt64Field?: bigint;
+  optionalInt64Field: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_js_number_field = 106 [jstype = JS_NUMBER];
    */
-  optionalInt64JsNumberField?: bigint;
+  optionalInt64JsNumberField: bigint;
 
   /**
    * @generated from field: optional int64 optional_int64_js_string_field = 105 [jstype = JS_STRING];
    */
-  optionalInt64JsStringField?: string;
+  optionalInt64JsStringField: string;
 
   /**
    * @generated from field: optional float optional_float_field = 13;
    */
-  optionalFloatField?: number;
+  optionalFloatField: number;
 
   /**
    * @generated from field: optional bool optional_bool_field = 14;
    */
-  optionalBoolField?: boolean;
+  optionalBoolField: boolean;
 
   /**
    * @generated from field: optional spec.Proto3Enum optional_enum_field = 15;
    */
-  optionalEnumField?: Proto3Enum;
+  optionalEnumField: Proto3Enum;
 
   /**
    * @generated from field: optional spec.Proto3Message optional_message_field = 16;
    */
-  optionalMessageField?: Proto3Message;
+  optionalMessageField: Proto3Message;
 
   /**
    * @generated from field: optional google.protobuf.UInt32Value optional_wrapped_uint32_field = 212;
    */
-  optionalWrappedUint32Field?: number;
+  optionalWrappedUint32Field: number;
 
   /**
    * @generated from field: optional google.protobuf.Struct optional_struct_field = 215;
    */
-  optionalStructField?: JsonObject;
+  optionalStructField: JsonObject;
 
   /**
    * @generated from field: repeated string repeated_string_field = 17;
@@ -319,7 +319,7 @@ export type Proto3Message = Message<"spec.Proto3Message"> & {
      */
     value: JsonObject;
     case: "oneofStructField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_string_string_field = 39;

--- a/packages/protobuf-test/src/gen/ts/extra/ts-types-proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/ts-types-proto2_pb.ts
@@ -38,7 +38,7 @@ export type TsTypeA = Message<"spec.TsTypeA"> & {
   /**
    * @generated from field: optional spec.TsTypeA child = 2;
    */
-  child?: TsTypeA;
+  child: TsTypeA;
 };
 
 /**
@@ -60,7 +60,7 @@ export type TsTypeB = Message<"spec.TsTypeB"> & {
   /**
    * @generated from field: optional spec.TsTypeB child = 2;
    */
-  child?: TsTypeB;
+  child: TsTypeB;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/valid_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/valid_types_pb.ts
@@ -40,7 +40,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg = 1;
    */
-  msg?: VTypes_Other;
+  msg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -49,7 +49,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg = 2;
    */
-  requiredMsg?: VTypes_Other;
+  requiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -58,7 +58,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other required_msg_ignore_always = 3;
    */
-  requiredMsgIgnoreAlways?: VTypes_Other;
+  requiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -67,14 +67,14 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other msg_ignore_unpopulated = 4;
    */
-  msgIgnoreUnpopulated?: VTypes_Other;
+  msgIgnoreUnpopulated: VTypes_Other;
 
   /**
    * In the generated valid type, this property should be the same as the regular type
    *
    * @generated from field: spec.VTypes.Other msg_ignore_default = 5;
    */
-  msgIgnoreDefault?: VTypes_Other;
+  msgIgnoreDefault: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -169,7 +169,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg = 20 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsg?: VTypes_Other;
+  legacyRequiredMsg: VTypes_Other;
 
   /**
    * In the generated valid type, this property should:
@@ -178,7 +178,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: spec.VTypes.Other legacy_required_msg_ignore_always = 21 [features.field_presence = LEGACY_REQUIRED];
    */
-  legacyRequiredMsgIgnoreAlways?: VTypes_Other;
+  legacyRequiredMsgIgnoreAlways: VTypes_Other;
 
   /**
    * In the generated valid type, this property should point to the regular
@@ -186,7 +186,7 @@ export type VTypes = Message<"spec.VTypes"> & {
    *
    * @generated from field: google.protobuf.Timestamp wkt = 22;
    */
-  wkt?: Timestamp;
+  wkt: Timestamp;
 };
 
 /**
@@ -221,7 +221,7 @@ export type VTypes2 = Message<"spec.VTypes2"> & {
    *
    * @generated from field: spec.VTypes msg = 1;
    */
-  msg?: VTypes;
+  msg: VTypes;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/extra/wkt-wrappers_pb.ts
@@ -37,47 +37,47 @@ export type WrappersMessage = Message<"spec.WrappersMessage"> & {
   /**
    * @generated from field: google.protobuf.DoubleValue double_value_field = 1;
    */
-  doubleValueField?: number;
+  doubleValueField: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_value_field = 2;
    */
-  boolValueField?: boolean;
+  boolValueField: boolean;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_value_field = 3;
    */
-  floatValueField?: number;
+  floatValueField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_value_field = 4;
    */
-  int64ValueField?: bigint;
+  int64ValueField: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_value_field = 5;
    */
-  uint64ValueField?: bigint;
+  uint64ValueField: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_value_field = 6;
    */
-  int32ValueField?: number;
+  int32ValueField: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_value_field = 7;
    */
-  uint32ValueField?: number;
+  uint32ValueField: number;
 
   /**
    * @generated from field: google.protobuf.StringValue string_value_field = 8;
    */
-  stringValueField?: string;
+  stringValueField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_value_field = 9;
    */
-  bytesValueField?: Uint8Array;
+  bytesValueField: Uint8Array;
 
   /**
    * @generated from oneof spec.WrappersMessage.oneof_fields
@@ -137,7 +137,7 @@ export type WrappersMessage = Message<"spec.WrappersMessage"> & {
      */
     value: BytesValue;
     case: "oneofBytesValueField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: repeated google.protobuf.DoubleValue repeated_double_value_field = 21;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/map_proto2_unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/map_proto2_unittest_pb.ts
@@ -317,7 +317,7 @@ export type TestSubmessageMaps = Message<"proto2_unittest.TestSubmessageMaps"> &
   /**
    * @generated from field: optional proto2_unittest.TestMaps m = 1;
    */
-  m?: TestMaps;
+  m: TestMaps;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto2_pb.ts
@@ -120,12 +120,12 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto2_NestedMessage;
+  optionalNestedMessage: TestAllTypesProto2_NestedMessage;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessageProto2;
+  optionalForeignMessage: ForeignMessageProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum optional_nested_enum = 21;
@@ -150,7 +150,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto2;
+  recursiveMessage: TestAllTypesProto2;
 
   /**
    * Repeated
@@ -567,17 +567,17 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
      */
     value: TestAllTypesProto2_NestedEnum;
     case: "oneofEnum";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.Data data = 201;
    */
-  data?: TestAllTypesProto2_Data;
+  data: TestAllTypesProto2_Data;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MultiWordGroupField multiwordgroupfield = 204;
    */
-  multiwordgroupfield?: TestAllTypesProto2_MultiWordGroupField;
+  multiwordgroupfield: TestAllTypesProto2_MultiWordGroupField;
 
   /**
    * default values
@@ -752,7 +752,7 @@ export type TestAllTypesProto2 = Message<"protobuf_test_messages.proto2.TestAllT
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect message_set_correct = 500;
    */
-  messageSetCorrect?: TestAllTypesProto2_MessageSetCorrect;
+  messageSetCorrect: TestAllTypesProto2_MessageSetCorrect;
 };
 
 /**
@@ -774,7 +774,7 @@ export type TestAllTypesProto2_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto2;
+  corecursive: TestAllTypesProto2;
 };
 
 /**
@@ -910,7 +910,7 @@ export type TestAllTypesProto2_ExtensionWithOneof = Message<"protobuf_test_messa
      */
     value: number;
     case: "b";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -1015,12 +1015,12 @@ export type UnknownToTestAllTypes = Message<"protobuf_test_messages.proto2.Unkno
   /**
    * @generated from field: optional protobuf_test_messages.proto2.ForeignMessageProto2 nested_message = 1003;
    */
-  nestedMessage?: ForeignMessageProto2;
+  nestedMessage: ForeignMessageProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup optionalgroup = 1004;
    */
-  optionalgroup?: UnknownToTestAllTypes_OptionalGroup;
+  optionalgroup: UnknownToTestAllTypes_OptionalGroup;
 
   /**
    * @generated from field: optional bool optional_bool = 1006;
@@ -1232,12 +1232,12 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedMessage required_nested_message = 18;
    */
-  requiredNestedMessage?: TestAllRequiredTypesProto2_NestedMessage;
+  requiredNestedMessage: TestAllRequiredTypesProto2_NestedMessage;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.ForeignMessageProto2 required_foreign_message = 19;
    */
-  requiredForeignMessage?: ForeignMessageProto2;
+  requiredForeignMessage: ForeignMessageProto2;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.NestedEnum required_nested_enum = 21;
@@ -1262,17 +1262,17 @@ export type TestAllRequiredTypesProto2 = Message<"protobuf_test_messages.proto2.
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 recursive_message = 27;
    */
-  recursiveMessage?: TestAllRequiredTypesProto2;
+  recursiveMessage: TestAllRequiredTypesProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_recursive_message = 28;
    */
-  optionalRecursiveMessage?: TestAllRequiredTypesProto2;
+  optionalRecursiveMessage: TestAllRequiredTypesProto2;
 
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2.Data data = 201;
    */
-  data?: TestAllRequiredTypesProto2_Data;
+  data: TestAllRequiredTypesProto2_Data;
 
   /**
    * default values
@@ -1371,12 +1371,12 @@ export type TestAllRequiredTypesProto2_NestedMessage = Message<"protobuf_test_me
   /**
    * @generated from field: required protobuf_test_messages.proto2.TestAllRequiredTypesProto2 corecursive = 2;
    */
-  corecursive?: TestAllRequiredTypesProto2;
+  corecursive: TestAllRequiredTypesProto2;
 
   /**
    * @generated from field: optional protobuf_test_messages.proto2.TestAllRequiredTypesProto2 optional_corecursive = 3;
    */
-  optionalCorecursive?: TestAllRequiredTypesProto2;
+  optionalCorecursive: TestAllRequiredTypesProto2;
 };
 
 /**
@@ -1541,7 +1541,7 @@ export type TestLargeOneof = Message<"protobuf_test_messages.proto2.TestLargeOne
      */
     value: TestLargeOneof_A5;
     case: "a5";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/test_messages_proto3_pb.ts
@@ -121,12 +121,12 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypesProto3_NestedMessage;
+  optionalNestedMessage: TestAllTypesProto3_NestedMessage;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum optional_nested_enum = 21;
@@ -156,7 +156,7 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 recursive_message = 27;
    */
-  recursiveMessage?: TestAllTypesProto3;
+  recursiveMessage: TestAllTypesProto3;
 
   /**
    * Repeated
@@ -569,54 +569,54 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
      */
     value: NullValue;
     case: "oneofNullValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * Well-known types
    *
    * @generated from field: google.protobuf.BoolValue optional_bool_wrapper = 201;
    */
-  optionalBoolWrapper?: boolean;
+  optionalBoolWrapper: boolean;
 
   /**
    * @generated from field: google.protobuf.Int32Value optional_int32_wrapper = 202;
    */
-  optionalInt32Wrapper?: number;
+  optionalInt32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value optional_int64_wrapper = 203;
    */
-  optionalInt64Wrapper?: bigint;
+  optionalInt64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt32Value optional_uint32_wrapper = 204;
    */
-  optionalUint32Wrapper?: number;
+  optionalUint32Wrapper: number;
 
   /**
    * @generated from field: google.protobuf.UInt64Value optional_uint64_wrapper = 205;
    */
-  optionalUint64Wrapper?: bigint;
+  optionalUint64Wrapper: bigint;
 
   /**
    * @generated from field: google.protobuf.FloatValue optional_float_wrapper = 206;
    */
-  optionalFloatWrapper?: number;
+  optionalFloatWrapper: number;
 
   /**
    * @generated from field: google.protobuf.DoubleValue optional_double_wrapper = 207;
    */
-  optionalDoubleWrapper?: number;
+  optionalDoubleWrapper: number;
 
   /**
    * @generated from field: google.protobuf.StringValue optional_string_wrapper = 208;
    */
-  optionalStringWrapper?: string;
+  optionalStringWrapper: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue optional_bytes_wrapper = 209;
    */
-  optionalBytesWrapper?: Uint8Array;
+  optionalBytesWrapper: Uint8Array;
 
   /**
    * @generated from field: repeated google.protobuf.BoolValue repeated_bool_wrapper = 211;
@@ -666,32 +666,32 @@ export type TestAllTypesProto3 = Message<"protobuf_test_messages.proto3.TestAllT
   /**
    * @generated from field: google.protobuf.Duration optional_duration = 301;
    */
-  optionalDuration?: Duration;
+  optionalDuration: Duration;
 
   /**
    * @generated from field: google.protobuf.Timestamp optional_timestamp = 302;
    */
-  optionalTimestamp?: Timestamp;
+  optionalTimestamp: Timestamp;
 
   /**
    * @generated from field: google.protobuf.FieldMask optional_field_mask = 303;
    */
-  optionalFieldMask?: FieldMask;
+  optionalFieldMask: FieldMask;
 
   /**
    * @generated from field: google.protobuf.Struct optional_struct = 304;
    */
-  optionalStruct?: JsonObject;
+  optionalStruct: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Any optional_any = 305;
    */
-  optionalAny?: Any;
+  optionalAny: Any;
 
   /**
    * @generated from field: google.protobuf.Value optional_value = 306;
    */
-  optionalValue?: Value;
+  optionalValue: Value;
 
   /**
    * @generated from field: google.protobuf.NullValue optional_null_value = 307;
@@ -846,7 +846,7 @@ export type TestAllTypesProto3_NestedMessage = Message<"protobuf_test_messages.p
   /**
    * @generated from field: protobuf_test_messages.proto3.TestAllTypesProto3 corecursive = 2;
    */
-  corecursive?: TestAllTypesProto3;
+  corecursive: TestAllTypesProto3;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/type_pb.ts
@@ -72,7 +72,7 @@ export type Type = Message<"google.protobuf.Type"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * The source syntax.
@@ -411,7 +411,7 @@ export type Enum = Message<"google.protobuf.Enum"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * The source syntax.
@@ -504,7 +504,7 @@ export type Option = Message<"google.protobuf.Option"> & {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value: Any;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_custom_options_pb.ts
@@ -58,7 +58,7 @@ export type TestMessageWithCustomOptions = Message<"proto2_unittest.TestMessageW
      */
     value: number;
     case: "oneofField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: map<string, string> map_field = 3;
@@ -352,7 +352,7 @@ export type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionType2"> &
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType1 bar = 1;
    */
-  bar?: ComplexOptionType1;
+  bar: ComplexOptionType1;
 
   /**
    * @generated from field: optional int32 baz = 2;
@@ -362,7 +362,7 @@ export type ComplexOptionType2 = Message<"proto2_unittest.ComplexOptionType2"> &
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType2.ComplexOptionType4 fred = 3;
    */
-  fred?: ComplexOptionType2_ComplexOptionType4;
+  fred: ComplexOptionType2_ComplexOptionType4;
 
   /**
    * @generated from field: repeated proto2_unittest.ComplexOptionType2.ComplexOptionType4 barney = 4;
@@ -412,7 +412,7 @@ export type ComplexOptionType3 = Message<"proto2_unittest.ComplexOptionType3"> &
   /**
    * @generated from field: optional proto2_unittest.ComplexOptionType3.ComplexOptionType5 complexoptiontype5 = 2;
    */
-  complexoptiontype5?: ComplexOptionType3_ComplexOptionType5;
+  complexoptiontype5: ComplexOptionType3_ComplexOptionType5;
 };
 
 /**
@@ -528,28 +528,28 @@ export type Aggregate = Message<"proto2_unittest.Aggregate"> & {
    *
    * @generated from field: optional proto2_unittest.Aggregate sub = 3;
    */
-  sub?: Aggregate;
+  sub: Aggregate;
 
   /**
    * To test the parsing of extensions inside aggregate values
    *
    * @generated from field: optional google.protobuf.FileOptions file = 4;
    */
-  file?: FileOptions;
+  file: FileOptions;
 
   /**
    * An embedded message set
    *
    * @generated from field: optional proto2_unittest.AggregateMessageSet mset = 5;
    */
-  mset?: AggregateMessageSet;
+  mset: AggregateMessageSet;
 
   /**
    * An any
    *
    * @generated from field: optional google.protobuf.Any any = 6;
    */
-  any?: Any;
+  any: Any;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_embed_optimize_for_pb.ts
@@ -44,7 +44,7 @@ export type TestEmbedOptimizedForSize = Message<"proto2_unittest.TestEmbedOptimi
    *
    * @generated from field: optional proto2_unittest.TestOptimizedForSize optional_message = 1;
    */
-  optionalMessage?: TestOptimizedForSize;
+  optionalMessage: TestOptimizedForSize;
 
   /**
    * @generated from field: repeated proto2_unittest.TestOptimizedForSize repeated_message = 2;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_extension_set_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_extension_set_pb.ts
@@ -54,7 +54,7 @@ export type TestExtensionSetContainer = Message<"proto2_unittest.TestExtensionSe
   /**
    * @generated from field: optional proto2_unittest.TestExtensionSet extension = 1;
    */
-  extension?: TestExtensionSet;
+  extension: TestExtensionSet;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_lite_imports_nonlite_pb.ts
@@ -39,14 +39,14 @@ export type TestLiteImportsNonlite = Message<"proto2_unittest.TestLiteImportsNon
   /**
    * @generated from field: optional proto2_unittest.TestAllTypes message = 1;
    */
-  message?: TestAllTypes;
+  message: TestAllTypes;
 
   /**
    * Verifies that transitive required fields generates valid code.
    *
    * @generated from field: optional proto2_unittest.TestRequired message_with_required = 2;
    */
-  messageWithRequired?: TestRequired;
+  messageWithRequired: TestRequired;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_pb.ts
@@ -42,7 +42,7 @@ export type TestMessageSetContainer = Message<"proto2_unittest.TestMessageSetCon
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet: TestMessageSet;
 };
 
 /**
@@ -59,17 +59,17 @@ export type NestedTestMessageSetContainer = Message<"proto2_unittest.NestedTestM
   /**
    * @generated from field: optional proto2_unittest.TestMessageSetContainer container = 1;
    */
-  container?: TestMessageSetContainer;
+  container: TestMessageSetContainer;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer child = 2;
    */
-  child?: NestedTestMessageSetContainer;
+  child: NestedTestMessageSetContainer;
 
   /**
    * @generated from field: optional proto2_unittest.NestedTestMessageSetContainer lazy_child = 3;
    */
-  lazyChild?: NestedTestMessageSetContainer;
+  lazyChild: NestedTestMessageSetContainer;
 };
 
 /**
@@ -96,7 +96,7 @@ export type NestedTestInt = Message<"proto2_unittest.NestedTestInt"> & {
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt child = 2;
    */
-  child?: NestedTestInt;
+  child: NestedTestInt;
 };
 
 /**
@@ -118,7 +118,7 @@ export type TestMessageSetExtension1 = Message<"proto2_unittest.TestMessageSetEx
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet recursive = 16;
    */
-  recursive?: TestMessageSet;
+  recursive: TestMessageSet;
 
   /**
    * @generated from field: optional string test_aliasing = 17;
@@ -169,7 +169,7 @@ export type TestMessageSetExtension3 = Message<"proto2_unittest.TestMessageSetEx
   /**
    * @generated from field: optional proto2_unittest.NestedTestInt msg = 35;
    */
-  msg?: NestedTestInt;
+  msg: NestedTestInt;
 
   /**
    * @generated from field: required int32 required_int = 36;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_mset_wire_format_pb.ts
@@ -54,7 +54,7 @@ export type TestMessageSetWireFormatContainer = Message<"proto2_wireformat_unitt
   /**
    * @generated from field: optional proto2_wireformat_unittest.TestMessageSet message_set = 1;
    */
-  messageSet?: TestMessageSet;
+  messageSet: TestMessageSet;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_optimize_for_pb.ts
@@ -46,7 +46,7 @@ export type TestOptimizedForSize = Message<"proto2_unittest.TestOptimizedForSize
   /**
    * @generated from field: optional proto2_unittest.ForeignMessage msg = 19;
    */
-  msg?: ForeignMessage;
+  msg: ForeignMessage;
 
   /**
    * @generated from oneof proto2_unittest.TestOptimizedForSize.foo
@@ -63,7 +63,7 @@ export type TestOptimizedForSize = Message<"proto2_unittest.TestOptimizedForSize
      */
     value: string;
     case: "stringField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -109,7 +109,7 @@ export type TestOptionalOptimizedForSize = Message<"proto2_unittest.TestOptional
   /**
    * @generated from field: optional proto2_unittest.TestRequiredOptimizedForSize o = 1;
    */
-  o?: TestRequiredOptimizedForSize;
+  o: TestRequiredOptimizedForSize;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_pb.ts
@@ -131,22 +131,22 @@ export type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestAllTypes_OptionalGroup;
+  optionalgroup: TestAllTypes_OptionalGroup;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage: ImportMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -183,17 +183,17 @@ export type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage: PublicImportMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * Repeated
@@ -471,7 +471,7 @@ export type TestAllTypes = Message<"proto2_unittest.TestAllTypes"> & {
      */
     value: TestAllTypes_NestedMessage;
     case: "oneofLazyNestedMessage";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -578,12 +578,12 @@ export type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllTypes"> &
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child: NestedTestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.NestedTestAllTypes repeated_child = 3;
@@ -593,12 +593,12 @@ export type NestedTestAllTypes = Message<"proto2_unittest.NestedTestAllTypes"> &
   /**
    * @generated from field: proto2_unittest.NestedTestAllTypes lazy_child = 4;
    */
-  lazyChild?: NestedTestAllTypes;
+  lazyChild: NestedTestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes eager_child = 5;
    */
-  eagerChild?: TestAllTypes;
+  eagerChild: TestAllTypes;
 };
 
 /**
@@ -628,7 +628,7 @@ export type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecatedFields
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage deprecated_message = 3 [deprecated = true];
    * @deprecated
    */
-  deprecatedMessage?: TestAllTypes_NestedMessage;
+  deprecatedMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from oneof proto2_unittest.TestDeprecatedFields.oneof_fields
@@ -640,12 +640,12 @@ export type TestDeprecatedFields = Message<"proto2_unittest.TestDeprecatedFields
      */
     value: number;
     case: "deprecatedInt32InOneof";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: proto2_unittest.TestDeprecatedFields nested = 5;
    */
-  nested?: TestDeprecatedFields;
+  nested: TestDeprecatedFields;
 };
 
 /**
@@ -796,7 +796,7 @@ export type TestGroup = Message<"proto2_unittest.TestGroup"> & {
   /**
    * @generated from field: proto2_unittest.TestGroup.OptionalGroup optionalgroup = 16 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestGroup_OptionalGroup;
+  optionalgroup: TestGroup_OptionalGroup;
 
   /**
    * @generated from field: proto2_unittest.ForeignEnum optional_foreign_enum = 22;
@@ -925,7 +925,7 @@ export type TestChildExtension = Message<"proto2_unittest.TestChildExtension"> &
   /**
    * @generated from field: proto2_unittest.TestAllExtensions optional_extension = 3;
    */
-  optionalExtension?: TestAllExtensions;
+  optionalExtension: TestAllExtensions;
 };
 
 /**
@@ -955,7 +955,7 @@ export type TestChildExtensionData = Message<"proto2_unittest.TestChildExtension
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData optional_extension = 3;
    */
-  optionalExtension?: TestChildExtensionData_NestedTestAllExtensionsData;
+  optionalExtension: TestChildExtensionData_NestedTestAllExtensionsData;
 };
 
 /**
@@ -972,7 +972,7 @@ export type TestChildExtensionData_NestedTestAllExtensionsData = Message<"proto2
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData.NestedTestAllExtensionsData.NestedDynamicExtensions dynamic = 409707008;
    */
-  dynamic?: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
+  dynamic: TestChildExtensionData_NestedTestAllExtensionsData_NestedDynamicExtensions;
 };
 
 /**
@@ -1016,7 +1016,7 @@ export type TestNestedChildExtension = Message<"proto2_unittest.TestNestedChildE
   /**
    * @generated from field: proto2_unittest.TestChildExtension child = 2;
    */
-  child?: TestChildExtension;
+  child: TestChildExtension;
 };
 
 /**
@@ -1041,7 +1041,7 @@ export type TestNestedChildExtensionData = Message<"proto2_unittest.TestNestedCh
   /**
    * @generated from field: proto2_unittest.TestChildExtensionData child = 2;
    */
-  child?: TestChildExtensionData;
+  child: TestChildExtensionData;
 };
 
 /**
@@ -1492,7 +1492,7 @@ export type TestRequired = Message<"proto2_unittest.TestRequired"> & {
    *
    * @generated from field: proto2_unittest.ForeignMessage optional_foreign = 34;
    */
-  optionalForeign?: ForeignMessage;
+  optionalForeign: ForeignMessage;
 
   /**
    * @generated from field: map<string, proto2_unittest.TestRequired> map_field = 35;
@@ -1526,7 +1526,7 @@ export type TestRequiredForeign = Message<"proto2_unittest.TestRequiredForeign">
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage: TestRequired;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1543,7 +1543,7 @@ export type TestRequiredForeign = Message<"proto2_unittest.TestRequiredForeign">
    *
    * @generated from field: proto2_unittest.NestedTestAllTypes optional_lazy_message = 4;
    */
-  optionalLazyMessage?: NestedTestAllTypes;
+  optionalLazyMessage: NestedTestAllTypes;
 };
 
 /**
@@ -1560,7 +1560,7 @@ export type TestRequiredMessage = Message<"proto2_unittest.TestRequiredMessage">
   /**
    * @generated from field: proto2_unittest.TestRequired optional_message = 1;
    */
-  optionalMessage?: TestRequired;
+  optionalMessage: TestRequired;
 
   /**
    * @generated from field: repeated proto2_unittest.TestRequired repeated_message = 2;
@@ -1570,7 +1570,7 @@ export type TestRequiredMessage = Message<"proto2_unittest.TestRequiredMessage">
   /**
    * @generated from field: proto2_unittest.TestRequired required_message = 3 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredMessage?: TestRequired;
+  requiredMessage: TestRequired;
 };
 
 /**
@@ -1587,12 +1587,12 @@ export type TestRequiredLazyMessage = Message<"proto2_unittest.TestRequiredLazyM
   /**
    * @generated from field: proto2_unittest.TestRequired child = 1;
    */
-  child?: TestRequired;
+  child: TestRequired;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredLazyMessage recurse = 2;
    */
-  recurse?: TestRequiredLazyMessage;
+  recurse: TestRequiredLazyMessage;
 };
 
 /**
@@ -1609,12 +1609,12 @@ export type TestNestedRequiredForeign = Message<"proto2_unittest.TestNestedRequi
   /**
    * @generated from field: proto2_unittest.TestNestedRequiredForeign child = 1;
    */
-  child?: TestNestedRequiredForeign;
+  child: TestNestedRequiredForeign;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredForeign payload = 2;
    */
-  payload?: TestRequiredForeign;
+  payload: TestRequiredForeign;
 
   /**
    * @generated from field: int32 dummy = 3;
@@ -1626,22 +1626,22 @@ export type TestNestedRequiredForeign = Message<"proto2_unittest.TestNestedRequi
    *
    * @generated from field: proto2_unittest.TestRequiredEnum required_enum = 5;
    */
-  requiredEnum?: TestRequiredEnum;
+  requiredEnum: TestRequiredEnum;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask required_enum_no_mask = 6;
    */
-  requiredEnumNoMask?: TestRequiredEnumNoMask;
+  requiredEnumNoMask: TestRequiredEnumNoMask;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti required_enum_multi = 7;
    */
-  requiredEnumMulti?: TestRequiredEnumMulti;
+  requiredEnumMulti: TestRequiredEnumMulti;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti required_no_mask = 9;
    */
-  requiredNoMask?: TestRequiredNoMaskMulti;
+  requiredNoMask: TestRequiredNoMaskMulti;
 };
 
 /**
@@ -1660,7 +1660,7 @@ export type TestForeignNested = Message<"proto2_unittest.TestForeignNested"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes.NestedMessage foreign_nested = 1;
    */
-  foreignNested?: TestAllTypes_NestedMessage;
+  foreignNested: TestAllTypes_NestedMessage;
 };
 
 /**
@@ -1797,7 +1797,7 @@ export type TestRecursiveMessage = Message<"proto2_unittest.TestRecursiveMessage
   /**
    * @generated from field: proto2_unittest.TestRecursiveMessage a = 1;
    */
-  a?: TestRecursiveMessage;
+  a: TestRecursiveMessage;
 
   /**
    * @generated from field: int32 i = 2;
@@ -1821,12 +1821,12 @@ export type TestMutualRecursionA = Message<"proto2_unittest.TestMutualRecursionA
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB bb = 1;
    */
-  bb?: TestMutualRecursionB;
+  bb: TestMutualRecursionB;
 
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubGroup subgroup = 2 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestMutualRecursionA_SubGroup;
+  subgroup: TestMutualRecursionA_SubGroup;
 
   /**
    * @generated from field: repeated proto2_unittest.TestMutualRecursionA.SubGroupR subgroupr = 5 [features.message_encoding = DELIMITED];
@@ -1848,7 +1848,7 @@ export type TestMutualRecursionA_SubMessage = Message<"proto2_unittest.TestMutua
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionB b = 1;
    */
-  b?: TestMutualRecursionB;
+  b: TestMutualRecursionB;
 };
 
 /**
@@ -1867,12 +1867,12 @@ export type TestMutualRecursionA_SubGroup = Message<"proto2_unittest.TestMutualR
    *
    * @generated from field: proto2_unittest.TestMutualRecursionA.SubMessage sub_message = 3;
    */
-  subMessage?: TestMutualRecursionA_SubMessage;
+  subMessage: TestMutualRecursionA_SubMessage;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes not_in_this_scc = 4;
    */
-  notInThisScc?: TestAllTypes;
+  notInThisScc: TestAllTypes;
 };
 
 /**
@@ -1889,7 +1889,7 @@ export type TestMutualRecursionA_SubGroupR = Message<"proto2_unittest.TestMutual
   /**
    * @generated from field: proto2_unittest.TestAllTypes payload = 6;
    */
-  payload?: TestAllTypes;
+  payload: TestAllTypes;
 };
 
 /**
@@ -1906,7 +1906,7 @@ export type TestMutualRecursionB = Message<"proto2_unittest.TestMutualRecursionB
   /**
    * @generated from field: proto2_unittest.TestMutualRecursionA a = 1;
    */
-  a?: TestMutualRecursionA;
+  a: TestMutualRecursionA;
 
   /**
    * @generated from field: int32 optional_int32 = 2;
@@ -1928,7 +1928,7 @@ export type TestIsInitialized = Message<"proto2_unittest.TestIsInitialized"> & {
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage sub_message = 1;
    */
-  subMessage?: TestIsInitialized_SubMessage;
+  subMessage: TestIsInitialized_SubMessage;
 };
 
 /**
@@ -1945,7 +1945,7 @@ export type TestIsInitialized_SubMessage = Message<"proto2_unittest.TestIsInitia
   /**
    * @generated from field: proto2_unittest.TestIsInitialized.SubMessage.SubGroup subgroup = 1 [features.message_encoding = DELIMITED];
    */
-  subgroup?: TestIsInitialized_SubMessage_SubGroup;
+  subgroup: TestIsInitialized_SubMessage_SubGroup;
 };
 
 /**
@@ -1995,14 +1995,14 @@ export type TestDupFieldNumber = Message<"proto2_unittest.TestDupFieldNumber"> &
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Foo foo = 2 [features.message_encoding = DELIMITED];
    */
-  foo?: TestDupFieldNumber_Foo;
+  foo: TestDupFieldNumber_Foo;
 
   /**
    * NO_PROTO1
    *
    * @generated from field: proto2_unittest.TestDupFieldNumber.Bar bar = 3 [features.message_encoding = DELIMITED];
    */
-  bar?: TestDupFieldNumber_Bar;
+  bar: TestDupFieldNumber_Bar;
 };
 
 /**
@@ -2063,7 +2063,7 @@ export type TestEagerMessage = Message<"proto2_unittest.TestEagerMessage"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage: TestAllTypes;
 };
 
 /**
@@ -2080,7 +2080,7 @@ export type TestLazyMessage = Message<"proto2_unittest.TestLazyMessage"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes sub_message = 1;
    */
-  subMessage?: TestAllTypes;
+  subMessage: TestAllTypes;
 };
 
 /**
@@ -2097,27 +2097,27 @@ export type TestLazyRequiredEnum = Message<"proto2_unittest.TestLazyRequiredEnum
   /**
    * @generated from field: proto2_unittest.TestRequiredOpenEnum optional_required_open_enum = 1;
    */
-  optionalRequiredOpenEnum?: TestRequiredOpenEnum;
+  optionalRequiredOpenEnum: TestRequiredOpenEnum;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnum optional_required_enum = 2;
    */
-  optionalRequiredEnum?: TestRequiredEnum;
+  optionalRequiredEnum: TestRequiredEnum;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumNoMask optional_required_enum_no_mask = 3;
    */
-  optionalRequiredEnumNoMask?: TestRequiredEnumNoMask;
+  optionalRequiredEnumNoMask: TestRequiredEnumNoMask;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredEnumMulti optional_required_enum_multi = 4;
    */
-  optionalRequiredEnumMulti?: TestRequiredEnumMulti;
+  optionalRequiredEnumMulti: TestRequiredEnumMulti;
 
   /**
    * @generated from field: proto2_unittest.TestRequiredNoMaskMulti optional_required_no_mask = 5;
    */
-  optionalRequiredNoMask?: TestRequiredNoMaskMulti;
+  optionalRequiredNoMask: TestRequiredNoMaskMulti;
 };
 
 /**
@@ -2151,17 +2151,17 @@ export type TestEagerMaybeLazy = Message<"proto2_unittest.TestEagerMaybeLazy"> &
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_foo = 1;
    */
-  messageFoo?: TestAllTypes;
+  messageFoo: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes message_bar = 2;
    */
-  messageBar?: TestAllTypes;
+  messageBar: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestEagerMaybeLazy.NestedMessage message_baz = 3;
    */
-  messageBaz?: TestEagerMaybeLazy_NestedMessage;
+  messageBaz: TestEagerMaybeLazy_NestedMessage;
 };
 
 /**
@@ -2178,7 +2178,7 @@ export type TestEagerMaybeLazy_NestedMessage = Message<"proto2_unittest.TestEage
   /**
    * @generated from field: proto2_unittest.TestPackedTypes packed = 1;
    */
-  packed?: TestPackedTypes;
+  packed: TestPackedTypes;
 };
 
 /**
@@ -2197,7 +2197,7 @@ export type TestNestedMessageHasBits = Message<"proto2_unittest.TestNestedMessag
   /**
    * @generated from field: proto2_unittest.TestNestedMessageHasBits.NestedMessage optional_nested_message = 1;
    */
-  optionalNestedMessage?: TestNestedMessageHasBits_NestedMessage;
+  optionalNestedMessage: TestNestedMessageHasBits_NestedMessage;
 };
 
 /**
@@ -2254,7 +2254,7 @@ export type TestCamelCaseFieldNames = Message<"proto2_unittest.TestCamelCaseFiel
   /**
    * @generated from field: proto2_unittest.ForeignMessage MessageField = 4;
    */
-  MessageField?: ForeignMessage;
+  MessageField: ForeignMessage;
 
   /**
    * @generated from field: string StringPieceField = 5;
@@ -2329,7 +2329,7 @@ export type TestFieldOrderings = Message<"proto2_unittest.TestFieldOrderings"> &
   /**
    * @generated from field: proto2_unittest.TestFieldOrderings.NestedMessage optional_nested_message = 200;
    */
-  optionalNestedMessage?: TestFieldOrderings_NestedMessage;
+  optionalNestedMessage: TestFieldOrderings_NestedMessage;
 };
 
 /**
@@ -2978,7 +2978,7 @@ export type TestOneof = Message<"proto2_unittest.TestOneof"> & {
      */
     value: TestOneof_FooGroup;
     case: "foogroup";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -3027,12 +3027,12 @@ export type TestOneofBackwardsCompatible = Message<"proto2_unittest.TestOneofBac
   /**
    * @generated from field: proto2_unittest.TestAllTypes foo_message = 3;
    */
-  fooMessage?: TestAllTypes;
+  fooMessage: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestOneofBackwardsCompatible.FooGroup foogroup = 4 [features.message_encoding = DELIMITED];
    */
-  foogroup?: TestOneofBackwardsCompatible_FooGroup;
+  foogroup: TestOneofBackwardsCompatible_FooGroup;
 };
 
 /**
@@ -3131,7 +3131,7 @@ export type TestOneof2 = Message<"proto2_unittest.TestOneof2"> & {
      */
     value: Uint8Array;
     case: "fooBytesCord";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from oneof proto2_unittest.TestOneof2.bar
@@ -3196,7 +3196,7 @@ export type TestOneof2 = Message<"proto2_unittest.TestOneof2"> & {
      */
     value: Uint8Array;
     case: "barBytesWithEmptyDefault";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: int32 baz_int = 18;
@@ -3255,7 +3255,7 @@ export type TestOneof2_NestedMessage = Message<"proto2_unittest.TestOneof2.Neste
   /**
    * @generated from field: proto2_unittest.TestOneof2.NestedMessage child = 3;
    */
-  child?: TestOneof2_NestedMessage;
+  child: TestOneof2_NestedMessage;
 };
 
 /**
@@ -3322,7 +3322,7 @@ export type TestRequiredOneof = Message<"proto2_unittest.TestRequiredOneof"> & {
      */
     value: TestRequiredOneof_NestedMessage;
     case: "fooLazyMessage";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -3568,12 +3568,12 @@ export type TestDynamicExtensions = Message<"proto2_unittest.TestDynamicExtensio
   /**
    * @generated from field: proto2_unittest.ForeignMessage message_extension = 2003;
    */
-  messageExtension?: ForeignMessage;
+  messageExtension: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest.TestDynamicExtensions.DynamicMessageType dynamic_message_extension = 2004;
    */
-  dynamicMessageExtension?: TestDynamicExtensions_DynamicMessageType;
+  dynamicMessageExtension: TestDynamicExtensions_DynamicMessageType;
 
   /**
    * @generated from field: repeated string repeated_extension = 2005;
@@ -3730,12 +3730,12 @@ export type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes required_all_types = 1 [features.field_presence = LEGACY_REQUIRED];
    */
-  requiredAllTypes?: TestAllTypes;
+  requiredAllTypes: TestAllTypes;
 
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 2;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 3;
@@ -3745,7 +3745,7 @@ export type TestParsingMerge = Message<"proto2_unittest.TestParsingMerge"> & {
   /**
    * @generated from field: proto2_unittest.TestParsingMerge.OptionalGroup optionalgroup = 10 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestParsingMerge_OptionalGroup;
+  optionalgroup: TestParsingMerge_OptionalGroup;
 
   /**
    * @generated from field: repeated proto2_unittest.TestParsingMerge.RepeatedGroup repeatedgroup = 20 [features.message_encoding = DELIMITED];
@@ -3820,7 +3820,7 @@ export type TestParsingMerge_RepeatedFieldsGenerator_Group1 = Message<"proto2_un
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 11;
    */
-  field1?: TestAllTypes;
+  field1: TestAllTypes;
 };
 
 /**
@@ -3837,7 +3837,7 @@ export type TestParsingMerge_RepeatedFieldsGenerator_Group2 = Message<"proto2_un
   /**
    * @generated from field: proto2_unittest.TestAllTypes field1 = 21;
    */
-  field1?: TestAllTypes;
+  field1: TestAllTypes;
 };
 
 /**
@@ -3854,7 +3854,7 @@ export type TestParsingMerge_OptionalGroup = Message<"proto2_unittest.TestParsin
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_group_all_types = 11;
    */
-  optionalGroupAllTypes?: TestAllTypes;
+  optionalGroupAllTypes: TestAllTypes;
 };
 
 /**
@@ -3871,7 +3871,7 @@ export type TestParsingMerge_RepeatedGroup = Message<"proto2_unittest.TestParsin
   /**
    * @generated from field: proto2_unittest.TestAllTypes repeated_group_all_types = 21;
    */
-  repeatedGroupAllTypes?: TestAllTypes;
+  repeatedGroupAllTypes: TestAllTypes;
 };
 
 /**
@@ -3903,7 +3903,7 @@ export type TestMergeException = Message<"proto2_unittest.TestMergeException"> &
   /**
    * @generated from field: proto2_unittest.TestAllExtensions all_extensions = 1;
    */
-  allExtensions?: TestAllExtensions;
+  allExtensions: TestAllExtensions;
 };
 
 /**
@@ -4050,7 +4050,7 @@ export type TestEagerlyVerifiedLazyMessage = Message<"proto2_unittest.TestEagerl
   /**
    * @generated from field: proto2_unittest.TestEagerlyVerifiedLazyMessage.LazyMessage lazy_message = 1;
    */
-  lazyMessage?: TestEagerlyVerifiedLazyMessage_LazyMessage;
+  lazyMessage: TestEagerlyVerifiedLazyMessage_LazyMessage;
 };
 
 /**
@@ -4246,12 +4246,12 @@ export type TestHugeFieldNumbers = Message<"proto2_unittest.TestHugeFieldNumbers
   /**
    * @generated from field: proto2_unittest.ForeignMessage optional_message = 536870007;
    */
-  optionalMessage?: ForeignMessage;
+  optionalMessage: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest.TestHugeFieldNumbers.OptionalGroup optionalgroup = 536870008 [features.message_encoding = DELIMITED];
    */
-  optionalgroup?: TestHugeFieldNumbers_OptionalGroup;
+  optionalgroup: TestHugeFieldNumbers_OptionalGroup;
 
   /**
    * @generated from field: map<string, string> string_string_map = 536870010;
@@ -4285,7 +4285,7 @@ export type TestHugeFieldNumbers = Message<"proto2_unittest.TestHugeFieldNumbers
      */
     value: Uint8Array;
     case: "oneofBytes";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 
   /**
    * @generated from field: bool optional_bool = 536870015;
@@ -4413,7 +4413,7 @@ export type TestNestedGroupExtensionOuter = Message<"proto2_unittest.TestNestedG
   /**
    * @generated from field: proto2_unittest.TestNestedGroupExtensionOuter.Layer1OptionalGroup layer1optionalgroup = 1 [features.message_encoding = DELIMITED];
    */
-  layer1optionalgroup?: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
+  layer1optionalgroup: TestNestedGroupExtensionOuter_Layer1OptionalGroup;
 };
 
 /**
@@ -4617,7 +4617,7 @@ export type TestVerifyInt32 = Message<"proto2_unittest.TestVerifyInt32"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4674,7 +4674,7 @@ export type TestVerifyMostlyInt32 = Message<"proto2_unittest.TestVerifyMostlyInt
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4736,7 +4736,7 @@ export type TestVerifyMostlyInt32BigFieldNumber = Message<"proto2_unittest.TestV
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4810,7 +4810,7 @@ export type TestVerifyUint32 = Message<"proto2_unittest.TestVerifyUint32"> & {
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4852,7 +4852,7 @@ export type TestVerifyOneUint32 = Message<"proto2_unittest.TestVerifyOneUint32">
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4899,7 +4899,7 @@ export type TestVerifyOneInt32BigFieldNumber = Message<"proto2_unittest.TestVeri
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -4951,7 +4951,7 @@ export type TestVerifyInt32BigFieldNumber = Message<"proto2_unittest.TestVerifyI
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -5003,7 +5003,7 @@ export type TestVerifyUint32BigFieldNumber = Message<"proto2_unittest.TestVerify
   /**
    * @generated from field: proto2_unittest.TestAllTypes optional_all_types = 9;
    */
-  optionalAllTypes?: TestAllTypes;
+  optionalAllTypes: TestAllTypes;
 
   /**
    * @generated from field: repeated proto2_unittest.TestAllTypes repeated_all_types = 10;
@@ -5025,7 +5025,7 @@ export type TestVerifyBigFieldNumberUint32 = Message<"proto2_unittest.TestVerify
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 1;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested: TestVerifyBigFieldNumberUint32_Nested;
 };
 
 /**
@@ -5082,7 +5082,7 @@ export type TestVerifyBigFieldNumberUint32_Nested = Message<"proto2_unittest.Tes
   /**
    * @generated from field: proto2_unittest.TestVerifyBigFieldNumberUint32.Nested optional_nested = 9;
    */
-  optionalNested?: TestVerifyBigFieldNumberUint32_Nested;
+  optionalNested: TestVerifyBigFieldNumberUint32_Nested;
 
   /**
    * @generated from field: repeated proto2_unittest.TestVerifyBigFieldNumberUint32.Nested repeated_nested = 10;
@@ -5862,7 +5862,7 @@ export type InlinedStringIdxRegressionProto = Message<"proto2_unittest.InlinedSt
    *
    * @generated from field: proto2_unittest.InlinedStringIdxRegressionProto sub = 2;
    */
-  sub?: InlinedStringIdxRegressionProto;
+  sub: InlinedStringIdxRegressionProto;
 
   /**
    * aux_idx == 3, inlined_string_idx == 2
@@ -6011,12 +6011,12 @@ export type RedactedFields = Message<"proto2_unittest.RedactedFields"> & {
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_redacted_message = 5;
    */
-  optionalRedactedMessage?: TestNestedMessageRedaction;
+  optionalRedactedMessage: TestNestedMessageRedaction;
 
   /**
    * @generated from field: proto2_unittest.TestNestedMessageRedaction optional_unredacted_message = 6;
    */
-  optionalUnredactedMessage?: TestNestedMessageRedaction;
+  optionalUnredactedMessage: TestNestedMessageRedaction;
 
   /**
    * @generated from field: repeated proto2_unittest.TestNestedMessageRedaction repeated_redacted_message = 7;
@@ -6615,7 +6615,7 @@ export type MessageCreatorZeroInit = Message<"proto2_unittest.MessageCreatorZero
   /**
    * @generated from field: proto2_unittest.MessageCreatorZeroInit m = 3;
    */
-  m?: MessageCreatorZeroInit;
+  m: MessageCreatorZeroInit;
 
   /**
    * @generated from oneof proto2_unittest.MessageCreatorZeroInit.one
@@ -6644,7 +6644,7 @@ export type MessageCreatorZeroInit = Message<"proto2_unittest.MessageCreatorZero
      */
     value: MessageCreatorZeroInit;
     case: "ol";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -6671,7 +6671,7 @@ export type MessageCreatorMemcpy = Message<"proto2_unittest.MessageCreatorMemcpy
   /**
    * @generated from field: proto2_unittest.MessageCreatorMemcpy m = 3;
    */
-  m?: MessageCreatorMemcpy;
+  m: MessageCreatorMemcpy;
 
   /**
    * @generated from field: map<int32, int32> m2 = 4;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_optional_pb.ts
@@ -37,97 +37,97 @@ export type TestProto3Optional = Message<"proto2_unittest.TestProto3Optional"> &
    *
    * @generated from field: optional int32 optional_int32 = 1;
    */
-  optionalInt32?: number;
+  optionalInt32: number;
 
   /**
    * @generated from field: optional int64 optional_int64 = 2;
    */
-  optionalInt64?: bigint;
+  optionalInt64: bigint;
 
   /**
    * @generated from field: optional uint32 optional_uint32 = 3;
    */
-  optionalUint32?: number;
+  optionalUint32: number;
 
   /**
    * @generated from field: optional uint64 optional_uint64 = 4;
    */
-  optionalUint64?: bigint;
+  optionalUint64: bigint;
 
   /**
    * @generated from field: optional sint32 optional_sint32 = 5;
    */
-  optionalSint32?: number;
+  optionalSint32: number;
 
   /**
    * @generated from field: optional sint64 optional_sint64 = 6;
    */
-  optionalSint64?: bigint;
+  optionalSint64: bigint;
 
   /**
    * @generated from field: optional fixed32 optional_fixed32 = 7;
    */
-  optionalFixed32?: number;
+  optionalFixed32: number;
 
   /**
    * @generated from field: optional fixed64 optional_fixed64 = 8;
    */
-  optionalFixed64?: bigint;
+  optionalFixed64: bigint;
 
   /**
    * @generated from field: optional sfixed32 optional_sfixed32 = 9;
    */
-  optionalSfixed32?: number;
+  optionalSfixed32: number;
 
   /**
    * @generated from field: optional sfixed64 optional_sfixed64 = 10;
    */
-  optionalSfixed64?: bigint;
+  optionalSfixed64: bigint;
 
   /**
    * @generated from field: optional float optional_float = 11;
    */
-  optionalFloat?: number;
+  optionalFloat: number;
 
   /**
    * @generated from field: optional double optional_double = 12;
    */
-  optionalDouble?: number;
+  optionalDouble: number;
 
   /**
    * @generated from field: optional bool optional_bool = 13;
    */
-  optionalBool?: boolean;
+  optionalBool: boolean;
 
   /**
    * @generated from field: optional string optional_string = 14;
    */
-  optionalString?: string;
+  optionalString: string;
 
   /**
    * @generated from field: optional bytes optional_bytes = 15;
    */
-  optionalBytes?: Uint8Array;
+  optionalBytes: Uint8Array;
 
   /**
    * @generated from field: optional string optional_cord = 16;
    */
-  optionalCord?: string;
+  optionalCord: string;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestProto3Optional_NestedMessage;
+  optionalNestedMessage: TestProto3Optional_NestedMessage;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedMessage lazy_nested_message = 19;
    */
-  lazyNestedMessage?: TestProto3Optional_NestedMessage;
+  lazyNestedMessage: TestProto3Optional_NestedMessage;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3Optional.NestedEnum optional_nested_enum = 21;
    */
-  optionalNestedEnum?: TestProto3Optional_NestedEnum;
+  optionalNestedEnum: TestProto3Optional_NestedEnum;
 
   /**
    * Add some non-optional fields to verify we can mix them.
@@ -160,7 +160,7 @@ export type TestProto3Optional_NestedMessage = Message<"proto2_unittest.TestProt
    *
    * @generated from field: optional int32 bb = 1;
    */
-  bb?: number;
+  bb: number;
 };
 
 /**
@@ -215,12 +215,12 @@ export type TestProto3OptionalMessage = Message<"proto2_unittest.TestProto3Optio
   /**
    * @generated from field: proto2_unittest.TestProto3OptionalMessage.NestedMessage nested_message = 1;
    */
-  nestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  nestedMessage: TestProto3OptionalMessage_NestedMessage;
 
   /**
    * @generated from field: optional proto2_unittest.TestProto3OptionalMessage.NestedMessage optional_nested_message = 2;
    */
-  optionalNestedMessage?: TestProto3OptionalMessage_NestedMessage;
+  optionalNestedMessage: TestProto3OptionalMessage_NestedMessage;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_proto3_pb.ts
@@ -116,17 +116,17 @@ export type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
   /**
    * @generated from field: optional proto3_unittest.TestAllTypes.NestedMessage optional_nested_message = 18;
    */
-  optionalNestedMessage?: TestAllTypes_NestedMessage;
+  optionalNestedMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto3_unittest.ForeignMessage optional_foreign_message = 19;
    */
-  optionalForeignMessage?: ForeignMessage;
+  optionalForeignMessage: ForeignMessage;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_import_message = 20;
    */
-  optionalImportMessage?: ImportMessage;
+  optionalImportMessage: ImportMessage;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedEnum optional_nested_enum = 21;
@@ -153,22 +153,22 @@ export type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
    *
    * @generated from field: proto2_unittest_import.PublicImportMessage optional_public_import_message = 26;
    */
-  optionalPublicImportMessage?: PublicImportMessage;
+  optionalPublicImportMessage: PublicImportMessage;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27;
    */
-  optionalLazyMessage?: TestAllTypes_NestedMessage;
+  optionalLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28;
    */
-  optionalUnverifiedLazyMessage?: TestAllTypes_NestedMessage;
+  optionalUnverifiedLazyMessage: TestAllTypes_NestedMessage;
 
   /**
    * @generated from field: proto2_unittest_import.ImportMessage optional_lazy_import_message = 115;
    */
-  optionalLazyImportMessage?: ImportMessage;
+  optionalLazyImportMessage: ImportMessage;
 
   /**
    * Repeated
@@ -314,7 +314,7 @@ export type TestAllTypes = Message<"proto3_unittest.TestAllTypes"> & {
      */
     value: Uint8Array;
     case: "oneofBytes";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -558,12 +558,12 @@ export type NestedTestAllTypes = Message<"proto3_unittest.NestedTestAllTypes"> &
   /**
    * @generated from field: proto3_unittest.NestedTestAllTypes child = 1;
    */
-  child?: NestedTestAllTypes;
+  child: NestedTestAllTypes;
 
   /**
    * @generated from field: proto3_unittest.TestAllTypes payload = 2;
    */
-  payload?: TestAllTypes;
+  payload: TestAllTypes;
 };
 
 /**
@@ -646,7 +646,7 @@ export type TestOneof2 = Message<"proto3_unittest.TestOneof2"> & {
      */
     value: TestOneof2_NestedEnum;
     case: "fooEnum";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -1043,7 +1043,7 @@ export type TestHasbits = Message<"proto3_unittest.TestHasbits"> & {
   /**
    * @generated from field: proto3_unittest.TestAllTypes child = 100;
    */
-  child?: TestAllTypes;
+  child: TestAllTypes;
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_redaction_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_redaction_pb.ts
@@ -95,7 +95,7 @@ export type TestNestedMessageEnum = Message<"proto2_unittest.TestNestedMessageEn
   /**
    * @generated from field: proto2_unittest.TestMessageEnum nested_enum = 2;
    */
-  nestedEnum?: TestMessageEnum;
+  nestedEnum: TestMessageEnum;
 
   /**
    * @generated from field: string redacted_string = 3;
@@ -143,7 +143,7 @@ export type TestRedactedMessage = Message<"proto2_unittest.TestRedactedMessage">
   /**
    * @generated from field: google.protobuf.Any any_field = 18;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: string redactable_false = 19;

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_retention_pb.ts
@@ -88,7 +88,7 @@ export type TopLevelMessage = Message<"proto2_unittest.TopLevelMessage"> & {
      */
     value: bigint;
     case: "i";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
+++ b/packages/protobuf-test/src/gen/ts/google/protobuf/unittest_well_known_types_pb.ts
@@ -41,99 +41,99 @@ export type TestWellKnownTypes = Message<"proto2_unittest.TestWellKnownTypes"> &
   /**
    * @generated from field: google.protobuf.Any any_field = 1;
    */
-  anyField?: Any;
+  anyField: Any;
 
   /**
    * @generated from field: google.protobuf.Api api_field = 2;
    */
-  apiField?: Api;
+  apiField: Api;
 
   /**
    * @generated from field: google.protobuf.Duration duration_field = 3;
    */
-  durationField?: Duration;
+  durationField: Duration;
 
   /**
    * @generated from field: google.protobuf.Empty empty_field = 4;
    */
-  emptyField?: Empty;
+  emptyField: Empty;
 
   /**
    * @generated from field: google.protobuf.FieldMask field_mask_field = 5;
    */
-  fieldMaskField?: FieldMask;
+  fieldMaskField: FieldMask;
 
   /**
    * @generated from field: google.protobuf.SourceContext source_context_field = 6;
    */
-  sourceContextField?: SourceContext;
+  sourceContextField: SourceContext;
 
   /**
    * @generated from field: google.protobuf.Struct struct_field = 7;
    */
-  structField?: JsonObject;
+  structField: JsonObject;
 
   /**
    * @generated from field: google.protobuf.Timestamp timestamp_field = 8;
    */
-  timestampField?: Timestamp;
+  timestampField: Timestamp;
 
   /**
    * @generated from field: google.protobuf.Type type_field = 9;
    */
-  typeField?: Type;
+  typeField: Type;
 
   /**
    * @generated from field: google.protobuf.DoubleValue double_field = 10;
    */
-  doubleField?: number;
+  doubleField: number;
 
   /**
    * @generated from field: google.protobuf.FloatValue float_field = 11;
    */
-  floatField?: number;
+  floatField: number;
 
   /**
    * @generated from field: google.protobuf.Int64Value int64_field = 12;
    */
-  int64Field?: bigint;
+  int64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.UInt64Value uint64_field = 13;
    */
-  uint64Field?: bigint;
+  uint64Field: bigint;
 
   /**
    * @generated from field: google.protobuf.Int32Value int32_field = 14;
    */
-  int32Field?: number;
+  int32Field: number;
 
   /**
    * @generated from field: google.protobuf.UInt32Value uint32_field = 15;
    */
-  uint32Field?: number;
+  uint32Field: number;
 
   /**
    * @generated from field: google.protobuf.BoolValue bool_field = 16;
    */
-  boolField?: boolean;
+  boolField: boolean;
 
   /**
    * @generated from field: google.protobuf.StringValue string_field = 17;
    */
-  stringField?: string;
+  stringField: string;
 
   /**
    * @generated from field: google.protobuf.BytesValue bytes_field = 18;
    */
-  bytesField?: Uint8Array;
+  bytesField: Uint8Array;
 
   /**
    * Part of struct, but useful to be able to test separately
    *
    * @generated from field: google.protobuf.Value value_field = 19;
    */
-  valueField?: Value;
+  valueField: Value;
 };
 
 /**
@@ -364,7 +364,7 @@ export type OneofWellKnownTypes = Message<"proto2_unittest.OneofWellKnownTypes">
      */
     value: BytesValue;
     case: "bytesField";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**

--- a/packages/protobuf-test/src/json.test.ts
+++ b/packages/protobuf-test/src/json.test.ts
@@ -220,8 +220,8 @@ void suite("JSON serialization", () => {
           toggle: false,
         },
       },
-      scalar: { case: undefined },
-      enum: { case: undefined },
+      scalar: { case: "" },
+      enum: { case: "" },
     },
     {
       foo: { name: "max" },

--- a/packages/protobuf-test/src/reflect/reflect.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect.test.ts
@@ -102,7 +102,7 @@ void suite("ReflectMessage", () => {
     test("returns undefined for oneof w/o selected field", () => {
       const msg = create(proto3_ts.Proto3MessageSchema);
       msg.either = {
-        case: undefined,
+        case: "",
       };
       const r = reflect(proto3_ts.Proto3MessageSchema, msg);
       assert.ok(r.oneofs[0] !== undefined);

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -297,7 +297,7 @@ function createZeroField(
   | object
   | typeof tokenZeroMessageField {
   if (field.kind == "oneof") {
-    return { case: undefined };
+    return { case: "" };
   }
   if (field.fieldKind == "list") {
     return [];

--- a/packages/protobuf/src/reflect/guard.ts
+++ b/packages/protobuf/src/reflect/guard.ts
@@ -32,13 +32,12 @@ export function isOneofADT(arg: unknown): arg is OneofADT {
     typeof arg == "object" &&
     "case" in arg &&
     ((typeof arg.case == "string" && "value" in arg && arg.value != null) ||
-      (arg.case === undefined &&
-        (!("value" in arg) || arg.value === undefined)))
+      (arg.case === "" && !("value" in arg)))
   );
 }
 
 export type OneofADT =
-  | { case: undefined; value?: undefined }
+  | { case: "" }
   | { case: string; value: Message | ScalarValue };
 
 export function isReflectList(

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -648,7 +648,7 @@ function wktValueToLocal(val: Value): JsonValue {
     case "listValue":
       return val.kind.value.values.map(wktValueToLocal);
     case "nullValue":
-    case undefined:
+    case "":
       return null;
     default:
       return val.kind.value;
@@ -658,7 +658,7 @@ function wktValueToLocal(val: Value): JsonValue {
 function wktValueToReflect(json: JsonValue): Value {
   const value: Value = {
     $typeName: "google.protobuf.Value",
-    kind: { case: undefined },
+    kind: { case: "" },
   };
   switch (typeof json) {
     case "number":

--- a/packages/protobuf/src/reflect/unsafe.ts
+++ b/packages/protobuf/src/reflect/unsafe.ts
@@ -98,7 +98,7 @@ export function unsafeGet(
 ): unknown {
   if (field.oneof) {
     const oneof = target[field.oneof.localName] as OneofADT;
-    if (oneof.case === field.localName) {
+    if (oneof.case === field.localName && "value" in oneof) {
       return oneof.value;
     }
     return undefined;
@@ -140,7 +140,7 @@ export function unsafeClear(
   if (field.oneof) {
     const oneofLocalName = field.oneof.localName;
     if ((target[oneofLocalName] as OneofADT).case === name) {
-      target[oneofLocalName] = { case: undefined };
+      target[oneofLocalName] = { case: "" };
     }
   } else if (field.presence != IMPLICIT) {
     // Fields with explicit presence have properties on the prototype chain

--- a/packages/protobuf/src/wkt/gen/google/protobuf/any_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/any_pb.ts
@@ -252,7 +252,7 @@ export type Any = Message<"google.protobuf.Any"> & {
  * @generated from message google.protobuf.Any
  */
 export type AnyJson = {
-  "@type"?: string;
+  "@type": string;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/api_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/api_pb.ts
@@ -104,7 +104,7 @@ export type Api = Message<"google.protobuf.Api"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * Included interfaces. See [Mixin][].
@@ -153,21 +153,21 @@ export type ApiJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * The methods of this interface, in unspecified order.
    *
    * @generated from field: repeated google.protobuf.Method methods = 2;
    */
-  methods?: MethodJson[];
+  methods: MethodJson[];
 
   /**
    * Any metadata attached to the interface.
    *
    * @generated from field: repeated google.protobuf.Option options = 3;
    */
-  options?: OptionJson[];
+  options: OptionJson[];
 
   /**
    * A version string for this interface. If specified, must have the form
@@ -193,7 +193,7 @@ export type ApiJson = {
    *
    * @generated from field: string version = 4;
    */
-  version?: string;
+  version: string;
 
   /**
    * Source context for the protocol buffer service represented by this
@@ -201,28 +201,28 @@ export type ApiJson = {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContextJson;
+  sourceContext: SourceContextJson;
 
   /**
    * Included interfaces. See [Mixin][].
    *
    * @generated from field: repeated google.protobuf.Mixin mixins = 6;
    */
-  mixins?: MixinJson[];
+  mixins: MixinJson[];
 
   /**
    * The source syntax of the service.
    *
    * @generated from field: google.protobuf.Syntax syntax = 7;
    */
-  syntax?: SyntaxJson;
+  syntax: SyntaxJson;
 
   /**
    * The source edition string, only valid when syntax is SYNTAX_EDITIONS.
    *
    * @generated from field: string edition = 8;
    */
-  edition?: string;
+  edition: string;
 };
 
 /**
@@ -324,42 +324,42 @@ export type MethodJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * A URL of the input message type.
    *
    * @generated from field: string request_type_url = 2;
    */
-  requestTypeUrl?: string;
+  requestTypeUrl: string;
 
   /**
    * If true, the request is streamed.
    *
    * @generated from field: bool request_streaming = 3;
    */
-  requestStreaming?: boolean;
+  requestStreaming: boolean;
 
   /**
    * The URL of the output message type.
    *
    * @generated from field: string response_type_url = 4;
    */
-  responseTypeUrl?: string;
+  responseTypeUrl: string;
 
   /**
    * If true, the response is streamed.
    *
    * @generated from field: bool response_streaming = 5;
    */
-  responseStreaming?: boolean;
+  responseStreaming: boolean;
 
   /**
    * Any metadata attached to the method.
    *
    * @generated from field: repeated google.protobuf.Option options = 6;
    */
-  options?: OptionJson[];
+  options: OptionJson[];
 
   /**
    * The source syntax of this method.
@@ -370,7 +370,7 @@ export type MethodJson = {
    * @generated from field: google.protobuf.Syntax syntax = 7 [deprecated = true];
    * @deprecated
    */
-  syntax?: SyntaxJson;
+  syntax: SyntaxJson;
 
   /**
    * The source edition string, only valid when syntax is SYNTAX_EDITIONS.
@@ -381,7 +381,7 @@ export type MethodJson = {
    * @generated from field: string edition = 8 [deprecated = true];
    * @deprecated
    */
-  edition?: string;
+  edition: string;
 };
 
 /**
@@ -578,7 +578,7 @@ export type MixinJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * If non-empty specifies a path under which inherited HTTP paths
@@ -586,7 +586,7 @@ export type MixinJson = {
    *
    * @generated from field: string root = 2;
    */
-  root?: string;
+  root: string;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/compiler/plugin_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/compiler/plugin_pb.ts
@@ -82,17 +82,17 @@ export type VersionJson = {
   /**
    * @generated from field: optional int32 major = 1;
    */
-  major?: number;
+  major: number;
 
   /**
    * @generated from field: optional int32 minor = 2;
    */
-  minor?: number;
+  minor: number;
 
   /**
    * @generated from field: optional int32 patch = 3;
    */
-  patch?: number;
+  patch: number;
 
   /**
    * A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
@@ -100,7 +100,7 @@ export type VersionJson = {
    *
    * @generated from field: optional string suffix = 4;
    */
-  suffix?: string;
+  suffix: string;
 };
 
 /**
@@ -171,7 +171,7 @@ export type CodeGeneratorRequest = Message<"google.protobuf.compiler.CodeGenerat
    *
    * @generated from field: optional google.protobuf.compiler.Version compiler_version = 3;
    */
-  compilerVersion?: Version;
+  compilerVersion: Version;
 };
 
 /**
@@ -187,14 +187,14 @@ export type CodeGeneratorRequestJson = {
    *
    * @generated from field: repeated string file_to_generate = 1;
    */
-  fileToGenerate?: string[];
+  fileToGenerate: string[];
 
   /**
    * The generator parameter passed on the command-line.
    *
    * @generated from field: optional string parameter = 2;
    */
-  parameter?: string;
+  parameter: string;
 
   /**
    * FileDescriptorProtos for all files in files_to_generate and everything
@@ -219,7 +219,7 @@ export type CodeGeneratorRequestJson = {
    *
    * @generated from field: repeated google.protobuf.FileDescriptorProto proto_file = 15;
    */
-  protoFile?: FileDescriptorProtoJson[];
+  protoFile: FileDescriptorProtoJson[];
 
   /**
    * File descriptors with all options, including source-retention options.
@@ -228,14 +228,14 @@ export type CodeGeneratorRequestJson = {
    *
    * @generated from field: repeated google.protobuf.FileDescriptorProto source_file_descriptors = 17;
    */
-  sourceFileDescriptors?: FileDescriptorProtoJson[];
+  sourceFileDescriptors: FileDescriptorProtoJson[];
 
   /**
    * The version number of protocol compiler.
    *
    * @generated from field: optional google.protobuf.compiler.Version compiler_version = 3;
    */
-  compilerVersion?: VersionJson;
+  compilerVersion: VersionJson;
 };
 
 /**
@@ -317,7 +317,7 @@ export type CodeGeneratorResponseJson = {
    *
    * @generated from field: optional string error = 1;
    */
-  error?: string;
+  error: string;
 
   /**
    * A bitmask of supported features that the code generator supports.
@@ -325,7 +325,7 @@ export type CodeGeneratorResponseJson = {
    *
    * @generated from field: optional uint64 supported_features = 2;
    */
-  supportedFeatures?: string;
+  supportedFeatures: string;
 
   /**
    * The minimum edition this plugin supports.  This will be treated as an
@@ -335,7 +335,7 @@ export type CodeGeneratorResponseJson = {
    *
    * @generated from field: optional int32 minimum_edition = 3;
    */
-  minimumEdition?: number;
+  minimumEdition: number;
 
   /**
    * The maximum edition this plugin supports.  This will be treated as an
@@ -345,12 +345,12 @@ export type CodeGeneratorResponseJson = {
    *
    * @generated from field: optional int32 maximum_edition = 4;
    */
-  maximumEdition?: number;
+  maximumEdition: number;
 
   /**
    * @generated from field: repeated google.protobuf.compiler.CodeGeneratorResponse.File file = 15;
    */
-  file?: CodeGeneratorResponse_FileJson[];
+  file: CodeGeneratorResponse_FileJson[];
 };
 
 /**
@@ -440,7 +440,7 @@ export type CodeGeneratorResponse_File = Message<"google.protobuf.compiler.CodeG
    *
    * @generated from field: optional google.protobuf.GeneratedCodeInfo generated_code_info = 16;
    */
-  generatedCodeInfo?: GeneratedCodeInfo;
+  generatedCodeInfo: GeneratedCodeInfo;
 };
 
 /**
@@ -464,7 +464,7 @@ export type CodeGeneratorResponse_FileJson = {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * If non-empty, indicates that the named file should already exist, and the
@@ -507,14 +507,14 @@ export type CodeGeneratorResponse_FileJson = {
    *
    * @generated from field: optional string insertion_point = 2;
    */
-  insertionPoint?: string;
+  insertionPoint: string;
 
   /**
    * The file contents.
    *
    * @generated from field: optional string content = 15;
    */
-  content?: string;
+  content: string;
 
   /**
    * Information describing the file content being inserted. If an insertion
@@ -523,7 +523,7 @@ export type CodeGeneratorResponse_FileJson = {
    *
    * @generated from field: optional google.protobuf.GeneratedCodeInfo generated_code_info = 16;
    */
-  generatedCodeInfo?: GeneratedCodeInfoJson;
+  generatedCodeInfo: GeneratedCodeInfoJson;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/cpp_features_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/cpp_features_pb.ts
@@ -68,17 +68,17 @@ export type CppFeaturesJson = {
    *
    * @generated from field: optional bool legacy_closed_enum = 1;
    */
-  legacyClosedEnum?: boolean;
+  legacyClosedEnum: boolean;
 
   /**
    * @generated from field: optional pb.CppFeatures.StringType string_type = 2;
    */
-  stringType?: CppFeatures_StringTypeJson;
+  stringType: CppFeatures_StringTypeJson;
 
   /**
    * @generated from field: optional bool enum_name_uses_string_view = 3;
    */
-  enumNameUsesStringView?: boolean;
+  enumNameUsesStringView: boolean;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/descriptor_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/descriptor_pb.ts
@@ -59,7 +59,7 @@ export type FileDescriptorSetJson = {
   /**
    * @generated from field: repeated google.protobuf.FileDescriptorProto file = 1;
    */
-  file?: FileDescriptorProtoJson[];
+  file: FileDescriptorProtoJson[];
 };
 
 /**
@@ -144,7 +144,7 @@ export type FileDescriptorProto = Message<"google.protobuf.FileDescriptorProto">
   /**
    * @generated from field: optional google.protobuf.FileOptions options = 8;
    */
-  options?: FileOptions;
+  options: FileOptions;
 
   /**
    * This field contains optional information about the original source code.
@@ -154,7 +154,7 @@ export type FileDescriptorProto = Message<"google.protobuf.FileDescriptorProto">
    *
    * @generated from field: optional google.protobuf.SourceCodeInfo source_code_info = 9;
    */
-  sourceCodeInfo?: SourceCodeInfo;
+  sourceCodeInfo: SourceCodeInfo;
 
   /**
    * The syntax of the proto file.
@@ -191,28 +191,28 @@ export type FileDescriptorProtoJson = {
    *
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    *
    * @generated from field: optional string package = 2;
    */
-  package?: string;
+  package: string;
 
   /**
    * Names of files imported by this file.
    *
    * @generated from field: repeated string dependency = 3;
    */
-  dependency?: string[];
+  dependency: string[];
 
   /**
    * Indexes of the public imported files in the dependency list above.
    *
    * @generated from field: repeated int32 public_dependency = 10;
    */
-  publicDependency?: number[];
+  publicDependency: number[];
 
   /**
    * Indexes of the weak imported files in the dependency list.
@@ -220,7 +220,7 @@ export type FileDescriptorProtoJson = {
    *
    * @generated from field: repeated int32 weak_dependency = 11;
    */
-  weakDependency?: number[];
+  weakDependency: number[];
 
   /**
    * Names of files imported by this file purely for the purpose of providing
@@ -228,34 +228,34 @@ export type FileDescriptorProtoJson = {
    *
    * @generated from field: repeated string option_dependency = 15;
    */
-  optionDependency?: string[];
+  optionDependency: string[];
 
   /**
    * All top-level definitions in this file.
    *
    * @generated from field: repeated google.protobuf.DescriptorProto message_type = 4;
    */
-  messageType?: DescriptorProtoJson[];
+  messageType: DescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.EnumDescriptorProto enum_type = 5;
    */
-  enumType?: EnumDescriptorProtoJson[];
+  enumType: EnumDescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.ServiceDescriptorProto service = 6;
    */
-  service?: ServiceDescriptorProtoJson[];
+  service: ServiceDescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto extension = 7;
    */
-  extension?: FieldDescriptorProtoJson[];
+  extension: FieldDescriptorProtoJson[];
 
   /**
    * @generated from field: optional google.protobuf.FileOptions options = 8;
    */
-  options?: FileOptionsJson;
+  options: FileOptionsJson;
 
   /**
    * This field contains optional information about the original source code.
@@ -265,7 +265,7 @@ export type FileDescriptorProtoJson = {
    *
    * @generated from field: optional google.protobuf.SourceCodeInfo source_code_info = 9;
    */
-  sourceCodeInfo?: SourceCodeInfoJson;
+  sourceCodeInfo: SourceCodeInfoJson;
 
   /**
    * The syntax of the proto file.
@@ -278,7 +278,7 @@ export type FileDescriptorProtoJson = {
    *
    * @generated from field: optional string syntax = 12;
    */
-  syntax?: string;
+  syntax: string;
 
   /**
    * The edition of the proto file.
@@ -288,7 +288,7 @@ export type FileDescriptorProtoJson = {
    *
    * @generated from field: optional google.protobuf.Edition edition = 14;
    */
-  edition?: EditionJson;
+  edition: EditionJson;
 };
 
 /**
@@ -342,7 +342,7 @@ export type DescriptorProto = Message<"google.protobuf.DescriptorProto"> & {
   /**
    * @generated from field: optional google.protobuf.MessageOptions options = 7;
    */
-  options?: MessageOptions;
+  options: MessageOptions;
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9;
@@ -374,47 +374,47 @@ export type DescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto field = 2;
    */
-  field?: FieldDescriptorProtoJson[];
+  field: FieldDescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.FieldDescriptorProto extension = 6;
    */
-  extension?: FieldDescriptorProtoJson[];
+  extension: FieldDescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto nested_type = 3;
    */
-  nestedType?: DescriptorProtoJson[];
+  nestedType: DescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.EnumDescriptorProto enum_type = 4;
    */
-  enumType?: EnumDescriptorProtoJson[];
+  enumType: EnumDescriptorProtoJson[];
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5;
    */
-  extensionRange?: DescriptorProto_ExtensionRangeJson[];
+  extensionRange: DescriptorProto_ExtensionRangeJson[];
 
   /**
    * @generated from field: repeated google.protobuf.OneofDescriptorProto oneof_decl = 8;
    */
-  oneofDecl?: OneofDescriptorProtoJson[];
+  oneofDecl: OneofDescriptorProtoJson[];
 
   /**
    * @generated from field: optional google.protobuf.MessageOptions options = 7;
    */
-  options?: MessageOptionsJson;
+  options: MessageOptionsJson;
 
   /**
    * @generated from field: repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9;
    */
-  reservedRange?: DescriptorProto_ReservedRangeJson[];
+  reservedRange: DescriptorProto_ReservedRangeJson[];
 
   /**
    * Reserved field names, which may not be used by fields in the same message.
@@ -422,14 +422,14 @@ export type DescriptorProtoJson = {
    *
    * @generated from field: repeated string reserved_name = 10;
    */
-  reservedName?: string[];
+  reservedName: string[];
 
   /**
    * Support for `export` and `local` keywords on enums.
    *
    * @generated from field: optional google.protobuf.SymbolVisibility visibility = 11;
    */
-  visibility?: SymbolVisibilityJson;
+  visibility: SymbolVisibilityJson;
 };
 
 /**
@@ -460,7 +460,7 @@ export type DescriptorProto_ExtensionRange = Message<"google.protobuf.Descriptor
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
    */
-  options?: ExtensionRangeOptions;
+  options: ExtensionRangeOptions;
 };
 
 /**
@@ -472,19 +472,19 @@ export type DescriptorProto_ExtensionRangeJson = {
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end: number;
 
   /**
    * @generated from field: optional google.protobuf.ExtensionRangeOptions options = 3;
    */
-  options?: ExtensionRangeOptionsJson;
+  options: ExtensionRangeOptionsJson;
 };
 
 /**
@@ -530,14 +530,14 @@ export type DescriptorProto_ReservedRangeJson = {
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start: number;
 
   /**
    * Exclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end: number;
 };
 
 /**
@@ -572,7 +572,7 @@ export type ExtensionRangeOptions = Message<"google.protobuf.ExtensionRangeOptio
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 50;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * The verification state of the range.
@@ -593,7 +593,7 @@ export type ExtensionRangeOptionsJson = {
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 
   /**
    * For external users: DO NOT USE. We are in the process of open sourcing
@@ -602,14 +602,14 @@ export type ExtensionRangeOptionsJson = {
    *
    * @generated from field: repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2;
    */
-  declaration?: ExtensionRangeOptions_DeclarationJson[];
+  declaration: ExtensionRangeOptions_DeclarationJson[];
 
   /**
    * Any features defined in the specific edition.
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 50;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * The verification state of the range.
@@ -618,7 +618,7 @@ export type ExtensionRangeOptionsJson = {
    *
    * @generated from field: optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3 [default = UNVERIFIED];
    */
-  verification?: ExtensionRangeOptions_VerificationStateJson;
+  verification: ExtensionRangeOptions_VerificationStateJson;
 };
 
 /**
@@ -683,7 +683,7 @@ export type ExtensionRangeOptions_DeclarationJson = {
    *
    * @generated from field: optional int32 number = 1;
    */
-  number?: number;
+  number: number;
 
   /**
    * The fully-qualified name of the extension field. There must be a leading
@@ -691,7 +691,7 @@ export type ExtensionRangeOptions_DeclarationJson = {
    *
    * @generated from field: optional string full_name = 2;
    */
-  fullName?: string;
+  fullName: string;
 
   /**
    * The fully-qualified type name of the extension field. Unlike
@@ -700,7 +700,7 @@ export type ExtensionRangeOptions_DeclarationJson = {
    *
    * @generated from field: optional string type = 3;
    */
-  type?: string;
+  type: string;
 
   /**
    * If true, indicates that the number is reserved in the extension range,
@@ -709,7 +709,7 @@ export type ExtensionRangeOptions_DeclarationJson = {
    *
    * @generated from field: optional bool reserved = 5;
    */
-  reserved?: boolean;
+  reserved: boolean;
 
   /**
    * If true, indicates that the extension must be defined as repeated.
@@ -717,7 +717,7 @@ export type ExtensionRangeOptions_DeclarationJson = {
    *
    * @generated from field: optional bool repeated = 6;
    */
-  repeated?: boolean;
+  repeated: boolean;
 };
 
 /**
@@ -838,7 +838,7 @@ export type FieldDescriptorProto = Message<"google.protobuf.FieldDescriptorProto
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
    */
-  options?: FieldOptions;
+  options: FieldOptions;
 
   /**
    * If true, this is a proto3 "optional". When a proto3 field is optional, it
@@ -877,17 +877,17 @@ export type FieldDescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: optional int32 number = 3;
    */
-  number?: number;
+  number: number;
 
   /**
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Label label = 4;
    */
-  label?: FieldDescriptorProto_LabelJson;
+  label: FieldDescriptorProto_LabelJson;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
@@ -895,7 +895,7 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional google.protobuf.FieldDescriptorProto.Type type = 5;
    */
-  type?: FieldDescriptorProto_TypeJson;
+  type: FieldDescriptorProto_TypeJson;
 
   /**
    * For message and enum types, this is the name of the type.  If the name
@@ -906,7 +906,7 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional string type_name = 6;
    */
-  typeName?: string;
+  typeName: string;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
@@ -914,7 +914,7 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional string extendee = 2;
    */
-  extendee?: string;
+  extendee: string;
 
   /**
    * For numeric types, contains the original text representation of the value.
@@ -924,7 +924,7 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional string default_value = 7;
    */
-  defaultValue?: string;
+  defaultValue: string;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
@@ -932,7 +932,7 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional int32 oneof_index = 9;
    */
-  oneofIndex?: number;
+  oneofIndex: number;
 
   /**
    * JSON name of this field. The value is set by protocol compiler. If the
@@ -942,12 +942,12 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional string json_name = 10;
    */
-  jsonName?: string;
+  jsonName: string;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions options = 8;
    */
-  options?: FieldOptionsJson;
+  options: FieldOptionsJson;
 
   /**
    * If true, this is a proto3 "optional". When a proto3 field is optional, it
@@ -974,7 +974,7 @@ export type FieldDescriptorProtoJson = {
    *
    * @generated from field: optional bool proto3_optional = 17;
    */
-  proto3Optional?: boolean;
+  proto3Optional: boolean;
 };
 
 /**
@@ -1164,7 +1164,7 @@ export type OneofDescriptorProto = Message<"google.protobuf.OneofDescriptorProto
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
    */
-  options?: OneofOptions;
+  options: OneofOptions;
 };
 
 /**
@@ -1176,12 +1176,12 @@ export type OneofDescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: optional google.protobuf.OneofOptions options = 2;
    */
-  options?: OneofOptionsJson;
+  options: OneofOptionsJson;
 };
 
 /**
@@ -1210,7 +1210,7 @@ export type EnumDescriptorProto = Message<"google.protobuf.EnumDescriptorProto">
   /**
    * @generated from field: optional google.protobuf.EnumOptions options = 3;
    */
-  options?: EnumOptions;
+  options: EnumOptions;
 
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
@@ -1246,17 +1246,17 @@ export type EnumDescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: repeated google.protobuf.EnumValueDescriptorProto value = 2;
    */
-  value?: EnumValueDescriptorProtoJson[];
+  value: EnumValueDescriptorProtoJson[];
 
   /**
    * @generated from field: optional google.protobuf.EnumOptions options = 3;
    */
-  options?: EnumOptionsJson;
+  options: EnumOptionsJson;
 
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
@@ -1265,7 +1265,7 @@ export type EnumDescriptorProtoJson = {
    *
    * @generated from field: repeated google.protobuf.EnumDescriptorProto.EnumReservedRange reserved_range = 4;
    */
-  reservedRange?: EnumDescriptorProto_EnumReservedRangeJson[];
+  reservedRange: EnumDescriptorProto_EnumReservedRangeJson[];
 
   /**
    * Reserved enum value names, which may not be reused. A given name may only
@@ -1273,14 +1273,14 @@ export type EnumDescriptorProtoJson = {
    *
    * @generated from field: repeated string reserved_name = 5;
    */
-  reservedName?: string[];
+  reservedName: string[];
 
   /**
    * Support for `export` and `local` keywords on enums.
    *
    * @generated from field: optional google.protobuf.SymbolVisibility visibility = 6;
    */
-  visibility?: SymbolVisibilityJson;
+  visibility: SymbolVisibilityJson;
 };
 
 /**
@@ -1332,14 +1332,14 @@ export type EnumDescriptorProto_EnumReservedRangeJson = {
    *
    * @generated from field: optional int32 start = 1;
    */
-  start?: number;
+  start: number;
 
   /**
    * Inclusive.
    *
    * @generated from field: optional int32 end = 2;
    */
-  end?: number;
+  end: number;
 };
 
 /**
@@ -1368,7 +1368,7 @@ export type EnumValueDescriptorProto = Message<"google.protobuf.EnumValueDescrip
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
    */
-  options?: EnumValueOptions;
+  options: EnumValueOptions;
 };
 
 /**
@@ -1380,17 +1380,17 @@ export type EnumValueDescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: optional int32 number = 2;
    */
-  number?: number;
+  number: number;
 
   /**
    * @generated from field: optional google.protobuf.EnumValueOptions options = 3;
    */
-  options?: EnumValueOptionsJson;
+  options: EnumValueOptionsJson;
 };
 
 /**
@@ -1419,7 +1419,7 @@ export type ServiceDescriptorProto = Message<"google.protobuf.ServiceDescriptorP
   /**
    * @generated from field: optional google.protobuf.ServiceOptions options = 3;
    */
-  options?: ServiceOptions;
+  options: ServiceOptions;
 };
 
 /**
@@ -1431,17 +1431,17 @@ export type ServiceDescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * @generated from field: repeated google.protobuf.MethodDescriptorProto method = 2;
    */
-  method?: MethodDescriptorProtoJson[];
+  method: MethodDescriptorProtoJson[];
 
   /**
    * @generated from field: optional google.protobuf.ServiceOptions options = 3;
    */
-  options?: ServiceOptionsJson;
+  options: ServiceOptionsJson;
 };
 
 /**
@@ -1478,7 +1478,7 @@ export type MethodDescriptorProto = Message<"google.protobuf.MethodDescriptorPro
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
    */
-  options?: MethodOptions;
+  options: MethodOptions;
 
   /**
    * Identifies if client streams multiple client messages
@@ -1504,7 +1504,7 @@ export type MethodDescriptorProtoJson = {
   /**
    * @generated from field: optional string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -1512,31 +1512,31 @@ export type MethodDescriptorProtoJson = {
    *
    * @generated from field: optional string input_type = 2;
    */
-  inputType?: string;
+  inputType: string;
 
   /**
    * @generated from field: optional string output_type = 3;
    */
-  outputType?: string;
+  outputType: string;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions options = 4;
    */
-  options?: MethodOptionsJson;
+  options: MethodOptionsJson;
 
   /**
    * Identifies if client streams multiple client messages
    *
    * @generated from field: optional bool client_streaming = 5 [default = false];
    */
-  clientStreaming?: boolean;
+  clientStreaming: boolean;
 
   /**
    * Identifies if server streams multiple server messages
    *
    * @generated from field: optional bool server_streaming = 6 [default = false];
    */
-  serverStreaming?: boolean;
+  serverStreaming: boolean;
 };
 
 /**
@@ -1735,7 +1735,7 @@ export type FileOptions = Message<"google.protobuf.FileOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 50;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * The parser stores options it doesn't recognize here.
@@ -1758,7 +1758,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string java_package = 1;
    */
-  javaPackage?: string;
+  javaPackage: string;
 
   /**
    * Controls the name of the wrapper Java class generated for the .proto file.
@@ -1769,7 +1769,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string java_outer_classname = 8;
    */
-  javaOuterClassname?: string;
+  javaOuterClassname: string;
 
   /**
    * If enabled, then the Java code generator will generate a separate .java
@@ -1781,7 +1781,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional bool java_multiple_files = 10 [default = false];
    */
-  javaMultipleFiles?: boolean;
+  javaMultipleFiles: boolean;
 
   /**
    * This option does nothing.
@@ -1789,7 +1789,7 @@ export type FileOptionsJson = {
    * @generated from field: optional bool java_generate_equals_and_hash = 20 [deprecated = true];
    * @deprecated
    */
-  javaGenerateEqualsAndHash?: boolean;
+  javaGenerateEqualsAndHash: boolean;
 
   /**
    * A proto2 file can set this to true to opt in to UTF-8 checking for Java,
@@ -1805,12 +1805,12 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional bool java_string_check_utf8 = 27 [default = false];
    */
-  javaStringCheckUtf8?: boolean;
+  javaStringCheckUtf8: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9 [default = SPEED];
    */
-  optimizeFor?: FileOptions_OptimizeModeJson;
+  optimizeFor: FileOptions_OptimizeModeJson;
 
   /**
    * Sets the Go package where structs generated from this .proto will be
@@ -1821,7 +1821,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string go_package = 11;
    */
-  goPackage?: string;
+  goPackage: string;
 
   /**
    * Should generic services be generated in each language?  "Generic" services
@@ -1837,17 +1837,17 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional bool cc_generic_services = 16 [default = false];
    */
-  ccGenericServices?: boolean;
+  ccGenericServices: boolean;
 
   /**
    * @generated from field: optional bool java_generic_services = 17 [default = false];
    */
-  javaGenericServices?: boolean;
+  javaGenericServices: boolean;
 
   /**
    * @generated from field: optional bool py_generic_services = 18 [default = false];
    */
-  pyGenericServices?: boolean;
+  pyGenericServices: boolean;
 
   /**
    * Is this file deprecated?
@@ -1857,7 +1857,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 23 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
@@ -1865,7 +1865,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional bool cc_enable_arenas = 31 [default = true];
    */
-  ccEnableArenas?: boolean;
+  ccEnableArenas: boolean;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
@@ -1873,14 +1873,14 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string objc_class_prefix = 36;
    */
-  objcClassPrefix?: string;
+  objcClassPrefix: string;
 
   /**
    * Namespace for generated classes; defaults to the package.
    *
    * @generated from field: optional string csharp_namespace = 37;
    */
-  csharpNamespace?: string;
+  csharpNamespace: string;
 
   /**
    * By default Swift generators will take the proto package and CamelCase it
@@ -1890,7 +1890,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string swift_prefix = 39;
    */
-  swiftPrefix?: string;
+  swiftPrefix: string;
 
   /**
    * Sets the php class prefix which is prepended to all php generated classes
@@ -1898,7 +1898,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string php_class_prefix = 40;
    */
-  phpClassPrefix?: string;
+  phpClassPrefix: string;
 
   /**
    * Use this option to change the namespace of php generated classes. Default
@@ -1907,7 +1907,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string php_namespace = 41;
    */
-  phpNamespace?: string;
+  phpNamespace: string;
 
   /**
    * Use this option to change the namespace of php generated metadata classes.
@@ -1916,7 +1916,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string php_metadata_namespace = 44;
    */
-  phpMetadataNamespace?: string;
+  phpMetadataNamespace: string;
 
   /**
    * Use this option to change the package of ruby generated classes. Default
@@ -1925,7 +1925,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional string ruby_package = 45;
    */
-  rubyPackage?: string;
+  rubyPackage: string;
 
   /**
    * Any features defined in the specific edition.
@@ -1935,7 +1935,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 50;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * The parser stores options it doesn't recognize here.
@@ -1943,7 +1943,7 @@ export type FileOptionsJson = {
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -2095,7 +2095,7 @@ export type MessageOptions = Message<"google.protobuf.MessageOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 12;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2131,7 +2131,7 @@ export type MessageOptionsJson = {
    *
    * @generated from field: optional bool message_set_wire_format = 1 [default = false];
    */
-  messageSetWireFormat?: boolean;
+  messageSetWireFormat: boolean;
 
   /**
    * Disables the generation of the standard "descriptor()" accessor, which can
@@ -2140,7 +2140,7 @@ export type MessageOptionsJson = {
    *
    * @generated from field: optional bool no_standard_descriptor_accessor = 2 [default = false];
    */
-  noStandardDescriptorAccessor?: boolean;
+  noStandardDescriptorAccessor: boolean;
 
   /**
    * Is this message deprecated?
@@ -2150,7 +2150,7 @@ export type MessageOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Whether the message is an automatically generated map entry type for the
@@ -2177,7 +2177,7 @@ export type MessageOptionsJson = {
    *
    * @generated from field: optional bool map_entry = 7;
    */
-  mapEntry?: boolean;
+  mapEntry: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -2194,7 +2194,7 @@ export type MessageOptionsJson = {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -2204,14 +2204,14 @@ export type MessageOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 12;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -2355,12 +2355,12 @@ export type FieldOptions = Message<"google.protobuf.FieldOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 21;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 22;
    */
-  featureSupport?: FieldOptions_FeatureSupport;
+  featureSupport: FieldOptions_FeatureSupport;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2385,7 +2385,7 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FieldOptions.CType ctype = 1 [default = STRING];
    */
-  ctype?: FieldOptions_CTypeJson;
+  ctype: FieldOptions_CTypeJson;
 
   /**
    * The packed option can be enabled for repeated primitive fields to enable
@@ -2398,7 +2398,7 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional bool packed = 2;
    */
-  packed?: boolean;
+  packed: boolean;
 
   /**
    * The jstype option determines the JavaScript type used for values of the
@@ -2415,7 +2415,7 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL];
    */
-  jstype?: FieldOptions_JSTypeJson;
+  jstype: FieldOptions_JSTypeJson;
 
   /**
    * Should this field be parsed lazily?  Lazy applies only to message-type
@@ -2443,7 +2443,7 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional bool lazy = 5 [default = false];
    */
-  lazy?: boolean;
+  lazy: boolean;
 
   /**
    * unverified_lazy does no correctness checks on the byte stream. This should
@@ -2452,7 +2452,7 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional bool unverified_lazy = 15 [default = false];
    */
-  unverifiedLazy?: boolean;
+  unverifiedLazy: boolean;
 
   /**
    * Is this field deprecated?
@@ -2462,7 +2462,7 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * DEPRECATED. DO NOT USE!
@@ -2471,7 +2471,7 @@ export type FieldOptionsJson = {
    * @generated from field: optional bool weak = 10 [default = false, deprecated = true];
    * @deprecated
    */
-  weak?: boolean;
+  weak: boolean;
 
   /**
    * Indicate that the field value should not be printed out when using debug
@@ -2479,22 +2479,22 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional bool debug_redact = 16 [default = false];
    */
-  debugRedact?: boolean;
+  debugRedact: boolean;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.OptionRetention retention = 17;
    */
-  retention?: FieldOptions_OptionRetentionJson;
+  retention: FieldOptions_OptionRetentionJson;
 
   /**
    * @generated from field: repeated google.protobuf.FieldOptions.OptionTargetType targets = 19;
    */
-  targets?: FieldOptions_OptionTargetTypeJson[];
+  targets: FieldOptions_OptionTargetTypeJson[];
 
   /**
    * @generated from field: repeated google.protobuf.FieldOptions.EditionDefault edition_defaults = 20;
    */
-  editionDefaults?: FieldOptions_EditionDefaultJson[];
+  editionDefaults: FieldOptions_EditionDefaultJson[];
 
   /**
    * Any features defined in the specific edition.
@@ -2504,19 +2504,19 @@ export type FieldOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 21;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * @generated from field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 22;
    */
-  featureSupport?: FieldOptions_FeatureSupportJson;
+  featureSupport: FieldOptions_FeatureSupportJson;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -2550,14 +2550,14 @@ export type FieldOptions_EditionDefaultJson = {
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: EditionJson;
+  edition: EditionJson;
 
   /**
    * Textproto value.
    *
    * @generated from field: optional string value = 2;
    */
-  value?: string;
+  value: string;
 };
 
 /**
@@ -2621,7 +2621,7 @@ export type FieldOptions_FeatureSupportJson = {
    *
    * @generated from field: optional google.protobuf.Edition edition_introduced = 1;
    */
-  editionIntroduced?: EditionJson;
+  editionIntroduced: EditionJson;
 
   /**
    * The edition this feature becomes deprecated in.  Using this after this
@@ -2629,7 +2629,7 @@ export type FieldOptions_FeatureSupportJson = {
    *
    * @generated from field: optional google.protobuf.Edition edition_deprecated = 2;
    */
-  editionDeprecated?: EditionJson;
+  editionDeprecated: EditionJson;
 
   /**
    * The deprecation warning text if this feature is used after the edition it
@@ -2637,7 +2637,7 @@ export type FieldOptions_FeatureSupportJson = {
    *
    * @generated from field: optional string deprecation_warning = 3;
    */
-  deprecationWarning?: string;
+  deprecationWarning: string;
 
   /**
    * The edition this feature is no longer available in.  In editions after
@@ -2646,7 +2646,7 @@ export type FieldOptions_FeatureSupportJson = {
    *
    * @generated from field: optional google.protobuf.Edition edition_removed = 4;
    */
-  editionRemoved?: EditionJson;
+  editionRemoved: EditionJson;
 };
 
 /**
@@ -2854,7 +2854,7 @@ export type OneofOptions = Message<"google.protobuf.OneofOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 1;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2876,14 +2876,14 @@ export type OneofOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 1;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -2936,7 +2936,7 @@ export type EnumOptions = Message<"google.protobuf.EnumOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 7;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -2956,7 +2956,7 @@ export type EnumOptionsJson = {
    *
    * @generated from field: optional bool allow_alias = 2;
    */
-  allowAlias?: boolean;
+  allowAlias: boolean;
 
   /**
    * Is this enum deprecated?
@@ -2966,7 +2966,7 @@ export type EnumOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 3 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -2979,7 +2979,7 @@ export type EnumOptionsJson = {
    * @generated from field: optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
    * @deprecated
    */
-  deprecatedLegacyJsonFieldConflicts?: boolean;
+  deprecatedLegacyJsonFieldConflicts: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -2989,14 +2989,14 @@ export type EnumOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 7;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -3028,7 +3028,7 @@ export type EnumValueOptions = Message<"google.protobuf.EnumValueOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 2;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * Indicate that fields annotated with this enum value should not be printed
@@ -3044,7 +3044,7 @@ export type EnumValueOptions = Message<"google.protobuf.EnumValueOptions"> & {
    *
    * @generated from field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 4;
    */
-  featureSupport?: FieldOptions_FeatureSupport;
+  featureSupport: FieldOptions_FeatureSupport;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -3066,7 +3066,7 @@ export type EnumValueOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 1 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * Any features defined in the specific edition.
@@ -3076,7 +3076,7 @@ export type EnumValueOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 2;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * Indicate that fields annotated with this enum value should not be printed
@@ -3085,21 +3085,21 @@ export type EnumValueOptionsJson = {
    *
    * @generated from field: optional bool debug_redact = 3 [default = false];
    */
-  debugRedact?: boolean;
+  debugRedact: boolean;
 
   /**
    * Information about the support window of a feature value.
    *
    * @generated from field: optional google.protobuf.FieldOptions.FeatureSupport feature_support = 4;
    */
-  featureSupport?: FieldOptions_FeatureSupportJson;
+  featureSupport: FieldOptions_FeatureSupportJson;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -3121,7 +3121,7 @@ export type ServiceOptions = Message<"google.protobuf.ServiceOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 34;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * Is this service deprecated?
@@ -3153,7 +3153,7 @@ export type ServiceOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 34;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * Is this service deprecated?
@@ -3163,14 +3163,14 @@ export type ServiceOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -3207,7 +3207,7 @@ export type MethodOptions = Message<"google.protobuf.MethodOptions"> & {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 35;
    */
-  features?: FeatureSet;
+  features: FeatureSet;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
@@ -3229,12 +3229,12 @@ export type MethodOptionsJson = {
    *
    * @generated from field: optional bool deprecated = 33 [default = false];
    */
-  deprecated?: boolean;
+  deprecated: boolean;
 
   /**
    * @generated from field: optional google.protobuf.MethodOptions.IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
    */
-  idempotencyLevel?: MethodOptions_IdempotencyLevelJson;
+  idempotencyLevel: MethodOptions_IdempotencyLevelJson;
 
   /**
    * Any features defined in the specific edition.
@@ -3244,14 +3244,14 @@ export type MethodOptionsJson = {
    *
    * @generated from field: optional google.protobuf.FeatureSet features = 35;
    */
-  features?: FeatureSetJson;
+  features: FeatureSetJson;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    *
    * @generated from field: repeated google.protobuf.UninterpretedOption uninterpreted_option = 999;
    */
-  uninterpretedOption?: UninterpretedOptionJson[];
+  uninterpretedOption: UninterpretedOptionJson[];
 };
 
 /**
@@ -3368,7 +3368,7 @@ export type UninterpretedOptionJson = {
   /**
    * @generated from field: repeated google.protobuf.UninterpretedOption.NamePart name = 2;
    */
-  name?: UninterpretedOption_NamePartJson[];
+  name: UninterpretedOption_NamePartJson[];
 
   /**
    * The value of the uninterpreted option, in whatever type the tokenizer
@@ -3376,32 +3376,32 @@ export type UninterpretedOptionJson = {
    *
    * @generated from field: optional string identifier_value = 3;
    */
-  identifierValue?: string;
+  identifierValue: string;
 
   /**
    * @generated from field: optional uint64 positive_int_value = 4;
    */
-  positiveIntValue?: string;
+  positiveIntValue: string;
 
   /**
    * @generated from field: optional int64 negative_int_value = 5;
    */
-  negativeIntValue?: string;
+  negativeIntValue: string;
 
   /**
    * @generated from field: optional double double_value = 6;
    */
-  doubleValue?: number | "NaN" | "Infinity" | "-Infinity";
+  doubleValue: number | "NaN" | "Infinity" | "-Infinity";
 
   /**
    * @generated from field: optional bytes string_value = 7;
    */
-  stringValue?: string;
+  stringValue: string;
 
   /**
    * @generated from field: optional string aggregate_value = 8;
    */
-  aggregateValue?: string;
+  aggregateValue: string;
 };
 
 /**
@@ -3445,12 +3445,12 @@ export type UninterpretedOption_NamePartJson = {
   /**
    * @generated from field: required string name_part = 1;
    */
-  namePart?: string;
+  namePart: string;
 
   /**
    * @generated from field: required bool is_extension = 2;
    */
-  isExtension?: boolean;
+  isExtension: boolean;
 };
 
 /**
@@ -3526,42 +3526,42 @@ export type FeatureSetJson = {
   /**
    * @generated from field: optional google.protobuf.FeatureSet.FieldPresence field_presence = 1;
    */
-  fieldPresence?: FeatureSet_FieldPresenceJson;
+  fieldPresence: FeatureSet_FieldPresenceJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.EnumType enum_type = 2;
    */
-  enumType?: FeatureSet_EnumTypeJson;
+  enumType: FeatureSet_EnumTypeJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.RepeatedFieldEncoding repeated_field_encoding = 3;
    */
-  repeatedFieldEncoding?: FeatureSet_RepeatedFieldEncodingJson;
+  repeatedFieldEncoding: FeatureSet_RepeatedFieldEncodingJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.Utf8Validation utf8_validation = 4;
    */
-  utf8Validation?: FeatureSet_Utf8ValidationJson;
+  utf8Validation: FeatureSet_Utf8ValidationJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.MessageEncoding message_encoding = 5;
    */
-  messageEncoding?: FeatureSet_MessageEncodingJson;
+  messageEncoding: FeatureSet_MessageEncodingJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.JsonFormat json_format = 6;
    */
-  jsonFormat?: FeatureSet_JsonFormatJson;
+  jsonFormat: FeatureSet_JsonFormatJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style = 7;
    */
-  enforceNamingStyle?: FeatureSet_EnforceNamingStyleJson;
+  enforceNamingStyle: FeatureSet_EnforceNamingStyleJson;
 
   /**
    * @generated from field: optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8;
    */
-  defaultSymbolVisibility?: FeatureSet_VisibilityFeature_DefaultSymbolVisibilityJson;
+  defaultSymbolVisibility: FeatureSet_VisibilityFeature_DefaultSymbolVisibilityJson;
 };
 
 /**
@@ -3906,7 +3906,7 @@ export type FeatureSetDefaultsJson = {
   /**
    * @generated from field: repeated google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault defaults = 1;
    */
-  defaults?: FeatureSetDefaults_FeatureSetEditionDefaultJson[];
+  defaults: FeatureSetDefaults_FeatureSetEditionDefaultJson[];
 
   /**
    * The minimum supported edition (inclusive) when this was constructed.
@@ -3914,7 +3914,7 @@ export type FeatureSetDefaultsJson = {
    *
    * @generated from field: optional google.protobuf.Edition minimum_edition = 4;
    */
-  minimumEdition?: EditionJson;
+  minimumEdition: EditionJson;
 
   /**
    * The maximum known edition (inclusive) when this was constructed. Editions
@@ -3922,7 +3922,7 @@ export type FeatureSetDefaultsJson = {
    *
    * @generated from field: optional google.protobuf.Edition maximum_edition = 5;
    */
-  maximumEdition?: EditionJson;
+  maximumEdition: EditionJson;
 };
 
 /**
@@ -3951,14 +3951,14 @@ export type FeatureSetDefaults_FeatureSetEditionDefault = Message<"google.protob
    *
    * @generated from field: optional google.protobuf.FeatureSet overridable_features = 4;
    */
-  overridableFeatures?: FeatureSet;
+  overridableFeatures: FeatureSet;
 
   /**
    * Defaults of features that can't be overridden in this edition.
    *
    * @generated from field: optional google.protobuf.FeatureSet fixed_features = 5;
    */
-  fixedFeatures?: FeatureSet;
+  fixedFeatures: FeatureSet;
 };
 
 /**
@@ -3973,21 +3973,21 @@ export type FeatureSetDefaults_FeatureSetEditionDefaultJson = {
   /**
    * @generated from field: optional google.protobuf.Edition edition = 3;
    */
-  edition?: EditionJson;
+  edition: EditionJson;
 
   /**
    * Defaults of features that can be overridden in this edition.
    *
    * @generated from field: optional google.protobuf.FeatureSet overridable_features = 4;
    */
-  overridableFeatures?: FeatureSetJson;
+  overridableFeatures: FeatureSetJson;
 
   /**
    * Defaults of features that can't be overridden in this edition.
    *
    * @generated from field: optional google.protobuf.FeatureSet fixed_features = 5;
    */
-  fixedFeatures?: FeatureSetJson;
+  fixedFeatures: FeatureSetJson;
 };
 
 /**
@@ -4108,7 +4108,7 @@ export type SourceCodeInfoJson = {
    *
    * @generated from field: repeated google.protobuf.SourceCodeInfo.Location location = 1;
    */
-  location?: SourceCodeInfo_LocationJson[];
+  location: SourceCodeInfo_LocationJson[];
 };
 
 /**
@@ -4257,7 +4257,7 @@ export type SourceCodeInfo_LocationJson = {
    *
    * @generated from field: repeated int32 path = 1 [packed = true];
    */
-  path?: number[];
+  path: number[];
 
   /**
    * Always has exactly three or four elements: start line, start column,
@@ -4268,7 +4268,7 @@ export type SourceCodeInfo_LocationJson = {
    *
    * @generated from field: repeated int32 span = 2 [packed = true];
    */
-  span?: number[];
+  span: number[];
 
   /**
    * If this SourceCodeInfo represents a complete declaration, these are any
@@ -4321,17 +4321,17 @@ export type SourceCodeInfo_LocationJson = {
    *
    * @generated from field: optional string leading_comments = 3;
    */
-  leadingComments?: string;
+  leadingComments: string;
 
   /**
    * @generated from field: optional string trailing_comments = 4;
    */
-  trailingComments?: string;
+  trailingComments: string;
 
   /**
    * @generated from field: repeated string leading_detached_comments = 6;
    */
-  leadingDetachedComments?: string[];
+  leadingDetachedComments: string[];
 };
 
 /**
@@ -4372,7 +4372,7 @@ export type GeneratedCodeInfoJson = {
    *
    * @generated from field: repeated google.protobuf.GeneratedCodeInfo.Annotation annotation = 1;
    */
-  annotation?: GeneratedCodeInfo_AnnotationJson[];
+  annotation: GeneratedCodeInfo_AnnotationJson[];
 };
 
 /**
@@ -4434,14 +4434,14 @@ export type GeneratedCodeInfo_AnnotationJson = {
    *
    * @generated from field: repeated int32 path = 1 [packed = true];
    */
-  path?: number[];
+  path: number[];
 
   /**
    * Identifies the filesystem path to the original source .proto.
    *
    * @generated from field: optional string source_file = 2;
    */
-  sourceFile?: string;
+  sourceFile: string;
 
   /**
    * Identifies the starting offset in bytes in the generated code
@@ -4449,7 +4449,7 @@ export type GeneratedCodeInfo_AnnotationJson = {
    *
    * @generated from field: optional int32 begin = 3;
    */
-  begin?: number;
+  begin: number;
 
   /**
    * Identifies the ending offset in bytes in the generated code that
@@ -4458,12 +4458,12 @@ export type GeneratedCodeInfo_AnnotationJson = {
    *
    * @generated from field: optional int32 end = 4;
    */
-  end?: number;
+  end: number;
 
   /**
    * @generated from field: optional google.protobuf.GeneratedCodeInfo.Annotation.Semantic semantic = 5;
    */
-  semantic?: GeneratedCodeInfo_Annotation_SemanticJson;
+  semantic: GeneratedCodeInfo_Annotation_SemanticJson;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/go_features_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/go_features_pb.ts
@@ -66,19 +66,19 @@ export type GoFeaturesJson = {
    *
    * @generated from field: optional bool legacy_unmarshal_json_enum = 1;
    */
-  legacyUnmarshalJsonEnum?: boolean;
+  legacyUnmarshalJsonEnum: boolean;
 
   /**
    * One of OPEN, HYBRID or OPAQUE.
    *
    * @generated from field: optional pb.GoFeatures.APILevel api_level = 2;
    */
-  apiLevel?: GoFeatures_APILevelJson;
+  apiLevel: GoFeatures_APILevelJson;
 
   /**
    * @generated from field: optional pb.GoFeatures.StripEnumPrefix strip_enum_prefix = 3;
    */
-  stripEnumPrefix?: GoFeatures_StripEnumPrefixJson;
+  stripEnumPrefix: GoFeatures_StripEnumPrefixJson;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/java_features_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/java_features_pb.ts
@@ -91,12 +91,12 @@ export type JavaFeaturesJson = {
    *
    * @generated from field: optional bool legacy_closed_enum = 1;
    */
-  legacyClosedEnum?: boolean;
+  legacyClosedEnum: boolean;
 
   /**
    * @generated from field: optional pb.JavaFeatures.Utf8Validation utf8_validation = 2;
    */
-  utf8Validation?: JavaFeatures_Utf8ValidationJson;
+  utf8Validation: JavaFeatures_Utf8ValidationJson;
 
   /**
    * Allows creation of large Java enums, extending beyond the standard
@@ -104,7 +104,7 @@ export type JavaFeaturesJson = {
    *
    * @generated from field: optional bool large_enum = 3;
    */
-  largeEnum?: boolean;
+  largeEnum: boolean;
 
   /**
    * Whether to use the old default outer class name scheme, or the new feature
@@ -116,7 +116,7 @@ export type JavaFeaturesJson = {
    *
    * @generated from field: optional bool use_old_outer_classname_default = 4;
    */
-  useOldOuterClassnameDefault?: boolean;
+  useOldOuterClassnameDefault: boolean;
 
   /**
    * Whether to nest the generated class in the generated file class. This is
@@ -124,7 +124,7 @@ export type JavaFeaturesJson = {
    *
    * @generated from field: optional pb.JavaFeatures.NestInFileClassFeature.NestInFileClass nest_in_file_class = 5;
    */
-  nestInFileClass?: JavaFeatures_NestInFileClassFeature_NestInFileClassJson;
+  nestInFileClass: JavaFeatures_NestInFileClassFeature_NestInFileClassJson;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/source_context_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/source_context_pb.ts
@@ -56,7 +56,7 @@ export type SourceContextJson = {
    *
    * @generated from field: string file_name = 1;
    */
-  fileName?: string;
+  fileName: string;
 };
 
 /**

--- a/packages/protobuf/src/wkt/gen/google/protobuf/struct_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/struct_pb.ts
@@ -135,7 +135,7 @@ export type Value = Message<"google.protobuf.Value"> & {
      */
     value: ListValue;
     case: "listValue";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -214,7 +214,7 @@ export enum NullValue {
  *
  * @generated from enum google.protobuf.NullValue
  */
-export type NullValueJson = null;
+export type NullValueJson = "NULL_VALUE";
 
 /**
  * Describes the enum google.protobuf.NullValue.

--- a/packages/protobuf/src/wkt/gen/google/protobuf/type_pb.ts
+++ b/packages/protobuf/src/wkt/gen/google/protobuf/type_pb.ts
@@ -76,7 +76,7 @@ export type Type = Message<"google.protobuf.Type"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * The source syntax.
@@ -109,49 +109,49 @@ export type TypeJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * The list of fields.
    *
    * @generated from field: repeated google.protobuf.Field fields = 2;
    */
-  fields?: FieldJson[];
+  fields: FieldJson[];
 
   /**
    * The list of types appearing in `oneof` definitions in this type.
    *
    * @generated from field: repeated string oneofs = 3;
    */
-  oneofs?: string[];
+  oneofs: string[];
 
   /**
    * The protocol buffer options.
    *
    * @generated from field: repeated google.protobuf.Option options = 4;
    */
-  options?: OptionJson[];
+  options: OptionJson[];
 
   /**
    * The source context.
    *
    * @generated from field: google.protobuf.SourceContext source_context = 5;
    */
-  sourceContext?: SourceContextJson;
+  sourceContext: SourceContextJson;
 
   /**
    * The source syntax.
    *
    * @generated from field: google.protobuf.Syntax syntax = 6;
    */
-  syntax?: SyntaxJson;
+  syntax: SyntaxJson;
 
   /**
    * The source edition string, only valid when syntax is SYNTAX_EDITIONS.
    *
    * @generated from field: string edition = 7;
    */
-  edition?: string;
+  edition: string;
 };
 
 /**
@@ -261,28 +261,28 @@ export type FieldJson = {
    *
    * @generated from field: google.protobuf.Field.Kind kind = 1;
    */
-  kind?: Field_KindJson;
+  kind: Field_KindJson;
 
   /**
    * The field cardinality.
    *
    * @generated from field: google.protobuf.Field.Cardinality cardinality = 2;
    */
-  cardinality?: Field_CardinalityJson;
+  cardinality: Field_CardinalityJson;
 
   /**
    * The field number.
    *
    * @generated from field: int32 number = 3;
    */
-  number?: number;
+  number: number;
 
   /**
    * The field name.
    *
    * @generated from field: string name = 4;
    */
-  name?: string;
+  name: string;
 
   /**
    * The field type URL, without the scheme, for message or enumeration
@@ -290,7 +290,7 @@ export type FieldJson = {
    *
    * @generated from field: string type_url = 6;
    */
-  typeUrl?: string;
+  typeUrl: string;
 
   /**
    * The index of the field type in `Type.oneofs`, for message or enumeration
@@ -298,35 +298,35 @@ export type FieldJson = {
    *
    * @generated from field: int32 oneof_index = 7;
    */
-  oneofIndex?: number;
+  oneofIndex: number;
 
   /**
    * Whether to use alternative packed wire representation.
    *
    * @generated from field: bool packed = 8;
    */
-  packed?: boolean;
+  packed: boolean;
 
   /**
    * The protocol buffer options.
    *
    * @generated from field: repeated google.protobuf.Option options = 9;
    */
-  options?: OptionJson[];
+  options: OptionJson[];
 
   /**
    * The field JSON name.
    *
    * @generated from field: string json_name = 10;
    */
-  jsonName?: string;
+  jsonName: string;
 
   /**
    * The string value of the default value of this field. Proto2 syntax only.
    *
    * @generated from field: string default_value = 11;
    */
-  defaultValue?: string;
+  defaultValue: string;
 };
 
 /**
@@ -574,7 +574,7 @@ export type Enum = Message<"google.protobuf.Enum"> & {
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContext;
+  sourceContext: SourceContext;
 
   /**
    * The source syntax.
@@ -607,42 +607,42 @@ export type EnumJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * Enum value definitions.
    *
    * @generated from field: repeated google.protobuf.EnumValue enumvalue = 2;
    */
-  enumvalue?: EnumValueJson[];
+  enumvalue: EnumValueJson[];
 
   /**
    * Protocol buffer options.
    *
    * @generated from field: repeated google.protobuf.Option options = 3;
    */
-  options?: OptionJson[];
+  options: OptionJson[];
 
   /**
    * The source context.
    *
    * @generated from field: google.protobuf.SourceContext source_context = 4;
    */
-  sourceContext?: SourceContextJson;
+  sourceContext: SourceContextJson;
 
   /**
    * The source syntax.
    *
    * @generated from field: google.protobuf.Syntax syntax = 5;
    */
-  syntax?: SyntaxJson;
+  syntax: SyntaxJson;
 
   /**
    * The source edition string, only valid when syntax is SYNTAX_EDITIONS.
    *
    * @generated from field: string edition = 6;
    */
-  edition?: string;
+  edition: string;
 };
 
 /**
@@ -701,21 +701,21 @@ export type EnumValueJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * Enum value number.
    *
    * @generated from field: int32 number = 2;
    */
-  number?: number;
+  number: number;
 
   /**
    * Protocol buffer options.
    *
    * @generated from field: repeated google.protobuf.Option options = 3;
    */
-  options?: OptionJson[];
+  options: OptionJson[];
 };
 
 /**
@@ -754,7 +754,7 @@ export type Option = Message<"google.protobuf.Option"> & {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: Any;
+  value: Any;
 };
 
 /**
@@ -776,7 +776,7 @@ export type OptionJson = {
    *
    * @generated from field: string name = 1;
    */
-  name?: string;
+  name: string;
 
   /**
    * The option's value packed in an Any message. If the value is a primitive,
@@ -786,7 +786,7 @@ export type OptionJson = {
    *
    * @generated from field: google.protobuf.Any value = 2;
    */
-  value?: AnyJson;
+  value: AnyJson;
 };
 
 /**

--- a/packages/protoc-gen-es/src/gen/minimal-validate_pb.ts
+++ b/packages/protoc-gen-es/src/gen/minimal-validate_pb.ts
@@ -78,7 +78,7 @@ export type FieldRules = Message<"buf.validate.FieldRules"> & {
      */
     value: MapRules;
     case: "map";
-  } | { case: undefined; value?: undefined };
+  } | { case: ""; };
 };
 
 /**
@@ -95,7 +95,7 @@ export type RepeatedRules = Message<"buf.validate.RepeatedRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules items = 4;
    */
-  items?: FieldRules;
+  items: FieldRules;
 };
 
 /**
@@ -112,7 +112,7 @@ export type MapRules = Message<"buf.validate.MapRules"> & {
   /**
    * @generated from field: optional buf.validate.FieldRules values = 5;
    */
-  values?: FieldRules;
+  values: FieldRules;
 };
 
 /**

--- a/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
+++ b/packages/protoc-gen-es/src/protoc-gen-es-plugin.ts
@@ -38,9 +38,7 @@ import {
 } from "./util.js";
 import { version } from "../package.json";
 import {
-  isLegacyRequired,
   isProtovalidateDisabled,
-  isProtovalidateRequired,
   messageNeedsCustomValidType,
 } from "./valid-types.js";
 
@@ -411,15 +409,11 @@ function generateEnumJsonShape(f: GeneratedFile, enumeration: DescEnum, target: 
   f.print(f.jsDoc(enumeration));
   const declaration = target == "ts" ? "type" : "declare type";
   const values: Printable[] = [];
-  if (enumeration.typeName == "google.protobuf.NullValue") {
-    values.push("null");
-  } else {
-    for (const v of enumeration.values) {
-      if (enumeration.values.indexOf(v) > 0) {
-        values.push(" | ");
-      }
-      values.push(f.string(v.name));
+  for (const v of enumeration.values) {
+    if (enumeration.values.indexOf(v) > 0) {
+      values.push(" | ");
     }
+    values.push(f.string(v.name));
   }
   f.print(f.export(declaration, f.importJson(enumeration).name), " = ", values, ";");
   f.print();
@@ -477,22 +471,12 @@ function generateMessageShapeMember(f: GeneratedFile, member: DescField | DescOn
         f.print(`    value: `, typing, `;`);
         f.print(`    case: "`, field.localName, `";`);
       }
-      f.print(`  } | { case: undefined; value?: undefined };`);
+      f.print(`  } | { case: ""; };`);
       break;
     case "field":
       f.print(f.jsDoc(member, "  "));
-      let { typing, optional } = fieldTypeScriptType(member, f.runtime, validTypes && !isProtovalidateDisabled(member));
-      if (optional && validTypes) {
-        const isRequired = (validTypes.legacyRequired && isLegacyRequired(member)) || (validTypes.protovalidateRequired && isProtovalidateRequired(member));
-        if (isRequired) {
-          optional = false;
-        }
-      }
-      if (optional) {
-        f.print("  ", member.localName, "?: ", typing, ";");
-      } else {
-        f.print("  ", member.localName, ": ", typing, ";");
-      }
+      const { typing } = fieldTypeScriptType(member, f.runtime, validTypes && !isProtovalidateDisabled(member));
+      f.print("  ", member.localName, ": ", typing, ";");
       break;
   }
 }
@@ -504,7 +488,7 @@ function generateMessageJsonShape(f: GeneratedFile, message: DescMessage, target
   switch (message.typeName) {
     case "google.protobuf.Any":
       f.print(exp, " = {");
-      f.print(`  "@type"?: string;`);
+      f.print(`  "@type": string;`);
       f.print("};");
       break;
     case "google.protobuf.Timestamp":
@@ -543,7 +527,7 @@ function generateMessageJsonShape(f: GeneratedFile, message: DescMessage, target
             || containsSpecialChar.test(jsonName)) {
             jsonName = f.string(jsonName);
           }
-          f.print("  ", jsonName, "?: ", fieldJsonType(field), ";");
+          f.print("  ", jsonName, ": ", fieldJsonType(field), ";");
           if (message.fields.indexOf(field) < message.fields.length - 1) {
             f.print();
           }


### PR DESCRIPTION
Succeeds https://github.com/bufbuild/protobuf-es/pull/1347

I agree with @timostamm and @smaye81 that we should not put effort into supporting non-default TypeScript features. Having said that, I noticed huge potential in removing redundant code that was there to make it "strict"-friendlier. This avoids a huge bug surface and typing misuse which the previous PR was trying to fix. So we get less code, and fewer bugs, and easier maintenance. Win-win-win!

https://www.typescriptlang.org/docs/handbook/compiler-options.html#strict-boolean-default-false

I'll soon do a broader sweep to remove unnecessary code, but this seems like a good first quick win!