### PR TITLE
Add helper for unknown enum values

### DIFF
--- a/docs/src/content/docs/reference/generated-code/field-types.md
+++ b/docs/src/content/docs/reference/generated-code/field-types.md
@@ -71,7 +71,7 @@ const val: PhoneType = PhoneType.MOBILE;
 const name = PhoneType[val]; // "MOBILE"
 ```
 
-Protobuf has open and closed enums. Open enums can contain numeric values that are not declared in the generated TypeScript enum, so code that receives data from newer schemas should handle unknown enum numbers.
+Protobuf has open and closed enums. Open enums can contain numeric values that are not declared in the generated TypeScript enum, so code that receives data from newer schemas should handle unknown enum numbers (see `isUnknownEnum` from `@bufbuild/protobuf`).
 
 ## Repeated fields
 

--- a/packages/protobuf-test/src/enum-open-closed.test.ts
+++ b/packages/protobuf-test/src/enum-open-closed.test.ts
@@ -15,14 +15,14 @@
 import { suite, test } from "node:test";
 import * as assert from "node:assert";
 import { BinaryWriter, WireType } from "@bufbuild/protobuf/wire";
-import { fromBinary, isFieldSet } from "@bufbuild/protobuf";
+import { fromBinary, isFieldSet, isUnknownEnum } from "@bufbuild/protobuf";
 import * as proto3_ts from "./gen/ts/extra/proto3_pb.js";
 import * as proto2_ts from "./gen/ts/extra/proto2_pb.js";
 
 void suite("open enum", () => {
   test("from binary sets foreign value", () => {
     assert.strictEqual(proto3_ts.Proto3EnumSchema.open, true);
-    const foreignValue = 4;
+    const foreignValue = 99;
     assert.strictEqual(
       foreignValue in proto3_ts.Proto3EnumSchema.value,
       false,
@@ -41,6 +41,10 @@ void suite("open enum", () => {
       proto3_ts.Proto3MessageSchema.field.singularEnumField,
     );
     assert.strictEqual(set, true);
+    assert.strictEqual(
+      isUnknownEnum(proto3_ts.Proto3EnumSchema, msg.singularEnumField),
+      true,
+    );
     assert.strictEqual(msg.singularEnumField, foreignValue);
     assert.strictEqual(msg.$unknown, undefined);
   });
@@ -49,7 +53,7 @@ void suite("open enum", () => {
 void suite("closed enum", () => {
   test("from binary sets foreign value as unknown field", () => {
     assert.strictEqual(proto2_ts.Proto2EnumSchema.open, false);
-    const foreignValue = 4;
+    const foreignValue = 99;
     assert.strictEqual(
       foreignValue in proto2_ts.Proto2EnumSchema.value,
       false,
@@ -69,6 +73,10 @@ void suite("closed enum", () => {
     );
     assert.strictEqual(set, false);
     assert.strictEqual(msg.optionalEnumField, proto2_ts.Proto2Enum.YES);
+    assert.strictEqual(
+      isUnknownEnum(proto2_ts.Proto2EnumSchema, msg.optionalEnumField),
+      false,
+    );
     assert.ok(msg.$unknown !== undefined);
     assert.strictEqual(msg.$unknown?.length, 1);
     assert.strictEqual(

--- a/packages/protobuf-test/src/unknown-enum.test.ts
+++ b/packages/protobuf-test/src/unknown-enum.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "node:assert";
+import { suite, test } from "node:test";
+import { isUnknownEnum, type UnknownEnum } from "@bufbuild/protobuf";
+import { Proto3Enum } from "./gen/js/extra/proto3_pb.js";
+import { Proto3EnumSchema } from "./gen/ts/extra/proto3_pb.js";
+
+void suite("isUnknownEnum", () => {
+  test("returns true for value not defined by the enum", () => {
+    assert.strictEqual(isUnknownEnum(Proto3EnumSchema, 99 as number), true);
+    assert.strictEqual(isUnknownEnum(Proto3EnumSchema, -1 as number), true);
+  });
+  test("returns false for defined values", () => {
+    assert.strictEqual(isUnknownEnum(Proto3EnumSchema, Proto3Enum.YES), false);
+    assert.strictEqual(isUnknownEnum(Proto3EnumSchema, Proto3Enum.NO), false);
+  });
+  test("narrows down to UnknownEnum", () => {
+    function f(v: Proto3Enum): UnknownEnum {
+      if (isUnknownEnum(Proto3EnumSchema, v)) {
+        return v;
+      }
+      throw false;
+    }
+    assert.ok(f);
+  });
+});

--- a/packages/protobuf/src/codegenv2/symbols.ts
+++ b/packages/protobuf/src/codegenv2/symbols.ts
@@ -55,6 +55,7 @@ export const symbols = {
   protoInt64:          {typeOnly: false, bootstrapWktFrom: "../../proto-int64.js",          from: packageName },
   JsonValue:           {typeOnly: true,  bootstrapWktFrom: "../../json-value.js",           from: packageName },
   JsonObject:          {typeOnly: true,  bootstrapWktFrom: "../../json-value.js",           from: packageName },
+  UnknownEnum:         {typeOnly: true,  bootstrapWktFrom: "../../types.js",                from: packageName },
   codegen: {
     boot:              {typeOnly: false, bootstrapWktFrom: "../../codegenv2/boot.js",       from: packageName + "/codegenv2" },
     fileDesc:          {typeOnly: false, bootstrapWktFrom: "../../codegenv2/file.js",       from: packageName + "/codegenv2" },

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -37,3 +37,4 @@ export {
   getOption,
 } from "./extensions.js";
 export * from "./proto-int64.js";
+export * from "./unknown-enum.js";

--- a/packages/protobuf/src/types.ts
+++ b/packages/protobuf/src/types.ts
@@ -139,6 +139,12 @@ export type UnknownField = {
 };
 
 /**
+ * An unknown enum is a value that's not in the set of values defined by an
+ * enum. Open Protobuf enums may
+ */
+export type UnknownEnum = number & { __unknown_enum: true };
+
+/**
  * Describes a streaming RPC declaration.
  */
 export type DescMethodStreaming<

--- a/packages/protobuf/src/unknown-enum.ts
+++ b/packages/protobuf/src/unknown-enum.ts
@@ -1,0 +1,30 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescEnum } from "./descriptors.js";
+import type { UnknownEnum } from "./types.js";
+
+/**
+ * Open enums can contain numeric values that are not in the set of values
+ * defined by the enum.
+ *
+ * This function returns true for those values, and narrows the type to
+ * `UnknownEnum`.
+ */
+export function isUnknownEnum(
+  desc: DescEnum,
+  value: number,
+): value is UnknownEnum {
+  return desc.value[value] === undefined;
+}


### PR DESCRIPTION
This adds the function `isUnkownEnum()`, which narrows an enum value to `UnknownEnum` when it's not in the set of values defined by the enum.

For example, consider:

```protobuf
syntax = "proto3";
enum Color {
  COLOR_UNSPECIFIED = 0;
  COLOR_RED = 1;
  COLOR_GREEN = 2;
}
```

It generates the following enum in TypeScript:

```typescript
export enum Color {
  UNSPECIFIED = 0,
  RED = 1,
  GREEN = 2
}
```

When someone adds `COLOR_BLUE = 3` and sends a message with this value to an older peer, the field will contain `3` - a value that's not in the TypeScript enum.

The helper function helps identifying such values:

```typescript
import { isUnknownEnum } from "@bufbuild/protobuf";

function checkColor(color: Color) {
  if (isUnknownEnum(color)) {
    console.log(`unknown color: ${color}`); // e.g. 3
  }
  console.log(Color[color]); // e.g. "RED"
}
```
