### PR TITLE
Fix open enum range checks

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,299 b |  69,435 b |   16,004 b |
-| Protobuf-ES         |     4 |   136,488 b |  70,942 b |   16,731 b |
-| Protobuf-ES         |     8 |   139,250 b |  72,713 b |   17,235 b |
-| Protobuf-ES         |    16 |   149,700 b |  80,694 b |   19,551 b |
-| Protobuf-ES         |    32 |   177,491 b | 102,712 b |   25,074 b |
+| Protobuf-ES         |     1 |   134,317 b |  69,429 b |   16,016 b |
+| Protobuf-ES         |     4 |   136,506 b |  70,936 b |   16,671 b |
+| Protobuf-ES         |     8 |   139,268 b |  72,707 b |   17,223 b |
+| Protobuf-ES         |    16 |   149,718 b |  80,688 b |   19,534 b |
+| Protobuf-ES         |    32 |   177,509 b | 102,706 b |   25,040 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.676171875 140,242.61728515625 280,241.18994140625 420,234.63095703125 560,218.9896484375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.6421875 140,242.78720703125 280,241.22392578125 420,234.6791015625 560,219.0859375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.676171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.63 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.61728515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.34 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.18994140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.83 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.63095703125" r="4" fill="#ffa600"><title>Protobuf-ES 19.09 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.9896484375" r="4" fill="#ffa600"><title>Protobuf-ES 24.49 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.6421875" r="4" fill="#ffa600"><title>Protobuf-ES 15.64 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.78720703125" r="4" fill="#ffa600"><title>Protobuf-ES 16.28 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.22392578125" r="4" fill="#ffa600"><title>Protobuf-ES 16.82 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.6791015625" r="4" fill="#ffa600"><title>Protobuf-ES 19.08 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.0859375" r="4" fill="#ffa600"><title>Protobuf-ES 24.45 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf-test/src/json.test.ts
+++ b/packages/protobuf-test/src/json.test.ts
@@ -1024,6 +1024,14 @@ void suite("JSON parse errors", () => {
     );
   });
 
