### PR TITLE
Fix UTF-8 validation for proto3 and edition feature `utf8_validation`

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,010 b |  68,782 b |   15,803 b |
-| Protobuf-ES         |     4 |   135,199 b |  70,289 b |   16,433 b |
-| Protobuf-ES         |     8 |   137,961 b |  72,060 b |   16,996 b |
-| Protobuf-ES         |    16 |   148,411 b |  80,041 b |   19,330 b |
-| Protobuf-ES         |    32 |   176,202 b | 102,059 b |   24,783 b |
+| Protobuf-ES         |     1 |   133,886 b |  69,176 b |   15,907 b |
+| Protobuf-ES         |     4 |   136,075 b |  70,683 b |   16,591 b |
+| Protobuf-ES         |     8 |   138,837 b |  72,454 b |   17,109 b |
+| Protobuf-ES         |    16 |   149,287 b |  80,435 b |   19,458 b |
+| Protobuf-ES         |    32 |   177,078 b | 102,453 b |   24,888 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,886 b |  69,176 b |   15,907 b |
-| Protobuf-ES         |     4 |   136,075 b |  70,683 b |   16,591 b |
-| Protobuf-ES         |     8 |   138,837 b |  72,454 b |   17,109 b |
-| Protobuf-ES         |    16 |   149,287 b |  80,435 b |   19,458 b |
-| Protobuf-ES         |    32 |   177,078 b | 102,453 b |   24,888 b |
+| Protobuf-ES         |     1 |   133,665 b |  69,054 b |   15,873 b |
+| Protobuf-ES         |     4 |   135,854 b |  70,561 b |   16,573 b |
+| Protobuf-ES         |     8 |   138,616 b |  72,332 b |   17,082 b |
+| Protobuf-ES         |    16 |   149,066 b |  80,313 b |   19,393 b |
+| Protobuf-ES         |    32 |   176,857 b | 102,331 b |   24,873 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,665 b |  69,054 b |   15,873 b |
-| Protobuf-ES         |     4 |   135,854 b |  70,561 b |   16,573 b |
-| Protobuf-ES         |     8 |   138,616 b |  72,332 b |   17,082 b |
-| Protobuf-ES         |    16 |   149,066 b |  80,313 b |   19,393 b |
-| Protobuf-ES         |    32 |   176,857 b | 102,331 b |   24,873 b |
+| Protobuf-ES         |     1 |   133,674 b |  69,054 b |   15,873 b |
+| Protobuf-ES         |     4 |   135,863 b |  70,561 b |   16,573 b |
+| Protobuf-ES         |     8 |   138,625 b |  72,332 b |   17,082 b |
+| Protobuf-ES         |    16 |   149,075 b |  80,313 b |   19,393 b |
+| Protobuf-ES         |    32 |   176,866 b | 102,331 b |   24,873 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.24541015625 140,243.46123046875 280,241.866796875 420,235.2568359375 560,219.81376953125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.95087890625 140,243.01376953125 280,241.54677734375 420,234.8943359375 560,219.51640625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.24541015625" r="4" fill="#ffa600"><title>Protobuf-ES 15.43 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.46123046875" r="4" fill="#ffa600"><title>Protobuf-ES 16.05 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.866796875" r="4" fill="#ffa600"><title>Protobuf-ES 16.6 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.2568359375" r="4" fill="#ffa600"><title>Protobuf-ES 18.88 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.81376953125" r="4" fill="#ffa600"><title>Protobuf-ES 24.2 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.95087890625" r="4" fill="#ffa600"><title>Protobuf-ES 15.53 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.01376953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.2 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.54677734375" r="4" fill="#ffa600"><title>Protobuf-ES 16.71 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.8943359375" r="4" fill="#ffa600"><title>Protobuf-ES 19 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.51640625" r="4" fill="#ffa600"><title>Protobuf-ES 24.3 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.95087890625 140,243.01376953125 280,241.54677734375 420,234.8943359375 560,219.51640625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.04716796875 140,243.06474609375 280,241.6232421875 420,235.07841796875 560,219.55888671875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.95087890625" r="4" fill="#ffa600"><title>Protobuf-ES 15.53 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.01376953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.2 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.54677734375" r="4" fill="#ffa600"><title>Protobuf-ES 16.71 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.8943359375" r="4" fill="#ffa600"><title>Protobuf-ES 19 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.51640625" r="4" fill="#ffa600"><title>Protobuf-ES 24.3 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.04716796875" r="4" fill="#ffa600"><title>Protobuf-ES 15.5 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.06474609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.18 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.6232421875" r="4" fill="#ffa600"><title>Protobuf-ES 16.68 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.07841796875" r="4" fill="#ffa600"><title>Protobuf-ES 18.94 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.55888671875" r="4" fill="#ffa600"><title>Protobuf-ES 24.29 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf-test/src/binary.test.ts
+++ b/packages/protobuf-test/src/binary.test.ts
@@ -45,7 +45,7 @@ import { OneofMessageSchema } from "./gen/ts/extra/msg-oneof_pb.js";
 import { JsonNamesMessageSchema } from "./gen/ts/extra/msg-json-names_pb.js";
 import { JSTypeProto2NormalMessageSchema } from "./gen/ts/extra/jstype-proto2_pb.js";
 import { compileMessage } from "./helpers.js";
