### PR TITLE
Compile descriptors to closure trees

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   129,330 b |  64,906 b |   15,258 b |
-| Protobuf-ES         |     4 |   131,519 b |  66,412 b |   15,938 b |
-| Protobuf-ES         |     8 |   134,281 b |  68,183 b |   16,421 b |
-| Protobuf-ES         |    16 |   144,731 b |  76,166 b |   18,761 b |
-| Protobuf-ES         |    32 |   172,522 b |  98,186 b |   24,258 b |
+| Protobuf-ES         |     1 |   129,207 b |  64,864 b |   15,252 b |
+| Protobuf-ES         |     4 |   131,396 b |  66,370 b |   15,922 b |
+| Protobuf-ES         |     8 |   134,158 b |  68,141 b |   16,427 b |
+| Protobuf-ES         |    16 |   144,608 b |  76,124 b |   18,784 b |
+| Protobuf-ES         |    32 |   172,399 b |  98,144 b |   24,269 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   136,676 b |  70,698 b |   16,233 b |
-| Protobuf-ES         |     4 |   138,865 b |  72,206 b |   16,952 b |
-| Protobuf-ES         |     8 |   141,627 b |  73,977 b |   17,427 b |
-| Protobuf-ES         |    16 |   152,077 b |  81,958 b |   19,813 b |
-| Protobuf-ES         |    32 |   179,868 b | 103,976 b |   25,221 b |
+| Protobuf-ES         |     1 |   129,165 b |  65,049 b |   15,134 b |
+| Protobuf-ES         |     4 |   131,354 b |  66,555 b |   15,809 b |
+| Protobuf-ES         |     8 |   134,116 b |  68,326 b |   16,333 b |
+| Protobuf-ES         |    16 |   144,566 b |  76,309 b |   18,630 b |
+| Protobuf-ES         |    32 |   172,357 b |  98,329 b |   24,148 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   130,002 b |  65,237 b |   15,312 b |
-| Protobuf-ES         |     4 |   132,191 b |  66,743 b |   15,931 b |
-| Protobuf-ES         |     8 |   134,953 b |  68,514 b |   16,501 b |
-| Protobuf-ES         |    16 |   145,403 b |  76,497 b |   18,840 b |
-| Protobuf-ES         |    32 |   173,194 b |  98,517 b |   24,289 b |
+| Protobuf-ES         |     1 |   129,330 b |  64,906 b |   15,258 b |
+| Protobuf-ES         |     4 |   131,519 b |  66,412 b |   15,938 b |
+| Protobuf-ES         |     8 |   134,281 b |  68,183 b |   16,421 b |
+| Protobuf-ES         |    16 |   144,731 b |  76,166 b |   18,761 b |
+| Protobuf-ES         |    32 |   172,522 b |  98,186 b |   24,258 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,244.02763671875 140,241.99140625 280,240.64619140625 420,233.88896484375 560,218.57333984374998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.1400390625 140,245.22841796875 280,243.74443359375 420,237.2392578125 560,221.612109375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="244.02763671875" r="4" fill="#ffa600"><title>Protobuf-ES 15.85 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.99140625" r="4" fill="#ffa600"><title>Protobuf-ES 16.55 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.64619140625" r="4" fill="#ffa600"><title>Protobuf-ES 17.02 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.88896484375" r="4" fill="#ffa600"><title>Protobuf-ES 19.35 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.57333984374998" r="4" fill="#ffa600"><title>Protobuf-ES 24.63 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.1400390625" r="4" fill="#ffa600"><title>Protobuf-ES 14.78 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.22841796875" r="4" fill="#ffa600"><title>Protobuf-ES 15.44 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.74443359375" r="4" fill="#ffa600"><title>Protobuf-ES 15.95 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.2392578125" r="4" fill="#ffa600"><title>Protobuf-ES 18.19 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.612109375" r="4" fill="#ffa600"><title>Protobuf-ES 23.58 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.7888671875 140,244.8630859375 280,243.49521484375 420,236.86826171875 560,221.3005859375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.805859375 140,244.9083984375 280,243.47822265625 420,236.803125 560,221.26943359375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.7888671875" r="4" fill="#ffa600"><title>Protobuf-ES 14.9 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.8630859375" r="4" fill="#ffa600"><title>Protobuf-ES 15.56 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.49521484375" r="4" fill="#ffa600"><title>Protobuf-ES 16.04 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.86826171875" r="4" fill="#ffa600"><title>Protobuf-ES 18.32 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.3005859375" r="4" fill="#ffa600"><title>Protobuf-ES 23.69 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.805859375" r="4" fill="#ffa600"><title>Protobuf-ES 14.89 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.9083984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.55 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.47822265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.04 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.803125" r="4" fill="#ffa600"><title>Protobuf-ES 18.34 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.26943359375" r="4" fill="#ffa600"><title>Protobuf-ES 23.7 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.6359375 140,244.88291015625 280,243.26865234375 420,236.64453125 560,221.21279296875002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.7888671875 140,244.8630859375 280,243.49521484375 420,236.86826171875 560,221.3005859375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.6359375" r="4" fill="#ffa600"><title>Protobuf-ES 14.95 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.88291015625" r="4" fill="#ffa600"><title>Protobuf-ES 15.56 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.26865234375" r="4" fill="#ffa600"><title>Protobuf-ES 16.11 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.64453125" r="4" fill="#ffa600"><title>Protobuf-ES 18.4 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.21279296875002" r="4" fill="#ffa600"><title>Protobuf-ES 23.72 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.7888671875" r="4" fill="#ffa600"><title>Protobuf-ES 14.9 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.8630859375" r="4" fill="#ffa600"><title>Protobuf-ES 15.56 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.49521484375" r="4" fill="#ffa600"><title>Protobuf-ES 16.04 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.86826171875" r="4" fill="#ffa600"><title>Protobuf-ES 18.32 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.3005859375" r="4" fill="#ffa600"><title>Protobuf-ES 23.69 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 import { type DescField, type DescMessage, ScalarType } from "./descriptors.js";
-import type { MessageShape } from "./types.js";
-import type {
-  ReflectList,
-  ReflectMap,
-  ReflectMessage,
-} from "./reflect/index.js";
+import type { Message, MessageShape, UnknownField } from "./types.js";
 import { scalarZeroValue } from "./reflect/scalar.js";
-import type { ScalarValue } from "./reflect/scalar.js";
-import { reflect } from "./reflect/reflect.js";
+import type { ReflectMessage } from "./reflect/index.js";
+import { FieldError } from "./reflect/error.js";
+import { unsafeLocal } from "./reflect/unsafe.js";
+import { localMessageMapper } from "./reflect/message.js";
+import { create } from "./create.js";
+import { protoInt64 } from "./proto-int64.js";
 import { BinaryReader, WireType } from "./wire/binary-encoding.js";
 import { varint32write } from "./wire/varint.js";
 
