### PR TITLE
Extract ByteBuffer and use it in BinaryWriter

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   136,544 b |  70,588 b |   16,261 b |
-| Protobuf-ES         |     4 |   138,733 b |  72,096 b |   16,911 b |
-| Protobuf-ES         |     8 |   141,495 b |  73,867 b |   17,457 b |
-| Protobuf-ES         |    16 |   151,945 b |  81,848 b |   19,794 b |
-| Protobuf-ES         |    32 |   179,736 b | 103,866 b |   25,299 b |
+| Protobuf-ES         |     1 |   137,653 b |  70,628 b |   16,332 b |
+| Protobuf-ES         |     4 |   139,842 b |  72,138 b |   16,998 b |
+| Protobuf-ES         |     8 |   142,604 b |  73,909 b |   17,511 b |
+| Protobuf-ES         |    16 |   153,054 b |  81,890 b |   19,891 b |
+| Protobuf-ES         |    32 |   180,845 b | 103,905 b |   25,379 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.94833984375 140,242.10751953125 280,240.56123046875 420,233.9427734375 560,218.35244140625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.747265625 140,241.8611328125 280,240.40830078125 420,233.66806640625 560,218.12587890625002">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.94833984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.88 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.10751953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.51 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.56123046875" r="4" fill="#ffa600"><title>Protobuf-ES 17.05 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.9427734375" r="4" fill="#ffa600"><title>Protobuf-ES 19.33 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.35244140625" r="4" fill="#ffa600"><title>Protobuf-ES 24.71 KiB for 32 files</title></circle>
+<circle cx="0" cy="243.747265625" r="4" fill="#ffa600"><title>Protobuf-ES 15.95 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.8611328125" r="4" fill="#ffa600"><title>Protobuf-ES 16.6 KiB for 4 files</title></circle>
+<circle cx="280" cy="240.40830078125" r="4" fill="#ffa600"><title>Protobuf-ES 17.1 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.66806640625" r="4" fill="#ffa600"><title>Protobuf-ES 19.42 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.12587890625002" r="4" fill="#ffa600"><title>Protobuf-ES 24.78 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -15,6 +15,7 @@
 import { varint32read, varint64read } from "./varint.js";
 import { protoInt64 } from "../proto-int64.js";
 import { getTextEncoding } from "./text-encoding.js";
+import { ByteBuffer } from "./byte-buffer.js";
 
 /**
  * Protobuf binary format wire types.
@@ -90,15 +91,9 @@ export const INT32_MIN = -0x80000000;
 
 export class BinaryWriter {
   /**
-   * Growable byte buffer. We allocate a reasonably sized
-   * initial buffer and double its capacity when needed.
+   * Growable buffer that all values are written to.
    */
-  private buffer: Uint8Array<ArrayBuffer>;
-
-  /**
-   * Current write position in the buffer.
-   */
-  private pos: number;
+  private readonly buf = new ByteBuffer();
 
   /**
    * Previous fork positions (the write position at the time
@@ -106,36 +101,22 @@ export class BinaryWriter {
    */
   private stackPos: number[] = [];
 
-  private readonly initialSize = 128;
-
   constructor(
     private readonly encodeUtf8: (
       text: string,
     ) => Uint8Array = getTextEncoding().encodeUtf8,
-  ) {
-    // Defer the first Uint8Array allocation: small messages (e.g. a bool-only
-    // request) would otherwise pay for a full initialSize zeroed buffer.
-    this.buffer = EMPTY_BUFFER;
-    this.pos = 0;
-  }
-
-  private ensureCapacity(size: number) {
-    const required = this.pos + size;
-    if (required > this.buffer.length) {
-      let newLen = this.buffer.length || this.initialSize;
-      while (newLen < required) newLen *= 2;
-      const newBuf = new Uint8Array(newLen);
-      if (this.pos > 0) newBuf.set(this.buffer.subarray(0, this.pos));
-      this.buffer = newBuf;
-    }
-  }
+  ) {}
 
   /**
    * Return all bytes written and reset this writer.
    */
   finish(): Uint8Array<ArrayBuffer> {
-    const result = this.buffer.slice(0, this.pos);
-    this.pos = 0;
+    const buf = this.buf;
+    // Copy, so that the result is not invalidated by later writes: the buffer
+    // is retained for reuse. Slice the backing buffer directly rather than
+    // bytes(), which would allocate an intermediate view.
+    const result = buf.buffer.slice(0, buf.length);
+    buf.length = 0;
     this.stackPos = [];
     return result;
   }