-import { BinaryReader, WireType } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter, WireType } from "@bufbuild/protobuf/wire";
 
 void suite(`binary serialization`, () => {
   testBinary(ScalarValuesMessageSchema, {
@@ -324,6 +324,85 @@ void suite(`binary serialization`, () => {
       }
     }
     assert.strictEqual(r.pos, r.len);
+  });
+});
+
+void suite("UTF-8 validation on binary input", () => {
+  const invalid = new Uint8Array([0xa0, 0xb0, 0xc0, 0xd0]);
+  const fieldOneStringBytes = new BinaryWriter()
+    .tag(1, WireType.LengthDelimited)
+    .bytes(invalid)
+    .finish();
+  void test("rejects invalid UTF-8 on proto3 string", async () => {
+    const desc = await compileMessage(`
+      syntax="proto3";
+      message M { string f = 1; }
+    `);
+    assert.throws(() => fromBinary(desc, fieldOneStringBytes));
+  });
+  void test("rejects invalid UTF-8 on edition 2023 string", async () => {
+    const desc = await compileMessage(`
+      edition="2023";
+      message M { string f = 1; }
+    `);
+    assert.throws(() => fromBinary(desc, fieldOneStringBytes));
+  });
+  void test("accepts invalid UTF-8 on proto2 string", async () => {
+    const desc = await compileMessage(`
+      syntax="proto2";
+      message M { optional string f = 1; }
+    `);
+    fromBinary(desc, fieldOneStringBytes);
+  });
+  void test("accepts invalid UTF-8 when features.utf8_validation = NONE", async () => {
+    const desc = await compileMessage(`
+      edition="2023";
+      message M {
+        string f = 1 [features.utf8_validation = NONE];
+      }
+    `);
+    fromBinary(desc, fieldOneStringBytes);
+  });
+  void test("rejects invalid UTF-8 in map key", async () => {
+    const desc = await compileMessage(`
+      syntax="proto3";
+      message M { map<string, string> f = 1; }
+    `);
+    const entry = new BinaryWriter()
+      .tag(1, WireType.LengthDelimited)
+      .bytes(invalid)
+      .tag(2, WireType.LengthDelimited)
+      .bytes(new Uint8Array())
+      .finish();
+    const bytes = new BinaryWriter()
+      .tag(1, WireType.LengthDelimited)
+      .bytes(entry)
+      .finish();
+    assert.throws(() => fromBinary(desc, bytes));
+  });
+  void test("rejects invalid UTF-8 in map value", async () => {
+    const desc = await compileMessage(`
+      syntax="proto3";
+      message M { map<string, string> f = 1; }
+    `);
+    const entry = new BinaryWriter()
+      .tag(1, WireType.LengthDelimited)
+      .bytes(new Uint8Array())
+      .tag(2, WireType.LengthDelimited)
+      .bytes(invalid)
+      .finish();
+    const bytes = new BinaryWriter()
+      .tag(1, WireType.LengthDelimited)
+      .bytes(entry)
+      .finish();
+    assert.throws(() => fromBinary(desc, bytes));
+  });
+  void test("rejects invalid UTF-8 in repeated string", async () => {
+    const desc = await compileMessage(`
+      syntax="proto3";
+      message M { repeated string f = 1; }
+    `);
+    assert.throws(() => fromBinary(desc, fieldOneStringBytes));
   });
 });
 

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -1194,7 +1194,7 @@ void suite("DescField", () => {
       const field = await compileField(`
         edition="2023";
         option features.message_encoding = DELIMITED;
-        message M { 
+        message M {
           map <int32, string> f = 1;
         }
       `);
@@ -1202,6 +1202,63 @@ void suite("DescField", () => {
         field.fieldKind == "map" ? field.delimitedEncoding : undefined,
         false,
       );
+    });
+  });
+  void suite("utf8Validation", () => {
+    test("false for proto2 string field", async () => {
+      const field = await compileField(`
+        syntax="proto2";
+        message M {
+          optional string f = 1;
+        }
+      `);
+      assert.strictEqual(field.utf8Validation, false);
+    });
+    test("true for proto3 string field", async () => {
+      const field = await compileField(`
+        syntax="proto3";
+        message M {
+          string f = 1;
+        }
+      `);
+      assert.strictEqual(field.utf8Validation, true);
+    });
+    test("true for edition 2023 string field", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M {
+          string f = 1;
+        }
+      `);
+      assert.strictEqual(field.utf8Validation, true);
+    });
+    test("false for field with features.utf8_validation = NONE", async () => {
+      const field = await compileField(`
+        edition="2023";
+        message M {
+          string f = 1 [features.utf8_validation = NONE];
+        }
+      `);
+      assert.strictEqual(field.utf8Validation, false);
+    });
+    test("false for file with features.utf8_validation = NONE", async () => {
+      const field = await compileField(`
+        edition="2023";
+        option features.utf8_validation = NONE;
+        message M {
+          string f = 1;
+        }
+      `);
+      assert.strictEqual(field.utf8Validation, false);
+    });
+    test("true for map field in proto3", async () => {
+      const field = await compileField(`
+        syntax="proto3";
+        message M {
+          map <string, string> f = 1;
+        }
+      `);
+      assert.strictEqual(field.utf8Validation, true);
     });
   });
   void suite("longAsString", () => {

--- a/packages/protobuf/src/descriptors.ts
+++ b/packages/protobuf/src/descriptors.ts
@@ -371,6 +371,13 @@ interface descFieldAndExtensionShared {
    */
   readonly presence: SupportedFieldPresence;
   /**
+   * Whether to reject invalid UTF-8 when reading this field from the binary
+   * wire format. Reflects the resolved `utf8_validation` feature: true for
+   * VERIFY (proto3 and editions 2023+ default), false for NONE (proto2
+   * default).
+   */
+  readonly utf8Validation: boolean;
+  /**
    * The compiler-generated descriptor.
    */
   readonly proto: FieldDescriptorProto;

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -149,7 +149,10 @@ export function readField(
 ) {
   switch (field.fieldKind) {
     case "scalar":
-      message.set(field, readScalar(reader, field.scalar));
+      message.set(
+        field,
+        readScalar(reader, field.scalar, field.utf8Validation),
+      );
       break;
     case "enum":
       const val = readScalar(reader, ScalarType.INT32);
@@ -205,12 +208,12 @@ function readMapEntry(
     const [fieldNo] = reader.tag();
     switch (fieldNo) {
       case 1:
-        key = readScalar(reader, field.mapKey);
+        key = readScalar(reader, field.mapKey, field.utf8Validation);
         break;
       case 2:
         switch (field.mapKind) {
           case "scalar":
-            val = readScalar(reader, field.scalar);
+            val = readScalar(reader, field.scalar, field.utf8Validation);
             break;
           case "enum":
             val = reader.int32();
@@ -258,12 +261,12 @@ function readListField(
     scalarType != ScalarType.STRING &&
     scalarType != ScalarType.BYTES;
   if (!packed) {
-    list.add(readScalar(reader, scalarType));
+    list.add(readScalar(reader, scalarType, field.utf8Validation));
     return;
   }
   const e = reader.uint32() + reader.pos;
   while (reader.pos < e) {
-    list.add(readScalar(reader, scalarType));
+    list.add(readScalar(reader, scalarType, field.utf8Validation));
   }
 }
 
@@ -285,10 +288,14 @@ function readMessageField(
   return message;
 }
 
-function readScalar(reader: BinaryReader, type: ScalarType): ScalarValue {
+function readScalar(
+  reader: BinaryReader,
+  type: ScalarType,
+  validateUtf8 = false,
+): ScalarValue {
   switch (type) {
     case ScalarType.STRING:
-      return reader.string();
+      return validateUtf8 ? reader.stringStrict() : reader.string();
     case ScalarType.BOOL:
       return reader.bool();
     case ScalarType.DOUBLE:

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -295,7 +295,7 @@ function readScalar(
 ): ScalarValue {
   switch (type) {
     case ScalarType.STRING:
-      return validateUtf8 ? reader.stringStrict() : reader.string();
+      return reader.string(validateUtf8);
     case ScalarType.BOOL:
       return reader.bool();
     case ScalarType.DOUBLE:

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -21,6 +21,7 @@ import type {
   FeatureSet_RepeatedFieldEncoding,
   FeatureSet_MessageEncoding,
   FeatureSet_EnumType,
+  FeatureSet_Utf8Validation,
   FieldDescriptorProto,
   FieldDescriptorProto_Type,
   FieldDescriptorProto_Label,
@@ -422,6 +423,9 @@ const DELIMITED: FeatureSet_MessageEncoding.DELIMITED = 2;
 
 // bootstrap-inject google.protobuf.FeatureSet.EnumType.OPEN: const $name: FeatureSet_EnumType.$localName = $number;
 const OPEN: FeatureSet_EnumType.OPEN = 1;
+
+// bootstrap-inject google.protobuf.FeatureSet.Utf8Validation.VERIFY: const $name: FeatureSet_Utf8Validation.$localName = $number;
+const VERIFY: FeatureSet_Utf8Validation.VERIFY = 2;
 
 // biome-ignore format: want this to read well
 // bootstrap-inject defaults: EDITION_PROTO2 to EDITION_2024: export const minimumEdition: SupportedEdition = $minimumEdition, maximumEdition: SupportedEdition = $maximumEdition;
@@ -839,6 +843,7 @@ function newField(
     message: undefined,
     enum: undefined,
     presence: getFieldPresence(proto, oneof, isExtension, parentOrFile),
+    utf8Validation: isUtf8Validated(proto, parentOrFile),
     listKind: undefined,
     mapKind: undefined,
     mapKey: undefined,
@@ -1224,6 +1229,24 @@ function isDelimitedEncoding(
   return (
     DELIMITED ==
     resolveFeature("messageEncoding", {
+      proto,
+      parent,
+    })
+  );
+}
+
+/**
+ * Reject invalid UTF-8 when reading string fields from the binary wire format?
+ * Driven by the resolved `utf8_validation` feature: VERIFY (proto3 / editions
+ * 2023+ default) enforces; NONE (proto2 default) does not.
+ */
+function isUtf8Validated(
+  proto: FieldDescriptorProto,
+  parent: DescMessage | DescFile,
+): boolean {
+  return (
+    VERIFY ==
+    resolveFeature("utf8Validation", {
       proto,
       parent,
     })

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -376,10 +376,8 @@ export class BinaryReader {
     buf: Uint8Array,
     private readonly decodeUtf8: (
       bytes: Uint8Array,
+      fatal?: boolean,
     ) => string = getTextEncoding().decodeUtf8,
-    private readonly decodeUtf8Strict: (
-      bytes: Uint8Array,
-    ) => string = defaultDecodeUtf8Strict,
   ) {
     this.buf = buf;
     this.len = buf.length;
@@ -566,37 +564,12 @@ export class BinaryReader {
   }
 
   /**
-   * Read a `string` field, length-delimited data converted to UTF-8 text.
-   * Invalid UTF-8 sequences are silently replaced with U+FFFD.
+   * Read a `string` field, length-delimited data converted to UTF-8 text. If
+   * `fatal` is true, throw on invalid UTF-8 instead of substituting U+FFFD.
    */
-  string(): string {
-    return this.decodeUtf8(this.bytes());
+  string(fatal?: boolean): string {
+    return this.decodeUtf8(this.bytes(), fatal);
   }
-
-  /**
-   * Read a `string` field, throwing on invalid UTF-8.
-   */
-  stringStrict(): string {
-    return this.decodeUtf8Strict(this.bytes());
-  }
-}
-
-// Lazily constructed fatal UTF-8 decoder used as the default for
-// BinaryReader.decodeUtf8Strict. Independent of configureTextEncoding.
-let strictDecoder: { decode(data: Uint8Array): string } | undefined;
-
-function defaultDecodeUtf8Strict(bytes: Uint8Array): string {
-  if (strictDecoder === undefined) {
-    strictDecoder = new (
-      globalThis as unknown as {
-        TextDecoder: new (
-          label?: string,
-          options?: { fatal?: boolean },
-        ) => { decode(data: Uint8Array): string };
-      }
-    ).TextDecoder("utf-8", { fatal: true });
-  }
-  return strictDecoder.decode(bytes);
 }
 
 /**

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -377,6 +377,9 @@ export class BinaryReader {
     private readonly decodeUtf8: (
       bytes: Uint8Array,
     ) => string = getTextEncoding().decodeUtf8,
+    private readonly decodeUtf8Strict: (
+      bytes: Uint8Array,
+    ) => string = defaultDecodeUtf8Strict,
   ) {
     this.buf = buf;
     this.len = buf.length;
@@ -564,10 +567,36 @@ export class BinaryReader {
 
   /**
    * Read a `string` field, length-delimited data converted to UTF-8 text.
+   * Invalid UTF-8 sequences are silently replaced with U+FFFD.
    */
   string(): string {
     return this.decodeUtf8(this.bytes());
   }
+
+  /**
+   * Read a `string` field, throwing on invalid UTF-8.
+   */
+  stringStrict(): string {
+    return this.decodeUtf8Strict(this.bytes());
+  }
+}
+
+// Lazily constructed fatal UTF-8 decoder used as the default for
+// BinaryReader.decodeUtf8Strict. Independent of configureTextEncoding.
+let strictDecoder: { decode(data: Uint8Array): string } | undefined;
+
+function defaultDecodeUtf8Strict(bytes: Uint8Array): string {
+  if (strictDecoder === undefined) {
+    strictDecoder = new (
+      globalThis as unknown as {
+        TextDecoder: new (
+          label?: string,
+          options?: { fatal?: boolean },
+        ) => { decode(data: Uint8Array): string };
+      }
+    ).TextDecoder("utf-8", { fatal: true });
+  }
+  return strictDecoder.decode(bytes);
 }
 
 /**

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -376,7 +376,7 @@ export class BinaryReader {
     buf: Uint8Array,
     private readonly decodeUtf8: (
       bytes: Uint8Array,
-      fatal?: boolean,
+      strict?: boolean,
     ) => string = getTextEncoding().decodeUtf8,
   ) {
     this.buf = buf;
@@ -565,10 +565,10 @@ export class BinaryReader {
 
   /**
    * Read a `string` field, length-delimited data converted to UTF-8 text. If
-   * `fatal` is true, throw on invalid UTF-8 instead of substituting U+FFFD.
+   * `strict` is true, throw on invalid UTF-8 instead of substituting U+FFFD.
    */
-  string(fatal?: boolean): string {
-    return this.decodeUtf8(this.bytes(), fatal);
+  string(strict?: boolean): string {
+    return this.decodeUtf8(this.bytes(), strict);
   }
 }
 

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -24,11 +24,11 @@ interface TextEncoding {
    */
   encodeUtf8: (text: string) => Uint8Array<ArrayBuffer>;
   /**
-   * Decode UTF-8 text from binary. If `fatal` is true, throw on invalid byte
+   * Decode UTF-8 text from binary. If `strict` is true, throw on invalid byte
    * sequences instead of silently substituting U+FFFD. Implementations that
    * do not support strict decoding may ignore the flag.
    */
-  decodeUtf8: (bytes: Uint8Array, fatal?: boolean) => string;
+  decodeUtf8: (bytes: Uint8Array, strict?: boolean) => string;
 }
 
 /**
@@ -52,19 +52,19 @@ export function getTextEncoding() {
     const td = new (
       globalThis as unknown as GlobalWithTextEncoderDecoder
     ).TextDecoder();
-    let tdFatal: { decode(data: Uint8Array): string } | undefined;
+    let tdStrict: { decode(data: Uint8Array): string } | undefined;
     (globalThis as GlobalWithTextEncoding)[symbol] = {
       encodeUtf8(text: string): Uint8Array<ArrayBuffer> {
         return te.encode(text);
       },
-      decodeUtf8(bytes: Uint8Array, fatal?: boolean): string {
-        if (fatal) {
-          if (tdFatal === undefined) {
-            tdFatal = new (
+      decodeUtf8(bytes: Uint8Array, strict?: boolean): string {
+        if (strict) {
+          if (tdStrict === undefined) {
+            tdStrict = new (
               globalThis as unknown as GlobalWithTextEncoderDecoder
             ).TextDecoder("utf-8", { fatal: true });
           }
-          return tdFatal.decode(bytes);
+          return tdStrict.decode(bytes);
         }
         return td.decode(bytes);
       },

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -24,9 +24,11 @@ interface TextEncoding {
    */
   encodeUtf8: (text: string) => Uint8Array<ArrayBuffer>;
   /**
-   * Decode UTF-8 text from binary.
+   * Decode UTF-8 text from binary. If `fatal` is true, throw on invalid byte
+   * sequences instead of silently substituting U+FFFD. Implementations that
+   * do not support strict decoding may ignore the flag.
    */
-  decodeUtf8: (bytes: Uint8Array) => string;
+  decodeUtf8: (bytes: Uint8Array, fatal?: boolean) => string;
 }
 
 /**
@@ -50,11 +52,20 @@ export function getTextEncoding() {
     const td = new (
       globalThis as unknown as GlobalWithTextEncoderDecoder
     ).TextDecoder();
+    let tdFatal: { decode(data: Uint8Array): string } | undefined;
     (globalThis as GlobalWithTextEncoding)[symbol] = {
       encodeUtf8(text: string): Uint8Array<ArrayBuffer> {
         return te.encode(text);
       },
-      decodeUtf8(bytes: Uint8Array): string {
+      decodeUtf8(bytes: Uint8Array, fatal?: boolean): string {
+        if (fatal) {
+          if (tdFatal === undefined) {
+            tdFatal = new (
+              globalThis as unknown as GlobalWithTextEncoderDecoder
+            ).TextDecoder("utf-8", { fatal: true });
+          }
+          return tdFatal.decode(bytes);
+        }
         return td.decode(bytes);
       },
       checkUtf8(text: string): boolean {
@@ -81,7 +92,10 @@ type GlobalWithTextEncoderDecoder = {
     };
   };
   TextDecoder: {
-    new (): {
+    new (
+      label?: string,
+      options?: { fatal?: boolean },
+    ): {
       decode(data: Uint8Array): string;
     };
   };


### PR DESCRIPTION
This PR adds support for UTF-8 validation in `fromBinary`, and fixes a bug: proto3 and editions require strings to be valid UTF-8, but this was never checked in `fromBinary`. Invalid data would silently be replaced by the Unicode Replacement Character.

The new behavior is that `fromBinary` throws on invalid strings. If you parse binary data that contains invalid strings and rely on the old behavior, you have to handle the error, or configure text encoding to ignore the new `strict` argument:

```typescript
import { configureTextEncoding, getTextEncoding } from "@bufbuild/protobuf/wire";
const { encodeUtf8, checkUtf8, decodeUtf8 } = getTextEncoding();
configureTextEncoding({
  encodeUtf8,
  checkUtf8,
  // Ignore `strict`: invalid UTF-8 becomes U+FFFD instead of throwing.
  decodeUtf8: (bytes, _strict) => decodeUtf8(bytes),
});
```

With editions, UTF-8 validation can be configured per field or per file. See the [documentation](https://protobuf.dev/editions/features/#utf8_validation) for details.

Note: `BinaryReader` does not change behavior. To opt-in to UTF-8 validation, call `reader.string(true)`.
