### PR TITLE
Add root configurations to turbo's global dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.base.json", "biome.base.json"],
   "globalEnv": ["BUF_BIGINT_DISABLE"],
   "tasks": {
     "build": {


### PR DESCRIPTION
Adds `tsconfig.base.json` and `biome.base.json` to turbo's [globalDependencies](https://turborepo.dev/docs/reference/configuration#globaldependencies) list, so that the turbo cache for packages invalidates when they change.