+  test("open enum value out of int32 range", () => {
+    // Open enums accept unrecognized values, but enum values are always int32.
+    expectJsonParseError(
+      { optionalNestedEnum: 2147483648 },
+      "cannot decode field protobuf_test_messages.proto3.TestAllTypesProto3.optional_nested_enum from JSON: expected enum protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum: 2147483648 out of range",
+    );
+  });
+
   void suite("Any", () => {
     test("without @type", () => {
       assert.throws(

--- a/packages/protobuf-test/src/reflect/reflect.test.ts
+++ b/packages/protobuf-test/src/reflect/reflect.test.ts
@@ -16,6 +16,7 @@ import { suite, test, beforeEach } from "node:test";
 import * as assert from "node:assert";
 import type { DescMessage, Message } from "@bufbuild/protobuf";
 import { create, protoInt64 } from "@bufbuild/protobuf";
+import { INT32_MAX, INT32_MIN } from "@bufbuild/protobuf/wire";
 import type { ReflectMessage } from "@bufbuild/protobuf/reflect";
 import {
   isReflectList,
@@ -370,8 +371,10 @@ void suite("ReflectMessage", () => {
     });
     test("sets unknown value for open enum", () => {
       const f = desc.field.singularEnumField;
-      r.set(f, 99);
-      assert.strictEqual(msg.singularEnumField, 99);
+      r.set(f, INT32_MIN);
+      assert.strictEqual(msg.singularEnumField, INT32_MIN);
+      r.set(f, INT32_MAX);
+      assert.strictEqual(msg.singularEnumField, INT32_MAX);
     });
     test("selects oneof field", () => {
       const f = desc.field.oneofInt32Field;
@@ -409,7 +412,7 @@ void suite("ReflectMessage", () => {
           /^cannot use field Foreign.foreign with message spec.Proto3Message$/,
       });
     });
-    test("returns error setting number out of range", () => {
+    test("throws error setting number out of range", () => {
       const f = desc.field.singularInt32Field;
       const err = catchFieldError(() => r.set(f, Number.MAX_SAFE_INTEGER));
       assert.ok(err !== undefined);
@@ -419,14 +422,14 @@ void suite("ReflectMessage", () => {
       );
       assert.equal(err.name, "FieldValueInvalidError");
     });
-    test("returns error setting float for int", () => {
+    test("throws error setting float for int", () => {
       const f = desc.field.singularInt32Field;
       const err = catchFieldError(() => r.set(f, 3.14));
       assert.ok(err !== undefined);
       assert.match(err.message, /^expected number \(int32\), got 3.14$/);
       assert.equal(err.name, "FieldValueInvalidError");
     });
-    void suite("returns error setting undefined", () => {
+    void suite("throws error setting undefined", () => {
       for (const f of desc.fields) {
         void test(`for proto3 field ${f.name}`, () => {
           const err = catchFieldError(() => r.set(f, undefined));
@@ -436,7 +439,7 @@ void suite("ReflectMessage", () => {
         });
       }
     });
-    void suite("returns error setting null", () => {
+    void suite("throws error setting null", () => {
       for (const f of desc.fields) {
         void test(`for proto3 field ${f.name}`, () => {
           const err = catchFieldError(() => r.set(f, null));
@@ -508,31 +511,40 @@ void suite("ReflectMessage", () => {
         });
       }
     });
-    void suite("throws error setting non-integer value for enum field", () => {
+    void suite("throws error setting invalid value for enum field", () => {
       const fields = desc.fields.filter((f) => f.fieldKind == "enum");
+      const cases: { label: string; value: unknown; message: RegExp }[] = [
+        { label: "true", value: true, message: /^expected enum .*, got true$/ },
+        {
+          label: "'abc'",
+          value: "abc",
+          message: /^expected enum .*, got "abc"$/,
+        },
+        {
+          label: "3.14",
+          value: 3.14,
+          message: /^expected enum .*, got 3\.14$/,
+        },
+        {
+          label: `${INT32_MAX + 1}`,
+          value: INT32_MAX + 1,
+          message: /^expected enum .*: .* out of range$/,
+        },
+        {
+          label: `${INT32_MIN - 1}`,
+          value: INT32_MIN - 1,
+          message: /^expected enum .*: .* out of range$/,
+        },
+      ];
       for (const f of fields) {
-        void test(`set ${f.name} true`, () => {
-          const err = catchFieldError(() => r.set(f, true));
-          assert.ok(err !== undefined);
-          assert.match(err.message, /^expected enum .*, got true$/);
-          assert.equal(err.name, "FieldValueInvalidError");
-        });
-      }
-      for (const f of fields) {
-        void test(`set ${f.name} 'abc'`, () => {
-          const err = catchFieldError(() => r.set(f, "abc"));
-          assert.ok(err !== undefined);
-          assert.match(err.message, /^expected enum .*, got "abc"$/);
-          assert.equal(err.name, "FieldValueInvalidError");
-        });
-      }
-      for (const f of fields) {
-        void test(`set ${f.name} 3.14`, () => {
-          const err = catchFieldError(() => r.set(f, 3.14));
-          assert.ok(err !== undefined);
-          assert.match(err.message, /^expected enum .*, got 3.14$/);
-          assert.equal(err.name, "FieldValueInvalidError");
-        });
+        for (const { label, value, message } of cases) {
+          void test(`set ${f.name} ${label}`, () => {
+            const err = catchFieldError(() => r.set(f, value));
+            assert.ok(err !== undefined);
+            assert.match(err.message, message);
+            assert.equal(err.name, "FieldValueInvalidError");
+          });
+        }
       }
     });
     test("throws error setting incompatible ReflectMessage", () => {

--- a/packages/protobuf/src/reflect/reflect-check.ts
+++ b/packages/protobuf/src/reflect/reflect-check.ts
@@ -114,7 +114,9 @@ function checkSingular(
   }
   if (field.enum !== undefined) {
     if (field.enum.open) {
-      return Number.isInteger(value);
+      // Open enums accept unrecognized values, but enum values are always
+      // int32 (see https://protobuf.dev/programming-guides/proto3/#enum).
+      return checkScalarValue(value, ScalarType.INT32);
     }
     return field.enum.values.some((v) => v.number === value);
   }


### PR DESCRIPTION
Open enums accept unrecognized values, but enum values are always int32 (see https://protobuf.dev/programming-guides/proto3/#enum).

The reflection check used `Number.isInteger`, so it accepted any integer, including values outside int32 range that can't be serialized. This narrows the check to verify that open enum values are within range.