### PR TITLE
Avoid allocations in varint64

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   136,836 b |  70,486 b |   16,312 b |
-| Protobuf-ES         |     4 |   139,025 b |  71,994 b |   16,965 b |
-| Protobuf-ES         |     8 |   141,787 b |  73,765 b |   17,482 b |
-| Protobuf-ES         |    16 |   152,237 b |  81,746 b |   19,858 b |
-| Protobuf-ES         |    32 |   180,028 b | 103,764 b |   25,331 b |
+| Protobuf-ES         |     1 |   137,268 b |  70,790 b |   16,365 b |
+| Protobuf-ES         |     4 |   139,457 b |  72,298 b |   17,063 b |
+| Protobuf-ES         |     8 |   142,219 b |  74,069 b |   17,577 b |
+| Protobuf-ES         |    16 |   152,669 b |  82,050 b |   19,926 b |
+| Protobuf-ES         |    32 |   180,460 b | 104,068 b |   25,336 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.80390625 140,241.95458984375 280,240.4904296875 420,233.7615234375 560,218.26181640625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.65380859375 140,241.67705078125 280,240.22138671875 420,233.5689453125 560,218.24765624999998">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.80390625" r="4" fill="#ffa600"><title>Protobuf-ES 15.93 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.95458984375" r="4" fill="#ffa600"><title>Protobuf-ES 16.57 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.4904296875" r="4" fill="#ffa600"><title>Protobuf-ES 17.07 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.7615234375" r="4" fill="#ffa600"><title>Protobuf-ES 19.39 KiB for 16 files</title></circle>
-<circle cx="560" cy="218.26181640625" r="4" fill="#ffa600"><title>Protobuf-ES 24.74 KiB for 32 files</title></circle>
+<circle cx="0" cy="243.65380859375" r="4" fill="#ffa600"><title>Protobuf-ES 15.98 KiB for 1 files</title></circle>
+<circle cx="140" cy="241.67705078125" r="4" fill="#ffa600"><title>Protobuf-ES 16.66 KiB for 4 files</title></circle>
+<circle cx="280" cy="240.22138671875" r="4" fill="#ffa600"><title>Protobuf-ES 17.17 KiB for 8 files</title></circle>
+<circle cx="420" cy="233.5689453125" r="4" fill="#ffa600"><title>Protobuf-ES 19.46 KiB for 16 files</title></circle>
+<circle cx="560" cy="218.24765624999998" r="4" fill="#ffa600"><title>Protobuf-ES 24.74 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -477,7 +477,7 @@ export class BinaryReader {
    */
   readonly len: number;
 
-  protected readonly buf: Uint8Array;
+  private readonly buf: Uint8Array;
   private readonly view: DataView;
 
   constructor(
@@ -562,9 +562,9 @@ export class BinaryReader {
     return this.buf.subarray(start, this.pos);
   }
 
-  protected varint64Lo = 0;
-  protected varint64Hi = 0;
-  protected varint64 = varint64read as () => void; // dirty cast for `this`
+  private varint64Lo = 0;
+  private varint64Hi = 0;
+  private varint64 = varint64read as () => void; // dirty cast for `this`
 
   /**
    * Throws error if position in byte array is out of range.

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -569,7 +569,7 @@ export class BinaryReader {
   /**
    * Throws error if position in byte array is out of range.
    */
-  protected assertBounds(): void {
+  private assertBounds(): void {
     if (this.pos > this.len) throw new RangeError("premature EOF");
   }
 

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -562,7 +562,9 @@ export class BinaryReader {
     return this.buf.subarray(start, this.pos);
   }
 
-  protected varint64 = varint64read as () => [number, number]; // dirty cast for `this`
+  protected varint64Lo = 0;
+  protected varint64Hi = 0;
+  protected varint64 = varint64read as () => void; // dirty cast for `this`
 
   /**
    * Throws error if position in byte array is out of range.
@@ -596,21 +598,25 @@ export class BinaryReader {
    * Read a `int64` field, a signed 64-bit varint.
    */
   int64(): bigint | string {
-    return protoInt64.dec(...this.varint64());
+    this.varint64();
+    return protoInt64.dec(this.varint64Lo, this.varint64Hi);
   }
 
   /**
    * Read a `uint64` field, an unsigned 64-bit varint.
    */
   uint64(): bigint | string {
-    return protoInt64.uDec(...this.varint64());
+    this.varint64();
+    return protoInt64.uDec(this.varint64Lo, this.varint64Hi);
   }
 
   /**
    * Read a `sint64` field, a signed, zig-zag-encoded 64-bit varint.
    */
   sint64(): bigint | string {
-    let [lo, hi] = this.varint64();
+    this.varint64();
+    let lo = this.varint64Lo;
+    let hi = this.varint64Hi;
     // decode zig zag
     let s = -(lo & 1);
     lo = ((lo >>> 1) | ((hi & 1) << 31)) ^ s;
@@ -622,8 +628,14 @@ export class BinaryReader {
    * Read a `bool` field, a variant.
    */
   bool(): boolean {
-    let [lo, hi] = this.varint64();
-    return lo !== 0 || hi !== 0;
+    // Fast path: most bools are 0x0 or 0x1.
+    const b = this.buf[this.pos];
+    if (b < 0x80) {
+      this.pos++;
+      return b !== 0;
+    }
+    this.varint64();
+    return this.varint64Lo !== 0 || this.varint64Hi !== 0;
   }
 
   /**

--- a/packages/protobuf/src/wire/varint.ts
+++ b/packages/protobuf/src/wire/varint.ts
@@ -34,46 +34,54 @@
 /**
  * Read a 64 bit varint as two JS numbers.
  *
- * Returns tuple:
- * [0]: low bits
- * [1]: high bits
+ * Stores the low and high words on the reader.
  *
  * Copyright 2008 Google Inc.  All rights reserved.
  *
  * See https://github.com/protocolbuffers/protobuf/blob/8a71927d74a4ce34efe2d8769fda198f52d20d12/js/experimental/runtime/kernel/buffer_decoder.js#L175
  */
-export function varint64read<T extends ReaderLike>(this: T): [number, number] {
-  let lowBits = 0;
-  let highBits = 0;
-
+export function varint64read<T extends ReaderLike>(this: T): void {
+  const buf = this.buf;
+  let pos = this.pos;
+  let lo = 0;
+  let hi = 0;
   for (let shift = 0; shift < 28; shift += 7) {
-    let b = this.buf[this.pos++];
-    lowBits |= (b & 0x7f) << shift;
+    const b = buf[pos++];
+    lo |= (b & 0x7f) << shift;
     if ((b & 0x80) == 0) {
+      this.pos = pos;
       this.assertBounds();
-      return [lowBits, highBits];
+      this.varint64Lo = lo;
+      this.varint64Hi = hi;
+      return;
     }
   }
 
-  let middleByte = this.buf[this.pos++];
+  const middleByte = buf[pos++];
 
   // last four bits of the first 32 bit number
-  lowBits |= (middleByte & 0x0f) << 28;
+  lo |= (middleByte & 0x0f) << 28;
 
   // 3 upper bits are part of the next 32 bit number
-  highBits = (middleByte & 0x70) >> 4;
+  hi = (middleByte & 0x70) >> 4;
 
   if ((middleByte & 0x80) == 0) {
+    this.pos = pos;
     this.assertBounds();
-    return [lowBits, highBits];
+    this.varint64Lo = lo;
+    this.varint64Hi = hi;
+    return;
   }
 
   for (let shift = 3; shift <= 31; shift += 7) {
-    let b = this.buf[this.pos++];
-    highBits |= (b & 0x7f) << shift;
+    const b = buf[pos++];
+    hi |= (b & 0x7f) << shift;
     if ((b & 0x80) == 0) {
+      this.pos = pos;
       this.assertBounds();
-      return [lowBits, highBits];
+      this.varint64Lo = lo;
+      this.varint64Hi = hi;
+      return;
     }
   }
 
@@ -351,5 +359,7 @@ type ReaderLike = {
   buf: Uint8Array;
   pos: number;
   len: number;
+  varint64Lo: number;
+  varint64Hi: number;
   assertBounds(): void;
 };


### PR DESCRIPTION
The `varint64` method currently returns a `[number, number]`, which causes an allocation on a fairly hot function. This PR modifies it to return nothing, and use `this.varint64Lo` and `this.varint64Hi` as scratch variables. It also contains a fast path for bools.

Putting this up for general review, but note that this PR does contain a breaking change on a `protected` method.

| Case                         | main (ns/op)  | this PR (ns/op) | Delta  |
|-------------------------------|---------------|------------------|--------|
| BinaryReader/bool             | 3.83          | 1.00             | -73.9% |
| BinaryReader/int64             | 12.32         | 6.25             | -49.2% |
| BinaryReader/sint64              | 10.62         | 6.43             | -39.5% |
| fromBinary/repeated-message       | 1,519,371.85  | 1,452,020.93     | -4.4%  |
| fromBinary/scalar                    | 1,505.08      | 1,444.06         | -4.1%  |
| fromBinary/repeated-scalar              | 3,844.59      | 3,725.59         | -3.1%  |
| fromBinary/general                        | 165,200.04    | 162,520.18       | -1.6%  |
| fromBinary/map-message                       | 1,713,279.28  | 1,713,810.44     | 0.0%   |
| fromBinary/user-normal                          | 2,245.20      | 2,250.30         | 0.2%   |
| fromBinary/user-tiny                               | 730.64        | 746.78           | 2.2%   |