### PR TITLE
Cache DataView in BinaryWriter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2532,7 +2532,7 @@
         "tinybench": "^3.1.1"
       },
       "devDependencies": {
-        "@bufbuild/buf": "^1.66.1",
+        "@bufbuild/buf": "^1.72.0",
         "@bufbuild/protoc-gen-es": "2.13.0",
         "@types/node": "^26.0.0",
         "tsx": "^4.22.4"

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,25 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-<<<<<<< HEAD
-| Protobuf-ES         |     1 |   136,538 b |  70,319 b |   16,283 b |
-| Protobuf-ES         |     4 |   138,727 b |  71,827 b |   16,971 b |
-| Protobuf-ES         |     8 |   141,489 b |  73,598 b |   17,465 b |
-| Protobuf-ES         |    16 |   151,939 b |  81,579 b |   19,831 b |
-| Protobuf-ES         |    32 |   179,730 b | 103,597 b |   25,303 b |
-||||||| 43676bc8
-| Protobuf-ES         |     1 |   136,544 b |  70,588 b |   16,261 b |
-| Protobuf-ES         |     4 |   138,733 b |  72,096 b |   16,911 b |
-| Protobuf-ES         |     8 |   141,495 b |  73,867 b |   17,457 b |
-| Protobuf-ES         |    16 |   151,945 b |  81,848 b |   19,794 b |
-| Protobuf-ES         |    32 |   179,736 b | 103,866 b |   25,299 b |
-=======
-| Protobuf-ES         |     1 |   136,676 b |  70,698 b |   16,233 b |
-| Protobuf-ES         |     4 |   138,865 b |  72,206 b |   16,952 b |
-| Protobuf-ES         |     8 |   141,627 b |  73,977 b |   17,427 b |
-| Protobuf-ES         |    16 |   152,077 b |  81,958 b |   19,813 b |
-| Protobuf-ES         |    32 |   179,868 b | 103,976 b |   25,221 b |
->>>>>>> main
+| Protobuf-ES         |     1 |   136,670 b |  70,429 b |   16,303 b |
+| Protobuf-ES         |     4 |   138,859 b |  71,937 b |   16,956 b |
+| Protobuf-ES         |     8 |   141,621 b |  73,708 b |   17,447 b |
+| Protobuf-ES         |    16 |   152,071 b |  81,689 b |   19,799 b |
+| Protobuf-ES         |    32 |   179,862 b | 103,707 b |   25,312 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   136,544 b |  70,588 b |   16,261 b |
-| Protobuf-ES         |     4 |   138,733 b |  72,096 b |   16,911 b |
-| Protobuf-ES         |     8 |   141,495 b |  73,867 b |   17,457 b |
-| Protobuf-ES         |    16 |   151,945 b |  81,848 b |   19,794 b |
-| Protobuf-ES         |    32 |   179,736 b | 103,866 b |   25,299 b |
+| Protobuf-ES         |     1 |   136,538 b |  70,319 b |   16,283 b |
+| Protobuf-ES         |     4 |   138,727 b |  71,827 b |   16,971 b |
+| Protobuf-ES         |     8 |   141,489 b |  73,598 b |   17,465 b |
+| Protobuf-ES         |    16 |   151,939 b |  81,579 b |   19,831 b |
+| Protobuf-ES         |    32 |   179,730 b | 103,597 b |   25,303 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,34 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-<<<<<<< HEAD
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.88603515625 140,241.93759765625 280,240.53857421875 420,233.83798828125 560,218.34111328125">
-||||||| 43676bc8
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.94833984375 140,242.10751953125 280,240.56123046875 420,233.9427734375 560,218.35244140625">
-=======
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.02763671875 140,241.99140625 280,240.64619140625 420,233.88896484375 560,218.57333984374998">
->>>>>>> main
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.82939453125 140,241.980078125 280,240.58955078125 420,233.92861328125 560,218.315625">
     <title>Protobuf-ES</title>
   </polyline>
-<<<<<<< HEAD
-<circle cx="0" cy="243.88603515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.9 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.93759765625" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.53857421875" r="4" fill="#ffa600"><title>Protobuf-ES 17.06 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.83798828125" r="4" fill="#ffa600"><title>Protobuf-ES 19.37 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.34111328125" r="4" fill="#ffa600"><title>Protobuf-ES 24.71 KiB for 32 files</title></circle>
-||||||| 43676bc8
-<circle cx="0" cy="243.94833984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.88 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.10751953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.51 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.56123046875" r="4" fill="#ffa600"><title>Protobuf-ES 17.05 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.9427734375" r="4" fill="#ffa600"><title>Protobuf-ES 19.33 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.35244140625" r="4" fill="#ffa600"><title>Protobuf-ES 24.71 KiB for 32 files</title></circle>
-=======
-<circle cx="0" cy="244.02763671875" r="4" fill="#ffa600"><title>Protobuf-ES 15.85 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.99140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.55 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.64619140625" r="4" fill="#ffa600"><title>Protobuf-ES 17.02 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.88896484375" r="4" fill="#ffa600"><title>Protobuf-ES 19.35 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.57333984374998" r="4" fill="#ffa600"><title>Protobuf-ES 24.63 KiB for 32 files</title></circle>
->>>>>>> main
+<circle cx="0" cy="243.82939453125" r="4" fill="#ffa600"><title>Protobuf-ES 15.92 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.980078125" r="4" fill="#ffa600"><title>Protobuf-ES 16.56 KiB for 4 files</title></circle>
+<circle cx="280" cy="240.58955078125" r="4" fill="#ffa600"><title>Protobuf-ES 17.04 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.92861328125" r="4" fill="#ffa600"><title>Protobuf-ES 19.33 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.315625" r="4" fill="#ffa600"><title>Protobuf-ES 24.72 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.94833984375 140,242.10751953125 280,240.56123046875 420,233.9427734375 560,218.35244140625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.88603515625 140,241.93759765625 280,240.53857421875 420,233.83798828125 560,218.34111328125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.94833984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.88 KiB for 1 files</title></circle>
-<circle cx="140" cy="242.10751953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.51 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.56123046875" r="4" fill="#ffa600"><title>Protobuf-ES 17.05 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.9427734375" r="4" fill="#ffa600"><title>Protobuf-ES 19.33 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.35244140625" r="4" fill="#ffa600"><title>Protobuf-ES 24.71 KiB for 32 files</title></circle>
+<circle cx="0" cy="243.88603515625" r="4" fill="#ffa600"><title>Protobuf-ES 15.9 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.93759765625" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 4 files</title></circle>
+<circle cx="280" cy="240.53857421875" r="4" fill="#ffa600"><title>Protobuf-ES 17.06 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.83798828125" r="4" fill="#ffa600"><title>Protobuf-ES 19.37 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.34111328125" r="4" fill="#ffa600"><title>Protobuf-ES 24.71 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -96,6 +96,12 @@ export class BinaryWriter {
   private buffer: Uint8Array<ArrayBuffer>;
 
   /**
+   * Cached DataView for fixed-width writes. Read it via `view()`, which
+   * rebuilds it if `buffer` has since grown.
+   */
+  private viewCache: DataView;
+
+  /**
    * Current write position in the buffer.
    */
   private pos: number;
@@ -106,28 +112,44 @@ export class BinaryWriter {
    */
   private stackPos: number[] = [];
 
-  private readonly initialSize = 128;
-
   constructor(
     private readonly encodeUtf8: (
       text: string,
     ) => Uint8Array = getTextEncoding().encodeUtf8,
   ) {
     // Defer the first Uint8Array allocation: small messages (e.g. a bool-only
-    // request) would otherwise pay for a full initialSize zeroed buffer.
+    // request) would otherwise pay for a full INITIAL_SIZE zeroed buffer.
     this.buffer = EMPTY_BUFFER;
+    this.viewCache = EMPTY_VIEW;
     this.pos = 0;
   }
 
   private ensureCapacity(size: number) {
     const required = this.pos + size;
     if (required > this.buffer.length) {
-      let newLen = this.buffer.length || this.initialSize;
+      let newLen = this.buffer.length || INITIAL_SIZE;
       while (newLen < required) newLen *= 2;
       const newBuf = new Uint8Array(newLen);
-      if (this.pos > 0) newBuf.set(this.buffer.subarray(0, this.pos));
+      if (this.pos > 0) newBuf.set(this.buffer);
       this.buffer = newBuf;
     }
+  }
+
+  /**
+   * The DataView over `buffer`, rebuilt only if the buffer has grown since it
+   * was last used.
+   */
+  private view(): DataView {
+    const bytes = this.buffer;
+    const view = this.viewCache;
+    // Since ensureCapacity() only ever replaces the buffer with a strictly larger one,
+    // equal lengths mean the view is still current. This is faster than comparing
+    // buffers directly.
+    if (view.byteLength === bytes.byteLength) return view;
+
+    const newView = new DataView(bytes.buffer);
+    this.viewCache = newView;
+    return newView;
   }
 
   /**
@@ -267,11 +289,7 @@ export class BinaryWriter {
   float(value: number): this {
     assertFloat32(value);
     this.ensureCapacity(4);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setFloat32(this.pos, value, true);
+    this.view().setFloat32(this.pos, value, true);
     this.pos += 4;
     return this;
   }
@@ -281,11 +299,7 @@ export class BinaryWriter {
    */
   double(value: number): this {
     this.ensureCapacity(8);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setFloat64(this.pos, value, true);
+    this.view().setFloat64(this.pos, value, true);
     this.pos += 8;
     return this;
   }
@@ -296,11 +310,7 @@ export class BinaryWriter {
   fixed32(value: number): this {
     assertUInt32(value);
     this.ensureCapacity(4);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setUint32(this.pos, value, true);
+    this.view().setUint32(this.pos, value, true);
     this.pos += 4;
     return this;
   }
@@ -311,11 +321,7 @@ export class BinaryWriter {
   sfixed32(value: number): this {
     assertInt32(value);
     this.ensureCapacity(4);
-    new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    ).setInt32(this.pos, value, true);
+    this.view().setInt32(this.pos, value, true);
     this.pos += 4;
     return this;
   }
@@ -335,11 +341,7 @@ export class BinaryWriter {
   sfixed64(value: string | number | bigint): this {
     const tc = protoInt64.enc(value);
     this.ensureCapacity(8);
-    const view = new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    );
+    const view = this.view();
     view.setInt32(this.pos, tc.lo, true);
     view.setInt32(this.pos + 4, tc.hi, true);
     this.pos += 8;
@@ -352,11 +354,7 @@ export class BinaryWriter {
   fixed64(value: string | number | bigint): this {
     const tc = protoInt64.uEnc(value);
     this.ensureCapacity(8);
-    const view = new DataView(
-      this.buffer.buffer,
-      this.buffer.byteOffset,
-      this.buffer.byteLength,
-    );
+    const view = this.view();
     view.setInt32(this.pos, tc.lo, true);
     view.setInt32(this.pos + 4, tc.hi, true);
     this.pos += 8;
@@ -440,11 +438,22 @@ export class BinaryWriter {
 }
 
 /**
+ * Capacity of the buffer allocated by the first write..
+ */
+const INITIAL_SIZE = 128;
+
+/**
  * Shared empty buffer used as the initial value before the first write.
- * Avoids allocating and zeroing `initialSize` bytes per BinaryWriter when a
+ * Avoids allocating and zeroing `INITIAL_SIZE` bytes per BinaryWriter when a
  * writer is only used for a tiny message (or not used at all).
  */
 const EMPTY_BUFFER = new Uint8Array(0) as Uint8Array<ArrayBuffer>;
+
+/**
+ * Shared empty view, paired with `EMPTY_BUFFER`. Never written to: any
+ * fixed-width write first grows the buffer, which replaces this view.
+ */
+const EMPTY_VIEW = new DataView(EMPTY_BUFFER.buffer);
 
 /**
  * Number of bytes needed to encode `value` as an unsigned 32-bit varint.


### PR DESCRIPTION
Avoids an allocation when writing scalars.

| case                        |     before (ns/op) |      after (ns/op) | delta |
| --------------------------- | ---------: | ---------: | ----: |
| `BinaryWriter/fixed32`      |      36.58 |       3.00 |  -92% |
| `BinaryWriter/float`        |      37.15 |       3.09 |  -92% |
| `BinaryWriter/double`       |      36.40 |       4.96 |  -86% |
| `BinaryWriter/fixed64`      |      39.20 |       5.46 |  -86% |
| `toBinary/repeated-message` |  1,217,692 |    971,780 |  -20% |
| `toBinary/map-message`      |  1,526,201 |  1,282,202 |  -16% |
| `toBinary/scalar`           |      1,533 |      1,349 |  -12% |
| `toBinary/repeated-scalar`  |      6,842 |      6,325 |   -8% |
| `toBinary/general`          |    191,374 |    184,646 |   -3% |