### PR TITLE
Change README title from Deno to Bun

### DIFF
--- a/bun/example/README.md
+++ b/bun/example/README.md
@@ -1,4 +1,4 @@
-# Protobuf Example on Deno
+# Protobuf Example on Bun
 
 This directory contains example code that uses Protocol Buffers to manage a list
 of users. The [add.ts](./src/add.ts) script adds a new user, prompting the user


### PR DESCRIPTION
Updated the title of the README to reflect the use of Bun instead of Deno.