### PR TITLE
Chore fix turbo license ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postsetversion": "npm run all",
     "release": "npm run all && node scripts/release.js",
     "format": "biome format --write --config-path biome.json",
-    "license-header": "license-header --ignore 'packages/**' --ignore 'bun/**' --ignore 'deno/**'",
+    "license-header": "license-header --ignore 'packages/**' --ignore 'bun/conformance/**' --ignore 'deno/conformance/**'",
     "lint": "biome lint --error-on-warnings --config-path biome.json",
     "postinstall": "node scripts/nohoist.js --check"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postsetversion": "npm run all",
     "release": "npm run all && node scripts/release.js",
     "format": "biome format --write --config-path biome.json",
-    "license-header": "license-header --ignore 'packages/**'",
+    "license-header": "license-header --ignore 'packages/**' --ignore 'bun/**' --ignore 'deno/**'",
     "lint": "biome lint --error-on-warnings --config-path biome.json",
     "postinstall": "node scripts/nohoist.js --check"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,12 @@
       "outputLogs": "new-only"
     },
     "//#license-header": {
-      "inputs": ["$TURBO_DEFAULT$", "!packages/**", "!bun/conformance/**", "!deno/conformance/**"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!packages/**",
+        "!bun/conformance/**",
+        "!deno/conformance/**"
+      ],
       "outputLogs": "new-only"
     },
     "//#lint": {

--- a/turbo.json
+++ b/turbo.json
@@ -37,12 +37,7 @@
       "outputLogs": "new-only"
     },
     "//#license-header": {
-      "dependsOn": [
-        "@bufbuild/bun-conformance#generate",
-        "@bufbuild/deno-conformance#generate",
-        "@bufbuild/protobuf-conformance#generate"
-      ],
-      "inputs": ["$TURBO_DEFAULT$", "!packages/**"],
+      "inputs": ["$TURBO_DEFAULT$", "!packages/**", "!bun/**", "!deno/**"],
       "outputLogs": "new-only"
     },
     "//#lint": {

--- a/turbo.json
+++ b/turbo.json
@@ -37,6 +37,11 @@
       "outputLogs": "new-only"
     },
     "//#license-header": {
+      "dependsOn": [
+        "@bufbuild/bun-conformance#generate",
+        "@bufbuild/deno-conformance#generate",
+        "@bufbuild/protobuf-conformance#generate"
+      ],
       "inputs": ["$TURBO_DEFAULT$", "!packages/**"],
       "outputLogs": "new-only"
     },

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,7 @@
       "outputLogs": "new-only"
     },
     "//#license-header": {
-      "inputs": ["$TURBO_DEFAULT$", "!packages/**", "!bun/**", "!deno/**"],
+      "inputs": ["$TURBO_DEFAULT$", "!packages/**", "!bun/conformance/**", "!deno/conformance/**"],
       "outputLogs": "new-only"
     },
     "//#lint": {


### PR DESCRIPTION
Fix license-header ignore to exclude `bun/conformance` and `deno/conformance` directories (they have their own) and fix cache inputs too. Related to this flake: https://github.com/bufbuild/protobuf-es/actions/runs/24792704111/job/72554213271