### PR TITLE
Inline binary tag parsing for performance 

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1252,6 +1252,12 @@ user.firstName; // "Homer"
 user.active; // true
 ```
 
+`BinaryReader.tag()` validates that the tag is a well-formed uint32 varint. Overlong varints (more than 5 bytes) and
+5-byte varints whose value overflows uint32 are rejected with an error. Earlier versions of Protobuf-ES silently decoded
+these cases by truncating the high bits, which caused malformed payloads to be stored as unknown fields instead of
+failing to parse. Producers generating tags via `BinaryWriter.tag()` are unaffected, since `BinaryWriter` only emits
+valid tags.
+
 ### Text encoding
 
 We require the WHATWG [Text Encoding API] to convert UTF-8 from and to binary. The API is widely available, but it is

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1252,12 +1252,6 @@ user.firstName; // "Homer"
 user.active; // true
 ```
 
-`BinaryReader.tag()` validates that the tag is a well-formed uint32 varint. Overlong varints (more than 5 bytes) and
-5-byte varints whose value overflows uint32 are rejected with an error. Earlier versions of Protobuf-ES silently decoded
-these cases by truncating the high bits, which caused malformed payloads to be stored as unknown fields instead of
-failing to parse. Producers generating tags via `BinaryWriter.tag()` are unaffected, since `BinaryWriter` only emits
-valid tags.
-
 ### Text encoding
 
 We require the WHATWG [Text Encoding API] to convert UTF-8 from and to binary. The API is widely available, but it is

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,976 b |  69,171 b |   15,890 b |
-| Protobuf-ES         |     4 |   136,165 b |  70,678 b |   16,587 b |
-| Protobuf-ES         |     8 |   138,927 b |  72,449 b |   17,134 b |
-| Protobuf-ES         |    16 |   149,377 b |  80,430 b |   19,442 b |
-| Protobuf-ES         |    32 |   177,168 b | 102,448 b |   24,922 b |
+| Protobuf-ES         |     1 |   134,690 b |  69,523 b |   15,945 b |
+| Protobuf-ES         |     4 |   136,879 b |  71,027 b |   16,621 b |
+| Protobuf-ES         |     8 |   139,641 b |  72,798 b |   17,182 b |
+| Protobuf-ES         |    16 |   150,091 b |  80,779 b |   19,489 b |
+| Protobuf-ES         |    32 |   177,882 b | 102,800 b |   24,953 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.9990234375 140,243.02509765625 280,241.4759765625 420,234.9396484375 560,219.4201171875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.84326171875 140,242.92880859375 280,241.3400390625 420,234.80654296875 560,219.33232421875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.9990234375" r="4" fill="#ffa600"><title>Protobuf-ES 15.52 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.02509765625" r="4" fill="#ffa600"><title>Protobuf-ES 16.2 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.4759765625" r="4" fill="#ffa600"><title>Protobuf-ES 16.73 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.9396484375" r="4" fill="#ffa600"><title>Protobuf-ES 18.99 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.4201171875" r="4" fill="#ffa600"><title>Protobuf-ES 24.34 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.84326171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.57 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.92880859375" r="4" fill="#ffa600"><title>Protobuf-ES 16.23 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.3400390625" r="4" fill="#ffa600"><title>Protobuf-ES 16.78 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.80654296875" r="4" fill="#ffa600"><title>Protobuf-ES 19.03 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.33232421875" r="4" fill="#ffa600"><title>Protobuf-ES 24.37 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -386,24 +386,45 @@ export class BinaryReader {
   }
 
   /**
-   * Reads a tag - field number and wire type. Tags are uint32 varints; values
-   * that do not fit in uint32 are rejected.
+   * Reads a tag - field number and wire type.
+   *
+   * Inlined for the hot path. Tags are uint32 varints: at most 5 bytes, and
+   * the 5th byte can carry only 4 value bits (its upper 4 bits and the
+   * continuation bit must all be zero). Rejects overlong or overflowing
+   * varints.
    */
   tag(): [number, WireType] {
-    const start = this.pos;
-    const tag = this.uint32();
-    const bytesRead = this.pos - start;
-    if (bytesRead > 5 || (bytesRead == 5 && this.buf[this.pos - 1] > 0x0f)) {
+    let b = this.buf[this.pos++];
+    if ((b & 0x80) == 0) {
+      this.assertBounds();
+      return parseTag(b);
+    }
+    let tag = b & 0x7f;
+    b = this.buf[this.pos++];
+    tag |= (b & 0x7f) << 7;
+    if ((b & 0x80) == 0) {
+      this.assertBounds();
+      return parseTag(tag);
+    }
+    b = this.buf[this.pos++];
+    tag |= (b & 0x7f) << 14;
+    if ((b & 0x80) == 0) {
+      this.assertBounds();
+      return parseTag(tag);
+    }
+    b = this.buf[this.pos++];
+    tag |= (b & 0x7f) << 21;
+    if ((b & 0x80) == 0) {
+      this.assertBounds();
+      return parseTag(tag);
+    }
+    b = this.buf[this.pos++];
+    if (b > 0x0f) {
       throw new Error("illegal tag: varint overflows uint32");
     }
-    const fieldNo = tag >>> 3;
-    const wireType = tag & 7;
-    if (fieldNo <= 0 || wireType > 5) {
-      throw new Error(
-        "illegal tag: field no " + fieldNo + " wire type " + wireType,
-      );
-    }
-    return [fieldNo, wireType];
+    tag = (tag | (b << 28)) >>> 0;
+    this.assertBounds();
+    return parseTag(tag);
   }
 
   /**
@@ -577,6 +598,21 @@ export class BinaryReader {
   string(strict?: boolean): string {
     return this.decodeUtf8(this.bytes(), strict);
   }
+}
+
+/**
+ * Split a decoded tag varint into field number and wire type, rejecting
+ * field number 0 and wire types outside 0-5.
+ */
+function parseTag(tag: number): [number, WireType] {
+  const fieldNo = tag >>> 3;
+  const wireType = tag & 7;
+  if (fieldNo <= 0 || wireType > 5) {
+    throw new Error(
+      "illegal tag: field no " + fieldNo + " wire type " + wireType,
+    );
+  }
+  return [fieldNo, wireType];
 }
 
 /**

--- a/packages/protobuf/src/wire/varint.ts
+++ b/packages/protobuf/src/wire/varint.ts
@@ -306,6 +306,10 @@ export function varint32write(value: number, bytes: number[]): void {
 /**
  * Read an unsigned 32 bit varint.
  *
+ * A uint32 value fits in 5 varint bytes, but this reader accepts up to 10
+ * bytes and discards the extra high bits. Negative `int32` values encode as
+ * 10-byte varints and must decode back to the original 32-bit value.
+ *
  * See https://github.com/protocolbuffers/protobuf/blob/8a71927d74a4ce34efe2d8769fda198f52d20d12/js/experimental/runtime/kernel/buffer_decoder.js#L220
  */
 export function varint32read<T extends ReaderLike>(this: T): number {


### PR DESCRIPTION
This inlines the binary tag parsing for performance. A simple benchmarks on Node v22 show ~15-35% higher throughput on 1-byte tag loop (common case).

Follow up to https://github.com/bufbuild/protobuf-es/pull/1387