### PR TITLE
Reserve bytes for lenPrefix in strings / fork-join

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   130,738 b |  65,454 b |   15,443 b |
-| Protobuf-ES         |     4 |   132,927 b |  66,960 b |   16,047 b |
-| Protobuf-ES         |     8 |   135,689 b |  68,731 b |   16,623 b |
-| Protobuf-ES         |    16 |   146,139 b |  76,713 b |   18,887 b |
-| Protobuf-ES         |    32 |   173,930 b |  98,735 b |   24,470 b |
+| Protobuf-ES         |     1 |   130,679 b |  65,323 b |   15,393 b |
+| Protobuf-ES         |     4 |   132,868 b |  66,829 b |   16,050 b |
+| Protobuf-ES         |     8 |   135,630 b |  68,600 b |   16,608 b |
+| Protobuf-ES         |    16 |   146,080 b |  76,582 b |   18,881 b |
+| Protobuf-ES         |    32 |   173,871 b |  98,604 b |   24,416 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   136,836 b |  70,486 b |   16,312 b |
-| Protobuf-ES         |     4 |   139,025 b |  71,994 b |   16,965 b |
-| Protobuf-ES         |     8 |   141,787 b |  73,765 b |   17,482 b |
-| Protobuf-ES         |    16 |   152,237 b |  81,746 b |   19,858 b |
-| Protobuf-ES         |    32 |   180,028 b | 103,764 b |   25,331 b |
+| Protobuf-ES         |     1 |   138,198 b |  70,938 b |   16,456 b |
+| Protobuf-ES         |     4 |   140,387 b |  72,448 b |   17,091 b |
+| Protobuf-ES         |     8 |   143,149 b |  74,219 b |   17,672 b |
+| Protobuf-ES         |    16 |   153,599 b |  82,200 b |   19,946 b |
+| Protobuf-ES         |    32 |   181,390 b | 104,216 b |   25,499 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   138,972 b |  71,441 b |   16,573 b |
-| Protobuf-ES         |     4 |   141,161 b |  72,951 b |   17,216 b |
-| Protobuf-ES         |     8 |   143,923 b |  74,722 b |   17,772 b |
-| Protobuf-ES         |    16 |   154,373 b |  82,703 b |   20,098 b |
-| Protobuf-ES         |    32 |   182,164 b | 104,719 b |   25,532 b |
+| Protobuf-ES         |     1 |   139,044 b |  71,475 b |   16,554 b |
+| Protobuf-ES         |     4 |   141,233 b |  72,985 b |   17,263 b |
+| Protobuf-ES         |     8 |   143,995 b |  74,756 b |   17,720 b |
+| Protobuf-ES         |    16 |   154,445 b |  82,737 b |   20,055 b |
+| Protobuf-ES         |    32 |   182,236 b | 104,753 b |   25,595 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -17,10 +17,10 @@ usually do. We repeat this for an increasing number of files.
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
 | Protobuf-ES         |     1 |   138,198 b |  70,938 b |   16,456 b |
-| Protobuf-ES         |     4 |   140,387 b |  72,448 b |   17,091 b |
-| Protobuf-ES         |     8 |   143,149 b |  74,219 b |   17,672 b |
-| Protobuf-ES         |    16 |   153,599 b |  82,200 b |   19,946 b |
-| Protobuf-ES         |    32 |   181,390 b | 104,216 b |   25,499 b |
+| Protobuf-ES         |     4 |   140,387 b |  72,448 b |   17,141 b |
+| Protobuf-ES         |     8 |   143,149 b |  74,219 b |   17,657 b |
+| Protobuf-ES         |    16 |   153,599 b |  82,200 b |   20,017 b |
+| Protobuf-ES         |    32 |   181,390 b | 104,216 b |   25,460 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.39609375 140,241.59775390625 280,239.95234375 420,233.5123046875 560,217.78603515625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.39609375 140,241.45615234375 280,239.99482421875 420,233.31123046875 560,217.896484375">
     <title>Protobuf-ES</title>
   </polyline>
 <circle cx="0" cy="243.39609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.07 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.59775390625" r="4" fill="#ffa600"><title>Protobuf-ES 16.69 KiB for 4 files</title></circle>
