### PR TITLE
Reserve a byte for length-prefix in BinaryWriter

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   136,836 b |  70,486 b |   16,312 b |
-| Protobuf-ES         |     4 |   139,025 b |  71,994 b |   16,965 b |
-| Protobuf-ES         |     8 |   141,787 b |  73,765 b |   17,482 b |
-| Protobuf-ES         |    16 |   152,237 b |  81,746 b |   19,858 b |
-| Protobuf-ES         |    32 |   180,028 b | 103,764 b |   25,331 b |
+| Protobuf-ES         |     1 |   136,993 b |  70,585 b |   16,336 b |
+| Protobuf-ES         |     4 |   139,182 b |  72,093 b |   16,973 b |
+| Protobuf-ES         |     8 |   141,944 b |  73,864 b |   17,506 b |
+| Protobuf-ES         |    16 |   152,394 b |  81,845 b |   19,878 b |
+| Protobuf-ES         |    32 |   180,185 b | 103,863 b |   25,299 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.80390625 140,241.95458984375 280,240.4904296875 420,233.7615234375 560,218.26181640625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.7359375 140,241.93193359375 280,240.4224609375 420,233.7048828125 560,218.35244140625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.80390625" r="4" fill="#ffa600"><title>Protobuf-ES 15.93 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.95458984375" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.4904296875" r="4" fill="#ffa600"><title>Protobuf-ES 17.07 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.7615234375" r="4" fill="#ffa600"><title>Protobuf-ES 19.39 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.26181640625" r="4" fill="#ffa600"><title>Protobuf-ES 24.74 KiB for 32 files</title></circle>
+<circle cx="0" cy="243.7359375" r="4" fill="#ffa600"><title>Protobuf-ES 15.95 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.93193359375" r="4" fill="#ffa600"><title>Protobuf-ES 16.58 KiB for 4 files</title></circle>
+<circle cx="280" cy="240.4224609375" r="4" fill="#ffa600"><title>Protobuf-ES 17.1 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.7048828125" r="4" fill="#ffa600"><title>Protobuf-ES 19.41 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.35244140625" r="4" fill="#ffa600"><title>Protobuf-ES 24.71 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -170,6 +170,10 @@ export class BinaryWriter {
    */
   fork(): this {
     this.stackPos.push(this.pos);
+    // Reserve one byte for the length prefix. Payloads under 128 bytes, fairly
+    // common, will need no copy in join().
+    this.ensureCapacity(1);
+    this.buffer[this.pos++] = 0;
     return this;
   }
 
@@ -181,12 +185,17 @@ export class BinaryWriter {
     const forkPos = this.stackPos.pop();
     if (forkPos === undefined)
       throw new Error("invalid state, fork stack empty");
-    const len = this.pos - forkPos;
+    const len = this.pos - forkPos - 1;
+    if (len < 0x80) {
+      this.buffer[forkPos] = len;
+      return this;
+    }
+    // Widen the single byte we reserved for the length in fork by
+    // shifting the payload forward by the prefix's additional bytes,
+    // then write the length varint in place.
     const size = varint32Size(len);
-    this.ensureCapacity(size);
-    // Make room for the length prefix by shifting the fork's data forward.
-    this.buffer.copyWithin(forkPos + size, forkPos, this.pos);
-    // Write the unsigned varint length directly in place.
+    this.ensureCapacity(size - 1);
+    this.buffer.copyWithin(forkPos + size, forkPos + 1, this.pos);
     let p = forkPos;
     let v = len;
     while (v > 0x7f) {
@@ -194,7 +203,7 @@ export class BinaryWriter {
       v >>>= 7;
     }
     this.buffer[p] = v;
-    this.pos += size;
+    this.pos += size - 1;
     return this;
   }
 


### PR DESCRIPTION
I just happened to be looking through this implementation, and noticed it feels "sort of obvious" to go ahead and reserve a byte for a length prefix, many submessages are small, and the theoeritical extra work from the byte reservation is mostly none while getting to completely avoid a memmove. I see about 5% improvement in a couple of cases and no change otherwise, not big but feels worth it. I went with it in Python where I saw a similar 5% improvement without regressions - https://github.com/bufbuild/protobuf-py/pull/42


fixture | main (median) | reserved byte | delta
-- | -- | -- | --
user-normal | 3139ns | 2899ns | ~7% faster (every reserve round beat the main median)
repeated-message | 1037µs | 1006µs | ~3% faster
others (earlier table) | — | — | within noise

