### PR TITLE
Propagate BUF_BIGINT_DISABLE to Turborepo test tasks

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,299 b |  69,435 b |   16,004 b |
-| Protobuf-ES         |     4 |   136,488 b |  70,942 b |   16,731 b |
-| Protobuf-ES         |     8 |   139,250 b |  72,713 b |   17,235 b |
-| Protobuf-ES         |    16 |   149,700 b |  80,694 b |   19,551 b |
-| Protobuf-ES         |    32 |   177,491 b | 102,712 b |   25,074 b |
+| Protobuf-ES         |     1 |   134,319 b |  69,453 b |   15,993 b |
+| Protobuf-ES         |     4 |   136,508 b |  70,960 b |   16,692 b |
+| Protobuf-ES         |     8 |   139,270 b |  72,731 b |   17,238 b |
+| Protobuf-ES         |    16 |   149,720 b |  80,712 b |   19,557 b |
+| Protobuf-ES         |    32 |   177,511 b | 102,730 b |   25,051 b |
 | protobuf-javascript |     1 |   314,120 b | 244,024 b |   35,999 b |
 | protobuf-javascript |     4 |   340,137 b | 258,996 b |   37,473 b |
 | protobuf-javascript |     8 |   360,931 b | 270,573 b |   38,585 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.676171875 140,242.61728515625 280,241.18994140625 420,234.63095703125 560,218.9896484375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.70732421875 140,242.727734375 280,241.1814453125 420,234.61396484375 560,219.05478515625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.676171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.63 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.61728515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.34 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.18994140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.83 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.63095703125" r="4" fill="#ffa600"><title>Protobuf-ES 19.09 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.9896484375" r="4" fill="#ffa600"><title>Protobuf-ES 24.49 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.70732421875" r="4" fill="#ffa600"><title>Protobuf-ES 15.62 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.727734375" r="4" fill="#ffa600"><title>Protobuf-ES 16.3 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.1814453125" r="4" fill="#ffa600"><title>Protobuf-ES 16.83 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.61396484375" r="4" fill="#ffa600"><title>Protobuf-ES 19.1 KiB for 16 files</title></circle>
+<circle cx="560" cy="219.05478515625" r="4" fill="#ffa600"><title>Protobuf-ES 24.46 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,188.04970703125 140,183.87529296875 280,180.72607421875 420,160.31279296875 560,76.125">

--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -7,7 +7,7 @@
     "pregenerate": "rm -rf src/gen/* && rm -rf .tmp/proto/* && conformance_proto_eject .tmp/proto",
     "generate": "protoc --es_out=src/gen --es_opt=target=ts --proto_path=.tmp/proto $(buf ls-files .tmp/proto)",
     "postgenerate": "license-header",
-    "test": "test '1' == \"$BUF_BIGINT_DISABLE\" && npm run test:string || npm run test:bigint",
+    "test": "test '1' = \"$BUF_BIGINT_DISABLE\" && npm run test:string || npm run test:bigint",
     "test:bigint": "conformance_test_runner --maximum_edition MAX --enforce_recommended --failure_list failing_tests_with_bigint.txt --text_format_failure_list failing_tests_text_format.txt bin/conformance.js",
     "test:string": "conformance_test_runner --maximum_edition MAX --enforce_recommended --failure_list failing_tests_without_bigint.txt --text_format_failure_list failing_tests_text_format.txt bin/conformance.js",
     "format": "biome format --write",

--- a/packages/protobuf-test/src/serialization-errors.test.ts
+++ b/packages/protobuf-test/src/serialization-errors.test.ts
@@ -14,7 +14,7 @@
 
 import { suite, test } from "node:test";
 import * as assert from "node:assert";
-import { create, toBinary, toJson } from "@bufbuild/protobuf";
+import { create, protoInt64, toBinary, toJson } from "@bufbuild/protobuf";
 import { FieldMaskSchema, ValueSchema } from "@bufbuild/protobuf/wkt";
 import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
 import * as proto2_ts from "./gen/ts/extra/proto2_pb.js";