-<circle cx="280" cy="239.95234375" r="4" fill="#ffa600"><title>Protobuf-ES 17.26 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.5123046875" r="4" fill="#ffa600"><title>Protobuf-ES 19.48 KiB for 16 files</title></circle>
-<circle cx="560" cy="217.78603515625" r="4" fill="#ffa600"><title>Protobuf-ES 24.9 KiB for 32 files</title></circle>
+<circle cx="140" cy="241.45615234375" r="4" fill="#ffa600"><title>Protobuf-ES 16.74 KiB for 4 files</title></circle>
+<circle cx="280" cy="239.99482421875" r="4" fill="#ffa600"><title>Protobuf-ES 17.24 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.31123046875" r="4" fill="#ffa600"><title>Protobuf-ES 19.55 KiB for 16 files</title></circle>
+<circle cx="560" cy="217.896484375" r="4" fill="#ffa600"><title>Protobuf-ES 24.86 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.06474609375 140,241.24375 280,239.669140625 420,233.0818359375 560,217.692578125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.1185546875 140,241.11064453125 280,239.81640625 420,233.20361328125 560,217.51416015625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.06474609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.18 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.24375" r="4" fill="#ffa600"><title>Protobuf-ES 16.81 KiB for 4 files</title></circle>
-<circle cx="280" cy="239.669140625" r="4" fill="#ffa600"><title>Protobuf-ES 17.36 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.0818359375" r="4" fill="#ffa600"><title>Protobuf-ES 19.63 KiB for 16 files</title></circle>
-<circle cx="560" cy="217.692578125" r="4" fill="#ffa600"><title>Protobuf-ES 24.93 KiB for 32 files</title></circle>
+<circle cx="0" cy="243.1185546875" r="4" fill="#ffa600"><title>Protobuf-ES 16.17 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.11064453125" r="4" fill="#ffa600"><title>Protobuf-ES 16.86 KiB for 4 files</title></circle>
+<circle cx="280" cy="239.81640625" r="4" fill="#ffa600"><title>Protobuf-ES 17.3 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.20361328125" r="4" fill="#ffa600"><title>Protobuf-ES 19.58 KiB for 16 files</title></circle>
+<circle cx="560" cy="217.51416015625" r="4" fill="#ffa600"><title>Protobuf-ES 25 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.80390625 140,241.95458984375 280,240.4904296875 420,233.7615234375 560,218.26181640625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.39609375 140,241.59775390625 280,239.95234375 420,233.5123046875 560,217.78603515625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.80390625" r="4" fill="#ffa600"><title>Protobuf-ES 15.93 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.95458984375" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.4904296875" r="4" fill="#ffa600"><title>Protobuf-ES 17.07 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.7615234375" r="4" fill="#ffa600"><title>Protobuf-ES 19.39 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.26181640625" r="4" fill="#ffa600"><title>Protobuf-ES 24.74 KiB for 32 files</title></circle>
+<circle cx="0" cy="243.39609375" r="4" fill="#ffa600"><title>Protobuf-ES 16.07 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.59775390625" r="4" fill="#ffa600"><title>Protobuf-ES 16.69 KiB for 4 files</title></circle>
+<circle cx="280" cy="239.95234375" r="4" fill="#ffa600"><title>Protobuf-ES 17.26 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.5123046875" r="4" fill="#ffa600"><title>Protobuf-ES 19.48 KiB for 16 files</title></circle>
+<circle cx="560" cy="217.78603515625" r="4" fill="#ffa600"><title>Protobuf-ES 24.9 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.26494140625 140,244.55439453125 280,242.92314453125 420,236.51142578125 560,220.7001953125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.40654296875 140,244.5458984375 280,242.965625 420,236.52841796875 560,220.853125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.26494140625" r="4" fill="#ffa600"><title>Protobuf-ES 15.08 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.55439453125" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.92314453125" r="4" fill="#ffa600"><title>Protobuf-ES 16.23 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.51142578125" r="4" fill="#ffa600"><title>Protobuf-ES 18.44 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.7001953125" r="4" fill="#ffa600"><title>Protobuf-ES 23.9 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.40654296875" r="4" fill="#ffa600"><title>Protobuf-ES 15.03 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.5458984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.965625" r="4" fill="#ffa600"><title>Protobuf-ES 16.22 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.52841796875" r="4" fill="#ffa600"><title>Protobuf-ES 18.44 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.853125" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf-test/src/wire/text-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/text-encoding.test.ts
@@ -38,6 +38,17 @@ void suite("getTextEncoding()", () => {
       );
     });
   });
