### PR TITLE
Remove redundant npmignore

### DIFF
--- a/packages/protobuf/.npmignore
+++ b/packages/protobuf/.npmignore
@@ -1,3 +1,0 @@
-/src
-/*.json
-/scripts/*


### PR DESCRIPTION
Looks like we don't need npmignore - `files: ["dist/**"]` already covers everything we need.