### PR TITLE
Add release.yaml to exclude dependabot from release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot[bot]


### PR DESCRIPTION
This adds a `release.yml` file to remove dependabot PRs from auto-generated release notes.