@@ -67,15 +66,14 @@ export function fromBinary<Desc extends DescMessage>(
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
 ): MessageShape<Desc> {
-  const msg = reflect(schema, undefined, false);
-  readMessage(
-    msg,
+  const message = create(schema);
+  compiledReader(schema).read(
+    message as Record<string, unknown>,
     new BinaryReader(bytes),
     makeReadContext(options),
-    false,
     bytes.byteLength,
   );
-  return msg.message as MessageShape<Desc>;
+  return message;
 }
 
 /**
@@ -93,66 +91,179 @@ export function mergeFromBinary<Desc extends DescMessage>(
   bytes: Uint8Array,
   options?: Partial<BinaryReadOptions>,
 ): MessageShape<Desc> {
-  readMessage(
-    reflect(schema, target, false),
+  if (
+    (target as Message).$typeName !== schema.typeName &&
+    schema.fields.length > 0
+  ) {
+    throw new FieldError(
+      schema.fields[0],
+      `cannot use ${schema.fields[0]} with message ${(target as Message).$typeName}`,
+      "ForeignFieldError",
+    );
+  }
+  compiledReader(schema).read(
+    target as Record<string, unknown>,
     new BinaryReader(bytes),
     makeReadContext(options),
-    false,
     bytes.byteLength,
   );
   return target;
 }
 
 /**
- * If `delimited` is false, read the length given in `lengthOrDelimitedFieldNo`.
- *
- * If `delimited` is true, read until an EndGroup tag. `lengthOrDelimitedFieldNo`
- * is the expected field number.
- *
- * @private
+ * A message decoder, compiled from a descriptor ahead of time so that
+ * decoding does not interpret the descriptor for every message.
  */
-function readMessage(
-  message: ReflectMessage,
+interface CompiledReader {
+  /**
+   * Read a message body of `length` bytes.
+   */
+  read(
+    message: Record<string, unknown>,
+    reader: BinaryReader,
+    ctx: BinaryReadContext,
+    length: number,
+  ): void;
+
+  /**
+   * Read a message with the delimited encoding (group), until the EndGroup
+   * tag with the field number `fieldNo`.
+   */
+  readGroup(
+    message: Record<string, unknown>,
+    reader: BinaryReader,
+    ctx: BinaryReadContext,
+    fieldNo: number,
+  ): void;
+}
+
+/**
+ * A decoder for a single field. Called with the reader positioned after
+ * the field's tag.
+ */
+type CompiledFieldReader = (
+  message: Record<string, unknown>,
   reader: BinaryReader,
   ctx: BinaryReadContext,
-  delimited: boolean,
-  lengthOrDelimitedFieldNo: number,
-): void {
-  if (++ctx.depth > ctx.recursionLimit) {
-    throw new Error(
-      `cannot decode ${message.desc} from binary: maximum recursion depth of ${ctx.recursionLimit} reached`,
-    );
+  wireType: WireType,
+) => void;
+
+const compiledReaders = new WeakMap<DescMessage, CompiledReader>();
+
+/**
+ * Return the compiled decoder for a message, compiling it on first use.
+ */
+function compiledReader(desc: DescMessage): CompiledReader {
+  let compiled = compiledReaders.get(desc);
+  if (compiled === undefined) {
+    compiled = compileMessage(desc);
   }
-  const end = delimited ? reader.len : reader.pos + lengthOrDelimitedFieldNo;
-  let fieldNo: number | undefined;
-  let wireType: WireType | undefined;
-  const unknownFields = message.getUnknown() ?? [];
-  while (reader.pos < end) {
-    [fieldNo, wireType] = reader.tag();
-    if (delimited && wireType == WireType.EndGroup) {
-      break;
+  return compiled;
+}
+
+function compileMessage(desc: DescMessage): CompiledReader {
+  const descString = String(desc);
+  const fieldReaders = new Map<number, CompiledFieldReader>();
+  const compiled: CompiledReader = {
+    read: compileMessageReader(descString, fieldReaders),
+    readGroup: compileGroupReader(descString, fieldReaders),
+  };
+  // Register before compiling fields, so that recursive message types
+  // resolve to this instance instead of compiling endlessly.
+  compiledReaders.set(desc, compiled);
+  for (const field of desc.fields) {
+    fieldReaders.set(field.number, compileFieldReader(field));
+  }
+  return compiled;
+}
+
+/**
+ * Create a decoder for a length-prefixed message body, dispatching wire
+ * records to the compiled field decoders by field number.
+ */
+function compileMessageReader(
+  descString: string,
+  fieldReaders: Map<number, CompiledFieldReader>,
+): CompiledReader["read"] {
+  return (message, reader, ctx, length) => {
+    if (++ctx.depth > ctx.recursionLimit) {
+      throw new Error(
+        `cannot decode ${descString} from binary: maximum recursion depth of ${ctx.recursionLimit} reached`,
+      );
     }
-    const field = message.findNumber(fieldNo);
-    if (!field) {
-      // Use remaining recursion budget for skipping nested groups
-      const recursionLimit = ctx.recursionLimit - ctx.depth;
-      const data = reader.skip(wireType, fieldNo, recursionLimit);
-      if (ctx.readUnknownFields) {
-        unknownFields.push({ no: fieldNo, wireType, data });
+    const end = reader.pos + length;
+    const unknownFields =
+      (message.$unknown as UnknownField[] | undefined) ?? [];
+    while (reader.pos < end) {
+      const [fieldNo, wireType] = reader.tag();
+      const fieldReader = fieldReaders.get(fieldNo);
+      if (fieldReader === undefined) {
+        // Use remaining recursion budget for skipping nested groups
+        const data = reader.skip(
+          wireType,
+          fieldNo,
+          ctx.recursionLimit - ctx.depth,
+        );
+        if (ctx.readUnknownFields) {
+          unknownFields.push({ no: fieldNo, wireType, data });
+        }
+        continue;
       }
-      continue;
+      fieldReader(message, reader, ctx, wireType);
     }
-    readField(message, reader, field, wireType, ctx);
-  }
-  if (delimited) {
-    if (wireType != WireType.EndGroup || fieldNo !== lengthOrDelimitedFieldNo) {
+    if (unknownFields.length > 0) {
+      message.$unknown = unknownFields;
+    }
+    ctx.depth--;
+  };
+}
+
+/**
+ * Create a decoder for a message with the delimited encoding (group),
+ * reading until the EndGroup tag, like compileMessageReader.
+ */
+function compileGroupReader(
+  descString: string,
+  fieldReaders: Map<number, CompiledFieldReader>,
+): CompiledReader["readGroup"] {
+  return (message, reader, ctx, fieldNo) => {
+    if (++ctx.depth > ctx.recursionLimit) {
+      throw new Error(
+        `cannot decode ${descString} from binary: maximum recursion depth of ${ctx.recursionLimit} reached`,
+      );
+    }
+    let recordFieldNo: number | undefined;
+    let wireType: WireType | undefined;
+    const unknownFields =
+      (message.$unknown as UnknownField[] | undefined) ?? [];
+    while (reader.pos < reader.len) {
+      [recordFieldNo, wireType] = reader.tag();
+      if (wireType == WireType.EndGroup) {
+        break;
+      }
+      const fieldReader = fieldReaders.get(recordFieldNo);
+      if (fieldReader === undefined) {
+        // Use remaining recursion budget for skipping nested groups
+        const data = reader.skip(
+          wireType,
+          recordFieldNo,
+          ctx.recursionLimit - ctx.depth,
+        );
+        if (ctx.readUnknownFields) {
+          unknownFields.push({ no: recordFieldNo, wireType, data });
+        }
+        continue;
+      }
+      fieldReader(message, reader, ctx, wireType);
+    }
+    if (wireType != WireType.EndGroup || recordFieldNo !== fieldNo) {
       throw new Error("invalid end group tag");
     }
-  }
-  if (unknownFields.length > 0) {
-    message.setUnknown(unknownFields);
-  }
-  ctx.depth--;
+    if (unknownFields.length > 0) {
+      message.$unknown = unknownFields;
+    }
+    ctx.depth--;
+  };
 }
 
 /**
@@ -164,183 +275,360 @@ export function readField(
   field: DescField,
   wireType: WireType,
   ctx: BinaryReadContext,
-) {
-  switch (field.fieldKind) {
-    case "scalar":
-      message.set(
-        field,
-        readScalar(reader, field.scalar, field.utf8Validation),
-      );
-      break;
-    case "enum":
-      const val = readScalar(reader, ScalarType.INT32);
-      if (field.enum.open) {
-        message.set(field, val);
-      } else {
-        const ok = field.enum.values.some((v) => v.number === val);
-        if (ok) {
-          message.set(field, val);
-        } else if (ctx.readUnknownFields) {
-          const bytes: number[] = [];
-          varint32write(val as number, bytes);
-          const unknownFields = message.getUnknown() ?? [];
-          unknownFields.push({
-            no: field.number,
-            wireType,
-            data: new Uint8Array(bytes),
-          });
-          message.setUnknown(unknownFields);
-        }
-      }
-      break;
-    case "message":
-      message.set(
-        field,
-        readMessageField(reader, ctx, field, message.get(field)),
-      );
-      break;
-    case "list":
-      readListField(reader, wireType, message.get(field), ctx);
-      break;
-    case "map":
-      readMapEntry(reader, message.get(field), ctx);
-      break;
-  }
-}
-
-// Read a map field, expecting key field = 1, value field = 2
-function readMapEntry(
-  reader: BinaryReader,
-  map: ReflectMap,
-  ctx: BinaryReadContext,
 ): void {
-  const field = map.field();
-  let key: ScalarValue | undefined;
-  let val: ScalarValue | ReflectMessage | undefined;
-  // Read the length of the map entry, which is a varint.
-  const len = reader.uint32();
-  // WARNING: Calculate end AFTER advancing reader.pos (above), so that
-  //          reader.pos is at the start of the map entry.
-  const end = reader.pos + len;
-  while (reader.pos < end) {
-    const [fieldNo] = reader.tag();
-    switch (fieldNo) {
-      case 1:
-        key = readScalar(reader, field.mapKey, field.utf8Validation);
-        break;
-      case 2:
-        switch (field.mapKind) {
-          case "scalar":
-            val = readScalar(reader, field.scalar, field.utf8Validation);
-            break;
-          case "enum":
-            val = reader.int32();
-            break;
-          case "message":
-            val = readMessageField(reader, ctx, field);
-            break;
-        }
-        break;
-    }
-  }
-  if (key === undefined) {
-    key = scalarZeroValue(field.mapKey, false);
-  }
-  if (val === undefined) {
-    switch (field.mapKind) {
-      case "scalar":
-        val = scalarZeroValue(field.scalar, false);
-        break;
-      case "enum":
-        val = field.enum.values[0].number;
-        break;
-      case "message":
-        val = reflect(field.message, undefined, false);
-        break;
-    }
-  }
-  map.set(key, val);
-}
-
-function readListField(
-  reader: BinaryReader,
-  wireType: WireType,
-  list: ReflectList,
-  ctx: BinaryReadContext,
-) {
-  const field = list.field();
-  if (field.listKind === "message") {
-    list.add(readMessageField(reader, ctx, field));
-    return;
-  }
-  const scalarType = field.scalar ?? ScalarType.INT32;
-  const packed =
-    wireType == WireType.LengthDelimited &&
-    scalarType != ScalarType.STRING &&
-    scalarType != ScalarType.BYTES;
-  if (!packed) {
-    list.add(readScalar(reader, scalarType, field.utf8Validation));
-    return;
-  }
-  const e = reader.uint32() + reader.pos;
-  while (reader.pos < e) {
-    list.add(readScalar(reader, scalarType, field.utf8Validation));
-  }
-}
-
-function readMessageField(
-  reader: BinaryReader,
-  ctx: BinaryReadContext,
-  field: DescField & { message: DescMessage },
-  mergeMessage?: ReflectMessage,
-): ReflectMessage {
-  const delimited = field.delimitedEncoding;
-  const message = mergeMessage ?? reflect(field.message, undefined, false);
-  readMessage(
-    message,
+  compileFieldReader(field)(
+    message[unsafeLocal] as unknown as Record<string, unknown>,
     reader,
     ctx,
-    delimited,
-    delimited ? field.number : reader.uint32(),
+    wireType,
   );
-  return message;
 }
 
-function readScalar(
+function compileFieldReader(field: DescField): CompiledFieldReader {
+  switch (field.fieldKind) {
+    case "scalar":
+      return compileScalarFieldReader(field);
+    case "enum":
+      return compileEnumFieldReader(field);
+    case "message":
+      return compileMessageFieldReader(field);
+    case "list":
+      return compileListFieldReader(field);
+    case "map":
+      return compileMapFieldReader(field);
+  }
+}
+
+function compileScalarFieldReader(
+  field: DescField & { fieldKind: "scalar" },
+): CompiledFieldReader {
+  const readScalar = compileScalarReader(
+    field.scalar,
+    field.utf8Validation,
+    field.longAsString,
+  );
+  const localName = field.localName;
+  if (field.oneof) {
+    const oneofLocalName = field.oneof.localName;
+    return (message, reader) => {
+      message[oneofLocalName] = {
+        case: localName,
+        value: readScalar(reader),
+      };
+    };
+  }
+  return (message, reader) => {
+    message[localName] = readScalar(reader);
+  };
+}
+
+function compileEnumFieldReader(
+  field: DescField & { fieldKind: "enum" },
+): CompiledFieldReader {
+  const localName = field.localName;
+  const oneofLocalName = field.oneof?.localName;
+  if (field.enum.open) {
+    if (oneofLocalName !== undefined) {
+      return (message, reader) => {
+        message[oneofLocalName] = { case: localName, value: reader.int32() };
+      };
+    }
+    return (message, reader) => {
+      message[localName] = reader.int32();
+    };
+  }
+  // Closed enums: unknown values are stored as unknown fields.
+  const values = field.enum.values;
+  const fieldNo = field.number;
+  return (message, reader, ctx, wireType) => {
+    const val = reader.int32();
+    if (values.some((v) => v.number === val)) {
+      if (oneofLocalName !== undefined) {
+        message[oneofLocalName] = { case: localName, value: val };
+      } else {
+        message[localName] = val;
+      }
+    } else if (ctx.readUnknownFields) {
+      const bytes: number[] = [];
+      varint32write(val, bytes);
+      const unknownFields =
+        (message.$unknown as UnknownField[] | undefined) ?? [];
+      unknownFields.push({
+        no: fieldNo,
+        wireType,
+        data: new Uint8Array(bytes),
+      });
+      message.$unknown = unknownFields;
+    }
+  };
+}
+
+function compileMessageFieldReader(
+  field: DescField & { fieldKind: "message" },
+): CompiledFieldReader {
+  const localName = field.localName;
+  const { toMessage, toLocal } = localMessageMapper(field);
+  const readChild = compileChildReader(field);
+  if (field.oneof) {
+    const oneofLocalName = field.oneof.localName;
+    return (message, reader, ctx) => {
+      const oneof = message[oneofLocalName] as {
+        case: string | undefined;
+        value?: unknown;
+      };
+      const child = toMessage(
+        oneof.case === localName ? oneof.value : undefined,
+      );
+      readChild(child, reader, ctx);
+      message[oneofLocalName] = { case: localName, value: toLocal(child) };
+    };
+  }
+  return (message, reader, ctx) => {
+    const child = toMessage(message[localName]);
+    readChild(child, reader, ctx);
+    message[localName] = toLocal(child);
+  };
+}
+
+/**
+ * Compile a decoder for the wire format of a message field, honoring the
+ * delimited encoding of the field.
+ */
+function compileChildReader(
+  field: DescField &
+    ({ fieldKind: "message" } | { fieldKind: "list"; listKind: "message" }),
+): (
+  child: Record<string, unknown>,
   reader: BinaryReader,
-  type: ScalarType,
-  validateUtf8 = false,
-): ScalarValue {
+  ctx: BinaryReadContext,
+) => void {
+  const compiledChild = compiledReader(field.message);
+  if (field.delimitedEncoding) {
+    const fieldNo = field.number;
+    return (child, reader, ctx) =>
+      compiledChild.readGroup(child, reader, ctx, fieldNo);
+  }
+  return (child, reader, ctx) =>
+    compiledChild.read(child, reader, ctx, reader.uint32());
+}
+
+function compileListFieldReader(
+  field: DescField & { fieldKind: "list" },
+): CompiledFieldReader {
+  const localName = field.localName;
+  if (field.listKind == "message") {
+    const { toMessage, toLocal } = localMessageMapper(field);
+    const readChild = compileChildReader(field);
+    return (message, reader, ctx) => {
+      const child = toMessage(undefined);
+      readChild(child, reader, ctx);
+      (message[localName] as unknown[]).push(toLocal(child));
+    };
+  }
+  const scalarType = field.listKind == "enum" ? ScalarType.INT32 : field.scalar;
+  const readScalar = compileScalarReader(
+    scalarType,
+    field.utf8Validation,
+    (field as { longAsString?: boolean }).longAsString ?? false,
+  );
+  const packedPossible =
+    scalarType != ScalarType.STRING && scalarType != ScalarType.BYTES;
+  return (message, reader, ctx, wireType) => {
+    const items = message[localName] as unknown[];
+    if (wireType == WireType.LengthDelimited && packedPossible) {
+      const end = reader.uint32() + reader.pos;
+      while (reader.pos < end) {
+        items.push(readScalar(reader));
+      }
+    } else {
+      items.push(readScalar(reader));
+    }
+  };
+}
+
+function compileMapFieldReader(
+  field: DescField & { fieldKind: "map" },
+): CompiledFieldReader {
+  const localName = field.localName;
+  const readKey = compileScalarReader(
+    field.mapKey,
+    field.utf8Validation,
+    false,
+  );
+  const keyToLocal = compileMapKeyToLocal(field.mapKey);
+  const keyZero = scalarZeroValue(field.mapKey, false);
+  let readValue: (reader: BinaryReader, ctx: BinaryReadContext) => unknown;
+  let valueDefault: () => unknown;
+  switch (field.mapKind) {
+    case "scalar": {
+      const scalar = field.scalar;
+      const longAsString =
+        (field as { longAsString?: boolean }).longAsString === true;
+      const readScalar = compileScalarReader(
+        scalar,
+        field.utf8Validation,
+        longAsString,
+      );
+      readValue = (reader) => readScalar(reader);
+      // The default is converted like a read value: with longAsString, the
+      // 64-bit zero value is a string. Bytes zero values are created per
+      // entry, so that entries do not share one instance.
+      if (longAsString) {
+        valueDefault = () => "0";
+      } else if (scalar == ScalarType.BYTES) {
+        valueDefault = () => new Uint8Array(0);
+      } else {
+        const zero = scalarZeroValue(scalar, false);
+        valueDefault = () => zero;
+      }
+      break;
+    }
+    case "enum": {
+      const zero = field.enum.values[0].number;
+      readValue = (reader) => reader.int32();
+      valueDefault = () => zero;
+      break;
+    }
+    case "message": {
+      const { toMessage, toLocal } = localMessageMapper(field);
+      const readChild = compiledReader(field.message).read;
+      readValue = (reader, ctx) => {
+        const child = toMessage(undefined);
+        readChild(child, reader, ctx, reader.uint32());
+        return toLocal(child);
+      };
+      valueDefault = () => toLocal(toMessage(undefined));
+      break;
+    }
+  }
+  return (message, reader, ctx) => {
+    const record = message[localName] as Record<string, unknown>;
+    let key: unknown;
+    let val: unknown;
+    // Read the length of the map entry, which is a varint.
+    const len = reader.uint32();
+    // Calculate end AFTER advancing reader.pos (above), so that reader.pos is
+    // at the start of the map entry.
+    const end = reader.pos + len;
+    while (reader.pos < end) {
+      // Map entries have the key in field 1, and the value in field 2.
+      const [fieldNo] = reader.tag();
+      switch (fieldNo) {
+        case 1:
+          key = readKey(reader);
+          break;
+        case 2:
+          val = readValue(reader, ctx);
+          break;
+      }
+    }
+    if (key === undefined) {
+      key = keyZero;
+    }
+    if (val === undefined) {
+      val = valueDefault();
+    }
+    record[keyToLocal(key) as string] = val;
+  };
+}
+
+/**
+ * Returns a converter from a map key value read from the wire to its local
+ * representation as an object key: booleans and 64-bit integers become
+ * strings, strings and numbers are used as-is.
+ */
+function compileMapKeyToLocal(
+  type: Exclude<
+    ScalarType,
+    ScalarType.FLOAT | ScalarType.DOUBLE | ScalarType.BYTES
+  >,
+): (key: unknown) => unknown {
   switch (type) {
     case ScalarType.STRING:
-      return reader.string(validateUtf8);
+      return (key) => key;
     case ScalarType.BOOL:
-      return reader.bool();
-    case ScalarType.DOUBLE:
-      return reader.double();
-    case ScalarType.FLOAT:
-      return reader.float();
-    case ScalarType.INT32:
-      return reader.int32();
+      return (key) => String(key);
     case ScalarType.INT64:
-      return reader.int64();
-    case ScalarType.UINT64:
-      return reader.uint64();
-    case ScalarType.FIXED64:
-      return reader.fixed64();
-    case ScalarType.BYTES:
-      return reader.bytes();
-    case ScalarType.FIXED32:
-      return reader.fixed32();
-    case ScalarType.SFIXED32:
-      return reader.sfixed32();
-    case ScalarType.SFIXED64:
-      return reader.sfixed64();
     case ScalarType.SINT64:
-      return reader.sint64();
+    case ScalarType.SFIXED64:
+    case ScalarType.UINT64:
+    case ScalarType.FIXED64:
+      // 64-bit keys are strings already when BigInt is unavailable.
+      return protoInt64.supported ? (key) => String(key) : (key) => key;
+    default:
+      // Handles INT32, UINT32, SINT32, FIXED32, SFIXED32.
+      // We do not use individual cases to save a few bytes code size.
+      return (key) => key;
+  }
+}
+
+/**
+ * Returns a reader for a scalar value, including the conversion to the
+ * local representation for 64-bit integers: the reader returns them as
+ * strings when BigInt is unavailable, and they are run through protoInt64,
+ * mirroring the reflect layer. Which case applies is fixed at load time,
+ * see protoInt64.supported.
+ */
+function compileScalarReader(
+  type: ScalarType,
+  utf8Validation: boolean,
+  longAsString: boolean,
+): (reader: BinaryReader) => unknown {
+  switch (type) {
+    case ScalarType.STRING:
+      return (reader) => reader.string(utf8Validation);
+    case ScalarType.BOOL:
+      return (reader) => reader.bool();
+    case ScalarType.DOUBLE:
+      return (reader) => reader.double();
+    case ScalarType.FLOAT:
+      return (reader) => reader.float();
+    case ScalarType.INT32:
+      return (reader) => reader.int32();
+    case ScalarType.INT64:
+      if (longAsString) {
+        return (reader) => String(reader.int64());
+      }
+      return protoInt64.supported
+        ? (reader) => reader.int64()
+        : (reader) => protoInt64.parse(reader.int64());
+    case ScalarType.UINT64:
+      if (longAsString) {
+        return (reader) => String(reader.uint64());
+      }
+      return protoInt64.supported
+        ? (reader) => reader.uint64()
+        : (reader) => protoInt64.uParse(reader.uint64());
+    case ScalarType.FIXED64:
+      if (longAsString) {
+        return (reader) => String(reader.fixed64());
+      }
+      return protoInt64.supported
+        ? (reader) => reader.fixed64()
+        : (reader) => protoInt64.uParse(reader.fixed64());
+    case ScalarType.BYTES:
+      return (reader) => reader.bytes();
+    case ScalarType.FIXED32:
+      return (reader) => reader.fixed32();
+    case ScalarType.SFIXED32:
+      return (reader) => reader.sfixed32();
+    case ScalarType.SFIXED64:
+      if (longAsString) {
+        return (reader) => String(reader.sfixed64());
+      }
+      return protoInt64.supported
+        ? (reader) => reader.sfixed64()
+        : (reader) => protoInt64.parse(reader.sfixed64());
+    case ScalarType.SINT64:
+      if (longAsString) {
+        return (reader) => String(reader.sint64());
+      }
+      return protoInt64.supported
+        ? (reader) => reader.sint64()
+        : (reader) => protoInt64.parse(reader.sint64());
     case ScalarType.UINT32:
-      return reader.uint32();
+      return (reader) => reader.uint32();
     case ScalarType.SINT32:
-      return reader.sint32();
+      return (reader) => reader.sint32();
   }
 }

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -461,20 +461,15 @@ function compileMapFieldReader(
   switch (field.mapKind) {
     case "scalar": {
       const scalar = field.scalar;
-      const longAsString =
-        (field as { longAsString?: boolean }).longAsString === true;
       const readScalar = compileScalarReader(
         scalar,
         field.utf8Validation,
         false,
       );
       readValue = (reader) => readScalar(reader);
-      // The default is converted like a read value: with longAsString, the
-      // 64-bit zero value is a string. Bytes zero values are created per
-      // entry, so that entries do not share one instance.
-      if (longAsString) {
-        valueDefault = () => "0";
-      } else if (scalar == ScalarType.BYTES) {
+      // Bytes zero values are created per entry, so that entries do not share
+      // one instance.
+      if (scalar == ScalarType.BYTES) {
         valueDefault = () => new Uint8Array(0);
       } else {
         const zero = scalarZeroValue(scalar, false);
@@ -527,16 +522,16 @@ function compileMapFieldReader(
     if (val === undefined) {
       val = valueDefault();
     }
+    // Object property keys are always strings or symbols. Assigning with a
+    // boolean, number, or bigint key implicitly converts it to a string.
     record[key as string] = val;
   };
 }
 
 /**
- * Returns a reader for a scalar value, including the conversion to the
- * local representation for 64-bit integers: the reader returns them as
- * strings when BigInt is unavailable, and they are run through protoInt64,
- * mirroring the reflect layer. Which case applies is fixed at load time,
- * see protoInt64.supported.
+ * Returns a reader for a scalar value. For 64-bit integers, BinaryReader
+ * already returns the local representation (bigint or string), so, unlike in
+ * the reflection layer, no validation is needed here.
  */
 function compileScalarReader(
   type: ScalarType,

--- a/packages/protobuf/src/from-binary.ts
+++ b/packages/protobuf/src/from-binary.ts
@@ -20,7 +20,6 @@ import { FieldError } from "./reflect/error.js";
 import { unsafeLocal } from "./reflect/unsafe.js";
 import { localMessageMapper } from "./reflect/message.js";
 import { create } from "./create.js";
-import { protoInt64 } from "./proto-int64.js";
 import { BinaryReader, WireType } from "./wire/binary-encoding.js";
 import { varint32write } from "./wire/varint.js";
 
@@ -426,10 +425,11 @@ function compileListFieldReader(
     };
   }
   const scalarType = field.listKind == "enum" ? ScalarType.INT32 : field.scalar;
+  const longAsString = field.listKind == "scalar" ? field.longAsString : false;
   const readScalar = compileScalarReader(
     scalarType,
     field.utf8Validation,
-    (field as { longAsString?: boolean }).longAsString ?? false,
+    longAsString,
   );
   const packedPossible =
     scalarType != ScalarType.STRING && scalarType != ScalarType.BYTES;
@@ -455,7 +455,6 @@ function compileMapFieldReader(
     field.utf8Validation,
     false,
   );
-  const keyToLocal = compileMapKeyToLocal(field.mapKey);
   const keyZero = scalarZeroValue(field.mapKey, false);
   let readValue: (reader: BinaryReader, ctx: BinaryReadContext) => unknown;
   let valueDefault: () => unknown;
@@ -467,7 +466,7 @@ function compileMapFieldReader(
       const readScalar = compileScalarReader(
         scalar,
         field.utf8Validation,
-        longAsString,
+        false,
       );
       readValue = (reader) => readScalar(reader);
       // The default is converted like a read value: with longAsString, the
@@ -528,38 +527,8 @@ function compileMapFieldReader(
     if (val === undefined) {
       val = valueDefault();
     }
-    record[keyToLocal(key) as string] = val;
+    record[key as string] = val;
   };
-}
-
-/**
- * Returns a converter from a map key value read from the wire to its local
- * representation as an object key: booleans and 64-bit integers become
- * strings, strings and numbers are used as-is.
- */
-function compileMapKeyToLocal(
-  type: Exclude<
-    ScalarType,
-    ScalarType.FLOAT | ScalarType.DOUBLE | ScalarType.BYTES
-  >,
-): (key: unknown) => unknown {
-  switch (type) {
-    case ScalarType.STRING:
-      return (key) => key;
-    case ScalarType.BOOL:
-      return (key) => String(key);
-    case ScalarType.INT64:
-    case ScalarType.SINT64:
-    case ScalarType.SFIXED64:
-    case ScalarType.UINT64:
-    case ScalarType.FIXED64:
-      // 64-bit keys are strings already when BigInt is unavailable.
-      return protoInt64.supported ? (key) => String(key) : (key) => key;
-    default:
-      // Handles INT32, UINT32, SINT32, FIXED32, SFIXED32.
-      // We do not use individual cases to save a few bytes code size.
-      return (key) => key;
-  }
 }
 
 /**
@@ -589,23 +558,17 @@ function compileScalarReader(
       if (longAsString) {
         return (reader) => String(reader.int64());
       }
-      return protoInt64.supported
-        ? (reader) => reader.int64()
-        : (reader) => protoInt64.parse(reader.int64());
+      return (reader) => reader.int64();
     case ScalarType.UINT64:
       if (longAsString) {
         return (reader) => String(reader.uint64());
       }
-      return protoInt64.supported
-        ? (reader) => reader.uint64()
-        : (reader) => protoInt64.uParse(reader.uint64());
+      return (reader) => reader.uint64();
     case ScalarType.FIXED64:
       if (longAsString) {
         return (reader) => String(reader.fixed64());
       }
-      return protoInt64.supported
-        ? (reader) => reader.fixed64()
-        : (reader) => protoInt64.uParse(reader.fixed64());
+      return (reader) => reader.fixed64();
     case ScalarType.BYTES:
       return (reader) => reader.bytes();
     case ScalarType.FIXED32:
@@ -616,16 +579,12 @@ function compileScalarReader(
       if (longAsString) {
         return (reader) => String(reader.sfixed64());
       }
-      return protoInt64.supported
-        ? (reader) => reader.sfixed64()
-        : (reader) => protoInt64.parse(reader.sfixed64());
+      return (reader) => reader.sfixed64();
     case ScalarType.SINT64:
       if (longAsString) {
         return (reader) => String(reader.sint64());
       }
-      return protoInt64.supported
-        ? (reader) => reader.sint64()
-        : (reader) => protoInt64.parse(reader.sint64());
+      return (reader) => reader.sint64();
     case ScalarType.UINT32:
       return (reader) => reader.uint32();
     case ScalarType.SINT32:

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -310,7 +310,9 @@ function compileMessage(desc: DescMessage): CompiledJsonReader {
     }
     const oneofSeen = new Map<DescOneof, DescField>();
     const fieldSeen = new Set<DescField>();
-    for (const jsonKey of Object.keys(json)) {
+    const jsonKeys = Object.keys(json);
+    for (let i = 0; i < jsonKeys.length; i++) {
+      const jsonKey = jsonKeys[i];
       const jsonValue = json[jsonKey];
       const entry = fieldsByJsonKey.get(jsonKey);
       if (entry !== undefined) {
@@ -597,8 +599,8 @@ function compileListFieldReader(
       throw new FieldError(field, "expected Array, got " + formatVal(json));
     }
     const items = message[localName] as unknown[];
-    for (const jsonItem of json) {
-      const value = readItem(jsonItem, ctx, items.length);
+    for (let i = 0; i < json.length; i++) {
+      const value = readItem(json[i], ctx, items.length);
       if (value !== tokenIgnoredUnknownEnum) {
         items.push(value);
       }
@@ -725,7 +727,9 @@ function compileMapFieldReader(
     }
     const record = message[localName] as Record<string, unknown>;
     const seen = new Set<unknown>();
-    for (const jsonMapKey of Object.keys(json)) {
+    const jsonMapKeys = Object.keys(json);
+    for (let i = 0; i < jsonMapKeys.length; i++) {
+      const jsonMapKey = jsonMapKeys[i];
       const jsonMapValue = json[jsonMapKey];
       const key = parseMapKey(jsonMapKey);
       if (seen.has(key)) {
@@ -1273,10 +1277,12 @@ function structFromJson(struct: Struct, json: JsonValue, ctx: JsonReadContext) {
       `cannot decode message ${struct.$typeName} from JSON ${formatVal(json)}`,
     );
   }
-  for (const k of Object.keys(json)) {
-    const parsedV = create(ValueSchema);
-    valueFromJson(parsedV, json[k], ctx);
-    struct.fields[k] = parsedV;
+  const keys = Object.keys(json);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const parsedValue = create(ValueSchema);
+    valueFromJson(parsedValue, json[key], ctx);
+    struct.fields[key] = parsedValue;
   }
 }
 
@@ -1328,9 +1334,9 @@ function listValueFromJson(
       `cannot decode message ${listValue.$typeName} from JSON ${formatVal(json)}`,
     );
   }
-  for (const e of json) {
+  for (let i = 0; i < json.length; i++) {
     const value = create(ValueSchema);
-    valueFromJson(value, e, ctx);
+    valueFromJson(value, json[i], ctx);
     listValue.values.push(value);
   }
 }

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -680,7 +680,6 @@ function compileMapFieldReader(
   const mapKey = field.mapKey;
   const parseMapKey = compileMapKeyParse(mapKey);
   const checkMapKey = checkScalarValue(mapKey);
-  const mapKeyToLocal = compileMapKeyToLocal(mapKey);
   let parseValue: (
     json: NonNullable<JsonValue>,
     ctx: JsonReadContext,
@@ -759,7 +758,7 @@ function compileMapFieldReader(
           );
         }
       }
-      record[mapKeyToLocal(key)] = toLocalValue(value);
+      record[key as string] = toLocalValue(value);
     }
   };
 }
@@ -929,8 +928,7 @@ function compileScalarParse(
 function compileScalarToLocal(
   field: DescField & { scalar: ScalarType },
 ): (value: unknown) => unknown {
-  const longAsString =
-    (field as { longAsString?: boolean }).longAsString === true;
+  const longAsString = field.fieldKind !== "map" && field.longAsString;
   switch (field.scalar) {
     case ScalarType.INT64:
     case ScalarType.SFIXED64:
@@ -998,25 +996,6 @@ function compileMapKeyParse(
       // ScalarType.STRING
       return (jsonString) => jsonString;
   }
-}
-
-/**
- * Return a converter from a parsed and checked map key to its
- * representation as an object key: booleans become strings, strings and
- * numbers are used as-is.
- */
-function compileMapKeyToLocal(
-  type: Exclude<
-    ScalarType,
-    ScalarType.BYTES | ScalarType.DOUBLE | ScalarType.FLOAT
-  >,
-): (key: unknown) => string | number {
-  if (type == ScalarType.BOOL) {
-    return (key) => String(key);
-  }
-  // Strings, 32-bit integers, and canonicalized 64-bit integer strings are
-  // used as object keys as-is.
-  return (key) => key as string | number;
 }
 
 /**

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -14,7 +14,6 @@
 
 import {
   type DescEnum,
-  type DescExtension,
   type DescField,
   type DescMessage,
   type DescOneof,
@@ -24,17 +23,22 @@ import type { JsonValue } from "./json-value.js";
 import { protoInt64 } from "./proto-int64.js";
 import { create } from "./create.js";
 import type { Registry } from "./registry.js";
-import type {
-  ReflectList,
-  ReflectMap,
-  ReflectMessage,
-} from "./reflect/reflect-types.js";
-import { reflect } from "./reflect/reflect.js";
 import { FieldError, isFieldError } from "./reflect/error.js";
-import { formatVal } from "./reflect/reflect-check.js";
+import {
+  formatVal,
+  reasonSingular,
+  checkScalarValue,
+} from "./reflect/reflect-check.js";
 import { protoSnakeCase } from "./reflect/names.js";
-import type { ScalarValue } from "./reflect/scalar.js";
-import type { EnumJsonType, EnumShape, MessageShape } from "./types.js";
+import { scalarZeroValue } from "./reflect/scalar.js";
+import { unsafeLocal } from "./reflect/unsafe.js";
+import { localMessageMapper } from "./reflect/message.js";
+import type {
+  EnumJsonType,
+  EnumShape,
+  Message,
+  MessageShape,
+} from "./types.js";
 import { base64Decode } from "./wire/base64-encoding.js";
 import type {
   Any,
@@ -55,6 +59,15 @@ import {
   ValueSchema,
 } from "./wkt/index.js";
 import { createExtensionContainer, setExtension } from "./extensions.js";
+import {
+  durationSecondsMax,
+  durationSecondsMin,
+  timestampMsMax,
+  timestampMsMin,
+} from "./wkt/json.js";
+
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name = $number;
+const IMPLICIT = 2;
 
 /**
  * Options for parsing JSON data.
@@ -145,19 +158,9 @@ export function fromJson<Desc extends DescMessage>(
   json: JsonValue,
   options?: Partial<JsonReadOptions>,
 ): MessageShape<Desc> {
-  const msg = reflect(schema);
-  try {
-    readMessage(msg, json, makeReadContext(options));
-  } catch (e) {
-    if (isFieldError(e)) {
-      // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
-      throw new Error(`cannot decode ${e.field()} from JSON: ${e.message}`, {
-        cause: e,
-      });
-    }
-    throw e;
-  }
-  return msg.message as MessageShape<Desc>;
+  const message = create(schema);
+  readMessage(schema, message, json, options);
+  return message;
 }
 
 /**
@@ -178,8 +181,36 @@ export function mergeFromJson<Desc extends DescMessage>(
   json: JsonValue,
   options?: Partial<JsonReadOptions>,
 ): MessageShape<Desc> {
+  if (
+    (target as Message).$typeName !== schema.typeName &&
+    schema.fields.length > 0
+  ) {
+    throw new FieldError(
+      schema.fields[0],
+      `cannot use ${schema.fields[0]} with message ${(target as Message).$typeName}`,
+      "ForeignFieldError",
+    );
+  }
+  readMessage(schema, target, json, options);
+  return target;
+}
+
+/**
+ * Run the compiled decoder for the message, wrapping FieldErrors with the
+ * standard error message.
+ */
+function readMessage(
+  schema: DescMessage,
+  message: MessageShape<DescMessage>,
+  json: JsonValue,
+  options: Partial<JsonReadOptions> | undefined,
+): void {
   try {
-    readMessage(reflect(schema, target), json, makeReadContext(options));
+    compiledReader(schema)(
+      message as Record<string, unknown>,
+      json,
+      makeReadContext(options),
+    );
   } catch (e) {
     if (isFieldError(e)) {
       // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
@@ -189,7 +220,6 @@ export function mergeFromJson<Desc extends DescMessage>(
     }
     throw e;
   }
-  return target;
 }
 
 /**
@@ -199,7 +229,9 @@ export function enumFromJson<Desc extends DescEnum>(
   descEnum: Desc,
   json: EnumJsonType<Desc>,
 ): EnumShape<Desc> {
-  return readEnum(descEnum, json, false) as EnumShape<Desc>;
+  // With ignoreUnknownFields false, the converter never returns the token
+  // for ignored unknown enum values.
+  return compileEnumConverter(descEnum)(json, false) as EnumShape<Desc>;
 }
 
 /**
@@ -212,336 +244,645 @@ export function isEnumJson<Desc extends DescEnum>(
   return undefined !== descEnum.values.find((v) => v.name === value);
 }
 
-const messageJsonFields = new WeakMap<DescMessage, Map<string, DescField>>();
-
-function getJsonField(desc: DescMessage, jsonKey: string) {
-  if (!messageJsonFields.has(desc)) {
-    const jsonNames = new Map<string, DescField>();
-    for (const field of desc.fields) {
-      jsonNames.set(field.name, field).set(field.jsonName, field);
-    }
-    messageJsonFields.set(desc, jsonNames);
-  }
-  return messageJsonFields.get(desc)?.get(jsonKey);
-}
-
-function readMessage(
-  msg: ReflectMessage,
+/**
+ * A message or field decoder, compiled from a descriptor ahead of time so
+ * that decoding does not interpret the descriptor for every message.
+ */
+type CompiledJsonReader = (
+  message: Record<string, unknown>,
   json: JsonValue,
   ctx: JsonReadContext,
-) {
-  if (++ctx.depth > ctx.recursionLimit) {
-    throw new Error(
-      `cannot decode ${msg.desc} from JSON: maximum recursion depth of ${ctx.recursionLimit} reached`,
-    );
+) => void;
+
+const compiledReaders = new WeakMap<DescMessage, CompiledJsonReader>();
+
+/**
+ * Return the compiled decoder for a message, compiling it on first use.
+ */
+function compiledReader(desc: DescMessage): CompiledJsonReader {
+  let compiled = compiledReaders.get(desc);
+  if (compiled === undefined) {
+    compiled = compileMessage(desc);
   }
-  if (tryWktFromJson(msg, json, ctx)) {
-    ctx.depth--;
-    return;
-  }
-  if (json == null || Array.isArray(json) || typeof json != "object") {
-    throw new Error(`cannot decode ${msg.desc} from JSON: ${formatVal(json)}`);
-  }
-  const oneofSeen = new Map<DescOneof, DescField>();
-  const fieldSeen = new Set<DescField>();
-  for (const [jsonKey, jsonValue] of Object.entries(json)) {
-    const field = getJsonField(msg.desc, jsonKey);
-    if (field) {
-      if (fieldSeen.has(field)) {
-        // The same field may be set by its proto name and its JSON name, or by
-        // a duplicate or unicode-escaped key that JSON.parse already collapsed.
-        // Checked before the null-skip below so that a null entry still counts.
-        throw new FieldError(field, "set multiple times");
-      }
-      fieldSeen.add(field);
-      if (field.oneof && jsonValue === null && field.fieldKind == "scalar") {
-        // see conformance test Required.Proto3.JsonInput.OneofFieldNull{First,Second}
-        continue;
-      }
-      if (field.oneof) {
-        const seen = oneofSeen.get(field.oneof);
-        if (seen !== undefined) {
-          throw new FieldError(
-            field.oneof,
-            `oneof set multiple times by ${seen.name} and ${field.name}`,
-          );
-        }
-        oneofSeen.set(field.oneof, field);
-      }
-      readField(msg, field, jsonValue, ctx);
-    } else {
-      let extension: DescExtension | undefined = undefined;
-      if (
-        jsonKey.startsWith("[") &&
-        jsonKey.endsWith("]") &&
-        // biome-ignore lint/suspicious/noAssignInExpressions: no
-        (extension = ctx.registry?.getExtension(
-          jsonKey.substring(1, jsonKey.length - 1),
-        )) &&
-        extension.extendee.typeName === msg.desc.typeName
-      ) {
-        const [container, field, get] = createExtensionContainer(extension);
-        readField(container, field, jsonValue, ctx);
-        setExtension(msg.message, extension, get());
-      }
-      if (!extension && !ctx.ignoreUnknownFields) {
+  return compiled;
+}
+
+interface CompiledFieldEntry {
+  read: CompiledJsonReader;
+  field: DescField;
+  oneof: DescOneof | undefined;
+  // A oneof member that is a scalar field skips JSON null, see conformance
+  // test Required.Proto3.JsonInput.OneofFieldNull{First,Second}.
+  oneofScalarNullSkip: boolean;
+}
+
+function compileMessage(desc: DescMessage): CompiledJsonReader {
+  const descString = String(desc);
+  const readWkt = compileWkt(desc);
+  if (readWkt !== undefined) {
+    // All message decoders count against the recursion limit, including
+    // well-known types with a custom JSON representation.
+    const compiled: CompiledJsonReader = (message, json, ctx) => {
+      if (++ctx.depth > ctx.recursionLimit) {
         throw new Error(
-          `cannot decode ${msg.desc} from JSON: key "${jsonKey}" is unknown`,
+          `cannot decode ${descString} from JSON: maximum recursion depth of ${ctx.recursionLimit} reached`,
         );
       }
+      readWkt(message, json, ctx);
+      ctx.depth--;
+    };
+    compiledReaders.set(desc, compiled);
+    return compiled;
+  }
+  const typeName = desc.typeName;
+  // Fields are looked up by their proto name and their JSON name.
+  const fieldsByJsonKey = new Map<string, CompiledFieldEntry>();
+  const compiled: CompiledJsonReader = (message, json, ctx) => {
+    if (++ctx.depth > ctx.recursionLimit) {
+      throw new Error(
+        `cannot decode ${descString} from JSON: maximum recursion depth of ${ctx.recursionLimit} reached`,
+      );
     }
-  }
-  ctx.depth--;
-}
-
-function readField(
-  msg: ReflectMessage,
-  field: DescField,
-  json: JsonValue,
-  ctx: JsonReadContext,
-) {
-  switch (field.fieldKind) {
-    case "scalar":
-      readScalarField(msg, field, json);
-      break;
-    case "enum":
-      readEnumField(msg, field, json, ctx);
-      break;
-    case "message":
-      readMessageField(msg, field, json, ctx);
-      break;
-    case "list":
-      readListField(msg.get(field), json, ctx);
-      break;
-    case "map":
-      readMapField(msg.get(field), json, ctx);
-      break;
-  }
-}
-
-function readListOrMapItem(
-  field: DescField & { fieldKind: "map" | "list" },
-  json: JsonValue,
-  ctx: JsonReadContext,
-) {
-  if (field.scalar && json !== null) {
-    return scalarFromJson(field, json);
-  }
-  if (field.message && !isResetSentinelNullValue(field, json)) {
-    const msgValue = reflect(field.message);
-    readMessage(msgValue, json, ctx);
-
-    return msgValue;
-  }
-  if (field.enum && !isResetSentinelNullValue(field, json)) {
-    return readEnum(field.enum, json, ctx.ignoreUnknownFields);
-  }
-
-  throw new FieldError(
-    field,
-    `${field.fieldKind === "list" ? "list item" : "map value"} must not be null`,
-  );
-}
-
-function readMapField(map: ReflectMap, json: JsonValue, ctx: JsonReadContext) {
-  if (json === null) {
-    return;
-  }
-  const field = map.field();
-  if (typeof json != "object" || Array.isArray(json)) {
-    throw new FieldError(field, "expected object, got " + formatVal(json));
-  }
-  const seen = new Set<unknown>();
-  for (const [jsonMapKey, jsonMapValue] of Object.entries(json)) {
-    const key = mapKeyFromJson(field.mapKey, jsonMapKey);
-    if (seen.has(key)) {
-      throw new FieldError(field, `duplicate map key "${jsonMapKey}"`);
+    if (json == null || Array.isArray(json) || typeof json != "object") {
+      throw new Error(
+        `cannot decode ${descString} from JSON: ${formatVal(json)}`,
+      );
     }
-    seen.add(key);
-    const value = readListOrMapItem(field, jsonMapValue, ctx);
-    if (value !== tokenIgnoredUnknownEnum) {
-      map.set(key, value);
+    const oneofSeen = new Map<DescOneof, DescField>();
+    const fieldSeen = new Set<DescField>();
+    for (const jsonKey of Object.keys(json)) {
+      const jsonValue = json[jsonKey];
+      const entry = fieldsByJsonKey.get(jsonKey);
+      if (entry !== undefined) {
+        const field = entry.field;
+        if (fieldSeen.has(field)) {
+          // The same field may be set by its proto name and its JSON name, or by
+          // a duplicate or unicode-escaped key that JSON.parse already collapsed.
+          // Checked before the null-skip below so that a null entry still counts.
+          throw new FieldError(field, "set multiple times");
+        }
+        fieldSeen.add(field);
+        if (entry.oneofScalarNullSkip && jsonValue === null) {
+          continue;
+        }
+        if (entry.oneof) {
+          const seen = oneofSeen.get(entry.oneof);
+          if (seen !== undefined) {
+            throw new FieldError(
+              entry.oneof,
+              `oneof set multiple times by ${seen.name} and ${field.name}`,
+            );
+          }
+          oneofSeen.set(entry.oneof, field);
+        }
+        entry.read(message, jsonValue, ctx);
+      } else {
+        const extension =
+          jsonKey.startsWith("[") && jsonKey.endsWith("]")
+            ? ctx.registry?.getExtension(
+                jsonKey.substring(1, jsonKey.length - 1),
+              )
+            : undefined;
+        if (extension?.extendee.typeName == typeName) {
+          const [container, field, get] = createExtensionContainer(extension);
+          compileFieldReader(field)(
+            container[unsafeLocal] as unknown as Record<string, unknown>,
+            jsonValue,
+            ctx,
+          );
+          setExtension(message as unknown as Message, extension, get());
+        }
+        if (extension === undefined && !ctx.ignoreUnknownFields) {
+          throw new Error(
+            `cannot decode ${descString} from JSON: key "${jsonKey}" is unknown`,
+          );
+        }
+      }
     }
+    ctx.depth--;
+  };
+  // Register before compiling fields, so that recursive message types
+  // resolve to this instance instead of compiling endlessly.
+  compiledReaders.set(desc, compiled);
+  for (const field of desc.fields) {
+    const entry: CompiledFieldEntry = {
+      read: compileFieldReader(field),
+      field,
+      oneof: field.oneof,
+      oneofScalarNullSkip:
+        field.oneof !== undefined && field.fieldKind == "scalar",
+    };
+    fieldsByJsonKey.set(field.name, entry).set(field.jsonName, entry);
   }
-}
-
-function readListField(
-  list: ReflectList,
-  json: JsonValue,
-  ctx: JsonReadContext,
-) {
-  if (json === null) {
-    return;
-  }
-  const field = list.field();
-  if (!Array.isArray(json)) {
-    throw new FieldError(field, "expected Array, got " + formatVal(json));
-  }
-  for (const jsonItem of json) {
-    const value = readListOrMapItem(field, jsonItem, ctx);
-    if (value !== tokenIgnoredUnknownEnum) {
-      list.add(value);
-    }
-  }
-}
-
-function readMessageField(
-  msg: ReflectMessage,
-  field: DescField & { fieldKind: "message" },
-  json: JsonValue,
-  ctx: JsonReadContext,
-) {
-  if (isResetSentinelNullValue(field, json)) {
-    msg.clear(field);
-    return;
-  }
-  const msgValue = msg.isSet(field) ? msg.get(field) : reflect(field.message);
-  readMessage(msgValue, json, ctx);
-  msg.set(field, msgValue);
-}
-
-function readEnumField(
-  msg: ReflectMessage,
-  field: DescField & { fieldKind: "enum" },
-  json: JsonValue,
-  ctx: JsonReadContext,
-) {
-  if (isResetSentinelNullValue(field, json)) {
-    msg.clear(field);
-    return;
-  }
-  const enumValue = readEnum(field.enum, json, ctx.ignoreUnknownFields);
-  if (enumValue !== tokenIgnoredUnknownEnum) {
-    msg.set(field, enumValue);
-  }
-}
-
-function readScalarField(
-  msg: ReflectMessage,
-  field: DescField & { fieldKind: "scalar" },
-  json: JsonValue,
-) {
-  if (json === null) {
-    msg.clear(field);
-  } else {
-    msg.set(field, scalarFromJson(field, json));
-  }
+  return compiled;
 }
 
 /**
- * Indicates whether a value is a sentinel for reseting a field.
- *
- * For this to be true, the value must be a JSON null and the field must not
- * permit a present, Protobuf-serializable null.
- *
- * Only message google.protobuf.Value and enum google.protobuf.NullValue fields
- * permit Protobuf-serializable nulls.
- *
- * Note that field-resetting sentinel nulls are not permitted in lists and maps.
+ * Compile a decoder for a well-known type with a custom JSON representation,
+ * or return undefined for other messages. The recursion limit is enforced by
+ * the caller.
  */
-function isResetSentinelNullValue(
-  field: DescField & ({ message: DescMessage } | { enum: DescEnum }),
-  json: JsonValue,
-): boolean {
-  return (
-    json === null &&
-    field.message?.typeName != "google.protobuf.Value" &&
-    field.enum?.typeName != "google.protobuf.NullValue"
-  );
+function compileWkt(desc: DescMessage): CompiledJsonReader | undefined {
+  if (!desc.typeName.startsWith("google.protobuf.")) {
+    return undefined;
+  }
+  switch (desc.typeName) {
+    case "google.protobuf.Any":
+      return (message, json, ctx) =>
+        anyFromJson(message as unknown as Any, json, ctx);
+    case "google.protobuf.Timestamp":
+      return (message, json) =>
+        timestampFromJson(message as unknown as Timestamp, json);
+    case "google.protobuf.Duration":
+      return (message, json) =>
+        durationFromJson(message as unknown as Duration, json);
+    case "google.protobuf.FieldMask":
+      return (message, json) =>
+        fieldMaskFromJson(message as unknown as FieldMask, json);
+    case "google.protobuf.Struct":
+      return (message, json, ctx) =>
+        structFromJson(message as unknown as Struct, json, ctx);
+    case "google.protobuf.Value":
+      return (message, json, ctx) =>
+        valueFromJson(message as unknown as Value, json, ctx);
+    case "google.protobuf.ListValue":
+      return (message, json, ctx) =>
+        listValueFromJson(message as unknown as ListValue, json, ctx);
+    default:
+      if (isWrapperDesc(desc)) {
+        const valueField = desc.fields[0];
+        const localName = valueField.localName;
+        const scalar = valueField.scalar;
+        const longAsString = valueField.longAsString;
+        const readScalar = compileScalarConverter(valueField);
+        return (message, json) => {
+          if (json === null) {
+            message[localName] = scalarZeroValue(scalar, longAsString);
+          } else {
+            message[localName] = readScalar(json);
+          }
+        };
+      }
+      return undefined;
+  }
+}
+
+function compileFieldReader(field: DescField): CompiledJsonReader {
+  switch (field.fieldKind) {
+    case "scalar":
+      return compileScalarFieldReader(field);
+    case "enum":
+      return compileEnumFieldReader(field);
+    case "message":
+      return compileMessageFieldReader(field);
+    case "list":
+      return compileListFieldReader(field);
+    case "map":
+      return compileMapFieldReader(field);
+  }
+}
+
+function compileScalarFieldReader(
+  field: DescField & { fieldKind: "scalar" },
+): CompiledJsonReader {
+  const readScalar = compileScalarConverter(field);
+  const localName = field.localName;
+  if (field.oneof) {
+    // JSON null for a oneof scalar member is skipped by the message decoder.
+    const oneofLocalName = field.oneof.localName;
+    return (message, json) => {
+      message[oneofLocalName] = {
+        case: localName,
+        value: readScalar(json as NonNullable<JsonValue>),
+      };
+    };
+  }
+  const clear = compileClear(field);
+  return (message, json) => {
+    if (json === null) {
+      clear(message);
+    } else {
+      message[localName] = readScalar(json);
+    }
+  };
+}
+
+/**
+ * Compile a function that resets the field to unset, mirroring the clear
+ * operation of the reflect API for fields that are not part of a oneof.
+ */
+function compileClear(
+  field: DescField & ({ fieldKind: "scalar" } | { fieldKind: "enum" }),
+): (message: Record<string, unknown>) => void {
+  const localName = field.localName;
+  if (field.presence != IMPLICIT) {
+    // Fields with explicit presence have properties on the prototype chain
+    // for default / zero values (except for proto3). By deleting their own
+    // property, the field is reset.
+    return (message) => {
+      delete message[localName];
+    };
+  }
+  if (field.fieldKind == "enum") {
+    const zero = field.enum.values[0].number;
+    return (message) => {
+      message[localName] = zero;
+    };
+  }
+  const scalar = field.scalar;
+  const longAsString = field.longAsString;
+  return (message) => {
+    message[localName] = scalarZeroValue(scalar, longAsString);
+  };
+}
+
+function compileEnumFieldReader(
+  field: DescField & { fieldKind: "enum" },
+): CompiledJsonReader {
+  const readEnumValue = compileEnumConverter(field.enum);
+  const checkEnum = compileEnumCheck(field.enum);
+  const localName = field.localName;
+  // Fields with enum google.protobuf.NullValue permit a Protobuf-serializable
+  // null; for all other enums, JSON null resets the field.
+  const nullResets = field.enum.typeName != "google.protobuf.NullValue";
+  if (field.oneof) {
+    const oneofLocalName = field.oneof.localName;
+    return (message, json, ctx) => {
+      if (json === null && nullResets) {
+        const oneof = message[oneofLocalName] as { case: string | undefined };
+        if (oneof.case === localName) {
+          message[oneofLocalName] = { case: undefined };
+        }
+        return;
+      }
+      const value = readEnumValue(json, ctx.ignoreUnknownFields);
+      if (value === tokenIgnoredUnknownEnum) {
+        return;
+      }
+      const check = checkEnum(value);
+      if (check !== true) {
+        throw new FieldError(field, reasonSingular(field, value, check));
+      }
+      message[oneofLocalName] = { case: localName, value };
+    };
+  }
+  const clear = compileClear(field);
+  return (message, json, ctx) => {
+    if (json === null && nullResets) {
+      clear(message);
+      return;
+    }
+    const value = readEnumValue(json, ctx.ignoreUnknownFields);
+    if (value === tokenIgnoredUnknownEnum) {
+      return;
+    }
+    const check = checkEnum(value);
+    if (check !== true) {
+      throw new FieldError(field, reasonSingular(field, value, check));
+    }
+    message[localName] = value;
+  };
+}
+
+function compileMessageFieldReader(
+  field: DescField & { fieldKind: "message" },
+): CompiledJsonReader {
+  const localName = field.localName;
+  const { toMessage, toLocal } = localMessageMapper(field);
+  const readChild = compiledReader(field.message);
+  // Fields with message google.protobuf.Value permit a Protobuf-serializable
+  // null; for all other messages, JSON null resets the field.
+  const nullResets = field.message.typeName != "google.protobuf.Value";
+  if (field.oneof) {
+    const oneofLocalName = field.oneof.localName;
+    return (message, json, ctx) => {
+      const oneof = message[oneofLocalName] as {
+        case: string | undefined;
+        value?: unknown;
+      };
+      if (json === null && nullResets) {
+        if (oneof.case === localName) {
+          message[oneofLocalName] = { case: undefined };
+        }
+        return;
+      }
+      const child = toMessage(
+        oneof.case === localName ? oneof.value : undefined,
+      );
+      readChild(child, json, ctx);
+      message[oneofLocalName] = { case: localName, value: toLocal(child) };
+    };
+  }
+  return (message, json, ctx) => {
+    if (json === null && nullResets) {
+      delete message[localName];
+      return;
+    }
+    const child = toMessage(message[localName]);
+    readChild(child, json, ctx);
+    message[localName] = toLocal(child);
+  };
+}
+
+function compileListFieldReader(
+  field: DescField & { fieldKind: "list" },
+): CompiledJsonReader {
+  const localName = field.localName;
+  const readItem = compileListItemReader(field);
+  return (message, json, ctx) => {
+    if (json === null) {
+      return;
+    }
+    if (!Array.isArray(json)) {
+      throw new FieldError(field, "expected Array, got " + formatVal(json));
+    }
+    const items = message[localName] as unknown[];
+    for (const jsonItem of json) {
+      const value = readItem(jsonItem, ctx, items.length);
+      if (value !== tokenIgnoredUnknownEnum) {
+        items.push(value);
+      }
+    }
+  };
+}
+
+/**
+ * Compile a decoder for a list item. The index is only used in errors, and
+ * accounts for previously merged items.
+ */
+function compileListItemReader(
+  field: DescField & { fieldKind: "list" },
+): (json: JsonValue, ctx: JsonReadContext, index: number) => unknown {
+  switch (field.listKind) {
+    case "scalar": {
+      const parseScalar = compileScalarParse(field);
+      const checkValue = checkScalarValue(field.scalar);
+      const toLocal = compileScalarToLocal(field);
+      return (json, ctx, index) => {
+        if (json === null) {
+          throw new FieldError(field, "list item must not be null");
+        }
+        const value = parseScalar(json);
+        const check = checkValue(value);
+        if (check !== true) {
+          throw new FieldError(
+            field,
+            `list item #${index + 1}: ${reasonSingular(field, value, check)}`,
+          );
+        }
+        return toLocal(value);
+      };
+    }
+    case "enum": {
+      const readEnumValue = compileEnumConverter(field.enum);
+      const checkEnum = compileEnumCheck(field.enum);
+      const nullResets = field.enum.typeName != "google.protobuf.NullValue";
+      return (json, ctx, index) => {
+        if (json === null && nullResets) {
+          throw new FieldError(field, "list item must not be null");
+        }
+        const value = readEnumValue(json, ctx.ignoreUnknownFields);
+        if (value === tokenIgnoredUnknownEnum) {
+          return value;
+        }
+        const check = checkEnum(value);
+        if (check !== true) {
+          throw new FieldError(
+            field,
+            `list item #${index + 1}: ${reasonSingular(field, value, check)}`,
+          );
+        }
+        return value;
+      };
+    }
+    case "message": {
+      const { toMessage, toLocal } = localMessageMapper(field);
+      const readChild = compiledReader(field.message);
+      const nullResets = field.message.typeName != "google.protobuf.Value";
+      return (json, ctx) => {
+        if (json === null && nullResets) {
+          throw new FieldError(field, "list item must not be null");
+        }
+        const child = toMessage(undefined);
+        readChild(child, json, ctx);
+        return toLocal(child);
+      };
+    }
+  }
+}
+
+function compileMapFieldReader(
+  field: DescField & { fieldKind: "map" },
+): CompiledJsonReader {
+  const localName = field.localName;
+  const mapKey = field.mapKey;
+  const parseMapKey = compileMapKeyParse(mapKey);
+  const checkMapKey = checkScalarValue(mapKey);
+  const mapKeyToLocal = compileMapKeyToLocal(mapKey);
+  let parseValue: (
+    json: NonNullable<JsonValue>,
+    ctx: JsonReadContext,
+  ) => unknown;
+  // Additional validation for scalar and enum values, matching the checks
+  // of the reflect API. Message values need no validation.
+  let checkValue: ((value: unknown) => true | string | false) | undefined;
+  let toLocalValue: (value: unknown) => unknown = (value) => value;
+  // Fields with google.protobuf.Value or google.protobuf.NullValue values
+  // permit a Protobuf-serializable null.
+  let nullResets = true;
+  switch (field.mapKind) {
+    case "scalar": {
+      parseValue = compileScalarParse(field);
+      checkValue = checkScalarValue(field.scalar);
+      toLocalValue = compileScalarToLocal(field);
+      break;
+    }
+    case "enum": {
+      const readEnumValue = compileEnumConverter(field.enum);
+      parseValue = (json, ctx) => readEnumValue(json, ctx.ignoreUnknownFields);
+      checkValue = compileEnumCheck(field.enum);
+      nullResets = field.enum.typeName != "google.protobuf.NullValue";
+      break;
+    }
+    case "message": {
+      const { toMessage, toLocal } = localMessageMapper(field);
+      const readChild = compiledReader(field.message);
+      nullResets = field.message.typeName != "google.protobuf.Value";
+      parseValue = (json, ctx) => {
+        const child = toMessage(undefined);
+        readChild(child, json, ctx);
+        return toLocal(child);
+      };
+      break;
+    }
+  }
+  return (message, json, ctx) => {
+    if (json === null) {
+      return;
+    }
+    if (typeof json != "object" || Array.isArray(json)) {
+      throw new FieldError(field, "expected object, got " + formatVal(json));
+    }
+    const record = message[localName] as Record<string, unknown>;
+    const seen = new Set<unknown>();
+    for (const jsonMapKey of Object.keys(json)) {
+      const jsonMapValue = json[jsonMapKey];
+      const key = parseMapKey(jsonMapKey);
+      if (seen.has(key)) {
+        throw new FieldError(field, `duplicate map key "${jsonMapKey}"`);
+      }
+      seen.add(key);
+      if (jsonMapValue === null && nullResets) {
+        throw new FieldError(field, "map value must not be null");
+      }
+      const value = parseValue(jsonMapValue as NonNullable<JsonValue>, ctx);
+      if (value === tokenIgnoredUnknownEnum) {
+        continue;
+      }
+      const checkKey = checkMapKey(key);
+      if (checkKey !== true) {
+        throw new FieldError(
+          field,
+          `invalid map key: ${reasonSingular({ scalar: mapKey }, key, checkKey)}`,
+        );
+      }
+      if (checkValue !== undefined) {
+        const check = checkValue(value);
+        if (check !== true) {
+          throw new FieldError(
+            field,
+            `map entry ${formatVal(key)}: ${reasonSingular(field, value, check)}`,
+          );
+        }
+      }
+      record[mapKeyToLocal(key)] = toLocalValue(value);
+    }
+  };
 }
 
 const tokenIgnoredUnknownEnum = Symbol();
 
 /**
- * Try to parse a JSON value to an enum value. JSON null returns the enum's first value.
- * With ignoreUnknownFields false, unknown values raise a FieldError
- * With ignoreUnknownFields true, unknown values return tokenIgnoredUnknownEnum.
+ * Compile a converter from a JSON value to an enum value. JSON null returns
+ * the enum's first value. With ignoreUnknownFields false, unknown string
+ * values raise an error; with true, they return tokenIgnoredUnknownEnum.
+ * The value is not checked against the enum's values, see compileEnumCheck.
  */
-function readEnum(
+function compileEnumConverter(
   desc: DescEnum,
-  json: JsonValue,
-  ignoreUnknownFields: false,
-): number;
-function readEnum(
-  desc: DescEnum,
+): (
   json: JsonValue,
   ignoreUnknownFields: boolean,
-): number | typeof tokenIgnoredUnknownEnum;
-function readEnum(
-  desc: DescEnum,
-  json: JsonValue,
-  ignoreUnknownFields: boolean,
-): number | typeof tokenIgnoredUnknownEnum {
-  if (json === null) {
-    return desc.values[0].number;
-  }
-  switch (typeof json) {
-    case "number":
-      if (Number.isInteger(json)) {
-        return json;
+) => number | typeof tokenIgnoredUnknownEnum {
+  const zero = desc.values[0].number;
+  const values = desc.values;
+  return (json, ignoreUnknownFields) => {
+    if (json === null) {
+      return zero;
+    }
+    switch (typeof json) {
+      case "number":
+        if (Number.isInteger(json)) {
+          return json;
+        }
+        break;
+      case "string": {
+        const value = values.find((ev) => ev.name === json);
+        if (value !== undefined) {
+          return value.number;
+        }
+        if (ignoreUnknownFields) {
+          return tokenIgnoredUnknownEnum;
+        }
+        break;
       }
-      break;
-    case "string":
-      const value = desc.values.find((ev) => ev.name === json);
-      if (value !== undefined) {
-        return value.number;
-      }
-      if (ignoreUnknownFields) {
-        return tokenIgnoredUnknownEnum;
-      }
-      break;
-  }
-  throw new Error(`cannot decode ${desc} from JSON: ${formatVal(json)}`);
+    }
+    throw new Error(`cannot decode ${desc} from JSON: ${formatVal(json)}`);
+  };
 }
 
 /**
- * Try to parse a JSON value to a scalar value for the reflect API.
- *
- * Returns the input if the JSON value cannot be converted. Raises a FieldError
- * if conversion would be ambiguous.
+ * Compile the check that the reflect API performs for enum values: open
+ * enums accept any int32 value, closed enums accept only declared values.
  */
-function scalarFromJson(
+function compileEnumCheck(
+  desc: DescEnum,
+): (value: unknown) => true | string | false {
+  if (desc.open) {
+    return checkScalarValue(ScalarType.INT32);
+  }
+  const values = desc.values;
+  return (value) => values.some((v) => v.number === value);
+}
+
+/**
+ * Compile a converter from a JSON value to the local representation of a
+ * scalar, fusing JSON parsing, the validation of the reflect API, and the
+ * conversion to the local 64-bit integer representation.
+ */
+function compileScalarConverter(
   field: DescField & { scalar: ScalarType },
-  json: NonNullable<JsonValue>,
-): ScalarValue | NonNullable<JsonValue> {
-  // int64, sfixed64, sint64, fixed64, uint64: Reflect supports string and number.
-  // string, bool: Supported by reflect.
+): (json: NonNullable<JsonValue>) => unknown {
+  const parseScalar = compileScalarParse(field);
+  const checkValue = checkScalarValue(field.scalar);
+  const toLocal = compileScalarToLocal(field);
+  return (json) => {
+    const value = parseScalar(json);
+    const check = checkValue(value);
+    if (check !== true) {
+      throw new FieldError(field, reasonSingular(field, value, check));
+    }
+    return toLocal(value);
+  };
+}
+
+/**
+ * Compile the JSON-specific parsing step for a scalar value: the special
+ * string values of float and double, string-encoded numbers, and base64
+ * bytes. Returns the input unchanged if the JSON value cannot be converted;
+ * the validation step raises an error for it.
+ */
+function compileScalarParse(
+  field: DescField & { scalar: ScalarType },
+): (json: NonNullable<JsonValue>) => unknown {
   switch (field.scalar) {
     // float, double: JSON value will be a number or one of the special string values "NaN", "Infinity", and "-Infinity".
     // Either numbers or strings are accepted. Exponent notation is also accepted.
     case ScalarType.DOUBLE:
     case ScalarType.FLOAT:
-      if (json === "NaN") return NaN;
-      if (json === "Infinity") return Number.POSITIVE_INFINITY;
-      if (json === "-Infinity") return Number.NEGATIVE_INFINITY;
-      if (typeof json == "number") {
-        if (Number.isNaN(json)) {
-          // NaN must be encoded with string constants
-          throw new FieldError(field, "unexpected NaN number");
+      return (json) => {
+        if (json === "NaN") return NaN;
+        if (json === "Infinity") return Number.POSITIVE_INFINITY;
+        if (json === "-Infinity") return Number.NEGATIVE_INFINITY;
+        if (typeof json == "number") {
+          if (Number.isNaN(json)) {
+            // NaN must be encoded with string constants
+            throw new FieldError(field, "unexpected NaN number");
+          }
+          if (!Number.isFinite(json)) {
+            // Infinity must be encoded with string constants
+            throw new FieldError(field, "unexpected infinite number");
+          }
+          return json;
         }
-        if (!Number.isFinite(json)) {
-          // Infinity must be encoded with string constants
-          throw new FieldError(field, "unexpected infinite number");
+        if (typeof json == "string") {
+          if (json === "") {
+            // empty string is not a number
+            return json;
+          }
+          if (json.trim().length !== json.length) {
+            // extra whitespace
+            return json;
+          }
+          const float = Number(json);
+          if (!Number.isFinite(float)) {
+            // Infinity and NaN must be encoded with string constants
+            return json;
+          }
+          return float;
         }
-        break;
-      }
-      if (typeof json == "string") {
-        if (json === "") {
-          // empty string is not a number
-          break;
-        }
-        if (json.trim().length !== json.length) {
-          // extra whitespace
-          break;
-        }
-        const float = Number(json);
-        if (!Number.isFinite(float)) {
-          // Infinity and NaN must be encoded with string constants
-          break;
-        }
-        return float;
-      }
-      break;
+        return json;
+      };
 
     // int32, fixed32, uint32: JSON value will be a decimal number. Either numbers or strings are accepted.
     case ScalarType.INT32:
@@ -549,66 +890,129 @@ function scalarFromJson(
     case ScalarType.SFIXED32:
     case ScalarType.SINT32:
     case ScalarType.UINT32:
-      return int32FromJson(json);
+      return int32FromJson;
 
     // bytes: JSON value will be the data encoded as a string using standard base64 encoding with paddings.
     // Either standard or URL-safe base64 encoding with/without paddings are accepted.
     case ScalarType.BYTES:
-      if (typeof json == "string") {
-        if (json === "") {
-          return new Uint8Array(0);
+      return (json) => {
+        if (typeof json == "string") {
+          if (json === "") {
+            return new Uint8Array(0);
+          }
+          try {
+            return base64Decode(json);
+          } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            throw new FieldError(field, message);
+          }
         }
-        try {
-          return base64Decode(json);
-        } catch (e) {
-          const message = e instanceof Error ? e.message : String(e);
-          throw new FieldError(field, message);
-        }
-      }
-      break;
+        return json;
+      };
+
+    // int64, sfixed64, sint64, fixed64, uint64: The validation step accepts
+    // string and number. string, bool: no conversion.
+    default:
+      return (json) => json;
   }
-  return json;
 }
 
 /**
- * Try to parse a JSON value to a map key for the reflect API.
- * Canonicalizes 64-bit integers given as string, so that "01 and "1" are one
- * key, and duplicates can raise an error.
- * Returns the input if the JSON value cannot be converted.
+ * Compile the conversion of a validated scalar value to its local
+ * representation: 64-bit integers become bigint, or string with the
+ * longAsString option.
  */
-function mapKeyFromJson(
+function compileScalarToLocal(
+  field: DescField & { scalar: ScalarType },
+): (value: unknown) => unknown {
+  const longAsString =
+    (field as { longAsString?: boolean }).longAsString === true;
+  switch (field.scalar) {
+    case ScalarType.INT64:
+    case ScalarType.SFIXED64:
+    case ScalarType.SINT64:
+      if (longAsString) {
+        return (value) => String(value);
+      }
+      return (value) =>
+        typeof value == "string" || typeof value == "number"
+          ? protoInt64.parse(value)
+          : value;
+    case ScalarType.FIXED64:
+    case ScalarType.UINT64:
+      if (longAsString) {
+        return (value) => String(value);
+      }
+      return (value) =>
+        typeof value == "string" || typeof value == "number"
+          ? protoInt64.uParse(value)
+          : value;
+    default:
+      return (value) => value;
+  }
+}
+
+/**
+ * Return a parser from a JSON value to a map key for the given key type.
+ * Canonicalizes 64-bit integers given as string, so that "01" and "1" are
+ * one key, and duplicates can raise an error.
+ * The parser returns the input if the JSON value cannot be converted.
+ */
+function compileMapKeyParse(
   type: Exclude<
     ScalarType,
     ScalarType.BYTES | ScalarType.DOUBLE | ScalarType.FLOAT
   >,
-  jsonString: string,
-) {
+): (jsonString: string) => unknown {
   switch (type) {
     case ScalarType.BOOL:
-      switch (jsonString) {
-        case "true":
-          return true;
-        case "false":
-          return false;
-      }
-      return jsonString;
+      return (jsonString) => {
+        switch (jsonString) {
+          case "true":
+            return true;
+          case "false":
+            return false;
+        }
+        return jsonString;
+      };
     case ScalarType.INT32:
     case ScalarType.FIXED32:
     case ScalarType.UINT32:
     case ScalarType.SFIXED32:
     case ScalarType.SINT32:
-      return int32FromJson(jsonString);
+      return int32FromJson;
     case ScalarType.INT64:
     case ScalarType.SINT64:
     case ScalarType.SFIXED64:
     case ScalarType.UINT64:
     case ScalarType.FIXED64:
-      return /^-?0+$/.test(jsonString)
-        ? "0"
-        : jsonString.replace(/^(-?)0+(?=\d)/, "$1");
+      return (jsonString) =>
+        /^-?0+$/.test(jsonString)
+          ? "0"
+          : jsonString.replace(/^(-?)0+(?=\d)/, "$1");
     default:
-      return jsonString;
+      // ScalarType.STRING
+      return (jsonString) => jsonString;
   }
+}
+
+/**
+ * Return a converter from a parsed and checked map key to its
+ * representation as an object key: booleans become strings, strings and
+ * numbers are used as-is.
+ */
+function compileMapKeyToLocal(
+  type: Exclude<
+    ScalarType,
+    ScalarType.BYTES | ScalarType.DOUBLE | ScalarType.FLOAT
+  >,
+): (key: unknown) => string | number {
+  if (type == ScalarType.BOOL) {
+    return (key) => String(key);
+  }
+  // Strings, 32-bit integers, and canonicalized 64-bit integer strings are
+  // used as object keys as-is.
+  return (key) => key as string | number;
 }
 
 /**
@@ -734,50 +1138,6 @@ function checkDuplicateKeys(jsonString: string, typeName: string): void {
   }
 }
 
-function tryWktFromJson(
-  msg: ReflectMessage,
-  jsonValue: JsonValue,
-  ctx: JsonReadContext,
-): boolean {
-  if (!msg.desc.typeName.startsWith("google.protobuf.")) {
-    return false;
-  }
-  switch (msg.desc.typeName) {
-    case "google.protobuf.Any":
-      anyFromJson(msg.message as Any, jsonValue, ctx);
-      return true;
-    case "google.protobuf.Timestamp":
-      timestampFromJson(msg.message as Timestamp, jsonValue);
-      return true;
-    case "google.protobuf.Duration":
-      durationFromJson(msg.message as Duration, jsonValue);
-      return true;
-    case "google.protobuf.FieldMask":
-      fieldMaskFromJson(msg.message as FieldMask, jsonValue);
-      return true;
-    case "google.protobuf.Struct":
-      structFromJson(msg.message as Struct, jsonValue, ctx);
-      return true;
-    case "google.protobuf.Value":
-      valueFromJson(msg.message as Value, jsonValue, ctx);
-      return true;
-    case "google.protobuf.ListValue":
-      listValueFromJson(msg.message as ListValue, jsonValue, ctx);
-      return true;
-    default:
-      if (isWrapperDesc(msg.desc)) {
-        const valueField = msg.desc.fields[0];
-        if (jsonValue === null) {
-          msg.clear(valueField);
-        } else {
-          msg.set(valueField, scalarFromJson(valueField, jsonValue));
-        }
-        return true;
-      }
-      return false;
-  }
-}
-
 function anyFromJson(any: Any, json: JsonValue, ctx: JsonReadContext) {
   if (json === null || Array.isArray(json) || typeof json != "object") {
     throw new Error(
@@ -807,20 +1167,19 @@ function anyFromJson(any: Any, json: JsonValue, ctx: JsonReadContext) {
       `cannot decode message ${any.$typeName} from JSON: ${typeUrl} is not in the type registry`,
     );
   }
-  const msg = reflect(desc);
+  const message = create(desc) as Record<string, unknown>;
   if (
     hasCustomJsonRepresentation(desc) &&
     Object.prototype.hasOwnProperty.call(json, "value")
   ) {
-    const value = json.value;
-    readMessage(msg, value, ctx);
+    compiledReader(desc)(message, json.value, ctx);
   } else {
     const copy = Object.assign({}, json);
     // biome-ignore lint/performance/noDelete: <explanation>
     delete copy["@type"];
-    readMessage(msg, copy, ctx);
+    compiledReader(desc)(message, copy, ctx);
   }
-  anyPack(msg.desc, msg.message, any);
+  anyPack(desc, message as unknown as Message, any);
 }
 
 function timestampFromJson(timestamp: Timestamp, json: JsonValue) {
@@ -846,10 +1205,7 @@ function timestampFromJson(timestamp: Timestamp, json: JsonValue) {
       `cannot decode message ${timestamp.$typeName} from JSON: invalid RFC 3339 string`,
     );
   }
-  if (
-    ms < Date.parse("0001-01-01T00:00:00Z") ||
-    ms > Date.parse("9999-12-31T23:59:59Z")
-  ) {
+  if (ms < timestampMsMin || ms > timestampMsMax) {
     throw new Error(
       `cannot decode message ${timestamp.$typeName} from JSON: must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive`,
     );
@@ -876,7 +1232,7 @@ function durationFromJson(duration: Duration, json: JsonValue) {
     );
   }
   const longSeconds = Number(match[1]);
-  if (longSeconds > 315576000000 || longSeconds < -315576000000) {
+  if (longSeconds > durationSecondsMax || longSeconds < durationSecondsMin) {
     throw new Error(
       `cannot decode message ${duration.$typeName} from JSON: ${formatVal(json)}`,
     );
@@ -917,9 +1273,9 @@ function structFromJson(struct: Struct, json: JsonValue, ctx: JsonReadContext) {
       `cannot decode message ${struct.$typeName} from JSON ${formatVal(json)}`,
     );
   }
-  for (const [k, v] of Object.entries(json)) {
+  for (const k of Object.keys(json)) {
     const parsedV = create(ValueSchema);
-    valueFromJson(parsedV, v, ctx);
+    valueFromJson(parsedV, json[k], ctx);
     struct.fields[k] = parsedV;
   }
 }

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -758,6 +758,8 @@ function compileMapFieldReader(
           );
         }
       }
+      // Object property keys are always strings or symbols. Assigning with a
+      // boolean, number, or bigint key implicitly converts it to a string.
       record[key as string] = toLocalValue(value);
     }
   };

--- a/packages/protobuf/src/reflect/message.ts
+++ b/packages/protobuf/src/reflect/message.ts
@@ -1,0 +1,202 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DescField, DescMessage } from "../descriptors.js";
+import type { JsonObject, JsonValue } from "../json-value.js";
+import { create } from "../create.js";
+import { isObject } from "./guard.js";
+import { isWrapperDesc } from "../wkt/wrappers.js";
+import type {
+  ListValue,
+  Struct,
+  Value,
+} from "../wkt/gen/google/protobuf/struct_pb.js";
+
+// google.protobuf.NullValue.NULL_VALUE;
+const NULL_VALUE = 0;
+
+/**
+ * Mapper between the local representation of a message field value
+ * and the message it represents. For most fields, the local value is the
+ * message itself. Types from google/protobuf/wrappers.proto are unwrapped
+ * to the wrapped scalar value when used in a singular field that is not
+ * part of a oneof group, and google.protobuf.Struct is represented with
+ * JsonObject when used in a field, except when used in
+ * google.protobuf.Value.
+ */
+export interface LocalMessageMapper {
+  /**
+   * Wrap a local value in the message it represents. For undefined - an
+   * unset field - a new message is created. Like the reflect API, wrapping
+   * an existing Struct field value creates a normalized copy, so that
+   * merging does not mutate the previous value in place.
+   */
+  toMessage(local: unknown): Record<string, unknown>;
+
+  /**
+   * Convert a message to the local representation of the field value.
+   */
+  toLocal(message: Record<string, unknown>): unknown;
+}
+
+/**
+ * Return the conversions between the local representation of the field
+ * value and the message it represents.
+ */
+export function localMessageMapper(
+  field: DescField & { message: DescMessage },
+): LocalMessageMapper {
+  // google.protobuf.Struct fields are stored as JsonObject.
+  if (usesJsonRepresentation(field)) {
+    return {
+      toMessage: (local) =>
+        wktStructToReflect(local as JsonValue) as unknown as Record<
+          string,
+          unknown
+        >,
+      toLocal: (message) => wktStructToLocal(message as unknown as Struct),
+    };
+  }
+  // Singular wrapper fields outside a oneof are unwrapped to the scalar value.
+  if (
+    field.fieldKind == "message" &&
+    !field.oneof &&
+    isWrapperDesc(field.message)
+  ) {
+    const wrapperDesc = field.message;
+    const valueLocalName = wrapperDesc.fields[0].localName;
+    return {
+      toMessage: (local) => {
+        const message = create(wrapperDesc) as unknown as Record<
+          string,
+          unknown
+        >;
+        if (local !== undefined) {
+          message[valueLocalName] = local;
+        }
+        return message;
+      },
+      toLocal: (message) => message[valueLocalName],
+    };
+  }
+  // For all other fields, the local value is the message itself.
+  const childDesc = field.message;
+  return {
+    toMessage: (local) =>
+      (local === undefined ? create(childDesc) : local) as Record<
+        string,
+        unknown
+      >,
+    toLocal: (message) => message,
+  };
+}
+
+/**
+ * Returns true if values of this field are stored as JsonValue instead of
+ * a message: google.protobuf.Struct is represented with JsonObject when
+ * used in a field, except when used in google.protobuf.Value.
+ */
+function usesJsonRepresentation(
+  field: DescField & { message: DescMessage },
+): boolean {
+  return (
+    field.message.typeName == "google.protobuf.Struct" &&
+    field.parent.typeName != "google.protobuf.Value"
+  );
+}
+
+/**
+ * Convert the JsonValue representation of a google.protobuf.Struct to the
+ * message representation.
+ */
+export function wktStructToReflect(json: JsonValue): Struct {
+  const struct: Struct = {
+    $typeName: "google.protobuf.Struct",
+    fields: {},
+  };
+  if (isObject(json)) {
+    for (const k of Object.keys(json)) {
+      struct.fields[k] = wktValueToReflect(json[k]);
+    }
+  }
+  return struct;
+}
+
+/**
+ * Convert a google.protobuf.Struct message to its JsonValue representation.
+ */
+export function wktStructToLocal(val: Struct): JsonObject {
+  const json: JsonObject = {};
+  for (const k of Object.keys(val.fields)) {
+    json[k] = wktValueToLocal(val.fields[k]);
+  }
+  return json;
+}
+
+function wktValueToLocal(val: Value): JsonValue {
+  switch (val.kind.case) {
+    case "structValue":
+      return wktStructToLocal(val.kind.value);
+    case "listValue":
+      return val.kind.value.values.map(wktValueToLocal);
+    case "nullValue":
+    case undefined:
+      return null;
+    default:
+      return val.kind.value;
+  }
+}
+
+function wktValueToReflect(json: JsonValue): Value {
+  const value: Value = {
+    $typeName: "google.protobuf.Value",
+    kind: { case: undefined },
+  };
+  switch (typeof json) {
+    case "number":
+      value.kind = { case: "numberValue", value: json };
+      break;
+    case "string":
+      value.kind = { case: "stringValue", value: json };
+      break;
+    case "boolean":
+      value.kind = { case: "boolValue", value: json };
+      break;
+    case "object":
+      if (json === null) {
+        value.kind = { case: "nullValue", value: NULL_VALUE };
+      } else if (Array.isArray(json)) {
+        const listValue: ListValue = {
+          $typeName: "google.protobuf.ListValue",
+          values: [],
+        };
+        if (Array.isArray(json)) {
+          for (const e of json) {
+            listValue.values.push(wktValueToReflect(e));
+          }
+        }
+        value.kind = {
+          case: "listValue",
+          value: listValue,
+        };
+      } else {
+        value.kind = {
+          case: "structValue",
+          value: wktStructToReflect(json),
+        };
+      }
+      break;
+  }
+  return value;
+}

--- a/packages/protobuf/src/reflect/message.ts
+++ b/packages/protobuf/src/reflect/message.ts
@@ -34,6 +34,8 @@ const NULL_VALUE = 0;
  * part of a oneof group, and google.protobuf.Struct is represented with
  * JsonObject when used in a field, except when used in
  * google.protobuf.Value.
+ *
+ * @private
  */
 export interface LocalMessageMapper {
   /**
@@ -53,6 +55,8 @@ export interface LocalMessageMapper {
 /**
  * Return the conversions between the local representation of the field
  * value and the message it represents.
+ *
+ * @private
  */
 export function localMessageMapper(
   field: DescField & { message: DescMessage },
@@ -119,6 +123,8 @@ function usesJsonRepresentation(
 /**
  * Convert the JsonValue representation of a google.protobuf.Struct to the
  * message representation.
+ *
+ * @private
  */
 export function wktStructToReflect(json: JsonValue): Struct {
   const struct: Struct = {
@@ -135,6 +141,8 @@ export function wktStructToReflect(json: JsonValue): Struct {
 
 /**
  * Convert a google.protobuf.Struct message to its JsonValue representation.
+ *
+ * @private
  */
 export function wktStructToLocal(val: Struct): JsonObject {
   const json: JsonObject = {};

--- a/packages/protobuf/src/reflect/reflect-check.ts
+++ b/packages/protobuf/src/reflect/reflect-check.ts
@@ -127,6 +127,8 @@ type InvalidScalarValueErr = false | "invalid UTF8" | `${string} out of range`;
 
 /**
  * Return the check for values of the given scalar type.
+ *
+ * @private
  */
 export function checkScalarValue(
   scalar: ScalarType,
@@ -225,6 +227,8 @@ export function checkScalarValue(
 
 /**
  * Format the reason why a value is invalid for a singular field.
+ *
+ * @private
  */
 export function reasonSingular(
   field:

--- a/packages/protobuf/src/reflect/reflect-check.ts
+++ b/packages/protobuf/src/reflect/reflect-check.ts
@@ -88,7 +88,7 @@ export function checkMapEntry(
   key: unknown,
   value: unknown,
 ): FieldError | undefined {
-  const checkKey = checkScalarValue(key, field.mapKey);
+  const checkKey = checkScalarValue(field.mapKey)(key);
   if (checkKey !== true) {
     return new FieldError(
       field,
@@ -110,13 +110,13 @@ function checkSingular(
   value: unknown,
 ): true | false | InvalidScalarValueErr {
   if (field.scalar !== undefined) {
-    return checkScalarValue(value, field.scalar);
+    return checkScalarValue(field.scalar)(value);
   }
   if (field.enum !== undefined) {
     if (field.enum.open) {
       // Open enums accept unrecognized values, but enum values are always
       // int32 (see https://protobuf.dev/programming-guides/proto3/#enum).
-      return checkScalarValue(value, ScalarType.INT32);
+      return checkScalarValue(ScalarType.INT32)(value);
     }
     return field.enum.values.some((v) => v.number === value);
   }
@@ -125,93 +125,108 @@ function checkSingular(
 
 type InvalidScalarValueErr = false | "invalid UTF8" | `${string} out of range`;
 
-function checkScalarValue(
-  value: unknown,
+/**
+ * Return the check for values of the given scalar type.
+ */
+export function checkScalarValue(
   scalar: ScalarType,
-): true | InvalidScalarValueErr {
+): (value: unknown) => true | InvalidScalarValueErr {
   switch (scalar) {
     case ScalarType.DOUBLE:
-      return typeof value == "number";
+      return (value) => typeof value == "number";
     case ScalarType.FLOAT:
-      if (typeof value != "number") {
-        return false;
-      }
-      if (Number.isNaN(value) || !Number.isFinite(value)) {
+      return (value) => {
+        if (typeof value != "number") {
+          return false;
+        }
+        if (Number.isNaN(value) || !Number.isFinite(value)) {
+          return true;
+        }
+        if (value > FLOAT32_MAX || value < FLOAT32_MIN) {
+          return `${value.toFixed()} out of range`;
+        }
         return true;
-      }
-      if (value > FLOAT32_MAX || value < FLOAT32_MIN) {
-        return `${value.toFixed()} out of range`;
-      }
-      return true;
+      };
     case ScalarType.INT32:
     case ScalarType.SFIXED32:
     case ScalarType.SINT32:
       // signed
-      if (typeof value !== "number" || !Number.isInteger(value)) {
-        return false;
-      }
-      if (value > INT32_MAX || value < INT32_MIN) {
-        return `${value.toFixed()} out of range`;
-      }
-      return true;
+      return (value) => {
+        if (typeof value !== "number" || !Number.isInteger(value)) {
+          return false;
+        }
+        if (value > INT32_MAX || value < INT32_MIN) {
+          return `${value.toFixed()} out of range`;
+        }
+        return true;
+      };
     case ScalarType.FIXED32:
     case ScalarType.UINT32:
       // unsigned
-      if (typeof value !== "number" || !Number.isInteger(value)) {
-        return false;
-      }
-      if (value > UINT32_MAX || value < 0) {
-        return `${value.toFixed()} out of range`;
-      }
-      return true;
+      return (value) => {
+        if (typeof value !== "number" || !Number.isInteger(value)) {
+          return false;
+        }
+        if (value > UINT32_MAX || value < 0) {
+          return `${value.toFixed()} out of range`;
+        }
+        return true;
+      };
     case ScalarType.BOOL:
-      return typeof value == "boolean";
+      return (value) => typeof value == "boolean";
     case ScalarType.STRING:
-      if (typeof value != "string") {
-        return false;
-      }
-      return getTextEncoding().checkUtf8(value) || "invalid UTF8";
+      return (value) => {
+        if (typeof value != "string") {
+          return false;
+        }
+        return getTextEncoding().checkUtf8(value) || "invalid UTF8";
+      };
     case ScalarType.BYTES:
-      return value instanceof Uint8Array;
-
+      return (value) => value instanceof Uint8Array;
     case ScalarType.INT64:
     case ScalarType.SFIXED64:
     case ScalarType.SINT64:
       // signed
-      if (
-        typeof value == "bigint" ||
-        typeof value == "number" ||
-        (typeof value == "string" && value.length > 0)
-      ) {
-        try {
-          protoInt64.parse(value);
-          return true;
-        } catch (_) {
-          return `${value} out of range`;
+      return (value) => {
+        if (
+          typeof value == "bigint" ||
+          typeof value == "number" ||
+          (typeof value == "string" && value.length > 0)
+        ) {
+          try {
+            protoInt64.parse(value);
+            return true;
+          } catch (_) {
+            return `${value} out of range`;
+          }
         }
-      }
-      return false;
-
+        return false;
+      };
     case ScalarType.FIXED64:
     case ScalarType.UINT64:
       // unsigned
-      if (
-        typeof value == "bigint" ||
-        typeof value == "number" ||
-        (typeof value == "string" && value.length > 0)
-      ) {
-        try {
-          protoInt64.uParse(value);
-          return true;
-        } catch (_) {
-          return `${value} out of range`;
+      return (value) => {
+        if (
+          typeof value == "bigint" ||
+          typeof value == "number" ||
+          (typeof value == "string" && value.length > 0)
+        ) {
+          try {
+            protoInt64.uParse(value);
+            return true;
+          } catch (_) {
+            return `${value} out of range`;
+          }
         }
-      }
-      return false;
+        return false;
+      };
   }
 }
 
-function reasonSingular(
+/**
+ * Format the reason why a value is invalid for a singular field.
+ */
+export function reasonSingular(
   field:
     | { scalar: ScalarType; message?: undefined; enum?: undefined }
     | { scalar?: undefined; message: DescMessage; enum?: undefined }

--- a/packages/protobuf/src/reflect/reflect.ts
+++ b/packages/protobuf/src/reflect/reflect.ts
@@ -45,15 +45,9 @@ import {
   isReflectMap,
   isReflectMessage,
 } from "./guard.js";
-import type {
-  ListValue,
-  Struct,
-  Value,
-} from "../wkt/gen/google/protobuf/struct_pb.js";
-import type { JsonObject, JsonValue } from "../json-value.js";
-
-// google.protobuf.NullValue.NULL_VALUE;
-const NULL_VALUE = 0;
+import type { Struct } from "../wkt/gen/google/protobuf/struct_pb.js";
+import type { JsonObject } from "../json-value.js";
+import { wktStructToLocal, wktStructToReflect } from "./message.js";
 
 /**
  * Create a ReflectMessage.
@@ -616,84 +610,6 @@ function longToLocal(field: DescField, value: unknown) {
         value = String(value);
       } else if (typeof value == "string" || typeof value == "number") {
         value = protoInt64.uParse(value);
-      }
-      break;
-  }
-  return value;
-}
-
-function wktStructToReflect(json: JsonValue): Struct {
-  const struct: Struct = {
-    $typeName: "google.protobuf.Struct",
-    fields: {},
-  };
-  if (isObject(json)) {
-    for (const [k, v] of Object.entries(json)) {
-      struct.fields[k] = wktValueToReflect(v);
-    }
-  }
-  return struct;
-}
-
-function wktStructToLocal(val: Struct) {
-  const json: JsonObject = {};
-  for (const [k, v] of Object.entries(val.fields)) {
-    json[k] = wktValueToLocal(v);
-  }
-  return json;
-}
-
-function wktValueToLocal(val: Value): JsonValue {
-  switch (val.kind.case) {
-    case "structValue":
-      return wktStructToLocal(val.kind.value);
-    case "listValue":
-      return val.kind.value.values.map(wktValueToLocal);
-    case "nullValue":
-    case undefined:
-      return null;
-    default:
-      return val.kind.value;
-  }
-}
-
-function wktValueToReflect(json: JsonValue): Value {
-  const value: Value = {
-    $typeName: "google.protobuf.Value",
-    kind: { case: undefined },
-  };
-  switch (typeof json) {
-    case "number":
-      value.kind = { case: "numberValue", value: json };
-      break;
-    case "string":
-      value.kind = { case: "stringValue", value: json };
-      break;
-    case "boolean":
-      value.kind = { case: "boolValue", value: json };
-      break;
-    case "object":
-      if (json === null) {
-        value.kind = { case: "nullValue", value: NULL_VALUE };
-      } else if (Array.isArray(json)) {
-        const listValue: ListValue = {
-          $typeName: "google.protobuf.ListValue",
-          values: [],
-        };
-        if (Array.isArray(json)) {
-          for (const e of json) {
-            listValue.values.push(wktValueToReflect(e));
-          }
-        }
-        value.kind = {
-          case: "listValue",
-          value: listValue,
-        };
-      } else {
-        value.kind = {
-          case: "structValue",
-          value: wktStructToReflect(json),
-        };
       }
       break;
   }

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -109,7 +109,8 @@ function compileMessage(desc: DescMessage): CompiledWriter {
     }
     const unknown = message.$unknown as UnknownField[] | undefined;
     if (unknown !== undefined && opts.writeUnknownFields) {
-      for (const { no, wireType, data } of unknown) {
+      for (let i = 0; i < unknown.length; i++) {
+        const { no, wireType, data } = unknown[i];
         writer.tag(no, wireType).raw(data);
       }
     }
@@ -331,7 +332,9 @@ function compileMapField(
     const writeMessage = compiledWriter(field.message);
     return (writer, opts, message) => {
       const record = message[localName] as Record<string, unknown>;
-      for (const key of Object.keys(record)) {
+      const keys = Object.keys(record);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
         writer.tag(fieldNo, WireType.LengthDelimited).fork();
         writeKey(writer, key);
         // The value of a map entry is always field number 2.
@@ -351,7 +354,9 @@ function compileMapField(
   );
   return (writer, opts, message) => {
     const record = message[localName] as Record<string, unknown>;
-    for (const key of Object.keys(record)) {
+    const keys = Object.keys(record);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
       writer.tag(fieldNo, WireType.LengthDelimited).fork();
       writeKey(writer, key);
       // The value of a map entry is always field number 2.

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -12,12 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { MessageShape } from "./types.js";
-import { reflect } from "./reflect/reflect.js";
+import type { MessageShape, UnknownField } from "./types.js";
 import { BinaryWriter, WireType } from "./wire/binary-encoding.js";
-import type { ScalarValue } from "./reflect/scalar.js";
 import { type DescField, type DescMessage, ScalarType } from "./descriptors.js";
-import type { ReflectList, ReflectMessage } from "./reflect/index.js";
+import type { ReflectMessage } from "./reflect/index.js";
+import { FieldError } from "./reflect/error.js";
+import { unsafeLocal } from "./reflect/unsafe.js";
+import { localMessageMapper } from "./reflect/message.js";
+import { protoInt64 } from "./proto-int64.js";
+
+// bootstrap-inject google.protobuf.FeatureSet.FieldPresence.IMPLICIT: const $name = $number;
+const IMPLICIT = 2;
 
 // bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name = $number;
 const LEGACY_REQUIRED = 3;
@@ -54,36 +59,442 @@ export function toBinary<Desc extends DescMessage>(
   message: MessageShape<Desc>,
   options?: Partial<BinaryWriteOptions>,
 ): Uint8Array<ArrayBuffer> {
-  return writeFields(
-    new BinaryWriter(),
+  const writer = new BinaryWriter();
+  compiledWriter(schema)(
+    writer,
     makeWriteOptions(options),
-    reflect(schema, message),
-  ).finish();
-}
-
-function writeFields(
-  writer: BinaryWriter,
-  opts: BinaryWriteOptions,
-  msg: ReflectMessage,
-): BinaryWriter {
-  for (const f of msg.sortedFields) {
-    if (!msg.isSet(f)) {
-      if (f.presence == LEGACY_REQUIRED) {
-        throw new Error(`cannot encode ${f} to binary: required field not set`);
-      }
-      continue;
-    }
-    writeField(writer, opts, msg, f);
-  }
-  if (opts.writeUnknownFields) {
-    for (const { no, wireType, data } of msg.getUnknown() ?? []) {
-      writer.tag(no, wireType).raw(data);
-    }
-  }
-  return writer;
+    message as Record<string, unknown>,
+  );
+  return writer.finish();
 }
 
 /**
+ * A message or field encoder, compiled from a descriptor ahead of time.
+ */
+type CompiledWriter = (
+  writer: BinaryWriter,
+  opts: BinaryWriteOptions,
+  message: Record<string, unknown>,
+) => void;
+
+const compiledWriters = new WeakMap<DescMessage, CompiledWriter>();
+
+/**
+ * Return the compiled encoder for a message, compiling it on first use.
+ */
+function compiledWriter(desc: DescMessage): CompiledWriter {
+  let compiled = compiledWriters.get(desc);
+  if (compiled === undefined) {
+    compiled = compileMessage(desc);
+  }
+  return compiled;
+}
+
+function compileMessage(desc: DescMessage): CompiledWriter {
+  const typeName = desc.typeName;
+  const sortedFields = desc.fields.concat().sort((a, b) => a.number - b.number);
+  // The field reported in ForeignFieldError.
+  const foreignField: DescField | undefined = sortedFields[0];
+  const fieldWriters: CompiledWriter[] = [];
+  const compiled: CompiledWriter = (writer, opts, message) => {
+    if (message.$typeName !== typeName && foreignField !== undefined) {
+      throw new FieldError(
+        foreignField,
+        `cannot use ${foreignField} with message ${message.$typeName}`,
+        "ForeignFieldError",
+      );
+    }
+    for (let i = 0; i < fieldWriters.length; i++) {
+      fieldWriters[i](writer, opts, message);
+    }
+    const unknown = message.$unknown as UnknownField[] | undefined;
+    if (unknown !== undefined && opts.writeUnknownFields) {
+      for (const { no, wireType, data } of unknown) {
+        writer.tag(no, wireType).raw(data);
+      }
+    }
+  };
+  // Register before compiling fields, so that recursive message types
+  // resolve to this instance instead of compiling endlessly.
+  compiledWriters.set(desc, compiled);
+  for (const field of sortedFields) {
+    fieldWriters.push(compileField(field));
+  }
+  return compiled;
+}
+
+function compileField(field: DescField): CompiledWriter {
+  switch (field.fieldKind) {
+    case "message":
+    case "scalar":
+    case "enum":
+      return compileSingularField(field);
+    case "list":
+      return compileListField(field);
+    case "map":
+      return compileMapField(field);
+  }
+}
+
+type DescFieldSingular = DescField &
+  ({ fieldKind: "scalar" } | { fieldKind: "enum" } | { fieldKind: "message" });
+
+/**
+ * Compile an encoder for a singular field: the presence check, and the
+ * value encoder.
+ */
+function compileSingularField(field: DescFieldSingular): CompiledWriter {
+  const writeValue = compileSingularValue(field);
+  const localName = field.localName;
+  if (field.oneof) {
+    const oneofLocalName = field.oneof.localName;
+    return (writer, opts, message) => {
+      const oneof = message[oneofLocalName] as {
+        case: string | undefined;
+        value?: unknown;
+      };
+      if (oneof.case === localName) {
+        writeValue(writer, opts, oneof.value);
+      }
+    };
+  }
+  if (field.presence != IMPLICIT) {
+    const requiredError =
+      field.presence == LEGACY_REQUIRED
+        ? `cannot encode ${field} to binary: required field not set`
+        : undefined;
+    return (writer, opts, message) => {
+      const value = message[localName];
+      // Fields with explicit presence have properties on the prototype
+      // chain for default / zero values (except for proto3).
+      if (
+        value !== undefined &&
+        Object.prototype.hasOwnProperty.call(message, localName)
+      ) {
+        writeValue(writer, opts, value);
+      } else if (requiredError !== undefined) {
+        throw new Error(requiredError);
+      }
+    };
+  }
+  // Implicit presence: the field is set when the value is not the zero
+  // value. The check is inlined per type, see isScalarZeroValue.
+  if (field.fieldKind == "enum") {
+    const zero = field.enum.values[0].number;
+    return (writer, opts, message) => {
+      const value = message[localName];
+      if (value !== zero) {
+        writeValue(writer, opts, value);
+      }
+    };
+  }
+  switch (field.scalar) {
+    case ScalarType.BOOL:
+      return (writer, opts, message) => {
+        const value = message[localName];
+        if (value !== false) {
+          writeValue(writer, opts, value);
+        }
+      };
+    case ScalarType.STRING:
+      return (writer, opts, message) => {
+        const value = message[localName];
+        if (value !== "") {
+          writeValue(writer, opts, value);
+        }
+      };
+    case ScalarType.BYTES:
+      return (writer, opts, message) => {
+        const value = message[localName];
+        if (!(value instanceof Uint8Array) || value.byteLength > 0) {
+          writeValue(writer, opts, value);
+        }
+      };
+    case ScalarType.DOUBLE:
+    case ScalarType.FLOAT:
+      return (writer, opts, message) => {
+        const value = message[localName];
+        // Object.is distinguishes -0 from 0.
+        if (!Object.is(value, 0)) {
+          writeValue(writer, opts, value);
+        }
+      };
+    default:
+      return (writer, opts, message) => {
+        const value = message[localName];
+        // Loose comparison matches 0n, 0 and "0".
+        if (value != 0) {
+          writeValue(writer, opts, value);
+        }
+      };
+  }
+}
+
+/**
+ * An encoder for a field value. The tag is written by the encoder itself.
+ */
+type CompiledValueWriter = (
+  writer: BinaryWriter,
+  opts: BinaryWriteOptions,
+  value: unknown,
+) => void;
+
+/**
+ * Compile an encoder for the value of a singular field, including the tag.
+ */
+function compileSingularValue(field: DescFieldSingular): CompiledValueWriter {
+  switch (field.fieldKind) {
+    case "message": {
+      const { toMessage } = localMessageMapper(field);
+      const writeChild = compileChildWriter(field);
+      return (writer, opts, value) => {
+        writeChild(writer, opts, toMessage(value));
+      };
+    }
+    case "scalar":
+    case "enum": {
+      const scalarType =
+        field.fieldKind == "enum" ? ScalarType.INT32 : field.scalar;
+      const fieldNo = field.number;
+      const wireType = writeTypeOfScalar(scalarType);
+      const writeScalar = compileScalarValue(
+        scalarType,
+        field.parent.typeName,
+        field.name,
+      );
+      return (writer, opts, value) => {
+        writer.tag(fieldNo, wireType);
+        writeScalar(writer, value);
+      };
+    }
+  }
+}
+
+function compileListField(
+  field: DescField & { fieldKind: "list" },
+): CompiledWriter {
+  const localName = field.localName;
+  const fieldNo = field.number;
+  switch (field.listKind) {
+    case "message": {
+      const { toMessage } = localMessageMapper(field);
+      const writeChild = compileChildWriter(field);
+      return (writer, opts, message) => {
+        const items = message[localName] as unknown[];
+        for (let i = 0; i < items.length; i++) {
+          writeChild(writer, opts, toMessage(items[i]));
+        }
+      };
+    }
+    case "scalar":
+    case "enum": {
+      const scalarType =
+        field.listKind == "enum" ? ScalarType.INT32 : field.scalar;
+      const writeScalar = compileScalarValue(
+        scalarType,
+        field.parent.typeName,
+        field.name,
+      );
+      if (field.packed) {
+        return (writer, opts, message) => {
+          const items = message[localName] as unknown[];
+          if (items.length == 0) {
+            return;
+          }
+          writer.tag(fieldNo, WireType.LengthDelimited).fork();
+          for (let i = 0; i < items.length; i++) {
+            writeScalar(writer, items[i]);
+          }
+          writer.join();
+        };
+      }
+      const wireType = writeTypeOfScalar(scalarType);
+      return (writer, opts, message) => {
+        const items = message[localName] as unknown[];
+        for (let i = 0; i < items.length; i++) {
+          writer.tag(fieldNo, wireType);
+          writeScalar(writer, items[i]);
+        }
+      };
+    }
+  }
+}
+
+function compileMapField(
+  field: DescField & { fieldKind: "map" },
+): CompiledWriter {
+  const localName = field.localName;
+  const fieldNo = field.number;
+  const writeKey = compileMapKey(field);
+  if (field.mapKind == "message") {
+    const { toMessage } = localMessageMapper(field);
+    const writeMessage = compiledWriter(field.message);
+    return (writer, opts, message) => {
+      const record = message[localName] as Record<string, unknown>;
+      for (const key of Object.keys(record)) {
+        writer.tag(fieldNo, WireType.LengthDelimited).fork();
+        writeKey(writer, key);
+        // The value of a map entry is always field number 2.
+        writer.tag(2, WireType.LengthDelimited).fork();
+        writeMessage(writer, opts, toMessage(record[key]));
+        writer.join();
+        writer.join();
+      }
+    };
+  }
+  const scalarType = field.mapKind == "enum" ? ScalarType.INT32 : field.scalar;
+  const valueWireType = writeTypeOfScalar(scalarType);
+  const writeScalar = compileScalarValue(
+    scalarType,
+    field.parent.typeName,
+    field.name,
+  );
+  return (writer, opts, message) => {
+    const record = message[localName] as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      writer.tag(fieldNo, WireType.LengthDelimited).fork();
+      writeKey(writer, key);
+      // The value of a map entry is always field number 2.
+      writer.tag(2, valueWireType);
+      writeScalar(writer, record[key]);
+      writer.join();
+    }
+  };
+}
+
+/**
+ * Compile an encoder for a map key. Map keys are stored as object keys and
+ * are always strings locally. Convert them to their scalar type before
+ * writing, like the reflect API does when iterating map entries.
+ */
+function compileMapKey(
+  field: DescField & { fieldKind: "map" },
+): (writer: BinaryWriter, key: string) => void {
+  const wireType = writeTypeOfScalar(field.mapKey);
+  const writeScalar = compileScalarValue(
+    field.mapKey,
+    field.parent.typeName,
+    field.name,
+  );
+  const convertKey = compileMapKeyConverter(field.mapKey);
+  return (writer, key) => {
+    // The key of a map entry is always field number 1.
+    writer.tag(1, wireType);
+    writeScalar(writer, convertKey(key));
+  };
+}
+
+/**
+ * Returns a converter from an object key (always a string) to the closest
+ * possible type for the map key type. Invalid keys are passed through to
+ * the scalar writer, which raises an error for them.
+ */
+function compileMapKeyConverter(
+  type: Exclude<
+    ScalarType,
+    ScalarType.FLOAT | ScalarType.DOUBLE | ScalarType.BYTES
+  >,
+): (key: string) => unknown {
+  switch (type) {
+    case ScalarType.STRING:
+      return (key) => key;
+    case ScalarType.BOOL:
+      return (key) => (key === "true" ? true : key === "false" ? false : key);
+    case ScalarType.UINT64:
+    case ScalarType.FIXED64:
+      return (key) => {
+        try {
+          return protoInt64.uParse(key);
+        } catch {
+          return key;
+        }
+      };
+    case ScalarType.INT64:
+    case ScalarType.SFIXED64:
+    case ScalarType.SINT64:
+      return (key) => {
+        try {
+          return protoInt64.parse(key);
+        } catch {
+          return key;
+        }
+      };
+    default:
+      // Handles INT32, UINT32, SINT32, FIXED32, SFIXED32.
+      // We do not use individual cases to save a few bytes code size.
+      return (key) => {
+        const n = Number.parseInt(key);
+        return Number.isFinite(n) ? n : key;
+      };
+  }
+}
+
+/**
+ * Compile an encoder for a bare scalar value (no tag), wrapping errors from
+ * the writer with the message and field name.
+ */
+function compileScalarValue(
+  type: ScalarType,
+  messageName: string,
+  fieldName: string,
+): (writer: BinaryWriter, value: unknown) => void {
+  const writeScalar = compileScalarWrite(type);
+  return (writer, value) => {
+    try {
+      writeScalar(writer, value);
+    } catch (e) {
+      if (e instanceof Error) {
+        throw new Error(
+          `cannot encode field ${messageName}.${fieldName} to binary: ${e.message}`,
+        );
+      }
+      throw e;
+    }
+  };
+}
+
+function compileScalarWrite(
+  type: ScalarType,
+): (writer: BinaryWriter, value: unknown) => void {
+  switch (type) {
+    case ScalarType.STRING:
+      return (writer, value) => writer.string(value as string);
+    case ScalarType.BOOL:
+      return (writer, value) => writer.bool(value as boolean);
+    case ScalarType.DOUBLE:
+      return (writer, value) => writer.double(value as number);
+    case ScalarType.FLOAT:
+      return (writer, value) => writer.float(value as number);
+    case ScalarType.INT32:
+      return (writer, value) => writer.int32(value as number);
+    case ScalarType.INT64:
+      return (writer, value) => writer.int64(value as number);
+    case ScalarType.UINT64:
+      return (writer, value) => writer.uint64(value as number);
+    case ScalarType.FIXED64:
+      return (writer, value) => writer.fixed64(value as number);
+    case ScalarType.BYTES:
+      return (writer, value) => writer.bytes(value as Uint8Array);
+    case ScalarType.FIXED32:
+      return (writer, value) => writer.fixed32(value as number);
+    case ScalarType.SFIXED32:
+      return (writer, value) => writer.sfixed32(value as number);
+    case ScalarType.SFIXED64:
+      return (writer, value) => writer.sfixed64(value as number);
+    case ScalarType.SINT64:
+      return (writer, value) => writer.sint64(value as number);
+    case ScalarType.UINT32:
+      return (writer, value) => writer.uint32(value as number);
+    case ScalarType.SINT32:
+      return (writer, value) => writer.sint32(value as number);
+  }
+}
+
+/**
+ * Write a single field to binary format, if it is set. Used to serialize
+ * extensions: extensions always have explicit presence, so an extension
+ * value that was just set on the container is always written.
+ *
  * @private
  */
 export function writeField(
@@ -91,213 +502,36 @@ export function writeField(
   opts: BinaryWriteOptions,
   msg: ReflectMessage,
   field: DescField,
-) {
-  switch (field.fieldKind) {
-    case "scalar":
-    case "enum":
-      writeScalar(
-        writer,
-        msg.desc.typeName,
-        field.name,
-        field.scalar ?? ScalarType.INT32,
-        field.number,
-        msg.get(field),
-      );
-      break;
-    case "list":
-      writeListField(writer, opts, field, msg.get(field));
-      break;
-    case "message":
-      writeMessageField(writer, opts, field, msg.get(field));
-      break;
-    case "map":
-      for (const [key, val] of msg.get(field)) {
-        writeMapEntry(writer, opts, field, key, val);
-      }
-      break;
-  }
-}
-
-function writeScalar(
-  writer: BinaryWriter,
-  msgName: string,
-  fieldName: string,
-  scalarType: ScalarType,
-  fieldNo: number,
-  value: unknown,
-) {
-  writeScalarValue(
-    writer.tag(fieldNo, writeTypeOfScalar(scalarType)),
-    msgName,
-    fieldName,
-    scalarType,
-    value as ScalarValue,
+): void {
+  compileField(field)(
+    writer,
+    opts,
+    msg[unsafeLocal] as unknown as Record<string, unknown>,
   );
 }
 
-function writeMessageField(
-  writer: BinaryWriter,
-  opts: BinaryWriteOptions,
+/**
+ * Compile an encoder for the wire format of a message field, honoring the
+ * delimited encoding of the field. The tag is written by the encoder.
+ */
+function compileChildWriter(
   field: DescField &
     ({ fieldKind: "message" } | { fieldKind: "list"; listKind: "message" }),
-  message: ReflectMessage,
-) {
+): CompiledValueWriter {
+  const fieldNo = field.number;
+  const writeMessage = compiledWriter(field.message);
   if (field.delimitedEncoding) {
-    writeFields(
-      writer.tag(field.number, WireType.StartGroup),
-      opts,
-      message,
-    ).tag(field.number, WireType.EndGroup);
-  } else {
-    writeFields(
-      writer.tag(field.number, WireType.LengthDelimited).fork(),
-      opts,
-      message,
-    ).join();
+    return (writer, opts, child) => {
+      writer.tag(fieldNo, WireType.StartGroup);
+      writeMessage(writer, opts, child as Record<string, unknown>);
+      writer.tag(fieldNo, WireType.EndGroup);
+    };
   }
-}
-
-function writeListField(
-  writer: BinaryWriter,
-  opts: BinaryWriteOptions,
-  field: DescField & { fieldKind: "list" },
-  list: ReflectList,
-) {
-  if (field.listKind == "message") {
-    for (const item of list) {
-      writeMessageField(writer, opts, field, item as ReflectMessage);
-    }
-    return;
-  }
-  const scalarType = field.scalar ?? ScalarType.INT32;
-  if (field.packed) {
-    if (!list.size) {
-      return;
-    }
-    writer.tag(field.number, WireType.LengthDelimited).fork();
-    for (const item of list) {
-      writeScalarValue(
-        writer,
-        field.parent.typeName,
-        field.name,
-        scalarType,
-        item as ScalarValue,
-      );
-    }
+  return (writer, opts, child) => {
+    writer.tag(fieldNo, WireType.LengthDelimited).fork();
+    writeMessage(writer, opts, child as Record<string, unknown>);
     writer.join();
-    return;
-  }
-  for (const item of list) {
-    writeScalar(
-      writer,
-      field.parent.typeName,
-      field.name,
-      scalarType,
-      field.number,
-      item,
-    );
-  }
-}
-
-function writeMapEntry(
-  writer: BinaryWriter,
-  opts: BinaryWriteOptions,
-  field: DescField & { fieldKind: "map" },
-  key: unknown,
-  value: unknown,
-) {
-  writer.tag(field.number, WireType.LengthDelimited).fork();
-
-  // write key, expecting key field number = 1
-  writeScalar(writer, field.parent.typeName, field.name, field.mapKey, 1, key);
-
-  // write value, expecting value field number = 2
-  switch (field.mapKind) {
-    case "scalar":
-    case "enum":
-      writeScalar(
-        writer,
-        field.parent.typeName,
-        field.name,
-        field.scalar ?? ScalarType.INT32,
-        2,
-        value,
-      );
-      break;
-    case "message":
-      writeFields(
-        writer.tag(2, WireType.LengthDelimited).fork(),
-        opts,
-        value as ReflectMessage,
-      ).join();
-      break;
-  }
-  writer.join();
-}
-
-function writeScalarValue(
-  writer: BinaryWriter,
-  msgName: string,
-  fieldName: string,
-  type: ScalarType,
-  value: ScalarValue,
-) {
-  try {
-    switch (type) {
-      case ScalarType.STRING:
-        writer.string(value as string);
-        break;
-      case ScalarType.BOOL:
-        writer.bool(value as boolean);
-        break;
-      case ScalarType.DOUBLE:
-        writer.double(value as number);
-        break;
-      case ScalarType.FLOAT:
-        writer.float(value as number);
-        break;
-      case ScalarType.INT32:
-        writer.int32(value as number);
-        break;
-      case ScalarType.INT64:
-        writer.int64(value as number);
-        break;
-      case ScalarType.UINT64:
-        writer.uint64(value as number);
-        break;
-      case ScalarType.FIXED64:
-        writer.fixed64(value as number);
-        break;
-      case ScalarType.BYTES:
-        writer.bytes(value as Uint8Array);
-        break;
-      case ScalarType.FIXED32:
-        writer.fixed32(value as number);
-        break;
-      case ScalarType.SFIXED32:
-        writer.sfixed32(value as number);
-        break;
-      case ScalarType.SFIXED64:
-        writer.sfixed64(value as number);
-        break;
-      case ScalarType.SINT64:
-        writer.sint64(value as number);
-        break;
-      case ScalarType.UINT32:
-        writer.uint32(value as number);
-        break;
-      case ScalarType.SINT32:
-        writer.sint32(value as number);
-        break;
-    }
-  } catch (e) {
-    if (e instanceof Error) {
-      throw new Error(
-        `cannot encode field ${msgName}.${fieldName} to binary: ${e.message}`,
-      );
-    }
-    throw e;
-  }
+  };
 }
 
 function writeTypeOfScalar(type: ScalarType): WireType {

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -21,19 +21,14 @@ import {
 } from "./descriptors.js";
 import type { JsonObject, JsonValue } from "./json-value.js";
 import { protoCamelCase, protoSnakeCase } from "./reflect/names.js";
-import { reflect } from "./reflect/reflect.js";
 import type { Registry } from "./registry.js";
-import type {
-  ReflectList,
-  ReflectMap,
-  ReflectMessage,
-} from "./reflect/reflect-types.js";
 import type {
   EnumJsonType,
   EnumShape,
   Message,
   MessageJsonType,
   MessageShape,
+  UnknownField,
 } from "./types.js";
 import type {
   Any,
@@ -45,10 +40,23 @@ import type {
   Value,
 } from "./wkt/index.js";
 import { anyUnpack } from "./wkt/index.js";
-import { hasCustomJsonRepresentation, isWrapperDesc } from "./wkt/wrappers.js";
+import {
+  hasCustomJsonRepresentation,
+  isWrapperDesc,
+} from "./wkt/wrappers.js";
+import {
+  durationSecondsMax,
+  durationSecondsMin,
+  timestampMsMax,
+  timestampMsMin,
+} from "./wkt/json.js";
 import { base64Encode } from "./wire/index.js";
 import { createExtensionContainer, getExtension } from "./extensions.js";
 import { checkField, formatVal } from "./reflect/reflect-check.js";
+import { FieldError } from "./reflect/error.js";
+import { unsafeLocal } from "./reflect/unsafe.js";
+import { scalarZeroValue } from "./reflect/scalar.js";
+import { localMessageMapper } from "./reflect/message.js";
 
 // bootstrap-inject google.protobuf.FeatureSet.FieldPresence.LEGACY_REQUIRED: const $name = $number;
 const LEGACY_REQUIRED = 3;
@@ -130,9 +138,9 @@ export function toJson<
   message: MessageShape<Desc>,
   options?: Opts,
 ): ToJson<Desc, Opts> {
-  return reflectToJson(
-    reflect(schema, message),
+  return compiledWriter(schema)(
     makeWriteOptions(options),
+    message as Record<string, unknown>,
   ) as ToJson<Desc, Opts>;
 }
 
@@ -180,142 +188,451 @@ export function enumToJson<Desc extends DescEnum>(
   return name as EnumJsonType<Desc>;
 }
 
-function reflectToJson(msg: ReflectMessage, opts: JsonWriteOptions): JsonValue {
-  const wktJson = tryWktToJson(msg, opts);
-  if (wktJson !== undefined) return wktJson;
-  const json: JsonObject = {};
-  for (const f of msg.sortedFields) {
-    if (!msg.isSet(f)) {
-      if (f.presence == LEGACY_REQUIRED) {
-        throw new Error(`cannot encode ${f} to JSON: required field not set`);
-      }
-      if (!opts.alwaysEmitImplicit || f.presence !== IMPLICIT) {
-        // Fields with implicit presence omit zero values (e.g. empty string) by default
-        continue;
-      }
-    }
-    const jsonValue = fieldToJson(f, msg.get(f), opts);
-    if (jsonValue !== undefined) {
-      json[jsonName(f, opts)] = jsonValue;
-    }
+/**
+ * A message encoder, compiled from a descriptor ahead of time.
+ */
+type CompiledJsonWriter = (
+  opts: JsonWriteOptions,
+  message: Record<string, unknown>,
+) => JsonValue;
+
+/**
+ * An encoder for a field: checks presence and writes the value to the JSON
+ * object under the field's JSON name.
+ */
+type CompiledFieldJsonWriter = (
+  opts: JsonWriteOptions,
+  message: Record<string, unknown>,
+  json: JsonObject,
+) => void;
+
+/**
+ * An encoder for a value. Always produces a JSON value.
+ */
+type CompiledValueJsonWriter = (
+  opts: JsonWriteOptions,
+  value: unknown,
+) => JsonValue;
+
+/**
+ * An encoder for the value of a field of any kind. Returns undefined when
+ * the value is omitted from JSON output (empty list and map fields).
+ */
+type CompiledFieldValueJsonWriter = (
+  opts: JsonWriteOptions,
+  value: unknown,
+) => JsonValue | undefined;
+
+const compiledWriters = new WeakMap<DescMessage, CompiledJsonWriter>();
+
+/**
+ * Return the compiled encoder for a message, compiling it on first use.
+ */
+function compiledWriter(desc: DescMessage): CompiledJsonWriter {
+  let compiled = compiledWriters.get(desc);
+  if (compiled === undefined) {
+    compiled = compileMessage(desc);
   }
-  if (opts.registry) {
-    const tagSeen = new Set<number>();
-    for (const { no } of msg.getUnknown() ?? []) {
-      // Same tag can appear multiple times, so we
-      // keep track and skip identical ones.
-      if (!tagSeen.has(no)) {
-        tagSeen.add(no);
-        const extension = opts.registry.getExtensionFor(msg.desc, no);
-        if (!extension) {
-          continue;
-        }
-        const value = getExtension(msg.message, extension);
-        const [container, field] = createExtensionContainer(extension, value);
-        const jsonValue = fieldToJson(field, container.get(field), opts);
-        if (jsonValue !== undefined) {
-          json[extension.jsonName] = jsonValue;
-        }
-      }
-    }
-  }
-  return json;
+  return compiled;
 }
 
-function fieldToJson(f: DescField, val: unknown, opts: JsonWriteOptions) {
-  switch (f.fieldKind) {
+function compileMessage(desc: DescMessage): CompiledJsonWriter {
+  const typeName = desc.typeName;
+  const writeWkt = compileWkt(desc);
+  if (writeWkt !== undefined) {
+    // The field reported in ForeignFieldError. All well-known types with a
+    // custom JSON representation have at least one field.
+    const foreignField: DescField | undefined = desc.fields[0];
+    const compiledWriter: CompiledJsonWriter = (opts, message) => {
+      if (message.$typeName !== typeName && foreignField !== undefined) {
+        throw new FieldError(
+          foreignField,
+          `cannot use ${foreignField} with message ${message.$typeName}`,
+          "ForeignFieldError",
+        );
+      }
+      return writeWkt(opts, message);
+    };
+    compiledWriters.set(desc, compiledWriter);
+    return compiledWriter;
+  }
+  const sortedFields = desc.fields.concat().sort((a, b) => a.number - b.number);
+  // The field reported in ForeignFieldError.
+  const foreignField: DescField | undefined = sortedFields[0];
+  const fieldWriters: CompiledFieldJsonWriter[] = [];
+  const compiledWriter: CompiledJsonWriter = (opts, message) => {
+    if (message.$typeName !== typeName && foreignField !== undefined) {
+      throw new FieldError(
+        foreignField,
+        `cannot use ${foreignField} with message ${message.$typeName}`,
+        "ForeignFieldError",
+      );
+    }
+    const json: JsonObject = {};
+    for (let i = 0; i < fieldWriters.length; i++) {
+      fieldWriters[i](opts, message, json);
+    }
+    if (opts.registry) {
+      writeExtensions(json, opts, opts.registry, message, desc);
+    }
+    return json;
+  };
+  // Register before compiling fields, so that recursive message types
+  // resolve to this instance instead of compiling endlessly.
+  compiledWriters.set(desc, compiledWriter);
+  for (const field of sortedFields) {
+    fieldWriters.push(compileField(field));
+  }
+  return compiledWriter;
+}
+
+/**
+ * Compile an encoder for a well-known type with a custom JSON representation,
+ * or return undefined for other messages.
+ */
+function compileWkt(desc: DescMessage): CompiledJsonWriter | undefined {
+  if (!desc.typeName.startsWith("google.protobuf.")) {
+    return undefined;
+  }
+  switch (desc.typeName) {
+    case "google.protobuf.Any":
+      return (opts, message) => anyToJson(message as unknown as Any, opts);
+    case "google.protobuf.Timestamp":
+      return (opts, message) =>
+        timestampToJson(message as unknown as Timestamp);
+    case "google.protobuf.Duration":
+      return (opts, message) => durationToJson(message as unknown as Duration);
+    case "google.protobuf.FieldMask":
+      return (opts, message) =>
+        fieldMaskToJson(message as unknown as FieldMask);
+    case "google.protobuf.Struct":
+      return (opts, message) => structToJson(message as unknown as Struct);
+    case "google.protobuf.Value":
+      return (opts, message) => valueToJson(message as unknown as Value);
+    case "google.protobuf.ListValue":
+      return (opts, message) =>
+        listValueToJson(message as unknown as ListValue);
+    default:
+      if (isWrapperDesc(desc)) {
+        const valueField = desc.fields[0];
+        const localName = valueField.localName;
+        const zero = scalarZeroValue(valueField.scalar, false);
+        const writeScalar = compileScalarValue(valueField);
+        return (opts, message) => {
+          const value = message[localName];
+          return writeScalar(opts, value === undefined ? zero : value);
+        };
+      }
+      return undefined;
+  }
+}
+
+function compileField(field: DescField): CompiledFieldJsonWriter {
+  switch (field.fieldKind) {
     case "scalar":
-      return scalarToJson(f, val);
-    case "message":
-      return reflectToJson(val as ReflectMessage, opts);
     case "enum":
-      return enumToJsonInternal(f.enum, val, opts.enumAsInteger);
+    case "message":
+      return compileSingularField(field);
     case "list":
-      return listToJson(val as ReflectList, opts);
-    case "map":
-      return mapToJson(val as ReflectMap, opts);
+    case "map": {
+      const writeValue =
+        field.fieldKind == "list"
+          ? compileListValue(field)
+          : compileMapValue(field);
+      const protoName = field.name;
+      const jsonKey = field.jsonName;
+      const localName = field.localName;
+      return (opts, message, json) => {
+        const value = writeValue(opts, message[localName]);
+        if (value !== undefined) {
+          json[opts.useProtoFieldName ? protoName : jsonKey] = value;
+        }
+      };
+    }
   }
 }
 
-function mapToJson(map: ReflectMap, opts: JsonWriteOptions) {
-  const f = map.field();
-  const jsonObj: JsonObject = {};
-  switch (f.mapKind) {
-    case "scalar":
-      for (const [entryKey, entryValue] of map) {
-        jsonObj[entryKey as keyof object] = scalarToJson(f, entryValue);
-      }
-      break;
-    case "message":
-      for (const [entryKey, entryValue] of map) {
-        jsonObj[entryKey as keyof object] = reflectToJson(
-          entryValue as ReflectMessage,
+type DescFieldSingular = DescField &
+  ({ fieldKind: "scalar" } | { fieldKind: "enum" } | { fieldKind: "message" });
+
+/**
+ * Compile an encoder for a singular field: the presence check, and the
+ * value encoder.
+ */
+function compileSingularField(
+  field: DescFieldSingular,
+): CompiledFieldJsonWriter {
+  const writeValue = compileSingularValue(field);
+  const protoName = field.name;
+  const jsonKey = field.jsonName;
+  const localName = field.localName;
+  if (field.oneof) {
+    const oneofLocalName = field.oneof.localName;
+    return (opts, message, json) => {
+      const oneof = message[oneofLocalName] as {
+        case: string | undefined;
+        value?: unknown;
+      };
+      if (oneof.case === localName) {
+        json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
           opts,
+          oneof.value,
         );
       }
-      break;
-    case "enum":
-      for (const [entryKey, entryValue] of map) {
-        jsonObj[entryKey as keyof object] = enumToJsonInternal(
-          f.enum,
-          entryValue,
-          opts.enumAsInteger,
-        );
-      }
-      break;
+    };
   }
-  return opts.alwaysEmitImplicit || map.size > 0 ? jsonObj : undefined;
+  if (field.presence != IMPLICIT) {
+    const requiredError =
+      field.presence == LEGACY_REQUIRED
+        ? `cannot encode ${field} to JSON: required field not set`
+        : undefined;
+    return (opts, message, json) => {
+      const value = message[localName];
+      // Fields with explicit presence have properties on the prototype
+      // chain for default / zero values (except for proto3).
+      if (
+        value !== undefined &&
+        Object.prototype.hasOwnProperty.call(message, localName)
+      ) {
+        json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+          opts,
+          value,
+        );
+      } else if (requiredError !== undefined) {
+        throw new Error(requiredError);
+      }
+    };
+  }
+  // Implicit presence: the field is emitted when the value is not the zero
+  // value, or when alwaysEmitImplicit is enabled. The zero check is inlined
+  // per type, see isScalarZeroValue.
+  if (field.fieldKind == "enum") {
+    const zero = field.enum.values[0].number;
+    return (opts, message, json) => {
+      const value = message[localName];
+      if (value !== zero || opts.alwaysEmitImplicit) {
+        json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+          opts,
+          value,
+        );
+      }
+    };
+  }
+  switch (field.scalar) {
+    case ScalarType.BOOL:
+      return (opts, message, json) => {
+        const value = message[localName];
+        if (value !== false || opts.alwaysEmitImplicit) {
+          json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+            opts,
+            value,
+          );
+        }
+      };
+    case ScalarType.STRING:
+      return (opts, message, json) => {
+        const value = message[localName];
+        if (value !== "" || opts.alwaysEmitImplicit) {
+          json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+            opts,
+            value,
+          );
+        }
+      };
+    case ScalarType.BYTES:
+      return (opts, message, json) => {
+        const value = message[localName];
+        if (
+          !(value instanceof Uint8Array) ||
+          value.byteLength > 0 ||
+          opts.alwaysEmitImplicit
+        ) {
+          json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+            opts,
+            value,
+          );
+        }
+      };
+    case ScalarType.DOUBLE:
+    case ScalarType.FLOAT:
+      return (opts, message, json) => {
+        const value = message[localName];
+        // Object.is distinguishes -0 from 0.
+        if (!Object.is(value, 0) || opts.alwaysEmitImplicit) {
+          json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+            opts,
+            value,
+          );
+        }
+      };
+    default:
+      return (opts, message, json) => {
+        const value = message[localName];
+        // Loose comparison matches 0n, 0 and "0".
+        if (value != 0 || opts.alwaysEmitImplicit) {
+          json[opts.useProtoFieldName ? protoName : jsonKey] = writeValue(
+            opts,
+            value,
+          );
+        }
+      };
+  }
 }
 
-function listToJson(list: ReflectList, opts: JsonWriteOptions) {
-  const f = list.field();
-  const jsonArr: JsonValue[] = [];
-  switch (f.listKind) {
+/**
+ * Compile an encoder for the value of a field of any kind. Used for
+ * extension values.
+ */
+function compileFieldValue(field: DescField): CompiledFieldValueJsonWriter {
+  switch (field.fieldKind) {
     case "scalar":
-      for (const item of list) {
-        jsonArr.push(scalarToJson(f, item) as JsonValue);
-      }
-      break;
     case "enum":
-      for (const item of list) {
-        jsonArr.push(
-          enumToJsonInternal(f.enum, item, opts.enumAsInteger) as JsonValue,
-        );
-      }
-      break;
     case "message":
-      for (const item of list) {
-        jsonArr.push(reflectToJson(item as ReflectMessage, opts));
-      }
-      break;
+      return compileSingularValue(field);
+    case "list":
+      return compileListValue(field);
+    case "map":
+      return compileMapValue(field);
   }
-  return opts.alwaysEmitImplicit || jsonArr.length > 0 ? jsonArr : undefined;
 }
 
-function enumToJsonInternal(
-  desc: DescEnum,
-  value: unknown,
-  enumAsInteger: boolean,
-): string | number | null {
-  if (typeof value != "number") {
-    throw new Error(
-      `cannot encode ${desc} to JSON: expected number, got ${formatVal(value)}`,
-    );
+/**
+ * Compile an encoder for the value of a singular field.
+ */
+function compileSingularValue(
+  field: DescFieldSingular,
+): CompiledValueJsonWriter {
+  switch (field.fieldKind) {
+    case "scalar":
+      return compileScalarValue(field);
+    case "enum":
+      return compileEnumValue(field);
+    case "message":
+      return compileMessageValue(field);
   }
+}
+
+/**
+ * Compile an encoder for the value of a message field.
+ */
+function compileMessageValue(
+  field: DescField & { message: DescMessage },
+): CompiledValueJsonWriter {
+  const { toMessage } = localMessageMapper(field);
+  const writeMessage = compiledWriter(field.message);
+  return (opts, value) => writeMessage(opts, toMessage(value));
+}
+
+/**
+ * Compile an encoder for a list field value. Returns undefined for an empty
+ * list, unless alwaysEmitImplicit is enabled.
+ */
+function compileListValue(
+  field: DescField & { fieldKind: "list" },
+): CompiledFieldValueJsonWriter {
+  const writeItem = compileListItemValue(field);
+  return (opts, value) => {
+    const items = value as unknown[];
+    if (items.length == 0 && !opts.alwaysEmitImplicit) {
+      return undefined;
+    }
+    const jsonArray: JsonValue[] = [];
+    for (let i = 0; i < items.length; i++) {
+      jsonArray.push(writeItem(opts, items[i]));
+    }
+    return jsonArray;
+  };
+}
+
+function compileListItemValue(
+  field: DescField & { fieldKind: "list" },
+): CompiledValueJsonWriter {
+  switch (field.listKind) {
+    case "scalar":
+      return compileScalarValue(field);
+    case "enum":
+      return compileEnumValue(field);
+    case "message":
+      return compileMessageValue(field);
+  }
+}
+
+/**
+ * Compile an encoder for a map field value. Returns undefined for an empty
+ * map, unless alwaysEmitImplicit is enabled. Map keys are stored as object
+ * keys and are used as JSON keys as-is.
+ */
+function compileMapValue(
+  field: DescField & { fieldKind: "map" },
+): CompiledFieldValueJsonWriter {
+  const writeMapValue = compileMapEntryValue(field);
+  return (opts, value) => {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record);
+    if (keys.length == 0 && !opts.alwaysEmitImplicit) {
+      return undefined;
+    }
+    const jsonObject: JsonObject = {};
+    for (const key of keys) {
+      jsonObject[key] = writeMapValue(opts, record[key]);
+    }
+    return jsonObject;
+  };
+}
+
+function compileMapEntryValue(
+  field: DescField & { fieldKind: "map" },
+): CompiledValueJsonWriter {
+  switch (field.mapKind) {
+    case "scalar":
+      return compileScalarValue(field);
+    case "enum":
+      return compileEnumValue(field);
+    case "message":
+      return compileMessageValue(field);
+  }
+}
+
+/**
+ * Compile an encoder for an enum value.
+ */
+function compileEnumValue(
+  field: DescField & { enum: DescEnum },
+): CompiledValueJsonWriter {
+  const desc = field.enum;
   if (desc.typeName == "google.protobuf.NullValue") {
-    return null;
+    return (opts, value) => {
+      if (typeof value != "number") {
+        throw errorEnumValue(desc, value);
+      }
+      return null;
+    };
   }
-  if (enumAsInteger) {
-    return value;
-  }
-  const val = desc.value[value] as DescEnumValue | undefined;
-  return val?.name ?? value; // if we don't know the enum value, just return the number
+  return (opts, value) => {
+    if (typeof value != "number") {
+      throw errorEnumValue(desc, value);
+    }
+    if (opts.enumAsInteger) {
+      return value;
+    }
+    // If we don't know the enum value, just return the number.
+    return (desc.value[value] as DescEnumValue | undefined)?.name ?? value;
+  };
 }
 
-function scalarToJson(
+function errorEnumValue(desc: DescEnum, value: unknown): Error {
+  return new Error(
+    `cannot encode ${desc} to JSON: expected number, got ${formatVal(value)}`,
+  );
+}
+
+/**
+ * Compile an encoder for a scalar value. Errors report the original field
+ * descriptor, which may be a list or map field for items of those fields.
+ */
+function compileScalarValue(
   field: DescField & { scalar: ScalarType },
-  value: unknown,
-): string | number | boolean {
+): CompiledValueJsonWriter {
   switch (field.scalar) {
     // int32, fixed32, uint32: JSON value will be a decimal number. Either numbers or strings are accepted.
     case ScalarType.INT32:
@@ -323,44 +640,44 @@ function scalarToJson(
     case ScalarType.SINT32:
     case ScalarType.FIXED32:
     case ScalarType.UINT32:
-      if (typeof value != "number") {
-        throw new Error(
-          `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-        );
-      }
-      return value;
+      return (opts, value) => {
+        if (typeof value != "number") {
+          throw errorScalarValue(field, value);
+        }
+        return value;
+      };
 
     // float, double: JSON value will be a number or one of the special string values "NaN", "Infinity", and "-Infinity".
     // Either numbers or strings are accepted. Exponent notation is also accepted.
     case ScalarType.FLOAT:
-    case ScalarType.DOUBLE: // eslint-disable-line no-fallthrough
-      if (typeof value != "number") {
-        throw new Error(
-          `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-        );
-      }
-      if (Number.isNaN(value)) return "NaN";
-      if (value === Number.POSITIVE_INFINITY) return "Infinity";
-      if (value === Number.NEGATIVE_INFINITY) return "-Infinity";
-      return value;
+    case ScalarType.DOUBLE:
+      return (opts, value) => {
+        if (typeof value != "number") {
+          throw errorScalarValue(field, value);
+        }
+        if (Number.isNaN(value)) return "NaN";
+        if (value === Number.POSITIVE_INFINITY) return "Infinity";
+        if (value === Number.NEGATIVE_INFINITY) return "-Infinity";
+        return value;
+      };
 
     // string:
     case ScalarType.STRING:
-      if (typeof value != "string") {
-        throw new Error(
-          `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-        );
-      }
-      return value;
+      return (opts, value) => {
+        if (typeof value != "string") {
+          throw errorScalarValue(field, value);
+        }
+        return value;
+      };
 
     // bool:
     case ScalarType.BOOL:
-      if (typeof value != "boolean") {
-        throw new Error(
-          `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-        );
-      }
-      return value;
+      return (opts, value) => {
+        if (typeof value != "boolean") {
+          throw errorScalarValue(field, value);
+        }
+        return value;
+      };
 
     // JSON value will be a decimal string. Either numbers or strings are accepted.
     case ScalarType.UINT64:
@@ -368,62 +685,70 @@ function scalarToJson(
     case ScalarType.INT64:
     case ScalarType.SFIXED64:
     case ScalarType.SINT64:
-      if (
-        typeof value == "bigint" ||
-        typeof value == "string" ||
-        (typeof value == "number" && Number.isInteger(value))
-      ) {
-        return value.toString();
-      }
-      throw new Error(
-        `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-      );
+      return (opts, value) => {
+        if (
+          typeof value == "bigint" ||
+          typeof value == "string" ||
+          (typeof value == "number" && Number.isInteger(value))
+        ) {
+          return value.toString();
+        }
+        throw errorScalarValue(field, value);
+      };
 
     // bytes: JSON value will be the data encoded as a string using standard base64 encoding with paddings.
     // Either standard or URL-safe base64 encoding with/without paddings are accepted.
     case ScalarType.BYTES:
-      if (value instanceof Uint8Array) {
-        return base64Encode(value);
-      }
-      throw new Error(
-        `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
-      );
+      return (opts, value) => {
+        if (value instanceof Uint8Array) {
+          return base64Encode(value);
+        }
+        throw errorScalarValue(field, value);
+      };
   }
 }
 
-function jsonName(f: DescField, opts: JsonWriteOptions) {
-  return opts.useProtoFieldName ? f.name : f.jsonName;
+function errorScalarValue(field: DescField, value: unknown): Error {
+  return new Error(
+    `cannot encode ${field} to JSON: ${checkField(field, value)?.message}`,
+  );
 }
 
-// returns a json value if wkt, otherwise returns undefined.
-function tryWktToJson(
-  msg: ReflectMessage,
+/**
+ * Write extensions for unknown fields that are found in the registry.
+ */
+function writeExtensions(
+  json: JsonObject,
   opts: JsonWriteOptions,
-): JsonValue | undefined {
-  if (!msg.desc.typeName.startsWith("google.protobuf.")) {
-    return undefined;
+  registry: Registry,
+  message: Record<string, unknown>,
+  desc: DescMessage,
+): void {
+  const unknown = message.$unknown as UnknownField[] | undefined;
+  if (unknown === undefined) {
+    return;
   }
-  switch (msg.desc.typeName) {
-    case "google.protobuf.Any":
-      return anyToJson(msg.message as Any, opts);
-    case "google.protobuf.Timestamp":
-      return timestampToJson(msg.message as Timestamp);
-    case "google.protobuf.Duration":
-      return durationToJson(msg.message as Duration);
-    case "google.protobuf.FieldMask":
-      return fieldMaskToJson(msg.message as FieldMask);
-    case "google.protobuf.Struct":
-      return structToJson(msg.message as Struct);
-    case "google.protobuf.Value":
-      return valueToJson(msg.message as Value);
-    case "google.protobuf.ListValue":
-      return listValueToJson(msg.message as ListValue);
-    default:
-      if (isWrapperDesc(msg.desc)) {
-        const valueField = msg.desc.fields[0];
-        return scalarToJson(valueField, msg.get(valueField));
+  const tagSeen = new Set<number>();
+  for (const { no } of unknown) {
+    // Same tag can appear multiple times, so we
+    // keep track and skip identical ones.
+    if (!tagSeen.has(no)) {
+      tagSeen.add(no);
+      const extension = registry.getExtensionFor(desc, no);
+      if (!extension) {
+        continue;
       }
-      return undefined;
+      const value = getExtension(message as unknown as Message, extension);
+      const [container, field] = createExtensionContainer(extension, value);
+      const local = container[unsafeLocal] as unknown as Record<
+        string,
+        unknown
+      >;
+      const jsonValue = compileFieldValue(field)(opts, local[field.localName]);
+      if (jsonValue !== undefined) {
+        json[extension.jsonName] = jsonValue;
+      }
+    }
   }
 }
 
@@ -445,10 +770,17 @@ function anyToJson(val: Any, opts: JsonWriteOptions): JsonValue {
       `cannot encode message ${val.$typeName} to JSON: "${val.typeUrl}" is not in the type registry`,
     );
   }
-  const reflected = reflect(desc, message);
   const json: JsonObject = hasCustomJsonRepresentation(desc)
-    ? { value: tryWktToJson(reflected, opts) as JsonValue }
-    : (reflectToJson(reflected, opts) as JsonObject);
+    ? {
+        value: compiledWriter(desc)(
+          opts,
+          message as unknown as Record<string, unknown>,
+        ),
+      }
+    : (compiledWriter(desc)(
+        opts,
+        message as unknown as Record<string, unknown>,
+      ) as JsonObject);
   json["@type"] = val.typeUrl;
   return json;
 }
@@ -456,7 +788,7 @@ function anyToJson(val: Any, opts: JsonWriteOptions): JsonValue {
 function durationToJson(val: Duration) {
   const seconds = Number(val.seconds);
   const nanos = val.nanos;
-  if (seconds > 315576000000 || seconds < -315576000000) {
+  if (seconds > durationSecondsMax || seconds < durationSecondsMin) {
     throw new Error(
       `cannot encode message ${val.$typeName} to JSON: value out of range`,
     );
@@ -498,8 +830,8 @@ function fieldMaskToJson(val: FieldMask) {
 
 function structToJson(val: Struct) {
   const json: JsonObject = {};
-  for (const [k, v] of Object.entries(val.fields)) {
-    json[k] = valueToJson(v);
+  for (const k of Object.keys(val.fields)) {
+    json[k] = valueToJson(val.fields[k]);
   }
   return json;
 }
@@ -532,10 +864,7 @@ function listValueToJson(val: ListValue): JsonValue[] {
 
 function timestampToJson(val: Timestamp) {
   const ms = Number(val.seconds) * 1000;
-  if (
-    ms < Date.parse("0001-01-01T00:00:00Z") ||
-    ms > Date.parse("9999-12-31T23:59:59Z")
-  ) {
+  if (ms < timestampMsMin || ms > timestampMsMax) {
     throw new Error(
       `cannot encode message ${val.$typeName} to JSON: must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive`,
     );

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -40,10 +40,7 @@ import type {
   Value,
 } from "./wkt/index.js";
 import { anyUnpack } from "./wkt/index.js";
-import {
-  hasCustomJsonRepresentation,
-  isWrapperDesc,
-} from "./wkt/wrappers.js";
+import { hasCustomJsonRepresentation, isWrapperDesc } from "./wkt/wrappers.js";
 import {
   durationSecondsMax,
   durationSecondsMin,

--- a/packages/protobuf/src/to-json.ts
+++ b/packages/protobuf/src/to-json.ts
@@ -570,7 +570,8 @@ function compileMapValue(
       return undefined;
     }
     const jsonObject: JsonObject = {};
-    for (const key of keys) {
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
       jsonObject[key] = writeMapValue(opts, record[key]);
     }
     return jsonObject;
@@ -726,7 +727,8 @@ function writeExtensions(
     return;
   }
   const tagSeen = new Set<number>();
-  for (const { no } of unknown) {
+  for (let i = 0; i < unknown.length; i++) {
+    const { no } = unknown[i];
     // Same tag can appear multiple times, so we
     // keep track and skip identical ones.
     if (!tagSeen.has(no)) {
@@ -827,8 +829,10 @@ function fieldMaskToJson(val: FieldMask) {
 
 function structToJson(val: Struct) {
   const json: JsonObject = {};
-  for (const k of Object.keys(val.fields)) {
-    json[k] = valueToJson(val.fields[k]);
+  const keys = Object.keys(val.fields);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    json[key] = valueToJson(val.fields[key]);
   }
   return json;
 }

--- a/packages/protobuf/src/wkt/json.ts
+++ b/packages/protobuf/src/wkt/json.ts
@@ -13,21 +13,33 @@
 // limitations under the License.
 
 /**
- * Minimum google.protobuf.Timestamp in JSON, in milliseconds (inclusive).
+ * Minimum google.protobuf.Timestamp in milliseconds (inclusive).
+ * Only enforced in ProtoJSON.
+ *
+ * @private
  */
 export const timestampMsMin = /*@__PURE__*/ Date.parse("0001-01-01T00:00:00Z");
 
 /**
- * Maximum google.protobuf.Timestamp in JSON, in milliseconds (inclusive).
+ * Maximum google.protobuf.Timestamp in milliseconds (inclusive).
+ * Only enforced in ProtoJSON.
+ *
+ * @private
  */
 export const timestampMsMax = /*@__PURE__*/ Date.parse("9999-12-31T23:59:59Z");
 
 /**
- * Minimum google.protobuf.Duration in JSON, in seconds.
+ * Minimum google.protobuf.Duration in seconds.
+ * Only enforced in ProtoJSON.
+ *
+ * @private
  */
 export const durationSecondsMin = -315576000000;
 
 /**
- * Maximum google.protobuf.Duration in JSON, in seconds.
+ * Maximum google.protobuf.Duration in seconds.
+ * Only enforced in ProtoJSON.
+ *
+ * @private
  */
 export const durationSecondsMax = 315576000000;

--- a/packages/protobuf/src/wkt/json.ts
+++ b/packages/protobuf/src/wkt/json.ts
@@ -1,0 +1,33 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Minimum google.protobuf.Timestamp in JSON, in milliseconds (inclusive).
+ */
+export const timestampMsMin = /*@__PURE__*/ Date.parse("0001-01-01T00:00:00Z");
+
+/**
+ * Maximum google.protobuf.Timestamp in JSON, in milliseconds (inclusive).
+ */
+export const timestampMsMax = /*@__PURE__*/ Date.parse("9999-12-31T23:59:59Z");
+
+/**
+ * Minimum google.protobuf.Duration in JSON, in seconds.
+ */
+export const durationSecondsMin = -315576000000;
+
+/**
+ * Maximum google.protobuf.Duration in JSON, in seconds.
+ */
+export const durationSecondsMax = 315576000000;


### PR DESCRIPTION
The overhead of interpreting descriptors in codecs is substantial. This PR "compiles" descriptors at runtime to a tree of closures, which reduces that overhead to zero. This reduces the minified bundle size by 8%, and comes with substantial gains in performance:

| Case              | fromBinary | toBinary | fromJson | toJson |
|-------------------|------------|----------|----------|--------|
| general           | +37%       | +44%     | +15%     | +76%   |
| scalar            | +52%       | +43%     | +36%     | +54%   |
| repeated-scalar   | +39%       | +54%     | +15%     | +209%  |
| map-scalar        | +19%       | +13%     | +19%     | +153%  |
| repeated-message  | +56%       | +63%     | +34%     | +53%   |
| map-message       | +49%       | +58%     | +38%     | +64%   |
| user-tiny         | +84%       | +36%     | +51%     | +63%   |
| user-normal       | +37%       | +24%     | +56%     | +157%  |