### PR TITLE
Special-case prototype keys in maps

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,783 b |  69,594 b |   16,073 b |
-| Protobuf-ES         |     4 |   136,972 b |  71,101 b |   16,764 b |
-| Protobuf-ES         |     8 |   139,734 b |  72,872 b |   17,250 b |
-| Protobuf-ES         |    16 |   150,184 b |  80,853 b |   19,586 b |
-| Protobuf-ES         |    32 |   177,975 b | 102,871 b |   25,129 b |
+| Protobuf-ES         |     1 |   135,209 b |  69,818 b |   16,133 b |
+| Protobuf-ES         |     4 |   137,398 b |  71,322 b |   16,760 b |
+| Protobuf-ES         |     8 |   140,160 b |  73,093 b |   17,340 b |
+| Protobuf-ES         |    16 |   150,610 b |  81,074 b |   19,662 b |
+| Protobuf-ES         |    32 |   178,401 b | 103,095 b |   25,168 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.48076171875 140,242.523828125 280,241.1474609375 420,234.5318359375 560,218.83388671875002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.31083984375 140,242.53515625 280,240.892578125 420,234.3166015625 560,218.7234375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.48076171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.7 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.523828125" r="4" fill="#ffa600"><title>Protobuf-ES 16.37 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.1474609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.85 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.5318359375" r="4" fill="#ffa600"><title>Protobuf-ES 19.13 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.83388671875002" r="4" fill="#ffa600"><title>Protobuf-ES 24.54 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.31083984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.75 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.53515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.37 KiB for 4 files</title></circle>
+<circle cx="280" cy="240.892578125" r="4" fill="#ffa600"><title>Protobuf-ES 16.93 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.3166015625" r="4" fill="#ffa600"><title>Protobuf-ES 19.2 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.7234375" r="4" fill="#ffa600"><title>Protobuf-ES 24.58 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -23,7 +23,12 @@ import type { Message, MessageInitShape, MessageShape } from "./types.js";
 import { scalarZeroValue } from "./reflect/scalar.js";
 import type { FieldError } from "./reflect/error.js";
 import { isObject, type OneofADT } from "./reflect/guard.js";
-import { unsafeGet, unsafeOneofCase, unsafeSet } from "./reflect/unsafe.js";
+import {
+  unsafeGet,
+  unsafeMapSet,
+  unsafeOneofCase,
+  unsafeSet,
+} from "./reflect/unsafe.js";
 import { isWrapperDesc } from "./wkt/wrappers.js";
 import type {
   Edition,
@@ -181,7 +186,7 @@ function convertObjectValues(
 ): Record<string, unknown> {
   const ret: Record<string, unknown> = {};
   for (const entry of Object.entries(obj)) {
-    ret[entry[0]] = fn(entry[1]);
+    unsafeMapSet(ret, entry[0], fn(entry[1]));
   }
   return ret;
 }

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -33,6 +33,7 @@ import { reflect } from "./reflect/reflect.js";
 import { FieldError, isFieldError } from "./reflect/error.js";
 import { formatVal } from "./reflect/reflect-check.js";
 import { protoSnakeCase } from "./reflect/names.js";
+import { unsafeMapSet } from "./reflect/unsafe.js";
 import type { ScalarValue } from "./reflect/scalar.js";
 import type { EnumJsonType, EnumShape, MessageShape } from "./types.js";
 import { base64Decode } from "./wire/base64-encoding.js";
@@ -920,7 +921,7 @@ function structFromJson(struct: Struct, json: JsonValue, ctx: JsonReadContext) {
   for (const [k, v] of Object.entries(json)) {
     const parsedV = create(ValueSchema);
     valueFromJson(parsedV, v, ctx);
-    struct.fields[k] = parsedV;
+    unsafeMapSet(struct.fields, k, parsedV);
   }
 }
 

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -32,6 +32,8 @@ import {
   unsafeGet,
   unsafeIsSet,
   unsafeLocal,
+  unsafeMapGet,
+  unsafeMapSet,
   unsafeOneofCase,
   unsafeSet,
 } from "./unsafe.js";
@@ -349,7 +351,11 @@ class ReflectMapImpl<K, V> implements ReflectMap<K, V> {
         throw err;
       }
     }
