### PR TITLE
Document UTF-8 validation in fromBinary with escape hatch in configureTextEncoding

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1260,6 +1260,31 @@ not part of the ECMAScript standard.
 If the API is unavailable in your runtime, use the function `configureTextEncoding` from `@bufbuild/protobuf/wire` to
 provide your own implementation. Note that the function must be called early in the initialization.
 
+#### UTF-8 validation
+
+Proto3 and editions 2023+ require string fields to contain valid UTF-8. `fromBinary` validates this and throws on
+invalid byte sequences. Proto2 string fields accept invalid UTF-8 unchanged. Earlier versions of Protobuf-ES silently
+replaced invalid bytes with the Unicode replacement character U+FFFD; producers that emit non-conforming data will now
+cause `fromBinary` to throw where it previously succeeded with corrupted strings.
+
+`BinaryReader` and `BinaryWriter` default behavior is unchanged. `BinaryReader.string(strict?)` accepts an optional
+boolean; `strict = false` (the default) preserves the lax behavior, and `strict = true` enables fatal UTF-8 decoding.
+`fromBinary` passes `true` for fields whose resolved `utf8_validation` feature is `VERIFY`.
+
+To restore the pre-validation behavior globally, configure a `decodeUtf8` that ignores the `strict` flag:
+
+```typescript
+import { configureTextEncoding, getTextEncoding } from "@bufbuild/protobuf/wire";
+
+const { encodeUtf8, checkUtf8, decodeUtf8 } = getTextEncoding();
+configureTextEncoding({
+  encodeUtf8,
+  checkUtf8,
+  // Ignore `strict`: invalid UTF-8 becomes U+FFFD instead of throwing.
+  decodeUtf8: (bytes) => decodeUtf8(bytes),
+});
+```
+
 ### Base64 encoding
 
 Base64 encoding can be very useful when transmitting binary data. There is no convenient standard API in ECMAScript, but

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -51,6 +51,11 @@ function makeReadOptions(
 
 /**
  * Parse serialized binary data.
+ *
+ * Rejects invalid UTF-8 in string fields when the resolved `utf8_validation`
+ * feature is VERIFY (proto3 and editions 2023+ default). Use
+ * `configureTextEncoding` to install a custom `decodeUtf8` that ignores the
+ * `strict` flag if you need to accept invalid UTF-8.
  */
 export function fromBinary<Desc extends DescMessage>(
   schema: Desc,

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -39,6 +39,12 @@ interface TextEncoding {
  *
  * Note that the Text Encoding API does not provide a way to validate UTF-8.
  * Our implementation falls back to use encodeURIComponent().
+ *
+ * `decodeUtf8` receives an optional `strict` argument. When true, the
+ * implementation should throw on invalid UTF-8 byte sequences; when false or
+ * omitted, invalid bytes may be replaced with U+FFFD. Ignoring the flag is a
+ * valid escape hatch for consumers that need the pre-validation behavior of
+ * `fromBinary` on proto3 and editions messages.
  */
 export function configureTextEncoding(textEncoding: TextEncoding): void {
   (globalThis as GlobalWithTextEncoding)[symbol] = textEncoding;


### PR DESCRIPTION
Expand the Text encoding section of MANUAL with a subsection covering the UTF-8 validation added in #1386. Documents what fromBinary now rejects (vs. the prior silent U+FFFD replacement), that BinaryReader/BinaryWriter default behavior is unchanged, and a configureTextEncoding snippet that restores the lax behavior.
