### PR TITLE
Stop relying on enum reverse-mapping

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   134,783 b |  69,594 b |   16,073 b |
-| Protobuf-ES         |     4 |   136,972 b |  71,101 b |   16,764 b |
-| Protobuf-ES         |     8 |   139,734 b |  72,872 b |   17,250 b |
-| Protobuf-ES         |    16 |   150,184 b |  80,853 b |   19,586 b |
-| Protobuf-ES         |    32 |   177,975 b | 102,871 b |   25,129 b |
+| Protobuf-ES         |     1 |   134,775 b |  69,604 b |   16,071 b |
+| Protobuf-ES         |     4 |   136,964 b |  71,111 b |   16,746 b |
+| Protobuf-ES         |     8 |   139,726 b |  72,882 b |   17,288 b |
+| Protobuf-ES         |    16 |   150,176 b |  80,863 b |   19,630 b |
+| Protobuf-ES         |    32 |   177,967 b | 102,881 b |   25,094 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.48076171875 140,242.523828125 280,241.1474609375 420,234.5318359375 560,218.83388671875002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.48642578125 140,242.5748046875 280,241.03984375 420,234.4072265625 560,218.9330078125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.48076171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.7 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.523828125" r="4" fill="#ffa600"><title>Protobuf-ES 16.37 KiB for 4 files</title></circle>
-<circle cx="280" cy="241.1474609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.85 KiB for 8 files</title></circle>
-<circle cx="420" cy="234.5318359375" r="4" fill="#ffa600"><title>Protobuf-ES 19.13 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.83388671875002" r="4" fill="#ffa600"><title>Protobuf-ES 24.54 KiB for 32 files</title></circle>
+<circle cx="0" cy="244.48642578125" r="4" fill="#ffa600"><title>Protobuf-ES 15.69 KiB for 1 files</title></circle>
+<circle cx="140" cy="242.5748046875" r="4" fill="#ffa600"><title>Protobuf-ES 16.35 KiB for 4 files</title></circle>
+<circle cx="280" cy="241.03984375" r="4" fill="#ffa600"><title>Protobuf-ES 16.88 KiB for 8 files</title></circle>
+<circle cx="420" cy="234.4072265625" r="4" fill="#ffa600"><title>Protobuf-ES 19.17 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.9330078125" r="4" fill="#ffa600"><title>Protobuf-ES 24.51 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf-test/src/enum-open-closed.test.ts
+++ b/packages/protobuf-test/src/enum-open-closed.test.ts
@@ -23,7 +23,11 @@ void suite("open enum", () => {
   test("from binary sets foreign value", () => {
     assert.strictEqual(proto3_ts.Proto3EnumSchema.open, true);
     const foreignValue = 4;
-    assert.strictEqual(proto3_ts.Proto3Enum[foreignValue], undefined);
+    assert.strictEqual(
+      foreignValue in proto3_ts.Proto3EnumSchema.value,
+      false,
+      "fixture defines unexpected enum value",
+    );
     const bytes = new BinaryWriter()
       .tag(
         proto3_ts.Proto3MessageSchema.field.singularEnumField.number,
@@ -46,7 +50,11 @@ void suite("closed enum", () => {
   test("from binary sets foreign value as unknown field", () => {
     assert.strictEqual(proto2_ts.Proto2EnumSchema.open, false);
     const foreignValue = 4;
-    assert.strictEqual(proto2_ts.Proto2Enum[foreignValue], undefined);
+    assert.strictEqual(
+      foreignValue in proto2_ts.Proto2EnumSchema.value,
+      false,
+      "fixture defines unexpected enum value",
+    );
     const bytes = new BinaryWriter()
       .tag(
         proto2_ts.Proto2MessageSchema.field.optionalEnumField.number,

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -25,17 +25,13 @@ import type { FieldError } from "./reflect/error.js";
 import { isObject, type OneofADT } from "./reflect/guard.js";
 import { unsafeGet, unsafeOneofCase, unsafeSet } from "./reflect/unsafe.js";
 import { isWrapperDesc } from "./wkt/wrappers.js";
-import type {
-  Edition,
-  FeatureSet_FieldPresence,
-} from "./wkt/gen/google/protobuf/descriptor_pb.js";
 
-// bootstrap-inject google.protobuf.Edition.EDITION_PROTO3: const $name: Edition.$localName = $number;
-const EDITION_PROTO3: Edition.EDITION_PROTO3 = 999;
-// bootstrap-inject google.protobuf.Edition.EDITION_PROTO2: const $name: Edition.$localName = $number;
-const EDITION_PROTO2: Edition.EDITION_PROTO2 = 998;
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
-const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
+// bootstrap-inject google.protobuf.Edition.EDITION_PROTO3: const $name = $number;
+const EDITION_PROTO3 = 999;
+// bootstrap-inject google.protobuf.Edition.EDITION_PROTO2: const $name = $number;
+const EDITION_PROTO2 = 998;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name = $number;
+const IMPLICIT = 2;
 
 /**
  * Create a new message instance.

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -47,11 +47,13 @@ import {
 } from "./guard.js";
 import type {
   ListValue,
-  NullValue,
   Struct,
   Value,
 } from "../wkt/gen/google/protobuf/struct_pb.js";
 import type { JsonObject, JsonValue } from "../json-value.js";
+
+// google.protobuf.NullValue.NULL_VALUE;
+const NULL_VALUE = 0;
 
 /**
  * Create a ReflectMessage.
@@ -672,8 +674,7 @@ function wktValueToReflect(json: JsonValue): Value {
       break;
     case "object":
       if (json === null) {
-        const nullValue: NullValue.NULL_VALUE = 0;
-        value.kind = { case: "nullValue", value: nullValue };
+        value.kind = { case: "nullValue", value: NULL_VALUE };
       } else if (Array.isArray(json)) {
         const listValue: ListValue = {
           $typeName: "google.protobuf.ListValue",

--- a/packages/protobuf/src/reflect/unsafe.ts
+++ b/packages/protobuf/src/reflect/unsafe.ts
@@ -15,10 +15,9 @@
 import type { DescField, DescOneof } from "../descriptors.js";
 import type { OneofADT } from "./guard.js";
 import { isScalarZeroValue, scalarZeroValue } from "./scalar.js";
-import type { FeatureSet_FieldPresence } from "../wkt/gen/google/protobuf/descriptor_pb.js";
 
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
-const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name = $number;
+const IMPLICIT = 2;
 
 export const unsafeLocal = Symbol.for("reflect unsafe local");
 

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -14,14 +14,9 @@
 
 import type {
   DescriptorProto,
-  Edition,
   EnumDescriptorProto,
   FeatureSet,
   FeatureSet_FieldPresence,
-  FeatureSet_RepeatedFieldEncoding,
-  FeatureSet_MessageEncoding,
-  FeatureSet_EnumType,
-  FeatureSet_Utf8Validation,
   FieldDescriptorProto,
   FieldDescriptorProto_Type,
   FieldDescriptorProto_Label,
@@ -29,11 +24,11 @@ import type {
   FileDescriptorProto,
   FileDescriptorSet,
   MethodDescriptorProto,
-  MethodOptions_IdempotencyLevel,
   OneofDescriptorProto,
   ServiceDescriptorProto,
   EnumValueDescriptorProto,
 } from "./wkt/gen/google/protobuf/descriptor_pb.js";
+
 import {
   type DescEnum,
   type DescExtension,
@@ -381,53 +376,53 @@ function initBaseRegistry(
   return registry;
 }
 
-// bootstrap-inject google.protobuf.Edition.EDITION_PROTO2: const $name: Edition.$localName = $number;
-const EDITION_PROTO2: Edition.EDITION_PROTO2 = 998;
-// bootstrap-inject google.protobuf.Edition.EDITION_PROTO3: const $name: Edition.$localName = $number;
-const EDITION_PROTO3: Edition.EDITION_PROTO3 = 999;
-// bootstrap-inject google.protobuf.Edition.EDITION_UNSTABLE: const $name: Edition.$localName = $number;
-const EDITION_UNSTABLE: Edition.EDITION_UNSTABLE = 9999;
+// bootstrap-inject google.protobuf.Edition.EDITION_PROTO2: const $name = $number;
+const EDITION_PROTO2 = 998;
+// bootstrap-inject google.protobuf.Edition.EDITION_PROTO3: const $name = $number;
+const EDITION_PROTO3 = 999;
+// bootstrap-inject google.protobuf.Edition.EDITION_UNSTABLE: const $name = $number;
+const EDITION_UNSTABLE = 9999;
 
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_STRING: const $name: FieldDescriptorProto_Type.$localName = $number;
-const TYPE_STRING: FieldDescriptorProto_Type.STRING = 9;
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_GROUP: const $name: FieldDescriptorProto_Type.$localName = $number;
-const TYPE_GROUP: FieldDescriptorProto_Type.GROUP = 10;
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_MESSAGE: const $name: FieldDescriptorProto_Type.$localName = $number;
-const TYPE_MESSAGE: FieldDescriptorProto_Type.MESSAGE = 11;
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_BYTES: const $name: FieldDescriptorProto_Type.$localName = $number;
-const TYPE_BYTES: FieldDescriptorProto_Type.BYTES = 12;
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_ENUM: const $name: FieldDescriptorProto_Type.$localName = $number;
-const TYPE_ENUM: FieldDescriptorProto_Type.ENUM = 14;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_STRING: const $name = $number;
+const TYPE_STRING = 9;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_GROUP: const $name = $number;
+const TYPE_GROUP = 10;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_MESSAGE: const $name = $number;
+const TYPE_MESSAGE = 11;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_BYTES: const $name = $number;
+const TYPE_BYTES = 12;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Type.TYPE_ENUM: const $name = $number;
+const TYPE_ENUM = 14;
 
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_REPEATED: const $name: FieldDescriptorProto_Label.$localName = $number;
-const LABEL_REPEATED: FieldDescriptorProto_Label.REPEATED = 3;
-// bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_REQUIRED: const $name: FieldDescriptorProto_Label.$localName = $number;
-const LABEL_REQUIRED: FieldDescriptorProto_Label.REQUIRED = 2;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_REPEATED: const $name = $number;
+const LABEL_REPEATED = 3;
+// bootstrap-inject google.protobuf.FieldDescriptorProto.Label.LABEL_REQUIRED: const $name = $number;
+const LABEL_REQUIRED = 2;
 
-// bootstrap-inject google.protobuf.FieldOptions.JSType.JS_STRING: const $name: FieldOptions_JSType.$localName = $number;
-const JS_STRING: FieldOptions_JSType.JS_STRING = 1;
+// bootstrap-inject google.protobuf.FieldOptions.JSType.JS_STRING: const $name = $number;
+const JS_STRING = 1;
 
-// bootstrap-inject google.protobuf.MethodOptions.IdempotencyLevel.IDEMPOTENCY_UNKNOWN: const $name: MethodOptions_IdempotencyLevel.$localName = $number;
-const IDEMPOTENCY_UNKNOWN: MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN = 0;
+// bootstrap-inject google.protobuf.MethodOptions.IdempotencyLevel.IDEMPOTENCY_UNKNOWN: const $name = $number;
+const IDEMPOTENCY_UNKNOWN = 0;
 
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.EXPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
-const EXPLICIT: FeatureSet_FieldPresence.EXPLICIT = 1;
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
-const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name: FeatureSet_FieldPresence.$localName = $number;
-const LEGACY_REQUIRED: FeatureSet_FieldPresence.LEGACY_REQUIRED = 3;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.EXPLICIT: const $name = $number;
+const EXPLICIT = 1;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name = $number;
+const IMPLICIT = 2;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name = $number;
+const LEGACY_REQUIRED = 3;
 
-// bootstrap-inject google.protobuf.FeatureSet.RepeatedFieldEncoding.PACKED: const $name: FeatureSet_RepeatedFieldEncoding.$localName = $number;
-const PACKED: FeatureSet_RepeatedFieldEncoding.PACKED = 1;
+// bootstrap-inject google.protobuf.FeatureSet.RepeatedFieldEncoding.PACKED: const $name = $number;
+const PACKED = 1;
 
-// bootstrap-inject google.protobuf.FeatureSet.MessageEncoding.DELIMITED: const $name: FeatureSet_MessageEncoding.$localName = $number;
-const DELIMITED: FeatureSet_MessageEncoding.DELIMITED = 2;
+// bootstrap-inject google.protobuf.FeatureSet.MessageEncoding.DELIMITED: const $name = $number;
+const DELIMITED = 2;
 
-// bootstrap-inject google.protobuf.FeatureSet.EnumType.OPEN: const $name: FeatureSet_EnumType.$localName = $number;
-const OPEN: FeatureSet_EnumType.OPEN = 1;
+// bootstrap-inject google.protobuf.FeatureSet.EnumType.OPEN: const $name = $number;
+const OPEN = 1;
 
-// bootstrap-inject google.protobuf.FeatureSet.Utf8Validation.VERIFY: const $name: FeatureSet_Utf8Validation.$localName = $number;
-const VERIFY: FeatureSet_Utf8Validation.VERIFY = 2;
+// bootstrap-inject google.protobuf.FeatureSet.Utf8Validation.VERIFY: const $name = $number;
+const VERIFY = 2;
 
 // biome-ignore format: want this to read well
 // bootstrap-inject defaults: EDITION_PROTO2 to EDITION_2024: export const minimumEdition: SupportedEdition = $minimumEdition, maximumEdition: SupportedEdition = $maximumEdition;

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -15,13 +15,12 @@
 import type { MessageShape } from "./types.js";
 import { reflect } from "./reflect/reflect.js";
 import { BinaryWriter, WireType } from "./wire/binary-encoding.js";
-import type { FeatureSet_FieldPresence } from "./wkt/gen/google/protobuf/descriptor_pb.js";
 import type { ScalarValue } from "./reflect/scalar.js";
 import { type DescField, type DescMessage, ScalarType } from "./descriptors.js";
 import type { ReflectList, ReflectMessage } from "./reflect/index.js";
 
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name: FeatureSet_FieldPresence.$localName = $number;
-const LEGACY_REQUIRED: FeatureSet_FieldPresence.LEGACY_REQUIRED = 3;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name = $number;
+const LEGACY_REQUIRED = 3;
 
 /**
  * Options for serializing to binary data.

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -38,7 +38,6 @@ import type {
 import type {
   Any,
   Duration,
-  FeatureSet_FieldPresence,
   FieldMask,
   ListValue,
   Struct,
@@ -51,11 +50,11 @@ import { base64Encode } from "./wire/index.js";
 import { createExtensionContainer, getExtension } from "./extensions.js";
 import { checkField, formatVal } from "./reflect/reflect-check.js";
 
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name: FeatureSet_FieldPresence.$localName = $number;
-const LEGACY_REQUIRED: FeatureSet_FieldPresence.LEGACY_REQUIRED = 3;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name = $number;
+const LEGACY_REQUIRED = 3;
 
-// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name: FeatureSet_FieldPresence.$localName = $number;
-const IMPLICIT: FeatureSet_FieldPresence.IMPLICIT = 2;
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name = $number;
+const IMPLICIT = 2;
 
 /**
  * Options for serializing to JSON.

--- a/packages/protoplugin/src/file-preamble.ts
+++ b/packages/protoplugin/src/file-preamble.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Edition } from "@bufbuild/protobuf/wkt";
-import type { DescFile, DescComments } from "@bufbuild/protobuf";
+import { Edition, EditionSchema } from "@bufbuild/protobuf/wkt";
+import type { DescFile, DescComments, DescEnumValue } from "@bufbuild/protobuf";
 import {
   getPackageComments,
   getSyntaxComments,
@@ -71,9 +71,10 @@ export function makeFilePreamble(
       // Report the raw edition from the descriptor so files using
       // EDITION_UNSTABLE (which we collapse to maximumEdition internally)
       // still render as "edition unstable".
-      const editionString = Edition[file.proto.edition] as string | undefined;
-      if (typeof editionString == "string") {
-        const e = editionString.replace("EDITION_", "").toLowerCase();
+      const editionValue: DescEnumValue | undefined =
+        EditionSchema.value[file.proto.edition];
+      if (editionValue !== undefined) {
+        const e = editionValue.name.replace("EDITION_", "").toLowerCase();
         builder.push(`edition ${e})\n`);
       } else {
         builder.push("unknown edition\n");

--- a/packages/protoplugin/src/schema.ts
+++ b/packages/protoplugin/src/schema.ts
@@ -21,7 +21,11 @@ import type {
 } from "@bufbuild/protobuf";
 import { create, createFileRegistry } from "@bufbuild/protobuf";
 import type { CodeGeneratorRequest } from "@bufbuild/protobuf/wkt";
-import { Edition, FileDescriptorSetSchema } from "@bufbuild/protobuf/wkt";
+import {
+  Edition,
+  EditionSchema,
+  FileDescriptorSetSchema,
+} from "@bufbuild/protobuf/wkt";
 import { nestedTypes } from "@bufbuild/protobuf/reflect";
 import type {
   CreatePreambleFn,
@@ -294,8 +298,9 @@ function getFilesToGenerate(
 }
 
 function editionToString(edition: number): string {
-  if (edition in Edition) {
-    return Edition[edition].replace(/^EDITION_/, "");
+  const value = EditionSchema.values.find((e) => e.number == edition);
+  if (value !== undefined) {
+    return value.name.replace(/^EDITION_/, "");
   }
   return `unknown (${edition})`;
 }

--- a/packages/protoplugin/src/source-code-info.ts
+++ b/packages/protoplugin/src/source-code-info.ts
@@ -29,7 +29,6 @@ import {
   FieldDescriptorProto_Label,
   FieldDescriptorProto_Type,
   FieldDescriptorProtoSchema,
-  FieldOptions_JSType,
   FieldOptionsSchema,
   FeatureSetSchema,
   SourceCodeInfo_LocationSchema,
@@ -37,6 +36,7 @@ import {
   DescriptorProtoSchema,
   EnumDescriptorProtoSchema,
   ServiceDescriptorProtoSchema,
+  FieldOptions_JSTypeSchema,
 } from "@bufbuild/protobuf/wkt";
 
 /**
@@ -241,7 +241,8 @@ export function getDeclarationString(
     protoOptions !== undefined &&
     isFieldSet(protoOptions, FieldOptionsSchema.field.jstype)
   ) {
-    options.push(`jstype = ${FieldOptions_JSType[protoOptions.jstype]}`);
+    const value = FieldOptions_JSTypeSchema.value[protoOptions.jstype];
+    options.push(`jstype = ${value.name}`);
   }
   if (
     protoOptions !== undefined &&


### PR DESCRIPTION
This is an mechanical change without any impact on the user-facing API. We're stopping to rely on TypeScript enum reverse mapping, and generated constants drop the explicit type annotation (constants and enums are generated). 

This is a preparation for https://github.com/bufbuild/protobuf-es/issues/1139. It allows us to run most of the repositories logic and tests with object as const enums to investigate possible breaking changes.