@@ -205,7 +205,11 @@ void suite("serialization errors", () => {
       },
       jsonErr:
         /^cannot encode field spec.ScalarValuesMessage.int64_field to JSON: expected bigint \(int64\), got true/,
-      binaryErr: null,
+      // With bigint, BigInt(true) === 1n and the value silently encodes; the
+      // string fallback rejects "true".
+      binaryErr: protoInt64.supported
+        ? null
+        : /^cannot encode field spec.ScalarValuesMessage.int64_field to binary: invalid int64: true$/,
     },
     {
       name: "uint64 field -1",
@@ -224,8 +228,11 @@ void suite("serialization errors", () => {
       },
       jsonErr:
         /^cannot encode field spec.ScalarValuesMessage.uint64_field to JSON: expected bigint \(uint64\): Infinity out of range/,
-      binaryErr:
-        /^cannot encode field spec.ScalarValuesMessage.uint64_field to binary: The number Infinity cannot be converted to a BigInt because it is not an integer$/,
+      // bigint throws a native BigInt() error; the string fallback throws its
+      // own uniform message.
+      binaryErr: protoInt64.supported
+        ? /^cannot encode field spec.ScalarValuesMessage.uint64_field to binary: The number Infinity cannot be converted to a BigInt because it is not an integer$/
+        : /^cannot encode field spec.ScalarValuesMessage.uint64_field to binary: invalid uint64: Infinity$/,
     },
     {
       name: "bytes field true",

--- a/packages/protobuf/src/proto-int64.ts
+++ b/packages/protobuf/src/proto-int64.ts
@@ -119,7 +119,7 @@ interface Int64Support {
 }
 
 // The environment variable BUF_BIGINT_DISABLE=1 disables bigint support for
-// testing (unless globalThis.Deno is defined).
+// testing (unless globalThis.Deno or globalThis.Bun is defined).
 declare const process: {
   env: Record<string, string>;
 };
@@ -134,6 +134,7 @@ function makeInt64Support(): Int64Support {
     typeof dv.setBigInt64 === "function" &&
     typeof dv.setBigUint64 === "function" &&
     (!!(globalThis as { Deno?: unknown }).Deno ||
+      !!(globalThis as { Bun?: unknown }).Bun ||
       typeof process != "object" ||
       typeof process.env != "object" ||
       process.env.BUF_BIGINT_DISABLE !== "1");

--- a/packages/protoplugin-test/src/file-print.test.ts
+++ b/packages/protoplugin-test/src/file-print.test.ts
@@ -20,26 +20,30 @@ import { createImportSymbol } from "@bufbuild/protoplugin";
 import { createTestPluginAndRun } from "./helpers.js";
 
 void suite("GeneratedFile.print", () => {
-  void test("should print bigint literals", async () => {
-    const lines = await testGenerate((f) => {
-      f.print(0n);
-      f.print(-9223372036854775808n); // min signed
-      f.print(18446744073709551615n); // max unsigned
-    });
-    assert.deepStrictEqual(lines, [
-      `import { protoInt64 } from "@bufbuild/protobuf";`,
-      "",
-      "protoInt64.zero",
-      `protoInt64.parse("-9223372036854775808")`,
-      `protoInt64.uParse("18446744073709551615")`,
-    ]);
-    assert.ok(
-      protoInt64.parse("-9223372036854775808") === -9223372036854775808n,
-    );
-    assert.ok(
-      protoInt64.uParse("18446744073709551615") === 18446744073709551615n,
-    );
-  });
+  void test(
+    "should print bigint literals",
+    { skip: protoInt64.supported ? false : "requires BigInt" },
+    async () => {
+      const lines = await testGenerate((f) => {
+        f.print(0n);
+        f.print(-9223372036854775808n); // min signed
+        f.print(18446744073709551615n); // max unsigned
+      });
+      assert.deepStrictEqual(lines, [
+        `import { protoInt64 } from "@bufbuild/protobuf";`,
+        "",
+        "protoInt64.zero",
+        `protoInt64.parse("-9223372036854775808")`,
+        `protoInt64.uParse("18446744073709551615")`,
+      ]);
+      assert.ok(
+        protoInt64.parse("-9223372036854775808") === -9223372036854775808n,
+      );
+      assert.ok(
+        protoInt64.uParse("18446744073709551615") === 18446744073709551615n,
+      );
+    },
+  );
 
   void test("should print number literals", async () => {
     const lines = await testGenerate((f) => {

--- a/packages/protoplugin-test/src/plugin-edition-support.test.ts
+++ b/packages/protoplugin-test/src/plugin-edition-support.test.ts
@@ -14,7 +14,12 @@
 
 import { suite, test } from "node:test";
 import * as assert from "node:assert";
-import { fromBinary, minimumEdition, maximumEdition } from "@bufbuild/protobuf";
+import {
+  fromBinary,
+  minimumEdition,
+  maximumEdition,
+  protoInt64,
+} from "@bufbuild/protobuf";
 import {
   CodeGeneratorRequestSchema,
   CodeGeneratorResponse_Feature,
@@ -57,91 +62,95 @@ function noop() {
   //
 }
 
-void suite("editions support in plugins", () => {
-  void test("sets SUPPORTS_EDITIONS", async () => {
-    const res = await createTestPluginAndRun({
-      proto: `syntax="proto3";`,
-      generateAny: noop,
+void suite(
+  "editions support in plugins",
+  { skip: protoInt64.supported ? false : "requires BigInt" },
+  () => {
+    void test("sets SUPPORTS_EDITIONS", async () => {
+      const res = await createTestPluginAndRun({
+        proto: `syntax="proto3";`,
+        generateAny: noop,
+      });
+      const supportsEditions =
+        (res.supportedFeatures &
+          BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS)) ===
+        BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS);
+      assert.strictEqual(supportsEditions, true);
     });
-    const supportsEditions =
-      (res.supportedFeatures &
-        BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS)) ===
-      BigInt(CodeGeneratorResponse_Feature.SUPPORTS_EDITIONS);
-    assert.strictEqual(supportsEditions, true);
-  });
-  void test("sets supported edition range to @bufbuild/protobuf's supported range", async () => {
-    const res = await createTestPluginAndRun({
-      proto: `syntax="proto3";`,
-      generateAny: noop,
+    void test("sets supported edition range to @bufbuild/protobuf's supported range", async () => {
+      const res = await createTestPluginAndRun({
+        proto: `syntax="proto3";`,
+        generateAny: noop,
+      });
+      assert.strictEqual(res.minimumEdition, minimumEdition);
+      assert.strictEqual(res.maximumEdition, maximumEdition);
     });
-    assert.strictEqual(res.minimumEdition, minimumEdition);
-    assert.strictEqual(res.maximumEdition, maximumEdition);
-  });
-  void test("sets supported edition range to the provided range", async () => {
-    const res = await createTestPluginAndRun({
-      proto: `syntax="proto3";`,
-      minimumEdition: Edition.EDITION_PROTO2,
-      maximumEdition: Edition.EDITION_PROTO3,
-      generateAny: noop,
+    void test("sets supported edition range to the provided range", async () => {
+      const res = await createTestPluginAndRun({
+        proto: `syntax="proto3";`,
+        minimumEdition: Edition.EDITION_PROTO2,
+        maximumEdition: Edition.EDITION_PROTO3,
+        generateAny: noop,
+      });
+      assert.strictEqual(res.minimumEdition, Edition.EDITION_PROTO2);
+      assert.strictEqual(res.maximumEdition, Edition.EDITION_PROTO3);
     });
-    assert.strictEqual(res.minimumEdition, Edition.EDITION_PROTO2);
-    assert.strictEqual(res.maximumEdition, Edition.EDITION_PROTO3);
-  });
-  void test("raises error for minimumEdition > maximumEdition", async () => {
-    await assert.rejects(
-      async () =>
-        runPlugin(
-          Edition.EDITION_PROTO3,
-          Edition.EDITION_PROTO3,
-          Edition.EDITION_PROTO2,
-        ),
-      {
-        message:
-          /^configured minimumEdition PROTO3 > maximumEdition PROTO2 - please contact plugin author$/,
-      },
-    );
-  });
-  void test("raises error on unsupported edition from the past with default range", async () => {
-    await assert.rejects(async () => runPlugin(Edition.EDITION_1_TEST_ONLY), {
-      message:
-        /^test.proto: unsupported edition 1_TEST_ONLY - the earliest supported edition is PROTO2$/,
+    void test("raises error for minimumEdition > maximumEdition", async () => {
+      await assert.rejects(
+        async () =>
+          runPlugin(
+            Edition.EDITION_PROTO3,
+            Edition.EDITION_PROTO3,
+            Edition.EDITION_PROTO2,
+          ),
+        {
+          message:
+            /^configured minimumEdition PROTO3 > maximumEdition PROTO2 - please contact plugin author$/,
+        },
+      );
     });
-  });
-  void test("raises error on unsupported edition from the future with default range", async () => {
-    await assert.rejects(
-      async () => runPlugin(Edition.EDITION_99999_TEST_ONLY),
-      {
+    void test("raises error on unsupported edition from the past with default range", async () => {
+      await assert.rejects(async () => runPlugin(Edition.EDITION_1_TEST_ONLY), {
         message:
-          /^test.proto: unsupported edition 99999_TEST_ONLY - the latest supported edition is 2024$/,
-      },
-    );
-  });
-  void test("raises error on unsupported edition from the past with custom range", async () => {
-    await assert.rejects(
-      async () =>
-        runPlugin(
-          Edition.EDITION_PROTO2,
-          Edition.EDITION_PROTO3,
-          Edition.EDITION_PROTO3,
-        ),
-      {
-        message:
-          /^test.proto: unsupported edition PROTO2 - the earliest supported edition is PROTO3$/,
-      },
-    );
-  });
-  void test("raises error on unsupported edition from the future with custom range", async () => {
-    await assert.rejects(
-      async () =>
-        runPlugin(
-          Edition.EDITION_2023,
-          Edition.EDITION_PROTO3,
-          Edition.EDITION_PROTO3,
-        ),
-      {
-        message:
-          /^test.proto: unsupported edition 2023 - the latest supported edition is PROTO3$/,
-      },
-    );
-  });
-});
+          /^test.proto: unsupported edition 1_TEST_ONLY - the earliest supported edition is PROTO2$/,
+      });
+    });
+    void test("raises error on unsupported edition from the future with default range", async () => {
+      await assert.rejects(
+        async () => runPlugin(Edition.EDITION_99999_TEST_ONLY),
+        {
+          message:
+            /^test.proto: unsupported edition 99999_TEST_ONLY - the latest supported edition is 2024$/,
+        },
+      );
+    });
+    void test("raises error on unsupported edition from the past with custom range", async () => {
+      await assert.rejects(
+        async () =>
+          runPlugin(
+            Edition.EDITION_PROTO2,
+            Edition.EDITION_PROTO3,
+            Edition.EDITION_PROTO3,
+          ),
+        {
+          message:
+            /^test.proto: unsupported edition PROTO2 - the earliest supported edition is PROTO3$/,
+        },
+      );
+    });
+    void test("raises error on unsupported edition from the future with custom range", async () => {
+      await assert.rejects(
+        async () =>
+          runPlugin(
+            Edition.EDITION_2023,
+            Edition.EDITION_PROTO3,
+            Edition.EDITION_PROTO3,
+          ),
+        {
+          message:
+            /^test.proto: unsupported edition 2023 - the latest supported edition is PROTO3$/,
+        },
+      );
+    });
+  },
+);

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["BUF_BIGINT_DISABLE"],
   "tasks": {
     "build": {
       "dependsOn": ["^build", "generate"],


### PR DESCRIPTION
CI was silently running with bigint enabled. This fixes it, and adjusts two test assertions.

Also adds `globalThis.Bun` to the carve-out that keeps bigint enabled on runtimes that always support it, alongside the existing Deno check.