### PR TITLE
Fix binary tag parse validation to reject overlong values

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,010 b |  68,782 b |   15,803 b |
-| Protobuf-ES         |     4 |   135,199 b |  70,289 b |   16,433 b |
-| Protobuf-ES         |     8 |   137,961 b |  72,060 b |   16,996 b |
-| Protobuf-ES         |    16 |   148,411 b |  80,041 b |   19,330 b |
-| Protobuf-ES         |    32 |   176,202 b | 102,059 b |   24,783 b |
+| Protobuf-ES         |     1 |   133,495 b |  68,899 b |   15,835 b |
+| Protobuf-ES         |     4 |   135,684 b |  70,406 b |   16,516 b |
+| Protobuf-ES         |     8 |   138,446 b |  72,177 b |   17,047 b |
+| Protobuf-ES         |    16 |   148,896 b |  80,158 b |   19,357 b |
+| Protobuf-ES         |    32 |   176,687 b | 102,176 b |   24,874 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,010 b |  68,782 b |   15,803 b |
-| Protobuf-ES         |     4 |   135,199 b |  70,289 b |   16,433 b |
-| Protobuf-ES         |     8 |   137,961 b |  72,060 b |   16,996 b |
-| Protobuf-ES         |    16 |   148,411 b |  80,041 b |   19,330 b |
-| Protobuf-ES         |    32 |   176,202 b | 102,059 b |   24,783 b |
+| Protobuf-ES         |     1 |   133,976 b |  69,171 b |   15,890 b |
+| Protobuf-ES         |     4 |   136,165 b |  70,678 b |   16,587 b |
+| Protobuf-ES         |     8 |   138,927 b |  72,449 b |   17,134 b |
+| Protobuf-ES         |    16 |   149,377 b |  80,430 b |   19,442 b |
+| Protobuf-ES         |    32 |   177,168 b | 102,448 b |   24,922 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.24541015625 140,243.46123046875 280,241.866796875 420,235.2568359375 560,219.81376953125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.15478515625 140,243.226171875 280,241.72236328125 420,235.18037109375 560,219.5560546875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.24541015625" r="4" fill="#ffa600"><title>Protobuf-ES 15.43 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.46123046875" r="4" fill="#ffa600"><title>Protobuf-ES 16.05 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.866796875" r="4" fill="#ffa600"><title>Protobuf-ES 16.6 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.2568359375" r="4" fill="#ffa600"><title>Protobuf-ES 18.88 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.81376953125" r="4" fill="#ffa600"><title>Protobuf-ES 24.2 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.15478515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.46 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.226171875" r="4" fill="#ffa600"><title>Protobuf-ES 16.13 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.72236328125" r="4" fill="#ffa600"><title>Protobuf-ES 16.65 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.18037109375" r="4" fill="#ffa600"><title>Protobuf-ES 18.9 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.5560546875" r="4" fill="#ffa600"><title>Protobuf-ES 24.29 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.24541015625 140,243.46123046875 280,241.866796875 420,235.2568359375 560,219.81376953125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.9990234375 140,243.02509765625 280,241.4759765625 420,234.9396484375 560,219.4201171875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.24541015625" r="4" fill="#ffa600"><title>Protobuf-ES 15.43 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.46123046875" r="4" fill="#ffa600"><title>Protobuf-ES 16.05 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.866796875" r="4" fill="#ffa600"><title>Protobuf-ES 16.6 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.2568359375" r="4" fill="#ffa600"><title>Protobuf-ES 18.88 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.81376953125" r="4" fill="#ffa600"><title>Protobuf-ES 24.2 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.9990234375" r="4" fill="#ffa600"><title>Protobuf-ES 15.52 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.02509765625" r="4" fill="#ffa600"><title>Protobuf-ES 16.2 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.4759765625" r="4" fill="#ffa600"><title>Protobuf-ES 16.73 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.9396484375" r="4" fill="#ffa600"><title>Protobuf-ES 18.99 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.4201171875" r="4" fill="#ffa600"><title>Protobuf-ES 24.34 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf-test/src/wire/binary-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/binary-encoding.test.ts
@@ -240,4 +240,49 @@ void suite("BinaryReader", () => {
       }
     });
   });
+  void suite("tag", () => {
+    // Tag byte for (fieldNo=1, wireType=Varint) with the varint continuation
+    // bit set, so additional bytes can be appended to build malformed tags.
+    const field1TagContinued = 0x08 | 0x80;
+    void test("should reject varint longer than 5 bytes", () => {
+      const reader = new BinaryReader(
+        new Uint8Array([
+          field1TagContinued,
+          0x80,
+          0x80,
+          0x80,
+          0x80,
+          0x80,
+          0x00,
+        ]),
+      );
+      assert.throws(() => reader.tag(), {
+        message: "illegal tag: varint overflows uint32",
+      });
+    });
+    void test("should reject 5-byte varint whose value overflows uint32", () => {
+      const reader = new BinaryReader(
+        new Uint8Array([field1TagContinued, 0x80, 0x80, 0x80, 0x40]),
+      );
+      assert.throws(() => reader.tag(), {
+        message: "illegal tag: varint overflows uint32",
+      });
+    });
+    void test("should reject field number 0", () => {
+      const reader = new BinaryReader(new Uint8Array([0x00]));
+      assert.throws(() => reader.tag(), {
+        message: /^illegal tag: field no 0/,
+      });
+    });
+    void test("should accept the maximum valid tag", () => {
+      // fieldNo = 2^29 - 1 (the protobuf max), wireType = Varint.
+      // tag = (0x1FFFFFFF << 3) = 0xFFFFFFF8.
+      const reader = new BinaryReader(
+        new Uint8Array([0xf8, 0xff, 0xff, 0xff, 0x0f]),
+      );
+      const [fieldNo, wireType] = reader.tag();
+      assert.strictEqual(fieldNo, 0x1fffffff);
+      assert.strictEqual(wireType, WireType.Varint);
+    });
+  });
 });

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -385,16 +385,23 @@ export class BinaryReader {
   }
 
   /**
-   * Reads a tag - field number and wire type.
+   * Reads a tag - field number and wire type. Tags are uint32 varints; values
+   * that do not fit in uint32 are rejected.
    */
   tag(): [number, WireType] {
-    let tag = this.uint32(),
-      fieldNo = tag >>> 3,
-      wireType = tag & 7;
-    if (fieldNo <= 0 || wireType < 0 || wireType > 5)
+    const start = this.pos;
+    const tag = this.uint32();
+    const bytesRead = this.pos - start;
+    if (bytesRead > 5 || (bytesRead == 5 && this.buf[this.pos - 1] > 0x0f)) {
+      throw new Error("illegal tag: varint overflows uint32");
+    }
+    const fieldNo = tag >>> 3;
+    const wireType = tag & 7;
+    if (fieldNo <= 0 || wireType > 5) {
       throw new Error(
         "illegal tag: field no " + fieldNo + " wire type " + wireType,
       );
+    }
     return [fieldNo, wireType];
   }
 


### PR DESCRIPTION
This enforces binary tag parsing to reject values greater than uint32 sizes.

`BinaryReader.tag()` validates that the tag is a well-formed uint32 varint. Overlong varints (more than 5 bytes) and 5-byte varints whose value overflows uint32 are rejected with an error. Earlier versions of Protobuf-ES silently decoded these cases by truncating the high bits, which caused malformed payloads to be stored as unknown fields instead of failing to parse. Producers generating tags via `BinaryWriter.tag()` are unaffected, since `BinaryWriter` only emits valid tags.