### PR TITLE
Apply recursion limit to BinaryReader.skip

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,657 b |  69,533 b |   16,047 b |
-| Protobuf-ES         |     4 |   136,846 b |  71,040 b |   16,740 b |
-| Protobuf-ES         |     8 |   139,608 b |  72,811 b |   17,231 b |
-| Protobuf-ES         |    16 |   150,058 b |  80,792 b |   19,613 b |
-| Protobuf-ES         |    32 |   177,849 b | 102,810 b |   25,098 b |
+| Protobuf-ES         |     1 |   134,656 b |  69,533 b |   16,047 b |
+| Protobuf-ES         |     4 |   136,845 b |  71,040 b |   16,740 b |
+| Protobuf-ES         |     8 |   139,607 b |  72,811 b |   17,231 b |
+| Protobuf-ES         |    16 |   150,057 b |  80,792 b |   19,613 b |
+| Protobuf-ES         |    32 |   177,848 b | 102,810 b |   25,098 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,299 b |  69,435 b |   16,004 b |
-| Protobuf-ES         |     4 |   136,488 b |  70,942 b |   16,731 b |
-| Protobuf-ES         |     8 |   139,250 b |  72,713 b |   17,235 b |
-| Protobuf-ES         |    16 |   149,700 b |  80,694 b |   19,551 b |
-| Protobuf-ES         |    32 |   177,491 b | 102,712 b |   25,074 b |
+| Protobuf-ES         |     1 |   134,657 b |  69,533 b |   16,047 b |
+| Protobuf-ES         |     4 |   136,846 b |  71,040 b |   16,740 b |
+| Protobuf-ES         |     8 |   139,608 b |  72,811 b |   17,231 b |
+| Protobuf-ES         |    16 |   150,058 b |  80,792 b |   19,613 b |
+| Protobuf-ES         |    32 |   177,849 b | 102,810 b |   25,098 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.676171875 140,242.61728515625 280,241.18994140625 420,234.63095703125 560,218.9896484375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.55439453125 140,242.591796875 280,241.20126953125 420,234.45537109375 560,218.9216796875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.676171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.63 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.61728515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.34 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.18994140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.83 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.63095703125" r="4" fill="#ffa600"><title>Protobuf-ES 19.09 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.9896484375" r="4" fill="#ffa600"><title>Protobuf-ES 24.49 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.55439453125" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.591796875" r="4" fill="#ffa600"><title>Protobuf-ES 16.35 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.20126953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.83 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.45537109375" r="4" fill="#ffa600"><title>Protobuf-ES 19.15 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.9216796875" r="4" fill="#ffa600"><title>Protobuf-ES 24.51 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf-test/src/binary.test.ts
+++ b/packages/protobuf-test/src/binary.test.ts
@@ -27,7 +27,7 @@ import {
   type DescMessage,
   protoInt64,
 } from "@bufbuild/protobuf";
-import { StructSchema, ValueSchema } from "@bufbuild/protobuf/wkt";
+import { EmptySchema, StructSchema, ValueSchema } from "@bufbuild/protobuf/wkt";
 import {
   RepeatedScalarValuesMessageSchema,
   ScalarValuesMessageSchema,
@@ -445,6 +445,82 @@ void suite("fromBinary recursion limit", () => {
       fromBinary(TestAllTypesProto3Schema, makeNestedRecursiveMessage(5), {
         recursionLimit: 10,
       }),
+    );
+  });
+
+  test("honors recursionLimit for unknown groups", () => {
+    // A run of StartGroup tags at field 1, which is unknown to Empty. fromBinary
+    // skips unknown fields, and skipping a group recurses for each nested group.
+    function makeNestedUnknownGroups(
+      depth: number,
+      closed: boolean,
+    ): Uint8Array {
+      const writer = new BinaryWriter();
+      for (let i = 0; i < depth; i++) {
+        writer.tag(1, WireType.StartGroup);
+      }
+      if (closed) {
+        for (let i = 0; i < depth; i++) {
+          writer.tag(1, WireType.EndGroup);
+        }
+      }
+      return writer.finish();
+    }
+    assert.throws(
+      () => fromBinary(EmptySchema, makeNestedUnknownGroups(10000, false)),
+      /maximum recursion depth reached/,
+    );
+    assert.throws(
+      () =>
+        fromBinary(EmptySchema, makeNestedUnknownGroups(10000, false), {
+          readUnknownFields: false,
+        }),
+      /maximum recursion depth reached/,
+    );
+    assert.doesNotThrow(() =>
+      fromBinary(EmptySchema, makeNestedUnknownGroups(50, true)),
+    );
+    assert.throws(
+      () =>
+        fromBinary(EmptySchema, makeNestedUnknownGroups(50, true), {
+          recursionLimit: 10,
+        }),
+      /maximum recursion depth reached/,
+    );
+  });
+
+  test("uses the remaining recursion budget for unknown nested groups", () => {
+    // The helper function nest() creates a nested message with variable depth.
+    // The innermost message also holds unknown groups with variable depth.
+    const unknownNo =
+      Math.max(...TestAllTypesProto3Schema.fields.map((f) => f.number)) + 1;
+    const recursiveNo = TestAllTypesProto3Schema.field.recursiveMessage.number;
+    function nest(messageDepth: number, groupDepth: number): Uint8Array {
+      const inner = new BinaryWriter();
+      for (let i = 0; i < groupDepth; i++) {
+        inner.tag(unknownNo, WireType.StartGroup);
+      }
+      for (let i = 0; i < groupDepth; i++) {
+        inner.tag(unknownNo, WireType.EndGroup);
+      }
+      let message = inner.finish();
+      for (let i = 0; i < messageDepth; i++) {
+        message = new BinaryWriter()
+          .tag(recursiveNo, WireType.LengthDelimited)
+          .bytes(message)
+          .finish();
+      }
+      return message;
+    }
+    // groupDepth (60) is within the limit on its own, but combined with the
+    // surrounding message depth (60) it exceeds recursionLimit and is rejected.
+    assert.throws(
+      () => fromBinary(TestAllTypesProto3Schema, nest(60, 60)),
+      /maximum recursion depth reached/,
+    );
+    // The same group depth is accepted when the message depth leaves room.
+    assert.doesNotThrow(() =>
+      fromBinary(TestAllTypesProto3Schema, nest(30, 60)),
     );
   });
 });

