### PR TITLE
Add recursion limit to fromBinary and fromJson

### DIFF
--- a/docs/src/content/docs/guides/extensions.md
+++ b/docs/src/content/docs/guides/extensions.md
@@ -46,6 +46,8 @@ hasExtension(user, age); // false
 
 `getExtension` never returns `undefined`. If the extension is not set, it returns the default value for the field type (e.g., `0` for numeric types, `[]` for repeated fields, an empty message for message fields).
 
+Because extension values are decoded from binary on read, `getExtension` accepts an optional third argument with [binary serialization options](/guides/serialization/#binary-serialization-options), such as `recursionLimit`.
+
 ## Mutating repeated extension values
 
 Extensions are stored as [unknown fields](/guides/serialization/#unknown-fields) on the message. Reading an extension value deserializes it from binary data each time. To mutate a repeated extension, read the value, modify it, then store it back:

--- a/docs/src/content/docs/guides/serialization.md
+++ b/docs/src/content/docs/guides/serialization.md
@@ -38,9 +38,10 @@ If you want strings instead of `JsonValue`, use `toJsonString()` and `fromJsonSt
 
 - `writeUnknownFields?: boolean`: Include unknown fields in the serialized output. By default, unknown fields are preserved and written back out.
 
-`fromBinary()` accepts one option:
+`fromBinary()` accepts:
 
 - `readUnknownFields?: boolean`: Retain unknown fields while parsing. By default, unknown fields are kept.
+- `recursionLimit?: number`: Maximum depth of nested messages to parse. Parsing fails with an error instead of exhausting the call stack when input nests deeper. Defaults to 100.
 
 ## JSON serialization options
 
@@ -48,6 +49,7 @@ If you want strings instead of `JsonValue`, use `toJsonString()` and `fromJsonSt
 
 - `ignoreUnknownFields?: boolean`: Ignore unknown properties and unknown enum string values instead of rejecting them.
 - `registry?: Registry`: Use a registry when parsing `google.protobuf.Any` and extensions from JSON.
+- `recursionLimit?: number`: Maximum depth of nested messages to parse. Parsing fails with an error instead of exhausting the call stack when input nests deeper. Defaults to 100.
 
 `toJson()` and `toJsonString()` accept:
 

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,199 b |  69,273 b |   15,960 b |
-| Protobuf-ES         |     4 |   136,388 b |  70,780 b |   16,621 b |
-| Protobuf-ES         |     8 |   139,150 b |  72,551 b |   17,145 b |
-| Protobuf-ES         |    16 |   149,600 b |  80,532 b |   19,519 b |
-| Protobuf-ES         |    32 |   177,391 b | 102,550 b |   24,990 b |
+| Protobuf-ES         |     1 |   134,299 b |  69,435 b |   16,004 b |
+| Protobuf-ES         |     4 |   136,488 b |  70,942 b |   16,731 b |
+| Protobuf-ES         |     8 |   139,250 b |  72,713 b |   17,235 b |
+| Protobuf-ES         |    16 |   149,700 b |  80,694 b |   19,551 b |
+| Protobuf-ES         |    32 |   177,491 b | 102,712 b |   25,074 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.80078125 140,242.92880859375 280,241.44482421875 420,234.72158203125 560,219.2275390625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.676171875 140,242.61728515625 280,241.18994140625 420,234.63095703125 560,218.9896484375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.80078125" r="4" fill="#ffa600"><title>Protobuf-ES 15.59 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.92880859375" r="4" fill="#ffa600"><title>Protobuf-ES 16.23 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.44482421875" r="4" fill="#ffa600"><title>Protobuf-ES 16.74 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.72158203125" r="4" fill="#ffa600"><title>Protobuf-ES 19.06 KiB for 16 files</title></circle>
-<circle cx="560" cy="219.2275390625" r="4" fill="#ffa600"><title>Protobuf-ES 24.4 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.676171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.63 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.61728515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.34 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.18994140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.83 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.63095703125" r="4" fill="#ffa600"><title>Protobuf-ES 19.09 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.9896484375" r="4" fill="#ffa600"><title>Protobuf-ES 24.49 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf-test/src/binary.test.ts
+++ b/packages/protobuf-test/src/binary.test.ts
@@ -44,6 +44,7 @@ import {
 import { OneofMessageSchema } from "./gen/ts/extra/msg-oneof_pb.js";
 import { JsonNamesMessageSchema } from "./gen/ts/extra/msg-json-names_pb.js";
 import { JSTypeProto2NormalMessageSchema } from "./gen/ts/extra/jstype-proto2_pb.js";
+import { TestAllTypesProto3Schema } from "./gen/ts/google/protobuf/test_messages_proto3_pb.js";
 import { compileMessage } from "./helpers.js";
 import { BinaryReader, BinaryWriter, WireType } from "@bufbuild/protobuf/wire";
 
@@ -403,6 +404,48 @@ void suite("UTF-8 validation on binary input", () => {
       message M { repeated string f = 1; }
     `);
     assert.throws(() => fromBinary(desc, fieldOneStringBytes));
+  });
+});
+
+void suite("fromBinary recursion limit", () => {
+  // Nested TestAllTypesProto3 via its recursive_message field, as wire bytes.
+  function makeNestedRecursiveMessage(depth: number): Uint8Array {
+    let message = new Uint8Array(0);
+    const fieldNo = TestAllTypesProto3Schema.field.recursiveMessage.number;
+    for (let i = 0; i < depth; i++) {
+      message = new BinaryWriter()
+        .tag(fieldNo, WireType.LengthDelimited)
+        .bytes(message)
+        .finish();
+    }
+    return message;
+  }
+
+  test("rejects deeply nested messages instead of overflowing the stack", () => {
+    assert.throws(
+      () =>
+        fromBinary(TestAllTypesProto3Schema, makeNestedRecursiveMessage(1000)),
+      /maximum recursion depth of 100 reached/,
+    );
+  });
+  test("accepts nesting within the default limit", () => {
+    assert.doesNotThrow(() =>
+      fromBinary(TestAllTypesProto3Schema, makeNestedRecursiveMessage(50)),
+    );
+  });
+  test("honors a custom recursionLimit", () => {
+    assert.throws(
+      () =>
+        fromBinary(TestAllTypesProto3Schema, makeNestedRecursiveMessage(5), {
+          recursionLimit: 3,
+        }),
+      /maximum recursion depth of 3 reached/,
+    );
+    assert.doesNotThrow(() =>
+      fromBinary(TestAllTypesProto3Schema, makeNestedRecursiveMessage(5), {
+        recursionLimit: 10,
+      }),
+    );
   });
 });
 

--- a/packages/protobuf-test/src/json.test.ts
+++ b/packages/protobuf-test/src/json.test.ts
@@ -1294,6 +1294,76 @@ void suite("JSON parse errors", () => {
   }
 });
 
+void suite("fromJson recursion limit", () => {
+  // Nested google.protobuf.Any values.
+  function makeNestedAny(depth: number): JsonValue {
+    const root: Record<string, JsonValue> = {
+      "@type": "type.googleapis.com/google.protobuf.Any",
+    };
+    let cursor = root;
+    for (let i = 0; i < depth; i++) {
+      const next: Record<string, JsonValue> = {
+        "@type": "type.googleapis.com/google.protobuf.Any",
+      };
+      cursor.value = next;
+      cursor = next;
+    }
+    return root;
+  }
+  // Nested TestAllTypesProto3 via its recursive_message field, as JSON.
+  function makeNestedRecursiveMessage(depth: number): JsonValue {
+    let message: JsonValue = {};
+    for (let i = 0; i < depth; i++) {
+      message = { recursiveMessage: message };
+    }
+    return message;
+  }
+
+  test("rejects deeply nested Any instead of overflowing the stack", () => {
+    const registry = createRegistry(AnySchema);
+    assert.throws(
+      () => fromJson(AnySchema, makeNestedAny(1000), { registry }),
+      /cannot decode message google.protobuf.Any from JSON: maximum recursion depth of 100 reached/,
+    );
+  });
+  test("rejects deeply nested messages", () => {
+    assert.throws(
+      () =>
+        fromJson(TestAllTypesProto3Schema, makeNestedRecursiveMessage(1000)),
+      /maximum recursion depth of 100 reached/,
+    );
+  });
+  test("rejects deeply nested Struct", () => {
+    let struct: JsonValue = {};
+    for (let i = 0; i < 1000; i++) {
+      struct = { nested: struct };
+    }
+    assert.throws(
+      () => fromJson(StructSchema, struct),
+      /maximum recursion depth of 100 reached/,
+    );
+  });
+  test("accepts nesting within the default limit", () => {
+    assert.doesNotThrow(() =>
+      fromJson(TestAllTypesProto3Schema, makeNestedRecursiveMessage(50)),
+    );
+  });
+  test("honors a custom recursionLimit", () => {
+    assert.throws(
+      () =>
+        fromJson(TestAllTypesProto3Schema, makeNestedRecursiveMessage(5), {
+          recursionLimit: 3,
+        }),
+      /maximum recursion depth of 3 reached/,
+    );
+    assert.doesNotThrow(() =>
+      fromJson(TestAllTypesProto3Schema, makeNestedRecursiveMessage(5), {
+        recursionLimit: 10,
+      }),
+    );
+  });
+});
+
 function testJson<Desc extends DescMessage>(
   desc: Desc,
   init: MessageInitShape<Desc>,

--- a/packages/protobuf/src/extensions.ts
+++ b/packages/protobuf/src/extensions.ts
@@ -25,7 +25,8 @@ import type {
   DescService,
 } from "./descriptors.js";
 import { create } from "./create.js";
-import { readField } from "./from-binary.js";
+import { makeReadContext, readField } from "./from-binary.js";
+import type { BinaryReadOptions } from "./from-binary.js";
 import type { ReflectMessage } from "./reflect/reflect-types.js";
 import { reflect } from "./reflect/reflect.js";
 import { scalarZeroValue } from "./reflect/scalar.js";
@@ -66,14 +67,14 @@ import type {
 export function getExtension<Desc extends DescExtension>(
   message: Extendee<Desc>,
   extension: Desc,
+  options?: Partial<BinaryReadOptions>,
 ): ExtensionValueShape<Desc> {
   assertExtendee(extension, message);
   const ufs = filterUnknownFields(message.$unknown, extension);
   const [container, field, get] = createExtensionContainer(extension);
+  const ctx = makeReadContext(options);
   for (const uf of ufs) {
-    readField(container, new BinaryReader(uf.data), field, uf.wireType, {
-      readUnknownFields: true,
-    });
+    readField(container, new BinaryReader(uf.data), field, uf.wireType, ctx);
   }
   return get();
 }

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -36,17 +36,27 @@ export interface BinaryReadOptions {
    * For more details see https://developers.google.com/protocol-buffers/docs/proto3#unknowns
    */
   readUnknownFields: boolean;
+
+  /**
+   * The maximum depth of nested messages to parse. If a message nests deeper
+   * than this limit, parsing fails with an error instead of exhausting the
+   * call stack. Defaults to 100.
+   */
+  recursionLimit: number;
 }
 
-// Default options for parsing binary data.
-const readDefaults: Readonly<BinaryReadOptions> = {
-  readUnknownFields: true,
-};
+interface BinaryReadContext extends BinaryReadOptions {
+  // Recursion depth, guarded by recursionLimit.
+  depth: number;
+}
 
-function makeReadOptions(
+/**
+ * @private Only exported for getExtension()
+ */
+export function makeReadContext(
   options?: Partial<BinaryReadOptions>,
-): Readonly<BinaryReadOptions> {
-  return options ? { ...readDefaults, ...options } : readDefaults;
+): BinaryReadContext {
+  return { readUnknownFields: true, recursionLimit: 100, ...options, depth: 0 };
 }
 
 /**
@@ -61,7 +71,7 @@ export function fromBinary<Desc extends DescMessage>(
   readMessage(
     msg,
     new BinaryReader(bytes),
-    makeReadOptions(options),
+    makeReadContext(options),
     false,
     bytes.byteLength,
   );
@@ -86,7 +96,7 @@ export function mergeFromBinary<Desc extends DescMessage>(
   readMessage(
     reflect(schema, target, false),
     new BinaryReader(bytes),
-    makeReadOptions(options),
+    makeReadContext(options),
     false,
     bytes.byteLength,
   );
@@ -104,10 +114,15 @@ export function mergeFromBinary<Desc extends DescMessage>(
 function readMessage(
   message: ReflectMessage,
   reader: BinaryReader,
-  options: BinaryReadOptions,
+  ctx: BinaryReadContext,
   delimited: boolean,
   lengthOrDelimitedFieldNo: number,
 ): void {
+  if (++ctx.depth > ctx.recursionLimit) {
+    throw new Error(
+      `cannot decode ${message.desc} from binary: maximum recursion depth of ${ctx.recursionLimit} reached`,
+    );
+  }
   const end = delimited ? reader.len : reader.pos + lengthOrDelimitedFieldNo;
   let fieldNo: number | undefined;
   let wireType: WireType | undefined;
@@ -120,12 +135,12 @@ function readMessage(
     const field = message.findNumber(fieldNo);
     if (!field) {
       const data = reader.skip(wireType, fieldNo);
-      if (options.readUnknownFields) {
+      if (ctx.readUnknownFields) {
         unknownFields.push({ no: fieldNo, wireType, data });
       }
       continue;
     }
-    readField(message, reader, field, wireType, options);
+    readField(message, reader, field, wireType, ctx);
   }
   if (delimited) {
     if (wireType != WireType.EndGroup || fieldNo !== lengthOrDelimitedFieldNo) {
@@ -135,17 +150,18 @@ function readMessage(
   if (unknownFields.length > 0) {
     message.setUnknown(unknownFields);
   }
+  ctx.depth--;
 }
 
 /**
- * @private
+ * @private Only exported for getExtension()
  */
 export function readField(
   message: ReflectMessage,
   reader: BinaryReader,
   field: DescField,
   wireType: WireType,
-  options: BinaryReadOptions,
+  ctx: BinaryReadContext,
 ) {
   switch (field.fieldKind) {
     case "scalar":
@@ -162,7 +178,7 @@ export function readField(
         const ok = field.enum.values.some((v) => v.number === val);
         if (ok) {
           message.set(field, val);
-        } else if (options.readUnknownFields) {
+        } else if (ctx.readUnknownFields) {
           const bytes: number[] = [];
           varint32write(val as number, bytes);
           const unknownFields = message.getUnknown() ?? [];
@@ -178,14 +194,14 @@ export function readField(
     case "message":
       message.set(
         field,
-        readMessageField(reader, options, field, message.get(field)),
+        readMessageField(reader, ctx, field, message.get(field)),
       );
       break;
     case "list":
-      readListField(reader, wireType, message.get(field), options);
+      readListField(reader, wireType, message.get(field), ctx);
       break;
     case "map":
-      readMapEntry(reader, message.get(field), options);
+      readMapEntry(reader, message.get(field), ctx);
       break;
   }
 }
@@ -194,7 +210,7 @@ export function readField(
 function readMapEntry(
   reader: BinaryReader,
   map: ReflectMap,
-  options: BinaryReadOptions,
+  ctx: BinaryReadContext,
 ): void {
   const field = map.field();
   let key: ScalarValue | undefined;
@@ -219,7 +235,7 @@ function readMapEntry(
             val = reader.int32();
             break;
           case "message":
-            val = readMessageField(reader, options, field);
+            val = readMessageField(reader, ctx, field);
             break;
         }
         break;
@@ -248,11 +264,11 @@ function readListField(
   reader: BinaryReader,
   wireType: WireType,
   list: ReflectList,
-  options: BinaryReadOptions,
+  ctx: BinaryReadContext,
 ) {
   const field = list.field();
   if (field.listKind === "message") {
-    list.add(readMessageField(reader, options, field));
+    list.add(readMessageField(reader, ctx, field));
     return;
   }
   const scalarType = field.scalar ?? ScalarType.INT32;
@@ -272,7 +288,7 @@ function readListField(
 
 function readMessageField(
   reader: BinaryReader,
-  options: BinaryReadOptions,
+  ctx: BinaryReadContext,
   field: DescField & { message: DescMessage },
   mergeMessage?: ReflectMessage,
 ): ReflectMessage {
@@ -281,7 +297,7 @@ function readMessageField(
   readMessage(
     message,
     reader,
-    options,
+    ctx,
     delimited,
     delimited ? field.number : reader.uint32(),
   );

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -72,17 +72,27 @@ export interface JsonReadOptions {
    * from JSON format.
    */
   registry?: Registry | undefined;
+
+  /**
+   * The maximum depth of nested messages to parse. If a message nests deeper
+   * than this limit, parsing fails with an error instead of exhausting the
+   * call stack. Defaults to 100.
+   */
+  recursionLimit: number;
 }
 
-// Default options for parsing JSON.
-const jsonReadDefaults: Readonly<JsonReadOptions> = {
-  ignoreUnknownFields: false,
-};
+interface JsonReadContext extends JsonReadOptions {
+  // Recursion depth, guarded by recursionLimit.
+  depth: number;
+}
 
-function makeReadOptions(
-  options?: Partial<JsonReadOptions>,
-): Readonly<JsonReadOptions> {
-  return options ? { ...jsonReadDefaults, ...options } : jsonReadDefaults;
+function makeReadContext(options?: Partial<JsonReadOptions>): JsonReadContext {
+  return {
+    ignoreUnknownFields: false,
+    recursionLimit: 100,
+    ...options,
+    depth: 0,
+  };
 }
 
 /**
@@ -129,7 +139,7 @@ export function fromJson<Desc extends DescMessage>(
 ): MessageShape<Desc> {
   const msg = reflect(schema);
   try {
-    readMessage(msg, json, makeReadOptions(options));
+    readMessage(msg, json, makeReadContext(options));
   } catch (e) {
     if (isFieldError(e)) {
       // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
@@ -158,7 +168,7 @@ export function mergeFromJson<Desc extends DescMessage>(
   options?: Partial<JsonReadOptions>,
 ): MessageShape<Desc> {
   try {
-    readMessage(reflect(schema, target), json, makeReadOptions(options));
+    readMessage(reflect(schema, target), json, makeReadContext(options));
   } catch (e) {
     if (isFieldError(e)) {
       // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
@@ -207,9 +217,15 @@ function getJsonField(desc: DescMessage, jsonKey: string) {
 function readMessage(
   msg: ReflectMessage,
   json: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ) {
-  if (tryWktFromJson(msg, json, opts)) {
+  if (++ctx.depth > ctx.recursionLimit) {
+    throw new Error(
+      `cannot decode ${msg.desc} from JSON: maximum recursion depth of ${ctx.recursionLimit} reached`,
+    );
+  }
+  if (tryWktFromJson(msg, json, ctx)) {
+    ctx.depth--;
     return;
   }
   if (json == null || Array.isArray(json) || typeof json != "object") {
@@ -233,52 +249,53 @@ function readMessage(
         }
         oneofSeen.set(field.oneof, field);
       }
-      readField(msg, field, jsonValue, opts);
+      readField(msg, field, jsonValue, ctx);
     } else {
       let extension: DescExtension | undefined = undefined;
       if (
         jsonKey.startsWith("[") &&
         jsonKey.endsWith("]") &&
         // biome-ignore lint/suspicious/noAssignInExpressions: no
-        (extension = opts.registry?.getExtension(
+        (extension = ctx.registry?.getExtension(
           jsonKey.substring(1, jsonKey.length - 1),
         )) &&
         extension.extendee.typeName === msg.desc.typeName
       ) {
         const [container, field, get] = createExtensionContainer(extension);
-        readField(container, field, jsonValue, opts);
+        readField(container, field, jsonValue, ctx);
         setExtension(msg.message, extension, get());
       }
-      if (!extension && !opts.ignoreUnknownFields) {
+      if (!extension && !ctx.ignoreUnknownFields) {
         throw new Error(
           `cannot decode ${msg.desc} from JSON: key "${jsonKey}" is unknown`,
         );
       }
     }
   }
+  ctx.depth--;
 }
 
 function readField(
   msg: ReflectMessage,
   field: DescField,
   json: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ) {
   switch (field.fieldKind) {
     case "scalar":
       readScalarField(msg, field, json);
       break;
     case "enum":
-      readEnumField(msg, field, json, opts);
+      readEnumField(msg, field, json, ctx);
       break;
     case "message":
-      readMessageField(msg, field, json, opts);
+      readMessageField(msg, field, json, ctx);
       break;
     case "list":
-      readListField(msg.get(field), json, opts);
+      readListField(msg.get(field), json, ctx);
       break;
     case "map":
-      readMapField(msg.get(field), json, opts);
+      readMapField(msg.get(field), json, ctx);
       break;
   }
 }
@@ -286,19 +303,19 @@ function readField(
 function readListOrMapItem(
   field: DescField & { fieldKind: "map" | "list" },
   json: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ) {
   if (field.scalar && json !== null) {
     return scalarFromJson(field, json);
   }
   if (field.message && !isResetSentinelNullValue(field, json)) {
     const msgValue = reflect(field.message);
-    readMessage(msgValue, json, opts);
+    readMessage(msgValue, json, ctx);
 
     return msgValue;
   }
   if (field.enum && !isResetSentinelNullValue(field, json)) {
-    return readEnum(field.enum, json, opts.ignoreUnknownFields);
+    return readEnum(field.enum, json, ctx.ignoreUnknownFields);
   }
 
   throw new FieldError(
@@ -307,7 +324,7 @@ function readListOrMapItem(
   );
 }
 
-function readMapField(map: ReflectMap, json: JsonValue, opts: JsonReadOptions) {
+function readMapField(map: ReflectMap, json: JsonValue, ctx: JsonReadContext) {
   if (json === null) {
     return;
   }
@@ -317,7 +334,7 @@ function readMapField(map: ReflectMap, json: JsonValue, opts: JsonReadOptions) {
   }
   for (const [jsonMapKey, jsonMapValue] of Object.entries(json)) {
     const key = mapKeyFromJson(field.mapKey, jsonMapKey);
-    const value = readListOrMapItem(field, jsonMapValue, opts);
+    const value = readListOrMapItem(field, jsonMapValue, ctx);
     if (value !== tokenIgnoredUnknownEnum) {
       map.set(key, value);
     }
@@ -327,7 +344,7 @@ function readMapField(map: ReflectMap, json: JsonValue, opts: JsonReadOptions) {
 function readListField(
   list: ReflectList,
   json: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ) {
   if (json === null) {
     return;
@@ -337,7 +354,7 @@ function readListField(
     throw new FieldError(field, "expected Array, got " + formatVal(json));
   }
   for (const jsonItem of json) {
-    const value = readListOrMapItem(field, jsonItem, opts);
+    const value = readListOrMapItem(field, jsonItem, ctx);
     if (value !== tokenIgnoredUnknownEnum) {
       list.add(value);
     }
@@ -348,14 +365,14 @@ function readMessageField(
   msg: ReflectMessage,
   field: DescField & { fieldKind: "message" },
   json: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ) {
   if (isResetSentinelNullValue(field, json)) {
     msg.clear(field);
     return;
   }
   const msgValue = msg.isSet(field) ? msg.get(field) : reflect(field.message);
-  readMessage(msgValue, json, opts);
+  readMessage(msgValue, json, ctx);
   msg.set(field, msgValue);
 }
 
@@ -363,13 +380,13 @@ function readEnumField(
   msg: ReflectMessage,
   field: DescField & { fieldKind: "enum" },
   json: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ) {
   if (isResetSentinelNullValue(field, json)) {
     msg.clear(field);
     return;
   }
-  const enumValue = readEnum(field.enum, json, opts.ignoreUnknownFields);
+  const enumValue = readEnum(field.enum, json, ctx.ignoreUnknownFields);
   if (enumValue !== tokenIgnoredUnknownEnum) {
     msg.set(field, enumValue);
   }
@@ -602,14 +619,14 @@ function parseJsonString(jsonString: string, typeName: string) {
 function tryWktFromJson(
   msg: ReflectMessage,
   jsonValue: JsonValue,
-  opts: JsonReadOptions,
+  ctx: JsonReadContext,
 ): boolean {
   if (!msg.desc.typeName.startsWith("google.protobuf.")) {
     return false;
   }
   switch (msg.desc.typeName) {
     case "google.protobuf.Any":
-      anyFromJson(msg.message as Any, jsonValue, opts);
+      anyFromJson(msg.message as Any, jsonValue, ctx);
       return true;
     case "google.protobuf.Timestamp":
       timestampFromJson(msg.message as Timestamp, jsonValue);
@@ -621,13 +638,13 @@ function tryWktFromJson(
       fieldMaskFromJson(msg.message as FieldMask, jsonValue);
       return true;
     case "google.protobuf.Struct":
-      structFromJson(msg.message as Struct, jsonValue);
+      structFromJson(msg.message as Struct, jsonValue, ctx);
       return true;
     case "google.protobuf.Value":
-      valueFromJson(msg.message as Value, jsonValue);
+      valueFromJson(msg.message as Value, jsonValue, ctx);
       return true;
     case "google.protobuf.ListValue":
-      listValueFromJson(msg.message as ListValue, jsonValue);
+      listValueFromJson(msg.message as ListValue, jsonValue, ctx);
       return true;
     default:
       if (isWrapperDesc(msg.desc)) {
@@ -643,7 +660,7 @@ function tryWktFromJson(
   }
 }
 
-function anyFromJson(any: Any, json: JsonValue, opts: JsonReadOptions) {
+function anyFromJson(any: Any, json: JsonValue, ctx: JsonReadContext) {
   if (json === null || Array.isArray(json) || typeof json != "object") {
     throw new Error(
       `cannot decode message ${any.$typeName} from JSON: expected object but got ${formatVal(json)}`,
@@ -666,7 +683,7 @@ function anyFromJson(any: Any, json: JsonValue, opts: JsonReadOptions) {
       `cannot decode message ${any.$typeName} from JSON: "@type" is invalid`,
     );
   }
-  const desc = opts.registry?.getMessage(typeName);
+  const desc = ctx.registry?.getMessage(typeName);
   if (!desc) {
     throw new Error(
       `cannot decode message ${any.$typeName} from JSON: ${typeUrl} is not in the type registry`,
@@ -678,12 +695,12 @@ function anyFromJson(any: Any, json: JsonValue, opts: JsonReadOptions) {
     Object.prototype.hasOwnProperty.call(json, "value")
   ) {
     const value = json.value;
-    readMessage(msg, value, opts);
+    readMessage(msg, value, ctx);
   } else {
     const copy = Object.assign({}, json);
     // biome-ignore lint/performance/noDelete: <explanation>
     delete copy["@type"];
-    readMessage(msg, copy, opts);
+    readMessage(msg, copy, ctx);
   }
   anyPack(msg.desc, msg.message, any);
 }
@@ -776,7 +793,7 @@ function fieldMaskFromJson(fieldMask: FieldMask, json: JsonValue) {
   });
 }
 
-function structFromJson(struct: Struct, json: JsonValue) {
+function structFromJson(struct: Struct, json: JsonValue, ctx: JsonReadContext) {
   if (typeof json != "object" || json == null || Array.isArray(json)) {
     throw new Error(
       `cannot decode message ${struct.$typeName} from JSON ${formatVal(json)}`,
@@ -784,12 +801,17 @@ function structFromJson(struct: Struct, json: JsonValue) {
   }
   for (const [k, v] of Object.entries(json)) {
     const parsedV = create(ValueSchema);
-    valueFromJson(parsedV, v);
+    valueFromJson(parsedV, v, ctx);
     struct.fields[k] = parsedV;
   }
 }
 
-function valueFromJson(value: Value, json: JsonValue) {
+function valueFromJson(value: Value, json: JsonValue, ctx: JsonReadContext) {
+  if (++ctx.depth > ctx.recursionLimit) {
+    throw new Error(
+      `cannot decode ${value.$typeName} from JSON: maximum recursion depth of ${ctx.recursionLimit} reached`,
+    );
+  }
   switch (typeof json) {
     case "number":
       value.kind = { case: "numberValue", value: json };
@@ -805,11 +827,11 @@ function valueFromJson(value: Value, json: JsonValue) {
         value.kind = { case: "nullValue", value: NullValue.NULL_VALUE };
       } else if (Array.isArray(json)) {
         const listValue = create(ListValueSchema);
-        listValueFromJson(listValue, json);
+        listValueFromJson(listValue, json, ctx);
         value.kind = { case: "listValue", value: listValue };
       } else {
         const struct = create(StructSchema);
-        structFromJson(struct, json);
+        structFromJson(struct, json, ctx);
         value.kind = { case: "structValue", value: struct };
       }
       break;
@@ -818,10 +840,15 @@ function valueFromJson(value: Value, json: JsonValue) {
         `cannot decode message ${value.$typeName} from JSON ${formatVal(json)}`,
       );
   }
+  ctx.depth--;
   return value;
 }
 
-function listValueFromJson(listValue: ListValue, json: JsonValue) {
+function listValueFromJson(
+  listValue: ListValue,
+  json: JsonValue,
+  ctx: JsonReadContext,
+) {
   if (!Array.isArray(json)) {
     throw new Error(
       `cannot decode message ${listValue.$typeName} from JSON ${formatVal(json)}`,
@@ -829,7 +856,7 @@ function listValueFromJson(listValue: ListValue, json: JsonValue) {
   }
   for (const e of json) {
     const value = create(ValueSchema);
-    valueFromJson(value, e);
+    valueFromJson(value, e, ctx);
     listValue.values.push(value);
   }
 }

--- a/packages/protobuf/src/wire/size-delimited.ts
+++ b/packages/protobuf/src/wire/size-delimited.ts
@@ -51,7 +51,7 @@ export function sizeDelimitedEncode<Desc extends DescMessage>(
 export async function* sizeDelimitedDecodeStream<Desc extends DescMessage>(
   messageDesc: Desc,
   iterable: AsyncIterable<Uint8Array>,
-  options?: BinaryReadOptions,
+  options?: Partial<BinaryReadOptions>,
 ): AsyncIterableIterator<MessageShape<Desc>> {
   // append chunk to buffer, returning updated buffer
   function append(


### PR DESCRIPTION
Decoding does not currently limit recursion depth, so deeply-nested input can trivially exhaust the call stack.

This adds a `recursionLimit` option to both binary and ProtoJSON parsing:

```ts
  /**
   * The maximum depth of nested messages to parse. If a message nests deeper
   * than this limit, parsing fails with an error instead of exhausting the
   * call stack. Defaults to 100.
   */
  recursionLimit: number;
```

The default of 100 matches C++, Java, and Python's default.
When a message nests deeper than the limit, parsing fails with a catchable error before overflowing the stack:

```ts
try {
  fromBinary(schema, bytes);
} catch (e) {
  e; // cannot decode <type> from binary: maximum recursion depth of 100 reached
}
```

Note that this is a behavior change: input nested deeper than 100 levels used to decode and now throws. Code that relies on deeper nesting can raise the limit explicitly, e.g. `fromBinary(schema, bytes, { recursionLimit: 1000 })`.

The new option is made available on `getExtension` too, which didn't expose binary options so far.