-    this.obj[mapKeyToLocal(key)] = mapValueToLocal(this._field, value);
+    unsafeMapSet(
+      this.obj,
+      mapKeyToLocal(key),
+      mapValueToLocal(this._field, value),
+    );
     return this;
   }
   delete(key: K) {
@@ -366,7 +372,7 @@ class ReflectMapImpl<K, V> implements ReflectMap<K, V> {
     }
   }
   get(key: K) {
-    let val = this.obj[mapKeyToLocal(key)];
+    let val = unsafeMapGet(this.obj, mapKeyToLocal(key));
     if (val !== undefined) {
       val = mapValueToReflect(this._field, val, this.check);
     }
@@ -627,7 +633,7 @@ function wktStructToReflect(json: JsonValue): Struct {
   };
   if (isObject(json)) {
     for (const [k, v] of Object.entries(json)) {
-      struct.fields[k] = wktValueToReflect(v);
+      unsafeMapSet(struct.fields, k, wktValueToReflect(v));
     }
   }
   return struct;
@@ -636,7 +642,7 @@ function wktStructToReflect(json: JsonValue): Struct {
 function wktStructToLocal(val: Struct) {
   const json: JsonObject = {};
   for (const [k, v] of Object.entries(val.fields)) {
-    json[k] = wktValueToLocal(v);
+    unsafeMapSet(json, k, wktValueToLocal(v));
   }
   return json;
 }

--- a/packages/protobuf/src/reflect/unsafe.ts
+++ b/packages/protobuf/src/reflect/unsafe.ts
@@ -127,6 +127,58 @@ export function unsafeSet(
 }
 
 /**
+ * Set an entry on the plain object backing a map field.
+ *
+ * The key "__proto__" is special: assigning it with bracket notation invokes
+ * the inherited prototype setter instead of creating an own property, which
+ * would change the object's prototype to the map value.
+ *
+ * A null-prototype backing object would avoid this, but React Server
+ * Components reject null-prototype objects.
+ *
+ * @private
+ */
+export function unsafeMapSet(
+  obj: Record<string, unknown>,
+  key: string | number,
+  value: unknown,
+): void {
+  if (key === "__proto__") {
+    Object.defineProperty(obj, "__proto__", {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  } else {
+    // Plain assignment is the engine's optimized fast path: defineProperty is
+    // several times slower and can deoptimize the object, so we reserve it for
+    // the only key that actually needs it.
+    obj[key] = value;
+  }
+}
+
+/**
+ * Read an entry from the plain object backing a map field.
+ *
+ * Bracket access walks the prototype chain, so reading an unset key such as
+ * "__proto__", "toString", or "constructor" would return an inherited value
+ * instead of undefined. Guarding on own-property membership keeps map reads
+ * faithful for every key.
+ *
+ * A null-prototype backing object would avoid this, but React Server
+ * Components reject null-prototype objects.
+ *
+ * @private
+ */
+export function unsafeMapGet(
+  obj: Record<string, unknown>,
+  key: string | number,
+): unknown {
+  return Object.prototype.hasOwnProperty.call(obj, key) ? obj[key] : undefined;
+}
+
+/**
  * Resets the field, so that unsafeIsSet() will return false.
  *
  * @private

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -50,6 +50,7 @@ import { hasCustomJsonRepresentation, isWrapperDesc } from "./wkt/wrappers.js";
 import { base64Encode } from "./wire/index.js";
 import { createExtensionContainer, getExtension } from "./extensions.js";
 import { checkField, formatVal } from "./reflect/reflect-check.js";
+import { unsafeMapSet } from "./reflect/unsafe.js";
 
 // bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name: FeatureSet_FieldPresence.$localName = $number;
 const LEGACY_REQUIRED: FeatureSet_FieldPresence.LEGACY_REQUIRED = 3;
@@ -244,23 +245,28 @@ function mapToJson(map: ReflectMap, opts: JsonWriteOptions) {
   switch (f.mapKind) {
     case "scalar":
       for (const [entryKey, entryValue] of map) {
-        jsonObj[entryKey as keyof object] = scalarToJson(f, entryValue);
+        unsafeMapSet(
+          jsonObj,
+          entryKey as string | number,
+          scalarToJson(f, entryValue),
+        );
       }
       break;
     case "message":
       for (const [entryKey, entryValue] of map) {
-        jsonObj[entryKey as keyof object] = reflectToJson(
-          entryValue as ReflectMessage,
-          opts,
+        unsafeMapSet(
+          jsonObj,
+          entryKey as string | number,
+          reflectToJson(entryValue as ReflectMessage, opts),
         );
       }
       break;
     case "enum":
       for (const [entryKey, entryValue] of map) {
-        jsonObj[entryKey as keyof object] = enumToJsonInternal(
-          f.enum,
-          entryValue,
-          opts.enumAsInteger,
+        unsafeMapSet(
+          jsonObj,
+          entryKey as string | number,
+          enumToJsonInternal(f.enum, entryValue, opts.enumAsInteger),
         );
       }
       break;
@@ -500,7 +506,7 @@ function fieldMaskToJson(val: FieldMask) {
 function structToJson(val: Struct) {
   const json: JsonObject = {};
   for (const [k, v] of Object.entries(val.fields)) {
-    json[k] = valueToJson(v);
+    unsafeMapSet(json, k, valueToJson(v));
   }
   return json;
 }


### PR DESCRIPTION
Under certain conditions, map accesses can fall back to prototype fields and methods. This PR fixes map access to prevent this from happening. 