--- a/packages/protobuf-test/src/wire/binary-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/binary-encoding.test.ts
@@ -239,6 +239,42 @@ void suite("BinaryReader", () => {
         assert.strictEqual(sr.pos, sr.len);
       }
     });
+    void test("rejects deeply nested groups", () => {
+      // A run of StartGroup tags (0x0b = field 1, WireType.StartGroup) with no
+      // matching EndGroup tags. Without a recursion limit, skipping this
+      // overflows the call stack.
+      const startGroupTags = new Uint8Array(10000).fill(0x0b);
+      const reader = new BinaryReader(startGroupTags);
+      const [, wireType] = reader.tag();
+      assert.strictEqual(wireType, WireType.StartGroup);
+      assert.throws(
+        () => reader.skip(wireType),
+        /maximum recursion depth reached/,
+      );
+    });
+    void test("honors a custom recursionLimit when skipping groups", () => {
+      // `depth` nested groups, each closed by a matching EndGroup.
+      function nestedGroups(depth: number): Uint8Array {
+        const writer = new BinaryWriter();
+        for (let i = 0; i < depth; i++) {
+          writer.tag(1, WireType.StartGroup);
+        }
+        for (let i = 0; i < depth; i++) {
+          writer.tag(1, WireType.EndGroup);
+        }
+        return writer.finish();
+      }
+      function skipGroups(bytes: Uint8Array, recursionLimit: number): void {
+        const reader = new BinaryReader(bytes);
+        const [, wireType] = reader.tag();
+        reader.skip(wireType, 1, recursionLimit);
+      }
+      assert.doesNotThrow(() => skipGroups(nestedGroups(5), 10));
+      assert.throws(
+        () => skipGroups(nestedGroups(5), 3),
+        /maximum recursion depth reached/,
+      );
+    });
   });
   void suite("tag", () => {
     // Tag byte for (fieldNo=1, wireType=Varint) with the varint continuation

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -134,7 +134,9 @@ function readMessage(
     }
     const field = message.findNumber(fieldNo);
     if (!field) {
-      const data = reader.skip(wireType, fieldNo);
+      // Use remaining recursion budget for skipping nested groups
+      const recursionLimit = ctx.recursionLimit - ctx.depth;
+      const data = reader.skip(wireType, fieldNo, recursionLimit);
       if (ctx.readUnknownFields) {
         unknownFields.push({ no: fieldNo, wireType, data });
       }

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -410,9 +410,11 @@ export class BinaryReader {
    * Skip one element and return the skipped data.
    *
    * When skipping StartGroup, provide the tags field number to check for
-   * matching field number in the EndGroup tag.
+   * matching field number in the EndGroup tag. Recursion into nested groups
+   * is guarded by the `recursionLimit` argument: When the limit is reached,
+   * this method throws.
    */
-  skip(wireType: WireType, fieldNo?: number): Uint8Array {
+  skip(wireType: WireType, fieldNo?: number, recursionLimit = 100): Uint8Array {
     let start = this.pos;
     switch (wireType) {
       case WireType.Varint:
@@ -431,6 +433,9 @@ export class BinaryReader {
         this.pos += len;
         break;
       case WireType.StartGroup:
+        if (recursionLimit <= 0) {
+          throw new Error("maximum recursion depth reached");
+        }
         for (;;) {
           const [fn, wt] = this.tag();
           if (wt === WireType.EndGroup) {
@@ -439,7 +444,7 @@ export class BinaryReader {
             }
             break;
           }
-          this.skip(wt, fn);
+          this.skip(wt, fn, recursionLimit - 1);
         }
         break;
       default:


### PR DESCRIPTION
Following up on https://github.com/bufbuild/protobuf-es/pull/1436, this applies the recursion limit to `BinaryReader`'s method `skip`. 