+  void suite("encodeUtf8Into()", () => {
+    void test("encodes", () => {
+      const dest = new Uint8Array(10);
+      const { written } = getTextEncoding().encodeUtf8Into("hello 🌍", dest);
+      assert.strictEqual(written, 10);
+      assert.deepStrictEqual(
+        dest,
+        new Uint8Array([104, 101, 108, 108, 111, 32, 240, 159, 140, 141]),
+      );
+    });
+  });
   void suite("decodeUtf8()", () => {
     void test("decodes", () => {
       const text = getTextEncoding().decodeUtf8(
@@ -112,5 +123,43 @@ void suite("configureTextEncoding()", () => {
       new Uint8Array(10),
     );
     assert.strictEqual(arg, "test");
+  });
+  void test("configures encodeUtf8Into", () => {
+    configureTextEncoding({
+      checkUtf8: backup.checkUtf8,
+      decodeUtf8: backup.decodeUtf8,
+      encodeUtf8(): never {
+        throw new Error("must not be called when encodeUtf8Into is provided");
+      },
+      encodeUtf8Into(text: string, dest: Uint8Array) {
+        assert.strictEqual(text, "test");
+        dest.set([1, 2, 3]);
+        return { written: 3 };
+      },
+    });
+    const dest = new Uint8Array(10);
+    const result = getTextEncoding().encodeUtf8Into("test", dest);
+    assert.deepStrictEqual(result, { written: 3 });
+    assert.deepStrictEqual(
+      dest,
+      new Uint8Array([1, 2, 3, 0, 0, 0, 0, 0, 0, 0]),
+    );
+  });
+  void test("emulates encodeUtf8Into from encodeUtf8 when not provided", () => {
+    configureTextEncoding({
+      checkUtf8: backup.checkUtf8,
+      decodeUtf8: backup.decodeUtf8,
+      encodeUtf8(text: string) {
+        assert.strictEqual(text, "test");
+        return new Uint8Array([1, 2, 3]);
+      },
+    });
+    const dest = new Uint8Array(10);
+    const result = getTextEncoding().encodeUtf8Into("test", dest);
+    assert.deepStrictEqual(result, { written: 3 });
+    assert.deepStrictEqual(
+      dest,
+      new Uint8Array([1, 2, 3, 0, 0, 0, 0, 0, 0, 0]),
+    );
   });
 });

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -112,11 +112,28 @@ export class BinaryWriter {
    */
   private stackPos: number[] = [];
 
+  /**
+   * UTF-8 codec used by `string()`. Bundled into a single field (rather than
+   * one field per function) to keep the instance field count from growing.
+   */
+  private readonly encode: {
+    encodeUtf8: (text: string) => Uint8Array;
+    encodeUtf8Into?:
+      | ((text: string, dest: Uint8Array) => { read: number; written: number })
+      | undefined;
+  };
+
   constructor(
-    private readonly encodeUtf8: (
-      text: string,
-    ) => Uint8Array = getTextEncoding().encodeUtf8,
+    encodeUtf8: (text: string) => Uint8Array = getTextEncoding().encodeUtf8,
   ) {
+    const textEncoding = getTextEncoding();
+    this.encode = {
+      encodeUtf8,
+      encodeUtf8Into:
+        encodeUtf8 === textEncoding.encodeUtf8
+          ? textEncoding.encodeUtf8Into
+          : undefined,
+    };
     // Defer the first Uint8Array allocation: small messages (e.g. a bool-only
     // request) would otherwise pay for a full INITIAL_SIZE zeroed buffer.
     this.buffer = EMPTY_BUFFER;
@@ -170,6 +187,10 @@ export class BinaryWriter {
    */
   fork(): this {
     this.stackPos.push(this.pos);
+    // Reserve room for the length prefix. Payloads under 128 bytes, fairly
+    // common, will need no copy in join().
+    this.ensureCapacity(DEFAULT_LEN_PREFIX_SIZE);
+    this.buffer[this.pos++] = 0;
     return this;
   }
 
@@ -181,20 +202,26 @@ export class BinaryWriter {
     const forkPos = this.stackPos.pop();
     if (forkPos === undefined)
       throw new Error("invalid state, fork stack empty");
-    const len = this.pos - forkPos;
-    const size = varint32Size(len);
-    this.ensureCapacity(size);
-    // Make room for the length prefix by shifting the fork's data forward.
-    this.buffer.copyWithin(forkPos + size, forkPos, this.pos);
-    // Write the unsigned varint length directly in place.
-    let p = forkPos;
-    let v = len;
-    while (v > 0x7f) {
-      this.buffer[p++] = (v & 0x7f) | 0x80;
-      v >>>= 7;
+
+    // fork() presumed the payload would fit the prefix it reserved. If it
+    // doesn't, we need to shift the bytes we just wrote.
+    const len = this.pos - forkPos - DEFAULT_LEN_PREFIX_SIZE;
+    const lenPrefixSize = varint32Size(len);
+    if (lenPrefixSize > DEFAULT_LEN_PREFIX_SIZE) {
+      // Widening pushes the payload past the end of the buffer, so grow first:
+      // copyWithin clamps to the buffer instead of throwing, so a short buffer
+      // would silently drop the tail of the payload.
+      this.ensureCapacity(lenPrefixSize - DEFAULT_LEN_PREFIX_SIZE);
+      this.buffer.copyWithin(
+        forkPos + lenPrefixSize,
+        forkPos + DEFAULT_LEN_PREFIX_SIZE,
+        this.pos,
+      );
     }
-    this.buffer[p] = v;
-    this.pos += size;
+
+    this.pos = forkPos;
+    this.uint32(len);
+    this.pos += len;
     return this;
   }
 
@@ -278,7 +305,41 @@ export class BinaryWriter {
    * Write a `string` value, length-delimited data converted to UTF-8 text.
    */
   string(value: string): this {
-    let chunk = this.encodeUtf8(value);
+    const encodeUtf8Into = this.encode.encodeUtf8Into;
+    if (encodeUtf8Into && typeof value === "string") {
+      // encodeInto needs the full-length buffer upfront. The length prefix can
+      // be upto 5 bytes, and a UTF-16 code unit takes at most 3 UTF-8 bytes.
+      const len = value.length;
+      this.ensureCapacity(len * 3 + 5);
+
+      // The length prefix goes first, but the byte length is only known after
+      // encoding. We guess the final varint size here (assuming most text is
+      // ASCII) and then encode.
+      const lenPrefixSizeGuess = varint32Size(len);
+      const buf = this.buffer;
+      const start = this.pos;
+      const { written } = encodeUtf8Into(
+        value,
+        buf.subarray(start + lenPrefixSizeGuess),
+      );
+
+      // If our guess was incorrect, we need to shift the bytes we just wrote.
+      const lenPrefixSize = varint32Size(written);
+      if (lenPrefixSize != lenPrefixSizeGuess) {
+        buf.copyWithin(
+          start + lenPrefixSize,
+          start + lenPrefixSizeGuess,
+          start + lenPrefixSizeGuess + written,
+        );
+      }
+
+      // Write the lenPrefix and advance the pos.
+      this.uint32(written);
+      this.pos += written;
+      return this;
+    }
+
+    let chunk = this.encode.encodeUtf8(value);
     this.uint32(chunk.byteLength);
     return this.raw(chunk);
   }
@@ -441,6 +502,15 @@ export class BinaryWriter {
  * Capacity of the buffer allocated by the first write..
  */
 const INITIAL_SIZE = 128;
+
+/**
+ * Bytes `fork()` reserves for the length prefix, betting that the payload will
+ * be under 128 bytes. `join()` fills them in, and widens them if the bet was
+ * wrong. Documents the offset rather than parameterizing it: `fork()` writes
+ * exactly one byte, and reserving more would leave a gap for short payloads,
+ * since a length must be encoded in as few bytes as possible.
+ */
+const DEFAULT_LEN_PREFIX_SIZE = 1;
 
 /**
  * Shared empty buffer used as the initial value before the first write.

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -113,29 +113,23 @@ export class BinaryWriter {
   private stackPos: number[] = [];
 
   /**
-   * UTF-8 codec used by `string()`. Bundled into a single field (rather than
-   * one field per function) to keep the instance field count from growing.
+   * UTF-8 codec used by `string()`. Uses the text encoding's `encodeUtf8Into`,
+   * or emulates it if a custom `encodeUtf8` was passed to the constructor.
    */
-  private readonly encode: {
-    encodeUtf8: (text: string) => Uint8Array;
-    encodeUtf8Into?:
-      | ((text: string, dest: Uint8Array) => { read: number; written: number })
-      | undefined;
-  };
+  private readonly encodeUtf8Into: (
+    text: string,
+    dest: Uint8Array,
+  ) => { read: number; written: number };
 
-  constructor(
-    encodeUtf8: (text: string) => Uint8Array = getTextEncoding().encodeUtf8,
-  ) {
-    const textEncoding = getTextEncoding();
-    this.encode = {
-      encodeUtf8,
-      encodeUtf8Into:
-        encodeUtf8 === textEncoding.encodeUtf8
-          ? textEncoding.encodeUtf8Into
-          : undefined,
-    };
-    // Defer the first Uint8Array allocation: small messages (e.g. a bool-only
-    // request) would otherwise pay for a full INITIAL_SIZE zeroed buffer.
+  constructor(encodeUtf8?: (text: string) => Uint8Array) {
+    this.encodeUtf8Into =
+      encodeUtf8 === undefined
+        ? getTextEncoding().encodeUtf8Into
+        : (text, dest) => {
+            const bytes = encodeUtf8(text);
+            dest.set(bytes);
+            return { read: text.length, written: bytes.byteLength };
+          };
     this.buffer = EMPTY_BUFFER;
     this.viewCache = EMPTY_VIEW;
     this.pos = 0;
@@ -305,43 +299,36 @@ export class BinaryWriter {
    * Write a `string` value, length-delimited data converted to UTF-8 text.
    */
   string(value: string): this {
-    const encodeUtf8Into = this.encode.encodeUtf8Into;
-    if (encodeUtf8Into && typeof value === "string") {
-      // encodeInto needs the full-length buffer upfront. The length prefix can
-      // be upto 5 bytes, and a UTF-16 code unit takes at most 3 UTF-8 bytes.
-      const len = value.length;
-      this.ensureCapacity(len * 3 + 5);
+    // encodeUtf8Into needs the full-length buffer upfront. The length prefix
+    // can be upto 5 bytes, and a UTF-16 code unit takes at most 3 UTF-8 bytes.
+    const len = value.length;
+    this.ensureCapacity(len * 3 + 5);
 
-      // The length prefix goes first, but the byte length is only known after
-      // encoding. We guess the final varint size here (assuming most text is
-      // ASCII) and then encode.
-      const lenPrefixSizeGuess = varint32Size(len);
-      const buf = this.buffer;
-      const start = this.pos;
-      const { written } = encodeUtf8Into(
-        value,
-        buf.subarray(start + lenPrefixSizeGuess),
+    // The length prefix goes first, but the byte length is only known after
+    // encoding. We guess the final varint size here (assuming most text is
+    // ASCII) and then encode.
+    const lenPrefixSizeGuess = varint32Size(len);
+    const buf = this.buffer;
+    const start = this.pos;
+    const { written } = this.encodeUtf8Into(
+      value,
+      buf.subarray(start + lenPrefixSizeGuess),
+    );
+
+    // If our guess was incorrect, we need to shift the bytes we just wrote.
+    const lenPrefixSize = varint32Size(written);
+    if (lenPrefixSize != lenPrefixSizeGuess) {
+      buf.copyWithin(
+        start + lenPrefixSize,
+        start + lenPrefixSizeGuess,
+        start + lenPrefixSizeGuess + written,
       );
-
-      // If our guess was incorrect, we need to shift the bytes we just wrote.
-      const lenPrefixSize = varint32Size(written);
-      if (lenPrefixSize != lenPrefixSizeGuess) {
-        buf.copyWithin(
-          start + lenPrefixSize,
-          start + lenPrefixSizeGuess,
-          start + lenPrefixSizeGuess + written,
-        );
-      }
-
-      // Write the lenPrefix and advance the pos.
-      this.uint32(written);
-      this.pos += written;
-      return this;
     }
 
-    let chunk = this.encode.encodeUtf8(value);
-    this.uint32(chunk.byteLength);
-    return this.raw(chunk);
+    // Write the lenPrefix and advance the pos.
+    this.uint32(written);
+    this.pos += written;
+    return this;
   }
 
   /**

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -506,9 +506,7 @@ const INITIAL_SIZE = 128;
 /**
  * Bytes `fork()` reserves for the length prefix, betting that the payload will
  * be under 128 bytes. `join()` fills them in, and widens them if the bet was
- * wrong. Documents the offset rather than parameterizing it: `fork()` writes
- * exactly one byte, and reserving more would leave a gap for short payloads,
- * since a length must be encoded in as few bytes as possible.
+ * wrong.
  */
 const DEFAULT_LEN_PREFIX_SIZE = 1;
 

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -14,7 +14,7 @@
 
 import { varint32read, varint64read } from "./varint.js";
 import { protoInt64 } from "../proto-int64.js";
-import { getTextEncoding } from "./text-encoding.js";
+import { emulateEncodeInto, getTextEncoding } from "./text-encoding.js";
 
 /**
  * Protobuf binary format wire types.
@@ -119,17 +119,12 @@ export class BinaryWriter {
   private readonly encodeUtf8Into: (
     text: string,
     dest: Uint8Array,
-  ) => { read: number; written: number };
+  ) => { written: number };
 
   constructor(encodeUtf8?: (text: string) => Uint8Array) {
-    this.encodeUtf8Into =
-      encodeUtf8 === undefined
-        ? getTextEncoding().encodeUtf8Into
-        : (text, dest) => {
-            const bytes = encodeUtf8(text);
-            dest.set(bytes);
-            return { read: text.length, written: bytes.byteLength };
-          };
+    this.encodeUtf8Into = encodeUtf8
+      ? emulateEncodeInto(encodeUtf8)
+      : getTextEncoding().encodeUtf8Into;
     this.buffer = EMPTY_BUFFER;
     this.viewCache = EMPTY_VIEW;
     this.pos = 0;

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -299,6 +299,11 @@ export class BinaryWriter {
    * Write a `string` value, length-delimited data converted to UTF-8 text.
    */
   string(value: string): this {
+    // TextEncoder.encode() coerces its argument to string, but encodeInto()
+    // rejects non-strings.
+    if (typeof value !== "string") {
+      value = String(value);
+    }
     // encodeUtf8Into needs the full-length buffer upfront. The length prefix
     // can be upto 5 bytes, and a UTF-16 code unit takes at most 3 UTF-8 bytes.
     const len = value.length;

--- a/packages/protobuf/src/wire/index.ts
+++ b/packages/protobuf/src/wire/index.ts
@@ -14,6 +14,6 @@
 
 export * from "./binary-encoding.js";
 export * from "./base64-encoding.js";
-export * from "./text-encoding.js";
+export { getTextEncoding, configureTextEncoding } from "./text-encoding.js";
 export * from "./text-format.js";
 export * from "./size-delimited.js";

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -52,8 +52,24 @@ interface TextEncoding {
  * Note that the Text Encoding API does not provide a way to validate UTF-8.
  * Our implementation falls back to use encodeURIComponent().
  */
-export function configureTextEncoding(textEncoding: TextEncoding): void {
-  (globalThis as GlobalWithTextEncoding)[symbol] = textEncoding;
+export function configureTextEncoding(
+  textEncoding: Partial<TextEncoding>,
+): void {
+  const current = getTextEncoding();
+  const merged: TextEncoding = {
+    checkUtf8: textEncoding.checkUtf8 ?? current.checkUtf8,
+    decodeUtf8: textEncoding.decodeUtf8 ?? current.decodeUtf8,
+    encodeUtf8: textEncoding.encodeUtf8 ?? current.encodeUtf8,
+  };
+  // encodeUtf8Into must encode identically to encodeUtf8, so only carry over
+  // the previous encodeUtf8Into if encodeUtf8 wasn't also overridden.
+  const encodeUtf8Into = textEncoding.encodeUtf8
+    ? textEncoding.encodeUtf8Into
+    : (textEncoding.encodeUtf8Into ?? current.encodeUtf8Into);
+  if (encodeUtf8Into) {
+    merged.encodeUtf8Into = encodeUtf8Into;
+  }
+  (globalThis as GlobalWithTextEncoding)[symbol] = merged;
 }
 
 export function getTextEncoding() {

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -14,11 +14,6 @@
 
 const symbol = Symbol.for("@bufbuild/protobuf/text-encoding");
 
-// Native String.prototype.isWellFormed, if the runtime provides it.
-const nativeStringIsWellFormed = (
-  String.prototype as Partial<{ isWellFormed(): boolean }>
-).isWellFormed;
-
 interface TextEncoding {
   /**
    * Verify that the given text is valid UTF-8.
@@ -29,12 +24,9 @@ interface TextEncoding {
    */
   encodeUtf8: (text: string) => Uint8Array<ArrayBuffer>;
   /**
-   * Encode UTF-8 text to a Uint8Array.
+   * Encode UTF-8 text to a Uint8Array. The destination must be large enough.
    */
-  encodeUtf8Into: (
-    text: string,
-    dest: Uint8Array,
-  ) => { read: number; written: number };
+  encodeUtf8Into: (text: string, dest: Uint8Array) => { written: number };
   /**
    * Decode UTF-8 text from binary. If `strict` is true, throw on invalid byte
    * sequences instead of silently substituting U+FFFD. Implementations that
@@ -43,66 +35,54 @@ interface TextEncoding {
   decodeUtf8: (bytes: Uint8Array, strict?: boolean) => string;
 }
 
+type TextEncodingConfig = Omit<TextEncoding, "encodeUtf8Into"> &
+  Partial<Pick<TextEncoding, "encodeUtf8Into">>;
+
 /**
  * Protobuf-ES requires the Text Encoding API to convert UTF-8 from and to
  * binary. This WHATWG API is widely available, but it is not part of the
  * ECMAScript standard. On runtimes where it is not available, use this
  * function to provide your own implementation.
  *
+ * Providing `encodeUtf8Into` is optional for backwards compatibility. If it
+ * is omitted, we emulate it with a wrapper that calls `encodeUtf8`.
+ *
  * Note that the Text Encoding API does not provide a way to validate UTF-8.
- * Our implementation falls back to use encodeURIComponent().
+ * Our implementation uses String.prototype.isWellFormed, and falls back
+ * to use encodeURIComponent().
  */
-export function configureTextEncoding(
-  textEncoding: Omit<TextEncoding, "encodeUtf8Into"> &
-    Partial<Pick<TextEncoding, "encodeUtf8Into">>,
-): void {
+export function configureTextEncoding(textEncoding: TextEncodingConfig): void {
   (globalThis as GlobalWithTextEncoding)[symbol] = {
     ...textEncoding,
-    // Emulate encodeUtf8Into with encodeUtf8 if it is not provided.
     encodeUtf8Into:
       textEncoding.encodeUtf8Into ??
-      ((text, dest) => {
-        const bytes = textEncoding.encodeUtf8(text);
-        dest.set(bytes);
-        return { read: text.length, written: bytes.byteLength };
-      }),
+      emulateEncodeInto(textEncoding.encodeUtf8.bind(textEncoding)),
   };
 }
 
-export function getTextEncoding() {
-  if ((globalThis as GlobalWithTextEncoding)[symbol] == undefined) {
-    const textEncoder = new (
-      globalThis as unknown as GlobalWithTextEncoderDecoder
-    ).TextEncoder();
-    const textDecoder = new (
-      globalThis as unknown as GlobalWithTextEncoderDecoder
-    ).TextDecoder();
-    let textDecoderStrict: { decode(data: Uint8Array): string } | undefined;
-
-    configureTextEncoding({
+export function getTextEncoding(): TextEncoding {
+  const globals = globalThis as unknown as GlobalWithTextEncoding &
+    GlobalWithTextEncoderDecoder;
+  if (!globals[symbol]) {
+    const textEncoder = new globals.TextEncoder();
+    const textDecoder = new globals.TextDecoder();
+    let textDecoderStrict: typeof textDecoder | undefined;
+    const config: TextEncodingConfig = {
       encodeUtf8(text: string): Uint8Array<ArrayBuffer> {
         return textEncoder.encode(text);
       },
-      // With exactOptionalPropertyTypes, an explicit undefined is not
-      // assignable to the optional property, so spread conditionally.
-      ...(textEncoder.encodeInto !== undefined
-        ? { encodeUtf8Into: textEncoder.encodeInto.bind(textEncoder) }
-        : undefined),
       decodeUtf8(bytes: Uint8Array, strict?: boolean): string {
         if (strict) {
-          if (textDecoderStrict === undefined) {
-            textDecoderStrict = new (
-              globalThis as unknown as GlobalWithTextEncoderDecoder
-            ).TextDecoder("utf-8", { fatal: true });
+          if (!textDecoderStrict) {
+            textDecoderStrict = new globals.TextDecoder("utf-8", {
+              fatal: true,
+            });
           }
           return textDecoderStrict.decode(bytes);
         }
         return textDecoder.decode(bytes);
       },
       checkUtf8(text: string): boolean {
-        if (nativeStringIsWellFormed) {
-          return nativeStringIsWellFormed.call(text);
-        }
         try {
           encodeURIComponent(text);
           return true;
@@ -110,9 +90,24 @@ export function getTextEncoding() {
           return false;
         }
       },
-    });
+    };
+    // If encodeInto is available, use it. Otherwise, configureTextEncoding
+    // fills in a slower fallback that uses encodeUtf8.
+    if (textEncoder.encodeInto) {
+      config.encodeUtf8Into = textEncoder.encodeInto.bind(textEncoder);
+    }
+    // Native String.prototype.isWellFormed, if the runtime provides it.
+    const nativeStringIsWellFormed = (
+      String.prototype as Partial<{ isWellFormed(): boolean }>
+    ).isWellFormed;
+    if (nativeStringIsWellFormed) {
+      config.checkUtf8 = (text: string): boolean => {
+        return nativeStringIsWellFormed.call(text);
+      };
+    }
+    configureTextEncoding(config);
   }
-  return (globalThis as GlobalWithTextEncoding)[symbol] as TextEncoding;
+  return globals[symbol] as TextEncoding;
 }
 
 type GlobalWithTextEncoding = {
@@ -138,3 +133,18 @@ type GlobalWithTextEncoderDecoder = {
     };
   };
 };
+
+/**
+ * Simplistic polyfill for encodeUtf8Into.
+ *
+ * @private
+ */
+export function emulateEncodeInto(
+  encodeUtf8: (str: string) => Uint8Array,
+): TextEncoding["encodeUtf8Into"] {
+  return (text, dest) => {
+    const bytes = encodeUtf8(text);
+    dest.set(bytes);
+    return { written: bytes.byteLength };
+  };
+}

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -31,7 +31,7 @@ interface TextEncoding {
   /**
    * Encode UTF-8 text to a Uint8Array.
    */
-  encodeUtf8Into?: (
+  encodeUtf8Into: (
     text: string,
     dest: Uint8Array,
   ) => { read: number; written: number };
@@ -53,23 +53,20 @@ interface TextEncoding {
  * Our implementation falls back to use encodeURIComponent().
  */
 export function configureTextEncoding(
-  textEncoding: Partial<TextEncoding>,
+  textEncoding: Omit<TextEncoding, "encodeUtf8Into"> &
+    Partial<Pick<TextEncoding, "encodeUtf8Into">>,
 ): void {
-  const current = getTextEncoding();
-  const merged: TextEncoding = {
-    checkUtf8: textEncoding.checkUtf8 ?? current.checkUtf8,
-    decodeUtf8: textEncoding.decodeUtf8 ?? current.decodeUtf8,
-    encodeUtf8: textEncoding.encodeUtf8 ?? current.encodeUtf8,
+  (globalThis as GlobalWithTextEncoding)[symbol] = {
+    ...textEncoding,
+    // Emulate encodeUtf8Into with encodeUtf8 if it is not provided.
+    encodeUtf8Into:
+      textEncoding.encodeUtf8Into ??
+      ((text, dest) => {
+        const bytes = textEncoding.encodeUtf8(text);
+        dest.set(bytes);
+        return { read: text.length, written: bytes.byteLength };
+      }),
   };
-  // encodeUtf8Into must encode identically to encodeUtf8, so only carry over
-  // the previous encodeUtf8Into if encodeUtf8 wasn't also overridden.
-  const encodeUtf8Into = textEncoding.encodeUtf8
-    ? textEncoding.encodeUtf8Into
-    : (textEncoding.encodeUtf8Into ?? current.encodeUtf8Into);
-  if (encodeUtf8Into) {
-    merged.encodeUtf8Into = encodeUtf8Into;
-  }
-  (globalThis as GlobalWithTextEncoding)[symbol] = merged;
 }
 
 export function getTextEncoding() {
@@ -82,10 +79,15 @@ export function getTextEncoding() {
     ).TextDecoder();
     let textDecoderStrict: { decode(data: Uint8Array): string } | undefined;
 
-    const textEncoding: TextEncoding = {
+    configureTextEncoding({
       encodeUtf8(text: string): Uint8Array<ArrayBuffer> {
         return textEncoder.encode(text);
       },
+      // With exactOptionalPropertyTypes, an explicit undefined is not
+      // assignable to the optional property, so spread conditionally.
+      ...(textEncoder.encodeInto !== undefined
+        ? { encodeUtf8Into: textEncoder.encodeInto.bind(textEncoder) }
+        : undefined),
       decodeUtf8(bytes: Uint8Array, strict?: boolean): string {
         if (strict) {
           if (textDecoderStrict === undefined) {
@@ -108,12 +110,7 @@ export function getTextEncoding() {
           return false;
         }
       },
-    };
-    const encodeUtf8Into = textEncoder.encodeInto?.bind(textEncoder);
-    if (encodeUtf8Into !== undefined) {
-      textEncoding.encodeUtf8Into = encodeUtf8Into;
-    }
-    (globalThis as GlobalWithTextEncoding)[symbol] = textEncoding;
+    });
   }
   return (globalThis as GlobalWithTextEncoding)[symbol] as TextEncoding;
 }

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -29,6 +29,13 @@ interface TextEncoding {
    */
   encodeUtf8: (text: string) => Uint8Array<ArrayBuffer>;
   /**
+   * Encode UTF-8 text to a Uint8Array.
+   */
+  encodeUtf8Into?: (
+    text: string,
+    dest: Uint8Array,
+  ) => { read: number; written: number };
+  /**
    * Decode UTF-8 text from binary. If `strict` is true, throw on invalid byte
    * sequences instead of silently substituting U+FFFD. Implementations that
    * do not support strict decoding may ignore the flag.
@@ -51,27 +58,28 @@ export function configureTextEncoding(textEncoding: TextEncoding): void {
 
 export function getTextEncoding() {
   if ((globalThis as GlobalWithTextEncoding)[symbol] == undefined) {
-    const te = new (
+    const textEncoder = new (
       globalThis as unknown as GlobalWithTextEncoderDecoder
     ).TextEncoder();
-    const td = new (
+    const textDecoder = new (
       globalThis as unknown as GlobalWithTextEncoderDecoder
     ).TextDecoder();
-    let tdStrict: { decode(data: Uint8Array): string } | undefined;
-    (globalThis as GlobalWithTextEncoding)[symbol] = {
+    let textDecoderStrict: { decode(data: Uint8Array): string } | undefined;
+
+    const textEncoding: TextEncoding = {
       encodeUtf8(text: string): Uint8Array<ArrayBuffer> {
-        return te.encode(text);
+        return textEncoder.encode(text);
       },
       decodeUtf8(bytes: Uint8Array, strict?: boolean): string {
         if (strict) {
-          if (tdStrict === undefined) {
-            tdStrict = new (
+          if (textDecoderStrict === undefined) {
+            textDecoderStrict = new (
               globalThis as unknown as GlobalWithTextEncoderDecoder
             ).TextDecoder("utf-8", { fatal: true });
           }
-          return tdStrict.decode(bytes);
+          return textDecoderStrict.decode(bytes);
         }
-        return td.decode(bytes);
+        return textDecoder.decode(bytes);
       },
       checkUtf8(text: string): boolean {
         if (nativeStringIsWellFormed) {
@@ -85,6 +93,11 @@ export function getTextEncoding() {
         }
       },
     };
+    const encodeUtf8Into = textEncoder.encodeInto?.bind(textEncoder);
+    if (encodeUtf8Into !== undefined) {
+      textEncoding.encodeUtf8Into = encodeUtf8Into;
+    }
+    (globalThis as GlobalWithTextEncoding)[symbol] = textEncoding;
   }
   return (globalThis as GlobalWithTextEncoding)[symbol] as TextEncoding;
 }
@@ -97,6 +110,10 @@ type GlobalWithTextEncoderDecoder = {
   TextEncoder: {
     new (): {
       encode(text: string): Uint8Array<ArrayBuffer>;
+      encodeInto?(
+        text: string,
+        dest: Uint8Array,
+      ): { read: number; written: number };
     };
   };
   TextDecoder: {


### PR DESCRIPTION
In both strings and fork-join, we prefix the payload with its length as a varint. However, we don't know the length upfront, so we don't know how much space to reserve for the varint. Instead, we can make a guess:

- Strings: most strings are ASCII, so we can assume a length = number of bytes
- Fork-join: we're going with a length of 1, which works with payloads of size < 128 bytes

For strings, this also means we can use a faster API (`encodeInto` instead of `encode`). This avoids an allocation in all cases, and a copy in the happy path. Benchmarks are happy:

case | main (ops/s) | branch (ops/s) | change
-- | -- | -- | --
BinaryWriter/string-ascii | 6,871,110 | 19,021,976 | +176.8%
BinaryWriter/string-utf8 | 6,061,158 | 13,874,788 | +128.9%
toBinary/map-scalar | 60,388 | 108,101 | +79.0%
toBinary/user-normal | 360,969 | 630,710 | +74.7%
BinaryWriter/fork-join | 33,719,181 | 48,604,550 | +44.1%
toBinary/general | 5,276 | 7,088 | +34.3%
toBinary/repeated-scalar | 158,816 | 205,442 | +29.4%
toBinary/map-message | 759 | 878 | +15.7%
toBinary/repeated-message | 1,009 | 1,115 | +10.5%
toBinary/user-tiny | 2,270,830 | 2,316,987 | +2.0%