@@ -147,7 +128,7 @@ export class BinaryWriter {
    * Must be joined later with `join()`.
    */
   fork(): this {
-    this.stackPos.push(this.pos);
+    this.stackPos.push(this.buf.length);
     return this;
   }
 
@@ -159,20 +140,22 @@ export class BinaryWriter {
     const forkPos = this.stackPos.pop();
     if (forkPos === undefined)
       throw new Error("invalid state, fork stack empty");
-    const len = this.pos - forkPos;
+    const buf = this.buf;
+    const len = buf.length - forkPos;
     const size = varint32Size(len);
-    this.ensureCapacity(size);
+    buf.reserve(size);
+    const bytes = buf.buffer;
     // Make room for the length prefix by shifting the fork's data forward.
-    this.buffer.copyWithin(forkPos + size, forkPos, this.pos);
+    bytes.copyWithin(forkPos + size, forkPos, buf.length);
     // Write the unsigned varint length directly in place.
     let p = forkPos;
     let v = len;
     while (v > 0x7f) {
-      this.buffer[p++] = (v & 0x7f) | 0x80;
+      bytes[p++] = (v & 0x7f) | 0x80;
       v >>>= 7;
     }
-    this.buffer[p] = v;
-    this.pos += size;
+    bytes[p] = v;
+    buf.length += size;
     return this;
   }
 
@@ -191,9 +174,7 @@ export class BinaryWriter {
    * Write a chunk of raw bytes.
    */
   raw(chunk: Uint8Array): this {
-    this.ensureCapacity(chunk.length);
-    this.buffer.set(chunk, this.pos);
-    this.pos += chunk.length;
+    this.buf.append(chunk);
     return this;
   }
 
@@ -204,16 +185,21 @@ export class BinaryWriter {
     assertUInt32(value);
     // uint32 varints are at most 5 bytes; reserve once and avoid per-byte
     // capacity checks.
-    this.ensureCapacity(5);
+    const buf = this.buf;
+    buf.reserve(5);
+    const bytes = buf.buffer;
+    let pos = buf.length;
     if (value < 0x80) {
-      this.buffer[this.pos++] = value;
+      bytes[pos] = value;
+      buf.length = pos + 1;
       return this;
     }
     while (value > 0x7f) {
-      this.buffer[this.pos++] = (value & 0x7f) | 0x80;
+      bytes[pos++] = (value & 0x7f) | 0x80;
       value >>>= 7;
     }
-    this.buffer[this.pos++] = value;
+    bytes[pos++] = value;
+    buf.length = pos;
     return this;
   }
 
@@ -226,12 +212,16 @@ export class BinaryWriter {
       return this.uint32(value);
     }
     // Negative: sign-extend to 64 bits, encodes to 10 bytes.
-    this.ensureCapacity(10);
+    const buf = this.buf;
+    buf.reserve(10);
+    const bytes = buf.buffer;
+    let pos = buf.length;
     for (let i = 0; i < 9; i++) {
-      this.buffer[this.pos++] = (value & 0x7f) | 0x80;
+      bytes[pos++] = (value & 0x7f) | 0x80;
       value >>= 7;
     }
-    this.buffer[this.pos++] = 1;
+    bytes[pos] = 1;
+    buf.length = pos + 1;
     return this;
   }
 
@@ -239,8 +229,10 @@ export class BinaryWriter {
    * Write a `bool` value, a varint.
    */
   bool(value: boolean): this {
-    this.ensureCapacity(1);
-    this.buffer[this.pos++] = value ? 1 : 0;
+    const buf = this.buf;
+    buf.reserve(1);
+    buf.buffer[buf.length] = value ? 1 : 0;
+    buf.length += 1;
     return this;
   }
 
@@ -266,13 +258,15 @@ export class BinaryWriter {
    */
   float(value: number): this {
     assertFloat32(value);
-    this.ensureCapacity(4);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setFloat32(this.pos, value, true);
-    this.pos += 4;
+    const buf = this.buf;
+    buf.reserve(4);
+    const bytes = buf.buffer;
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setFloat32(
+      buf.length,
+      value,
+      true,
+    );
+    buf.length += 4;
     return this;
   }
 
@@ -280,13 +274,15 @@ export class BinaryWriter {
    * Write a `double` value, a 64-bit floating point number.
    */
   double(value: number): this {
-    this.ensureCapacity(8);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setFloat64(this.pos, value, true);
-    this.pos += 8;
+    const buf = this.buf;
+    buf.reserve(8);
+    const bytes = buf.buffer;
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setFloat64(
+      buf.length,
+      value,
+      true,
+    );
+    buf.length += 8;
     return this;
   }
 
@@ -295,13 +291,15 @@ export class BinaryWriter {
    */
   fixed32(value: number): this {
     assertUInt32(value);
-    this.ensureCapacity(4);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setUint32(this.pos, value, true);
-    this.pos += 4;
+    const buf = this.buf;
+    buf.reserve(4);
+    const bytes = buf.buffer;
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(
+      buf.length,
+      value,
+      true,
+    );
+    buf.length += 4;
     return this;
   }
 
@@ -310,13 +308,15 @@ export class BinaryWriter {
    */
   sfixed32(value: number): this {
     assertInt32(value);
-    this.ensureCapacity(4);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setInt32(this.pos, value, true);
-    this.pos += 4;
+    const buf = this.buf;
+    buf.reserve(4);
+    const bytes = buf.buffer;
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setInt32(
+      buf.length,
+      value,
+      true,
+    );
+    buf.length += 4;
     return this;
   }
 
@@ -334,15 +334,13 @@ export class BinaryWriter {
    */
   sfixed64(value: string | number | bigint): this {
     const tc = protoInt64.enc(value);
-    this.ensureCapacity(8);
-    const view = new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    );
-    view.setInt32(this.pos, tc.lo, true);
-    view.setInt32(this.pos + 4, tc.hi, true);
-    this.pos += 8;
+    const buf = this.buf;
+    buf.reserve(8);
+    const bytes = buf.buffer;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    view.setInt32(buf.length, tc.lo, true);
+    view.setInt32(buf.length + 4, tc.hi, true);
+    buf.length += 8;
     return this;
   }
 
@@ -351,15 +349,13 @@ export class BinaryWriter {
    */
   fixed64(value: string | number | bigint): this {
     const tc = protoInt64.uEnc(value);
-    this.ensureCapacity(8);
-    const view = new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    );
-    view.setInt32(this.pos, tc.lo, true);
-    view.setInt32(this.pos + 4, tc.hi, true);
-    this.pos += 8;
+    const buf = this.buf;
+    buf.reserve(8);
+    const bytes = buf.buffer;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    view.setUint32(buf.length, tc.lo, true);
+    view.setUint32(buf.length + 4, tc.hi, true);
+    buf.length += 8;
     return this;
   }
 
@@ -400,51 +396,45 @@ export class BinaryWriter {
    */
   private writeVarint64(lo: number, hi: number): this {
     // Worst case: 10 bytes.
-    this.ensureCapacity(10);
-    const buf = this.buffer;
-    let pos = this.pos;
+    const buf = this.buf;
+    buf.reserve(10);
+    const bytes = buf.buffer;
+    let pos = buf.length;
 
     for (let i = 0; i < 28; i = i + 7) {
       const shift = lo >>> i;
       const hasNext = !(shift >>> 7 == 0 && hi == 0);
-      buf[pos++] = (hasNext ? shift | 0x80 : shift) & 0xff;
+      bytes[pos++] = (hasNext ? shift | 0x80 : shift) & 0xff;
       if (!hasNext) {
-        this.pos = pos;
+        buf.length = pos;
         return this;
       }
     }
 
     const splitBits = ((lo >>> 28) & 0x0f) | ((hi & 0x07) << 4);
     const hasMoreBits = !(hi >> 3 == 0);
-    buf[pos++] = (hasMoreBits ? splitBits | 0x80 : splitBits) & 0xff;
+    bytes[pos++] = (hasMoreBits ? splitBits | 0x80 : splitBits) & 0xff;
 
     if (!hasMoreBits) {
-      this.pos = pos;
+      buf.length = pos;
       return this;
     }
 
     for (let i = 3; i < 31; i = i + 7) {
       const shift = hi >>> i;
       const hasNext = !(shift >>> 7 == 0);
-      buf[pos++] = (hasNext ? shift | 0x80 : shift) & 0xff;
+      bytes[pos++] = (hasNext ? shift | 0x80 : shift) & 0xff;
       if (!hasNext) {
-        this.pos = pos;
+        buf.length = pos;
         return this;
       }
     }
 
-    buf[pos++] = (hi >>> 31) & 0x01;
-    this.pos = pos;
+    bytes[pos++] = (hi >>> 31) & 0x01;
+    buf.length = pos;
     return this;
   }
 }
-
-/**
- * Shared empty buffer used as the initial value before the first write.
- * Avoids allocating and zeroing `initialSize` bytes per BinaryWriter when a
- * writer is only used for a tiny message (or not used at all).
- */
-const EMPTY_BUFFER = new Uint8Array(0) as Uint8Array<ArrayBuffer>;
 
 /**
  * Number of bytes needed to encode `value` as an unsigned 32-bit varint.

--- a/packages/protobuf/src/wire/byte-buffer.ts
+++ b/packages/protobuf/src/wire/byte-buffer.ts
@@ -1,0 +1,69 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Capacity allocated by the first reserve() that needs to grow.
+const initialCapacity = 128;
+
+// Shared empty buffer, so that creating a ByteBuffer does not allocate. Small
+// messages (e.g. a bool-only request) would otherwise pay for a zeroed buffer
+// of initialCapacity bytes.
+const emptyBytes = new Uint8Array(0);
+
+/**
+ * A growable byte buffer. Used in place of a resizable ArrayBuffer, which is
+ * not widely available.
+ */
+export class ByteBuffer {
+  /**
+   * The backing buffer, valid up to the reserved capacity. Re-read it after
+   * reserve() or append(), which may have replaced it.
+   */
+  buffer: Uint8Array<ArrayBuffer> = emptyBytes;
+
+  /**
+   * Number of bytes written. Advance it after writing directly into buffer.
+   */
+  length = 0;
+
+  /**
+   * Return the bytes written so far, as a view into the backing buffer.
+   */
+  bytes(): Uint8Array<ArrayBuffer> {
+    return this.buffer.subarray(0, this.length);
+  }
+
+  /**
+   * Ensure there is capacity for at least additionalBytes beyond length.
+   * Starts at initialCapacity and doubles until the required size fits.
+   */
+  reserve(additionalBytes: number): void {
+    const required = this.length + additionalBytes;
+    if (required > this.buffer.byteLength) {
+      let capacity = this.buffer.byteLength || initialCapacity;
+      while (capacity < required) capacity *= 2;
+      const grown = new Uint8Array(capacity);
+      if (this.length > 0) grown.set(this.bytes());
+      this.buffer = grown;
+    }
+  }
+
+  /**
+   * Append a chunk of bytes, growing the backing buffer if necessary.
+   */
+  append(chunk: Uint8Array): void {
+    this.reserve(chunk.byteLength);
+    this.buffer.set(chunk, this.length);
+    this.length += chunk.byteLength;
+  }
+}

--- a/packages/protobuf/src/wire/size-delimited.ts
+++ b/packages/protobuf/src/wire/size-delimited.ts
@@ -19,6 +19,7 @@ import type { MessageShape } from "../types.js";
 import { BinaryReader, BinaryWriter } from "./binary-encoding.js";
 import type { BinaryReadOptions } from "../from-binary.js";
 import { fromBinary } from "../from-binary.js";
+import { ByteBuffer } from "./byte-buffer.js";
 
 /**
  * Serialize a message, prefixing it with its size.
@@ -56,36 +57,6 @@ export interface SizeDelimitedDecodeOptions extends BinaryReadOptions {
 
 // Default for SizeDelimitedDecodeOptions.readMaxBytes.
 const defaultReadMaxBytes = 64 * 1024 * 1024; // 64 MiB
-
-/**
- * A growable byte buffer. Used in place of a resizable ArrayBuffer, which is
- * not widely available.
- */
-class ByteBuffer {
-  private buffer = new Uint8Array(0);
-  private length = 0;
-
-  get byteLength(): number {
-    return this.length;
-  }
-
-  bytes(): Uint8Array {
-    return this.buffer.subarray(0, this.length);
-  }
-
-  append(chunk: Uint8Array): void {
-    const newByteLength = this.length + chunk.byteLength;
-    if (newByteLength > this.buffer.byteLength) {
-      const grown = new Uint8Array(
-        Math.max(this.buffer.byteLength * 2, newByteLength),
-      );
-      grown.set(this.buffer.subarray(0, this.length));
-      this.buffer = grown;
-    }
-    this.buffer.set(chunk, this.length);
-    this.length += chunk.byteLength;
-  }
-}
 
 /**
  * Parse a stream of size-delimited messages.
@@ -142,7 +113,7 @@ export async function* sizeDelimitedDecodeStream<Desc extends DescMessage>(
       buffer.append(bytes.subarray(offset));
     }
   }
-  if (buffer.byteLength > 0) {
+  if (buffer.length > 0) {
     throw new Error("incomplete data");
   }
 }


### PR DESCRIPTION
The growable buffer that BinaryWriter kept inline (buffer, pos,
ensureCapacity) is the same thing sizeDelimitedDecodeStream already had
as a private ByteBuffer class. Move that class into its own module, give
it a reserve() so callers can write directly into the backing buffer,
and have BinaryWriter hold one.

This is a refactor. Encoded output is unchanged, verified byte-identical
over 174 writer cases covering every scalar writer, payloads straddling
the capacity and varint-length boundaries, nested forks, and writer
reuse. finish() still returns a copy, and reserve() keeps the writer's
existing growth policy: start at 128 bytes, double until the required
size fits.

One incidental change worth noting: fixed64() now uses setUint32 rather
than setInt32 for its two halves. Both write identical bytes; setUint32
just matches the field type.
