### PR TITLE
Drop support for Node.js 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, v24.x]
+        node-version: [22.x, 24.x, 26.x]
         bigint-disable: [0, 1]
     name: test ${{ matrix.node-version }} (${{ matrix.bigint-disable && 'fallback' || 'bigint' }})
     steps:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, v24.x]
+        node-version: [22.x, 24.x, 26.x]
         bigint-disable: [0, 1]
     name: conformance ${{ matrix.node-version }} (${{ matrix.bigint-disable && 'fallback' || 'bigint' }})
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=20",
+        "node": ">=22",
         "npm": ">=10"
       }
     },
@@ -2599,7 +2599,7 @@
         "upstream-protobuf": "*"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "2.13.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "type": "module",
   "engineStrict": true,
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "npm": ">=10"
   },
   "packageManager": "npm@10.9.0",

--- a/packages/protoc-gen-es/package.json
+++ b/packages/protoc-gen-es/package.json
@@ -20,7 +20,7 @@
     "protoc-gen-es": "bin/protoc-gen-es"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "prebuild": "rm -rf ./dist/cjs/*",


### PR DESCRIPTION
This PR removes Node.js 20 from CI, and adds Node.js 26.

Node.js 20 reached its end of life earlier this year, on April 30, and does not receive security updates anymore (see the [release schedule](https://nodejs.org/en/about/previous-releases)).

If you are running Protobuf-ES on Node.js 20, this doesn't mean that it will stop working right away, but we stop testing on this version of Node.js, and will no longer consider failures a bug. 