### PR TITLE
Compile and cache create() function

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,727 b |  65,797 b |   15,523 b |
-| Protobuf-ES         |     4 |   134,916 b |  67,303 b |   16,182 b |
-| Protobuf-ES         |     8 |   137,678 b |  69,074 b |   16,695 b |
-| Protobuf-ES         |    16 |   148,128 b |  77,056 b |   19,013 b |
-| Protobuf-ES         |    32 |   175,919 b |  99,080 b |   24,603 b |
+| Protobuf-ES         |     1 |   132,846 b |  65,870 b |   15,526 b |
+| Protobuf-ES         |     4 |   135,035 b |  67,376 b |   16,175 b |
+| Protobuf-ES         |     8 |   137,797 b |  69,147 b |   16,737 b |
+| Protobuf-ES         |    16 |   148,247 b |  77,129 b |   19,001 b |
+| Protobuf-ES         |    32 |   176,038 b |  99,153 b |   24,564 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   133,029 b |  65,896 b |   15,562 b |
-| Protobuf-ES         |     4 |   135,218 b |  67,402 b |   16,185 b |
-| Protobuf-ES         |     8 |   137,980 b |  69,173 b |   16,712 b |
-| Protobuf-ES         |    16 |   148,430 b |  77,154 b |   19,018 b |
-| Protobuf-ES         |    32 |   176,221 b |  99,178 b |   24,546 b |
+| Protobuf-ES         |     1 |   131,886 b |  65,452 b |   15,370 b |
+| Protobuf-ES         |     4 |   134,075 b |  66,958 b |   16,050 b |
+| Protobuf-ES         |     8 |   136,837 b |  68,729 b |   16,565 b |
+| Protobuf-ES         |    16 |   147,287 b |  76,710 b |   18,870 b |
+| Protobuf-ES         |    32 |   175,078 b |  98,734 b |   24,408 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   131,886 b |  65,452 b |   15,370 b |
-| Protobuf-ES         |     4 |   134,075 b |  66,958 b |   16,050 b |
-| Protobuf-ES         |     8 |   136,837 b |  68,729 b |   16,565 b |
-| Protobuf-ES         |    16 |   147,287 b |  76,710 b |   18,870 b |
-| Protobuf-ES         |    32 |   175,078 b |  98,734 b |   24,408 b |
+| Protobuf-ES         |     1 |   131,050 b |  65,171 b |   15,383 b |
+| Protobuf-ES         |     4 |   133,239 b |  66,677 b |   16,039 b |
+| Protobuf-ES         |     8 |   136,001 b |  68,448 b |   16,588 b |
+| Protobuf-ES         |    16 |   146,451 b |  76,429 b |   18,913 b |
+| Protobuf-ES         |    32 |   174,242 b |  98,453 b |   24,395 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,846 b |  65,870 b |   15,526 b |
-| Protobuf-ES         |     4 |   135,035 b |  67,376 b |   16,175 b |
-| Protobuf-ES         |     8 |   137,797 b |  69,147 b |   16,737 b |
-| Protobuf-ES         |    16 |   148,247 b |  77,129 b |   19,001 b |
-| Protobuf-ES         |    32 |   176,038 b |  99,153 b |   24,564 b |
+| Protobuf-ES         |     1 |   133,029 b |  65,896 b |   15,562 b |
+| Protobuf-ES         |     4 |   135,218 b |  67,402 b |   16,185 b |
+| Protobuf-ES         |     8 |   137,980 b |  69,173 b |   16,712 b |
+| Protobuf-ES         |    16 |   148,430 b |  77,154 b |   19,018 b |
+| Protobuf-ES         |    32 |   176,221 b |  99,178 b |   24,546 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   131,050 b |  65,171 b |   15,383 b |
-| Protobuf-ES         |     4 |   133,239 b |  66,677 b |   16,039 b |
-| Protobuf-ES         |     8 |   136,001 b |  68,448 b |   16,588 b |
-| Protobuf-ES         |    16 |   146,451 b |  76,429 b |   18,913 b |
-| Protobuf-ES         |    32 |   174,242 b |  98,453 b |   24,395 b |
+| Protobuf-ES         |     1 |   131,182 b |  65,243 b |   15,428 b |
+| Protobuf-ES         |     4 |   133,371 b |  66,749 b |   16,092 b |
+| Protobuf-ES         |     8 |   136,133 b |  68,520 b |   16,600 b |
+| Protobuf-ES         |    16 |   146,583 b |  76,501 b |   18,914 b |
+| Protobuf-ES         |    32 |   174,374 b |  98,525 b |   24,437 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   137,513 b |  70,886 b |   16,415 b |
-| Protobuf-ES         |     4 |   139,702 b |  72,394 b |   17,083 b |
-| Protobuf-ES         |     8 |   142,464 b |  74,165 b |   17,585 b |
-| Protobuf-ES         |    16 |   152,914 b |  82,146 b |   19,918 b |
-| Protobuf-ES         |    32 |   180,705 b | 104,164 b |   25,443 b |
+| Protobuf-ES         |     1 |   140,384 b |  71,723 b |   16,672 b |
+| Protobuf-ES         |     4 |   142,573 b |  73,230 b |   17,327 b |
+| Protobuf-ES         |     8 |   145,335 b |  75,001 b |   17,868 b |
+| Protobuf-ES         |    16 |   155,785 b |  82,982 b |   20,220 b |
+| Protobuf-ES         |    32 |   183,576 b | 105,004 b |   25,712 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.51220703125 140,241.62041015625 280,240.19873046875 420,233.5916015625 560,217.94462890625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,242.784375 140,240.92939453125 280,239.397265625 420,232.736328125 560,217.1828125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="243.51220703125" r="4" fill="#ffa600"><title>Protobuf-ES 16.03 KiB for 1 files</title></circle>
-<circle cx="140" cy="241.62041015625" r="4" fill="#ffa600"><title>Protobuf-ES 16.68 KiB for 4 files</title></circle>
-<circle cx="280" cy="240.19873046875" r="4" fill="#ffa600"><title>Protobuf-ES 17.17 KiB for 8 files</title></circle>
-<circle cx="420" cy="233.5916015625" r="4" fill="#ffa600"><title>Protobuf-ES 19.45 KiB for 16 files</title></circle>
-<circle cx="560" cy="217.94462890625" r="4" fill="#ffa600"><title>Protobuf-ES 24.85 KiB for 32 files</title></circle>
+<circle cx="0" cy="242.784375" r="4" fill="#ffa600"><title>Protobuf-ES 16.28 KiB for 1 files</title></circle>
+<circle cx="140" cy="240.92939453125" r="4" fill="#ffa600"><title>Protobuf-ES 16.92 KiB for 4 files</title></circle>
+<circle cx="280" cy="239.397265625" r="4" fill="#ffa600"><title>Protobuf-ES 17.45 KiB for 8 files</title></circle>
+<circle cx="420" cy="232.736328125" r="4" fill="#ffa600"><title>Protobuf-ES 19.75 KiB for 16 files</title></circle>
+<circle cx="560" cy="217.1828125" r="4" fill="#ffa600"><title>Protobuf-ES 25.11 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.9279296875 140,244.16357421875 280,242.67109375 420,236.1404296875 560,220.48496093749998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.4716796875 140,244.5458984375 280,243.08740234375 420,236.5595703125 560,220.87578125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.9279296875" r="4" fill="#ffa600"><title>Protobuf-ES 15.2 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.16357421875" r="4" fill="#ffa600"><title>Protobuf-ES 15.81 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.67109375" r="4" fill="#ffa600"><title>Protobuf-ES 16.32 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.1404296875" r="4" fill="#ffa600"><title>Protobuf-ES 18.57 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.48496093749998" r="4" fill="#ffa600"><title>Protobuf-ES 23.97 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.4716796875" r="4" fill="#ffa600"><title>Protobuf-ES 15.01 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.5458984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.08740234375" r="4" fill="#ffa600"><title>Protobuf-ES 16.18 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.5595703125" r="4" fill="#ffa600"><title>Protobuf-ES 18.43 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.87578125" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.4716796875 140,244.5458984375 280,243.08740234375 420,236.5595703125 560,220.87578125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.43486328125 140,244.57705078125 280,243.022265625 420,236.43779296875 560,220.91259765625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.4716796875" r="4" fill="#ffa600"><title>Protobuf-ES 15.01 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.5458984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.08740234375" r="4" fill="#ffa600"><title>Protobuf-ES 16.18 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.5595703125" r="4" fill="#ffa600"><title>Protobuf-ES 18.43 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.87578125" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.43486328125" r="4" fill="#ffa600"><title>Protobuf-ES 15.02 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.57705078125" r="4" fill="#ffa600"><title>Protobuf-ES 15.66 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.022265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.2 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.43779296875" r="4" fill="#ffa600"><title>Protobuf-ES 18.47 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.91259765625" r="4" fill="#ffa600"><title>Protobuf-ES 23.82 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.03837890625 140,244.1720703125 280,242.71923828125 420,236.15458984375 560,220.32353515625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.0298828125 140,244.19189453125 280,242.60029296875 420,236.18857421875 560,220.43398437500002">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.03837890625" r="4" fill="#ffa600"><title>Protobuf-ES 15.16 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.1720703125" r="4" fill="#ffa600"><title>Protobuf-ES 15.8 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.71923828125" r="4" fill="#ffa600"><title>Protobuf-ES 16.3 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.15458984375" r="4" fill="#ffa600"><title>Protobuf-ES 18.57 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.32353515625" r="4" fill="#ffa600"><title>Protobuf-ES 24.03 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.0298828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.16 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.19189453125" r="4" fill="#ffa600"><title>Protobuf-ES 15.8 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.60029296875" r="4" fill="#ffa600"><title>Protobuf-ES 16.34 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.18857421875" r="4" fill="#ffa600"><title>Protobuf-ES 18.56 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.43398437500002" r="4" fill="#ffa600"><title>Protobuf-ES 23.99 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.43486328125 140,244.57705078125 280,243.022265625 420,236.43779296875 560,220.91259765625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.307421875 140,244.426953125 280,242.98828125 420,236.4349609375 560,220.79365234375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.43486328125" r="4" fill="#ffa600"><title>Protobuf-ES 15.02 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.57705078125" r="4" fill="#ffa600"><title>Protobuf-ES 15.66 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.022265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.2 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.43779296875" r="4" fill="#ffa600"><title>Protobuf-ES 18.47 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.91259765625" r="4" fill="#ffa600"><title>Protobuf-ES 23.82 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.307421875" r="4" fill="#ffa600"><title>Protobuf-ES 15.07 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.426953125" r="4" fill="#ffa600"><title>Protobuf-ES 15.71 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.98828125" r="4" fill="#ffa600"><title>Protobuf-ES 16.21 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.4349609375" r="4" fill="#ffa600"><title>Protobuf-ES 18.47 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.79365234375" r="4" fill="#ffa600"><title>Protobuf-ES 23.86 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.0298828125 140,244.19189453125 280,242.60029296875 420,236.18857421875 560,220.43398437500002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.9279296875 140,244.16357421875 280,242.67109375 420,236.1404296875 560,220.48496093749998">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.0298828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.16 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.19189453125" r="4" fill="#ffa600"><title>Protobuf-ES 15.8 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.60029296875" r="4" fill="#ffa600"><title>Protobuf-ES 16.34 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.18857421875" r="4" fill="#ffa600"><title>Protobuf-ES 18.56 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.43398437500002" r="4" fill="#ffa600"><title>Protobuf-ES 23.99 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.9279296875" r="4" fill="#ffa600"><title>Protobuf-ES 15.2 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.16357421875" r="4" fill="#ffa600"><title>Protobuf-ES 15.81 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.67109375" r="4" fill="#ffa600"><title>Protobuf-ES 16.32 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.1404296875" r="4" fill="#ffa600"><title>Protobuf-ES 18.57 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.48496093749998" r="4" fill="#ffa600"><title>Protobuf-ES 23.97 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -21,9 +21,7 @@ import {
 } from "./descriptors.js";
 import type { Message, MessageInitShape, MessageShape } from "./types.js";
 import { scalarZeroValue } from "./reflect/scalar.js";
-import type { FieldError } from "./reflect/error.js";
-import { isObject, type OneofADT } from "./reflect/guard.js";
-import { unsafeGet, unsafeOneofCase, unsafeSet } from "./reflect/unsafe.js";
+import { isObject } from "./reflect/guard.js";
 import { isWrapperDesc } from "./wkt/wrappers.js";
 
 // bootstrap-inject google.protobuf.Edition.EDITION_PROTO3: const $name = $number;
@@ -46,101 +44,330 @@ export function create<Desc extends DescMessage>(
   if (isMessage(init, schema)) {
     return init;
   }
-  const message = createZeroMessage(schema) as MessageShape<Desc>;
-  if (init !== undefined) {
-    initMessage(schema, message, init);
-  }
-  return message;
+  return compiledCreate(schema)(
+    init as Record<string, unknown> | undefined,
+  ) as MessageShape<Desc>;
 }
 
 /**
- * Sets field values from a MessageInitShape on a zero message.
+ * Creates a message: a zero message without an init, otherwise with member
+ * values from a MessageInitShape.
  */
-function initMessage<Desc extends DescMessage>(
-  messageDesc: Desc,
-  message: MessageShape<Desc>,
-  init: MessageInitShape<Desc>,
-): MessageShape<Desc> | FieldError {
-  for (const member of messageDesc.members) {
-    let value = (init as Record<string, unknown>)[member.localName];
-    if (value == null) {
-      // intentionally ignore undefined and null
+type CompiledCreate = (init?: Record<string, unknown>) => Message;
+
+const compiledCreates = new WeakMap<DescMessage, CompiledCreate>();
+
+/**
+ * Return the compiled create function for a message, compiling it on
+ * first use.
+ */
+function compiledCreate(desc: DescMessage): CompiledCreate {
+  let compiled = compiledCreates.get(desc);
+  if (compiled === undefined) {
+    compiled = compileCreate(desc);
+    compiledCreates.set(desc, compiled);
+  }
+  return compiled;
+}
+
+// Cutoff below which storing properties in a loop beats cloning the template.
+const smallMessageMaxProperties = 12;
+
+/**
+ * Compile the create function for this message type, so that creating a
+ * message does not interpret the descriptor every time.
+ */
+function compileCreate(desc: DescMessage): CompiledCreate {
+  const values = new Map<string, unknown>([["$typeName", desc.typeName]]);
+
+  // Default values for fields with explicit presence, served via the
+  // prototype chain, where presence is tracked by own properties.
+  const prototype: Record<string, unknown> = {};
+  const usePrototypeChain = needsPrototypeChain(desc);
+
+  const lists: string[] = [];
+  const maps: string[] = [];
+  const oneofs: string[] = [];
+
+  // Mutable values (lists, maps, oneofs) cannot be shared via the template.
+  // We store nulls in their slots that we replace later.
+  for (const member of desc.members) {
+    if (member.kind == "oneof") {
+      values.set(member.localName, null);
+      oneofs.push(member.localName);
       continue;
     }
-    let field: DescField;
-    if (member.kind == "oneof") {
-      const oneofField = unsafeOneofCase(init, member);
-      if (!oneofField) {
-        continue;
-      }
-      field = oneofField;
-      value = unsafeGet(init, oneofField);
-    } else {
-      field = member;
-    }
-    switch (field.fieldKind) {
+    switch (member.fieldKind) {
       case "message":
-        value = toMessage(field, value);
-        break;
-      case "scalar":
-        value = initScalar(field, value);
+        // Message fields track presence by absence of the property.
         break;
       case "list":
-        value = initList(field, value);
+        values.set(member.localName, null);
+        lists.push(member.localName);
         break;
       case "map":
-        value = initMap(field, value);
+        values.set(member.localName, null);
+        maps.push(member.localName);
+        break;
+      default:
+        if (member.presence == IMPLICIT) {
+          values.set(member.localName, createZeroValue(member));
+        } else if (usePrototypeChain) {
+          prototype[member.localName] = createZeroValue(member);
+        }
         break;
     }
-    unsafeSet(message, field, value);
   }
-  return message;
-}
 
-function initScalar(
-  field: DescField & { fieldKind: "scalar" },
-  value: unknown,
-): unknown {
-  if (field.scalar == ScalarType.BYTES) {
-    return toU8Arr(value);
-  }
-  return value;
-}
+  const initializers = desc.members.map((member) => compileInitMember(member));
+  const typeName = desc.typeName;
 
-function initMap(
-  field: DescField & { fieldKind: "map" },
-  value: unknown,
-): unknown {
-  if (isObject(value)) {
-    if (field.scalar == ScalarType.BYTES) {
-      return convertObjectValues(value, toU8Arr);
-    }
-    if (field.mapKind == "message") {
-      return convertObjectValues(value, (val) => toMessage(field, val));
-    }
-  }
-  return value;
-}
+  const zeroNames: string[] = [];
+  const zeroValues: unknown[] = [];
+  let template: Record<string, unknown> | undefined;
 
-function initList(
-  field: DescField & { fieldKind: "list" },
-  value: unknown,
-): unknown {
-  if (Array.isArray(value)) {
-    if (field.scalar == ScalarType.BYTES) {
-      return value.map(toU8Arr);
+  // Small messages are built with a store per property instead of cloning a
+  // template: below the threshold this beats the megamorphic clone.
+  const isSmallMessage = values.size <= smallMessageMaxProperties;
+  if (isSmallMessage) {
+    for (const [key, value] of values) {
+      if (key != "$typeName" && value !== null) {
+        zeroNames.push(key);
+        zeroValues.push(value);
+      }
     }
-    if (field.listKind == "message") {
-      return value.map((item: unknown) => toMessage(field, item));
+  } else {
+    const skeleton: Record<string, null> = {};
+    for (const key of values.keys()) {
+      skeleton[key] = null;
+    }
+    // Create the template shape in one shot via JSON.parse - adding properties
+    // one by one overflows V8's in-object slots.
+    template = JSON.parse(JSON.stringify(skeleton)) as Record<string, unknown>;
+    for (const [key, value] of values) {
+      template[key] = value;
     }
   }
-  return value;
+
+  return (init) => {
+    let message: Record<string, unknown>;
+    if (template !== undefined) {
+      if (usePrototypeChain) {
+        message = Object.assign(
+          Object.create(prototype) as Record<string, unknown>,
+          template,
+        );
+      } else {
+        message = { ...template };
+      }
+    } else if (usePrototypeChain) {
+      message = Object.create(prototype) as Record<string, unknown>;
+      message.$typeName = typeName;
+    } else {
+      message = { $typeName: typeName };
+    }
+    if (init === undefined) {
+      for (let i = 0; i < zeroNames.length; i++) {
+        message[zeroNames[i]] = zeroValues[i];
+      }
+      for (const name of lists) {
+        message[name] = [];
+      }
+      for (const name of maps) {
+        message[name] = {};
+      }
+      for (const name of oneofs) {
+        message[name] = { case: undefined };
+      }
+      return message as Message;
+    }
+    for (let i = 0; i < initializers.length; i++) {
+      initializers[i](message, init);
+    }
+    return message as Message;
+  };
 }
 
-function toMessage(
+/**
+ * Sets one member from a MessageInitShape on a cloned template.
+ */
+type MemberInit = (
+  message: Record<string, unknown>,
+  init: Record<string, unknown>,
+) => void;
+
+/**
+ * Converts a member value from a MessageInitShape to its message
+ * representation.
+ */
+type Converter = (value: unknown) => unknown;
+
+function compileInitMember(member: DescField | DescOneof): MemberInit {
+  if (member.kind == "oneof") {
+    return compileInitOneof(member);
+  }
+  switch (member.fieldKind) {
+    case "list":
+      return compileInitList(member);
+    case "map":
+      return compileInitMap(member);
+    case "message":
+      const convert = compileConvertMessage(member);
+      return compileInitExplicit(member.localName, convert);
+    case "scalar":
+    case "enum": {
+      const convert =
+        member.fieldKind == "scalar" && member.scalar == ScalarType.BYTES
+          ? toU8Arr
+          : undefined;
+      return member.presence == IMPLICIT
+        ? compileInitImplicit(
+            member.localName,
+            convert,
+            createZeroValue(member),
+          )
+        : compileInitExplicit(member.localName, convert);
+    }
+  }
+}
+
+function compileInitExplicit(
+  name: string,
+  convert: Converter | undefined,
+): MemberInit {
+  if (convert === undefined) {
+    return (message, init) => {
+      const value = init[name];
+      if (value != null) {
+        message[name] = value;
+      }
+    };
+  }
+  return (message, init) => {
+    const value = init[name];
+    if (value != null) {
+      message[name] = convert(value);
+    }
+  };
+}
+
+function compileInitImplicit(
+  name: string,
+  convert: Converter | undefined,
+  zeroValue: unknown,
+): MemberInit {
+  if (convert === undefined) {
+    return (message, init) => {
+      const value = init[name];
+      message[name] = value != null ? value : zeroValue;
+    };
+  }
+  return (message, init) => {
+    const value = init[name];
+    message[name] = value != null ? convert(value) : zeroValue;
+  };
+}
+
+function compileInitList(field: DescField & { fieldKind: "list" }): MemberInit {
+  const name = field.localName;
+  let convertItem: Converter | undefined;
+  if (field.listKind == "message") {
+    convertItem = compileConvertMessage(field);
+  } else if (field.scalar == ScalarType.BYTES) {
+    convertItem = toU8Arr;
+  }
+  if (convertItem === undefined) {
+    return (message, init) => {
+      const value = init[name];
+      message[name] = value == null ? [] : value;
+    };
+  }
+  return (message, init) => {
+    const value = init[name];
+    message[name] =
+      value == null
+        ? []
+        : Array.isArray(value)
+          ? value.map(convertItem)
+          : value;
+  };
+}
+
+function compileInitMap(field: DescField & { fieldKind: "map" }): MemberInit {
+  const name = field.localName;
+  let convertValue: Converter | undefined;
+  if (field.mapKind == "message") {
+    convertValue = compileConvertMessage(field);
+  } else if (field.scalar == ScalarType.BYTES) {
+    convertValue = toU8Arr;
+  }
+  if (convertValue === undefined) {
+    return (message, init) => {
+      const value = init[name];
+      // Object.create(null) would be desirable for the fresh map, but is
+      // unsupported by React:
+      // https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
+      message[name] = value == null ? {} : value;
+    };
+  }
+  return (message, init) => {
+    const value = init[name];
+    if (value == null) {
+      message[name] = {};
+    } else if (isObject(value)) {
+      const convertedValues: Record<string, unknown> = {};
+      for (const key of Object.keys(value)) {
+        convertedValues[key] = convertValue(value[key]);
+      }
+      message[name] = convertedValues;
+    } else {
+      message[name] = value;
+    }
+  };
+}
+
+function compileInitOneof(oneof: DescOneof): MemberInit {
+  const name = oneof.localName;
+  const converters = new Map<string, Converter>();
+  for (const field of oneof.fields) {
+    let convert: Converter | undefined;
+    if (field.fieldKind == "message") {
+      convert = compileConvertMessage(field);
+    } else if (
+      field.fieldKind == "scalar" &&
+      field.scalar == ScalarType.BYTES
+    ) {
+      convert = toU8Arr;
+    }
+    converters.set(field.localName, convert ?? ((value) => value));
+  }
+  return (message, init) => {
+    const oneofValue = init[name] as
+      | { case?: unknown; value?: unknown }
+      | null
+      | undefined;
+    if (oneofValue != null && oneofValue.case != null) {
+      const convert = converters.get(oneofValue.case as string);
+      if (convert !== undefined) {
+        message[name] = {
+          case: oneofValue.case,
+          value: convert(oneofValue.value),
+        };
+        return;
+      }
+    }
+    message[name] = { case: undefined };
+  };
+}
+
+/**
+ * Compile the conversion of an init value for a message field, a message
+ * list item, or a message map value. Returns undefined if values are used
+ * as-is.
+ */
+function compileConvertMessage(
   field: DescField & { message: DescMessage },
-  value: unknown,
-): unknown {
+): Converter | undefined {
   if (
     field.fieldKind == "message" &&
     !field.oneof &&
@@ -148,112 +375,25 @@ function toMessage(
   ) {
     // Types from google/protobuf/wrappers.proto are unwrapped when used in
     // a singular field that is not part of a oneof group.
-    return initScalar(field.message.fields[0], value);
+    return field.message.fields[0].scalar == ScalarType.BYTES
+      ? toU8Arr
+      : undefined;
   }
-  if (isObject(value)) {
-    if (
-      field.message.typeName == "google.protobuf.Struct" &&
-      field.parent.typeName !== "google.protobuf.Value"
-    ) {
-      // google.protobuf.Struct is represented with JsonObject when used in a
-      // field, except when used in google.protobuf.Value.
-      return value;
-    }
-    if (!isMessage(value, field.message)) {
-      return create(field.message, value);
-    }
+  if (
+    field.message.typeName == "google.protobuf.Struct" &&
+    field.parent.typeName !== "google.protobuf.Value"
+  ) {
+    // google.protobuf.Struct is represented with JsonObject when used in a
+    // field, except when used in google.protobuf.Value.
+    return undefined;
   }
-  return value;
+  const messageDesc = field.message;
+  return (value) => (isObject(value) ? create(messageDesc, value) : value);
 }
 
 // converts any ArrayLike<number> to Uint8Array if necessary.
 function toU8Arr(value: unknown) {
   return Array.isArray(value) ? new Uint8Array(value) : value;
-}
-
-function convertObjectValues(
-  obj: Record<string, unknown>,
-  fn: (val: unknown) => unknown,
-): Record<string, unknown> {
-  const ret: Record<string, unknown> = {};
-  for (const entry of Object.entries(obj)) {
-    ret[entry[0]] = fn(entry[1]);
-  }
-  return ret;
-}
-
-const tokenZeroMessageField = Symbol();
-
-const messagePrototypes = new WeakMap<
-  DescMessage,
-  { prototype: Record<string, unknown>; members: Set<DescField | DescOneof> }
->();
-
-/**
- * Create a zero message.
- */
-function createZeroMessage(desc: DescMessage): Message {
-  let msg: Record<string, unknown>;
-  if (!needsPrototypeChain(desc)) {
-    msg = {
-      $typeName: desc.typeName,
-    };
-    for (const member of desc.members) {
-      if (member.kind == "oneof" || member.presence == IMPLICIT) {
-        msg[member.localName] = createZeroField(member);
-      }
-    }
-  } else {
-    // Support default values and track presence via the prototype chain
-    const cached = messagePrototypes.get(desc);
-    let prototype: Record<string, unknown>;
-    let members: Set<DescField | DescOneof>;
-    if (cached) {
-      ({ prototype, members } = cached);
-    } else {
-      prototype = {};
-      members = new Set<DescField | DescOneof>();
-      for (const member of desc.members) {
-        if (member.kind == "oneof") {
-          // we can only put immutable values on the prototype,
-          // oneof ADTs are mutable
-          continue;
-        }
-        if (member.fieldKind != "scalar" && member.fieldKind != "enum") {
-          // only scalar and enum values are immutable, map, list, and message
-          // are not
-          continue;
-        }
-        if (member.presence == IMPLICIT) {
-          // implicit presence tracks field presence by zero values - e.g. 0, false, "", are unset, 1, true, "x" are set.
-          // message, map, list fields are mutable, and also have IMPLICIT presence.
-          continue;
-        }
-        members.add(member);
-        prototype[member.localName] = createZeroField(member);
-      }
-      messagePrototypes.set(desc, { prototype, members });
-    }
-    msg = Object.create(prototype) as Record<string, unknown>;
-    msg.$typeName = desc.typeName;
-    for (const member of desc.members) {
-      if (members.has(member)) {
-        continue;
-      }
-      if (member.kind == "field") {
-        if (member.fieldKind == "message") {
-          continue;
-        }
-        if (member.fieldKind == "scalar" || member.fieldKind == "enum") {
-          if (member.presence != IMPLICIT) {
-            continue;
-          }
-        }
-      }
-      msg[member.localName] = createZeroField(member);
-    }
-  }
-  return msg as Message;
 }
 
 /**
@@ -276,34 +416,14 @@ function needsPrototypeChain(desc: DescMessage): boolean {
       );
   }
 }
+
 /**
- * Returns a zero value for oneof groups, and for every field kind except
- * messages. Scalar and enum fields can have default values.
+ * Returns the zero value for a scalar or enum field. Scalar and enum fields
+ * can have default values.
  */
-function createZeroField(
-  field: DescOneof | DescField,
-):
-  | string
-  | boolean
-  | number
-  | bigint
-  | Uint8Array
-  | OneofADT
-  | []
-  | object
-  | typeof tokenZeroMessageField {
-  if (field.kind == "oneof") {
-    return { case: undefined };
-  }
-  if (field.fieldKind == "list") {
-    return [];
-  }
-  if (field.fieldKind == "map") {
-    return {}; // Object.create(null) would be desirable here, but is unsupported by react https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
-  }
-  if (field.fieldKind == "message") {
-    return tokenZeroMessageField;
-  }
+function createZeroValue(
+  field: DescField & { fieldKind: "scalar" | "enum" },
+): string | boolean | number | bigint | Uint8Array {
   const defaultValue = field.getDefaultValue();
   if (defaultValue !== undefined) {
     return field.fieldKind == "scalar" && field.longAsString

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -70,89 +70,93 @@ function compiledCreate(desc: DescMessage): CompiledCreate {
   return compiled;
 }
 
-// Cutoff below which storing properties in a loop beats cloning the template.
-const smallMessageMaxProperties = 12;
+// Cutoff below which storing properties one by one beats cloning a template.
+const smallMessageMaxProperties = 16;
 
 /**
  * Compile the create function for this message type, so that creating a
  * message does not interpret the descriptor every time.
  */
 function compileCreate(desc: DescMessage): CompiledCreate {
-  const values = new Map<string, unknown>([["$typeName", desc.typeName]]);
+  const typeName = desc.typeName;
 
-  // Default values for fields with explicit presence, served via the
-  // prototype chain, where presence is tracked by own properties.
+  // Fields with explicit presence store default values in a prototype.
   const prototype: Record<string, unknown> = {};
-  const usePrototypeChain = needsPrototypeChain(desc);
+  const usePrototype = needsPrototypeChain(desc);
 
+  // Scalar / enum fields with implicit presence, and their zero values.
+  const implicitScalars: string[] = [];
+  const implicitScalarValues: unknown[] = [];
+
+  // Fields containing mutable types - lists, maps, and oneofs.
   const lists: string[] = [];
   const maps: string[] = [];
   const oneofs: string[] = [];
 
-  // Mutable values (lists, maps, oneofs) cannot be shared via the template.
-  // We store nulls in their slots that we replace later.
   for (const member of desc.members) {
     if (member.kind == "oneof") {
-      values.set(member.localName, null);
       oneofs.push(member.localName);
       continue;
     }
     switch (member.fieldKind) {
       case "message":
-        // Message fields track presence by absence of the property.
         break;
       case "list":
-        values.set(member.localName, null);
         lists.push(member.localName);
         break;
       case "map":
-        values.set(member.localName, null);
         maps.push(member.localName);
         break;
       default:
         if (member.presence == IMPLICIT) {
-          values.set(member.localName, createZeroValue(member));
-        } else if (usePrototypeChain) {
+          implicitScalars.push(member.localName);
+          implicitScalarValues.push(createZeroValue(member));
+        } else if (usePrototype) {
           prototype[member.localName] = createZeroValue(member);
         }
         break;
     }
   }
 
-  const initializers = desc.members.map((member) => compileInitMember(member));
-  const typeName = desc.typeName;
-
-  const zeroNames: string[] = [];
-  const zeroValues: unknown[] = [];
+  // For smaller messages, a megamorphic clone has a high fixed cost, so we're
+  // better off setting fields to their zero values ourselves.
   let template: Record<string, unknown> | undefined;
-
-  // Small messages are built with a store per property instead of cloning a
-  // template: below the threshold this beats the megamorphic clone.
-  const isSmallMessage = values.size <= smallMessageMaxProperties;
-  if (isSmallMessage) {
-    for (const [key, value] of values) {
-      if (key != "$typeName" && value !== null) {
-        zeroNames.push(key);
-        zeroValues.push(value);
-      }
-    }
-  } else {
-    const skeleton: Record<string, null> = {};
-    for (const key of values.keys()) {
+  const isSmallMessage = desc.members.length + 1 <= smallMessageMaxProperties; // + 1 for $typeName
+  if (!isSmallMessage) {
+    const skeleton: Record<string, unknown> = { $typeName: typeName };
+    for (const key of [...implicitScalars, ...lists, ...maps, ...oneofs]) {
       skeleton[key] = null;
     }
-    // Create the template shape in one shot via JSON.parse - adding properties
-    // one by one overflows V8's in-object slots.
+    // Create the template shape via JSON.parse() - adding properties one by
+    // one overflows V8's in-object slots.
     template = JSON.parse(JSON.stringify(skeleton)) as Record<string, unknown>;
-    for (const [key, value] of values) {
-      template[key] = value;
+    for (let i = 0; i < implicitScalars.length; i++) {
+      template[implicitScalars[i]] = implicitScalarValues[i];
     }
   }
 
+  // Cloning the template already sets zero values, only set zero values if we
+  // are not cloning the template.
+  const initializers = desc.members.map((member) =>
+    compileInitMember(member, template === undefined),
+  );
+
   return (init) => {
     let message: Record<string, unknown>;
-    if (template !== undefined) {
-      if (usePrototypeChain) {
+    if (template === undefined) {
+      if (usePrototype) {
+        message = Object.create(prototype) as Record<string, unknown>;
+        message.$typeName = typeName;
+      } else {
+        message = { $typeName: typeName };
+      }
+      if (init === undefined) {
+        for (let i = 0; i < implicitScalars.length; i++) {
+          message[implicitScalars[i]] = implicitScalarValues[i];
+        }
+      }
+    } else {
+      if (usePrototype) {
         message = Object.assign(
           Object.create(prototype) as Record<string, unknown>,
           template,
@@ -160,16 +164,8 @@ function compileCreate(desc: DescMessage): CompiledCreate {
       } else {
         message = { ...template };
       }
-    } else if (usePrototypeChain) {
-      message = Object.create(prototype) as Record<string, unknown>;
-      message.$typeName = typeName;
-    } else {
-      message = { $typeName: typeName };
     }
     if (init === undefined) {
-      for (let i = 0; i < zeroNames.length; i++) {
-        message[zeroNames[i]] = zeroValues[i];
-      }
       for (const name of lists) {
         message[name] = [];
       }
@@ -189,7 +185,7 @@ function compileCreate(desc: DescMessage): CompiledCreate {
 }
 
 /**
- * Sets one member from a MessageInitShape on a cloned template.
+ * Sets one member from a MessageInitShape on a message under construction.
  */
 type MemberInit = (
   message: Record<string, unknown>,
@@ -202,7 +198,10 @@ type MemberInit = (
  */
 type Converter = (value: unknown) => unknown;
 
-function compileInitMember(member: DescField | DescOneof): MemberInit {
+function compileInitMember(
+  member: DescField | DescOneof,
+  setZeroValues: boolean,
+): MemberInit {
   if (member.kind == "oneof") {
     return compileInitOneof(member);
   }
@@ -213,25 +212,25 @@ function compileInitMember(member: DescField | DescOneof): MemberInit {
       return compileInitMap(member);
     case "message":
       const convert = compileConvertMessage(member);
-      return compileInitExplicit(member.localName, convert);
+      return compileInitProperty(member.localName, convert);
     case "scalar":
     case "enum": {
       const convert =
         member.fieldKind == "scalar" && member.scalar == ScalarType.BYTES
           ? toU8Arr
           : undefined;
-      return member.presence == IMPLICIT
-        ? compileInitImplicit(
+      return member.presence == IMPLICIT && setZeroValues
+        ? compileInitPropertyWithZeroValue(
             member.localName,
             convert,
             createZeroValue(member),
           )
-        : compileInitExplicit(member.localName, convert);
+        : compileInitProperty(member.localName, convert);
     }
   }
 }
 
-function compileInitExplicit(
+function compileInitProperty(
   name: string,
   convert: Converter | undefined,
 ): MemberInit {
@@ -251,7 +250,7 @@ function compileInitExplicit(
   };
 }
 
-function compileInitImplicit(
+function compileInitPropertyWithZeroValue(
   name: string,
   convert: Converter | undefined,
   zeroValue: unknown,

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -70,9 +70,6 @@ function compiledCreate(desc: DescMessage): CompiledCreate {
   return compiled;
 }
 
-// Cutoff below which storing properties one by one beats cloning a template.
-const smallMessageMaxProperties = 16;
-
 /**
  * Compile the create function for this message type, so that creating a
  * message does not interpret the descriptor every time.
@@ -84,98 +81,28 @@ function compileCreate(desc: DescMessage): CompiledCreate {
   const prototype: Record<string, unknown> = {};
   const usePrototype = needsPrototypeChain(desc);
 
-  // Scalar / enum fields with implicit presence, and their zero values.
-  const implicitScalars: string[] = [];
-  const implicitScalarValues: unknown[] = [];
-
-  // Fields containing mutable types - lists, maps, and oneofs.
-  const lists: string[] = [];
-  const maps: string[] = [];
-  const oneofs: string[] = [];
+  // Sets one member from an init / zero value, in declaration order.
+  const initializers: MemberInit[] = [];
 
   for (const member of desc.members) {
-    if (member.kind == "oneof") {
-      oneofs.push(member.localName);
-      continue;
-    }
-    switch (member.fieldKind) {
-      case "message":
-        break;
-      case "list":
-        lists.push(member.localName);
-        break;
-      case "map":
-        maps.push(member.localName);
-        break;
-      default:
-        if (member.presence == IMPLICIT) {
-          implicitScalars.push(member.localName);
-          implicitScalarValues.push(createZeroValue(member));
-        } else if (usePrototype) {
-          prototype[member.localName] = createZeroValue(member);
-        }
-        break;
+    initializers.push(compileInitMember(member));
+    if (
+      usePrototype &&
+      member.kind == "field" &&
+      member.presence != IMPLICIT &&
+      (member.fieldKind == "scalar" || member.fieldKind == "enum")
+    ) {
+      prototype[member.localName] = createZeroValue(member);
     }
   }
-
-  // For smaller messages, a megamorphic clone has a high fixed cost, so we're
-  // better off setting fields to their zero values ourselves.
-  let template: Record<string, unknown> | undefined;
-  const isSmallMessage = desc.members.length + 1 <= smallMessageMaxProperties; // + 1 for $typeName
-  if (!isSmallMessage) {
-    const skeleton: Record<string, unknown> = { $typeName: typeName };
-    for (const key of [...implicitScalars, ...lists, ...maps, ...oneofs]) {
-      skeleton[key] = null;
-    }
-    // Create the template shape via JSON.parse() - adding properties one by
-    // one overflows V8's in-object slots.
-    template = JSON.parse(JSON.stringify(skeleton)) as Record<string, unknown>;
-    for (let i = 0; i < implicitScalars.length; i++) {
-      template[implicitScalars[i]] = implicitScalarValues[i];
-    }
-  }
-
-  // Cloning the template already sets zero values, only set zero values if we
-  // are not cloning the template.
-  const initializers = desc.members.map((member) =>
-    compileInitMember(member, template === undefined),
-  );
 
   return (init) => {
     let message: Record<string, unknown>;
-    if (template === undefined) {
-      if (usePrototype) {
-        message = Object.create(prototype) as Record<string, unknown>;
-        message.$typeName = typeName;
-      } else {
-        message = { $typeName: typeName };
-      }
-      if (init === undefined) {
-        for (let i = 0; i < implicitScalars.length; i++) {
-          message[implicitScalars[i]] = implicitScalarValues[i];
-        }
-      }
+    if (usePrototype) {
+      message = Object.create(prototype) as Record<string, unknown>;
+      message.$typeName = typeName;
     } else {
-      if (usePrototype) {
-        message = Object.assign(
-          Object.create(prototype) as Record<string, unknown>,
-          template,
-        );
-      } else {
-        message = { ...template };
-      }
-    }
-    if (init === undefined) {
-      for (let i = 0; i < lists.length; i++) {
-        message[lists[i]] = [];
-      }
-      for (let i = 0; i < maps.length; i++) {
-        message[maps[i]] = {};
-      }
-      for (let i = 0; i < oneofs.length; i++) {
-        message[oneofs[i]] = { case: undefined };
-      }
-      return message as Message;
+      message = { $typeName: typeName };
     }
     for (let i = 0; i < initializers.length; i++) {
       initializers[i](message, init);
@@ -189,7 +116,7 @@ function compileCreate(desc: DescMessage): CompiledCreate {
  */
 type MemberInit = (
   message: Record<string, unknown>,
-  init: Record<string, unknown>,
+  init: Record<string, unknown> | undefined,
 ) => void;
 
 /**
@@ -198,10 +125,7 @@ type MemberInit = (
  */
 type Converter = (value: unknown) => unknown;
 
-function compileInitMember(
-  member: DescField | DescOneof,
-  setZeroValues: boolean,
-): MemberInit {
+function compileInitMember(member: DescField | DescOneof): MemberInit {
   if (member.kind == "oneof") {
     return compileInitOneof(member);
   }
@@ -219,7 +143,7 @@ function compileInitMember(
         member.fieldKind == "scalar" && member.scalar == ScalarType.BYTES
           ? toU8Arr
           : undefined;
-      return member.presence == IMPLICIT && setZeroValues
+      return member.presence == IMPLICIT
         ? compileInitPropertyWithZeroValue(
             member.localName,
             convert,
@@ -234,20 +158,19 @@ function compileInitProperty(
   name: string,
   convert: Converter | undefined,
 ): MemberInit {
-  if (convert === undefined) {
-    return (message, init) => {
-      const value = init[name];
-      if (value != null) {
-        message[name] = value;
+  return convert === undefined
+    ? (message, init) => {
+        const value = init?.[name];
+        if (value != null) {
+          message[name] = value;
+        }
       }
-    };
-  }
-  return (message, init) => {
-    const value = init[name];
-    if (value != null) {
-      message[name] = convert(value);
-    }
-  };
+    : (message, init) => {
+        const value = init?.[name];
+        if (value != null) {
+          message[name] = convert(value);
+        }
+      };
 }
 
 function compileInitPropertyWithZeroValue(
@@ -255,16 +178,23 @@ function compileInitPropertyWithZeroValue(
   convert: Converter | undefined,
   zeroValue: unknown,
 ): MemberInit {
-  if (convert === undefined) {
-    return (message, init) => {
-      const value = init[name];
-      message[name] = value ?? zeroValue;
-    };
-  }
-  return (message, init) => {
-    const value = init[name];
-    message[name] = value != null ? convert(value) : zeroValue;
-  };
+  return convert === undefined
+    ? (message, init) => {
+        if (init === undefined) {
+          message[name] = zeroValue;
+          return;
+        }
+        const value = init[name];
+        message[name] = value ?? zeroValue;
+      }
+    : (message, init) => {
+        if (init === undefined) {
+          message[name] = zeroValue;
+          return;
+        }
+        const value = init[name];
+        message[name] = value != null ? convert(value) : zeroValue;
+      };
 }
 
 function compileInitList(field: DescField & { fieldKind: "list" }): MemberInit {
@@ -275,18 +205,25 @@ function compileInitList(field: DescField & { fieldKind: "list" }): MemberInit {
   } else if (field.scalar == ScalarType.BYTES) {
     convertItem = toU8Arr;
   }
-  if (convertItem === undefined) {
-    return (message, init) => {
-      const value = init[name];
-      message[name] = value ?? [];
-    };
-  }
-  return (message, init) => {
-    const value = init[name];
-    message[name] = Array.isArray(value)
-      ? value.map(convertItem)
-      : (value ?? []);
-  };
+  return convertItem === undefined
+    ? (message, init) => {
+        if (init === undefined) {
+          message[name] = [];
+          return;
+        }
+        const value = init[name];
+        message[name] = value ?? [];
+      }
+    : (message, init) => {
+        if (init === undefined) {
+          message[name] = [];
+          return;
+        }
+        const value = init[name];
+        message[name] = Array.isArray(value)
+          ? value.map(convertItem)
+          : (value ?? []);
+      };
 }
 
 function compileInitMap(field: DescField & { fieldKind: "map" }): MemberInit {
@@ -297,31 +234,38 @@ function compileInitMap(field: DescField & { fieldKind: "map" }): MemberInit {
   } else if (field.scalar == ScalarType.BYTES) {
     convertValue = toU8Arr;
   }
-  if (convertValue === undefined) {
-    return (message, init) => {
-      const value = init[name];
-      // Object.create(null) would be desirable for the fresh map, but is
-      // unsupported by React:
-      // https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
-      message[name] = value ?? {};
-    };
-  }
-  return (message, init) => {
-    const value = init[name];
-    if (value == null) {
-      message[name] = {};
-    } else if (isObject(value)) {
-      const convertedValues: Record<string, unknown> = {};
-      const keys = Object.keys(value);
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        convertedValues[key] = convertValue(value[key]);
+  return convertValue === undefined
+    ? (message, init) => {
+        if (init === undefined) {
+          message[name] = {};
+          return;
+        }
+        const value = init[name];
+        // Object.create(null) would be desirable for the fresh map, but is
+        // unsupported by React:
+        // https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
+        message[name] = value ?? {};
       }
-      message[name] = convertedValues;
-    } else {
-      message[name] = value;
-    }
-  };
+    : (message, init) => {
+        if (init === undefined) {
+          message[name] = {};
+          return;
+        }
+        const value = init[name];
+        if (value == null) {
+          message[name] = {};
+        } else if (isObject(value)) {
+          const convertedValues: Record<string, unknown> = {};
+          const keys = Object.keys(value);
+          for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            convertedValues[key] = convertValue(value[key]);
+          }
+          message[name] = convertedValues;
+        } else {
+          message[name] = value;
+        }
+      };
 }
 
 function compileInitOneof(oneof: DescOneof): MemberInit {
@@ -340,6 +284,10 @@ function compileInitOneof(oneof: DescOneof): MemberInit {
     converters.set(field.localName, convert ?? ((value) => value));
   }
   return (message, init) => {
+    if (init === undefined) {
+      message[name] = { case: undefined };
+      return;
+    }
     const oneofValue = init[name] as
       | { case?: unknown; value?: unknown }
       | null

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -20,7 +20,7 @@ import {
   ScalarType,
 } from "./descriptors.js";
 import type { Message, MessageInitShape, MessageShape } from "./types.js";
-import { scalarZeroValue } from "./reflect/scalar.js";
+import { type ScalarValue, scalarZeroValue } from "./reflect/scalar.js";
 import { isObject } from "./reflect/guard.js";
 import { isWrapperDesc } from "./wkt/wrappers.js";
 
@@ -58,9 +58,7 @@ type CompiledCreate = (init?: Record<string, unknown>) => Message;
 const compiledCreates = new WeakMap<DescMessage, CompiledCreate>();
 
 /**
- * Return the compiled create function for a message, compiling it on
- * first use.
- */
+ * Return the compiled create function for a message, compiling it on first use. */
 function compiledCreate(desc: DescMessage): CompiledCreate {
   let compiled = compiledCreates.get(desc);
   if (compiled === undefined) {
@@ -70,206 +68,211 @@ function compiledCreate(desc: DescMessage): CompiledCreate {
   return compiled;
 }
 
+/** Singular field: scalar, enum, or message. */
+const INIT_SINGULAR = 0;
+/** List field: a zero message has a fresh empty array. */
+const INIT_LIST = 1;
+/** Map field: a zero message has a fresh empty object. */
+const INIT_MAP = 2;
+/** Oneof group: the ADT is always stored, cases convert by case name. */
+const INIT_ONEOF = 3;
+
+/** Definition of a message. */
+interface InitMessage {
+  /** One property per member of the message, in declaration order. */
+  readonly properties: InitProperty[];
+  /* Undefined for messages that track presence without the prototype chain. */
+  readonly prototype: Record<string, unknown> | undefined;
+}
+
+/** Definition for one property of a message. */
+type InitProperty = {
+  readonly name: string;
+} & (
+  | {
+      readonly kind: typeof INIT_SINGULAR;
+      /** The zero value for implicit presence, undefined for explicit. */
+      readonly constant: ScalarValue | undefined;
+      readonly convert: Converter | undefined;
+    }
+  | {
+      readonly kind: typeof INIT_LIST | typeof INIT_MAP;
+      readonly constant: undefined;
+      readonly convert: Converter | undefined;
+    }
+  | {
+      readonly kind: typeof INIT_ONEOF;
+      readonly constant: undefined;
+      readonly convert: Map<string, Converter>;
+    }
+);
+
 /**
- * Compile the create function for this message type, so that creating a
- * message does not interpret the descriptor every time.
+ * Compile the create function for this message type. It sets every property
+ * of the message in a single walk over the compiled properties, so the switch
+ * is the only dispatch. Every kind stores the zero value where the init has
+ * no value for the property, which is why a missing or empty init produces a
+ * zero message.
  */
 function compileCreate(desc: DescMessage): CompiledCreate {
   const typeName = desc.typeName;
-
-  // Fields with explicit presence store default values in a prototype.
-  const prototype: Record<string, unknown> = {};
-  const usePrototype = needsPrototypeChain(desc);
-
-  // Sets one member from an init / zero value, in declaration order.
-  const initializers: MemberInit[] = [];
-
-  for (const member of desc.members) {
-    initializers.push(compileInitMember(member));
-    if (
-      usePrototype &&
-      member.kind == "field" &&
-      member.presence != IMPLICIT &&
-      (member.fieldKind == "scalar" || member.fieldKind == "enum")
-    ) {
-      prototype[member.localName] = createZeroValue(member);
-    }
-  }
-
+  const { properties, prototype } = compileInitMessage(desc);
   return (init) => {
     let message: Record<string, unknown>;
-    if (usePrototype) {
+    if (prototype !== undefined) {
       message = Object.create(prototype) as Record<string, unknown>;
       message.$typeName = typeName;
     } else {
       message = { $typeName: typeName };
     }
-    for (let i = 0; i < initializers.length; i++) {
-      initializers[i](message, init);
+    for (let i = 0; i < properties.length; i++) {
+      const property = properties[i];
+      const name = property.name;
+      const initValue = init?.[name];
+      switch (property.kind) {
+        case INIT_SINGULAR:
+          if (initValue != null) {
+            message[name] =
+              property.convert !== undefined
+                ? property.convert(initValue)
+                : initValue;
+          } else if (property.constant !== undefined) {
+            message[name] = property.constant;
+          }
+          break;
+        case INIT_LIST:
+          message[name] =
+            property.convert !== undefined && Array.isArray(initValue)
+              ? initValue.map(property.convert)
+              : (initValue ?? []);
+          break;
+        case INIT_MAP:
+          // Object.create(null) would be desirable for the fresh map, but is
+          // unsupported by React:
+          // https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
+          if (property.convert === undefined || !isObject(initValue)) {
+            message[name] = initValue ?? {};
+          } else {
+            const converted: Record<string, unknown> = {};
+            const keys = Object.keys(initValue);
+            for (let k = 0; k < keys.length; k++) {
+              converted[keys[k]] = property.convert(initValue[keys[k]]);
+            }
+            message[name] = converted;
+          }
+          break;
+        case INIT_ONEOF: {
+          const oneofValue = initValue as
+            | { case?: unknown; value?: unknown }
+            | null
+            | undefined;
+          if (oneofValue?.case != null) {
+            const convert = property.convert.get(oneofValue.case as string);
+            if (convert !== undefined) {
+              message[name] = {
+                case: oneofValue.case,
+                value: convert(oneofValue.value),
+              };
+              break;
+            }
+          }
+          message[name] = { case: undefined };
+          break;
+        }
+      }
     }
     return message as Message;
   };
 }
 
 /**
- * Sets one member from a MessageInitShape on a message under construction.
+ * Classify every member once, so that creating a message is a walk over a
+ * compact list instead of a walk over the descriptor.
  */
-type MemberInit = (
-  message: Record<string, unknown>,
-  init: Record<string, unknown> | undefined,
-) => void;
+function compileInitMessage(desc: DescMessage): InitMessage {
+  const properties: InitProperty[] = [];
+  const prototype: Record<string, unknown> = {};
+  const usePrototype = needsPrototypeChain(desc);
 
-/**
- * Converts a member value from a MessageInitShape to its message
- * representation.
- */
-type Converter = (value: unknown) => unknown;
-
-function compileInitMember(member: DescField | DescOneof): MemberInit {
-  if (member.kind == "oneof") {
-    return compileInitOneof(member);
-  }
-  switch (member.fieldKind) {
-    case "list":
-      return compileInitList(member);
-    case "map":
-      return compileInitMap(member);
-    case "message":
-      const convert = compileConvertMessage(member);
-      return compileInitProperty(member.localName, convert);
-    case "scalar":
-    case "enum": {
-      const convert =
-        member.fieldKind == "scalar" && member.scalar == ScalarType.BYTES
-          ? toU8Arr
-          : undefined;
-      return member.presence == IMPLICIT
-        ? compileInitPropertyWithZeroValue(
-            member.localName,
-            convert,
-            createZeroValue(member),
-          )
-        : compileInitProperty(member.localName, convert);
+  for (const member of desc.members) {
+    const name = member.localName;
+    if (member.kind == "oneof") {
+      properties.push({
+        name,
+        kind: INIT_ONEOF,
+        constant: undefined,
+        convert: compileConvertOneof(member),
+      });
+      continue;
+    }
+    switch (member.fieldKind) {
+      case "message": {
+        // Singular message fields are absent from a zero message.
+        properties.push({
+          name,
+          kind: INIT_SINGULAR,
+          constant: undefined,
+          convert: compileConvertMessage(member),
+        });
+        break;
+      }
+      case "list": {
+        properties.push({
+          name,
+          kind: INIT_LIST,
+          constant: undefined,
+          convert:
+            member.listKind == "message"
+              ? compileConvertMessage(member)
+              : member.scalar == ScalarType.BYTES
+                ? toU8Arr
+                : undefined,
+        });
+        break;
+      }
+      case "map": {
+        properties.push({
+          name,
+          kind: INIT_MAP,
+          constant: undefined,
+          convert:
+            member.mapKind == "message"
+              ? compileConvertMessage(member)
+              : member.scalar == ScalarType.BYTES
+                ? toU8Arr
+                : undefined,
+        });
+        break;
+      }
+      default: {
+        const zeroValue = createZeroValue(member);
+        properties.push({
+          name,
+          kind: INIT_SINGULAR,
+          constant: member.presence == IMPLICIT ? zeroValue : undefined,
+          convert:
+            member.fieldKind == "scalar" && member.scalar == ScalarType.BYTES
+              ? toU8Arr
+              : undefined,
+        });
+        if (usePrototype) {
+          prototype[name] = zeroValue;
+        }
+        break;
+      }
     }
   }
+
+  return {
+    properties,
+    prototype: usePrototype ? prototype : undefined,
+  };
 }
 
-function compileInitProperty(
-  name: string,
-  convert: Converter | undefined,
-): MemberInit {
-  return convert === undefined
-    ? (message, init) => {
-        const value = init?.[name];
-        if (value != null) {
-          message[name] = value;
-        }
-      }
-    : (message, init) => {
-        const value = init?.[name];
-        if (value != null) {
-          message[name] = convert(value);
-        }
-      };
-}
-
-function compileInitPropertyWithZeroValue(
-  name: string,
-  convert: Converter | undefined,
-  zeroValue: unknown,
-): MemberInit {
-  return convert === undefined
-    ? (message, init) => {
-        if (init === undefined) {
-          message[name] = zeroValue;
-          return;
-        }
-        const value = init[name];
-        message[name] = value ?? zeroValue;
-      }
-    : (message, init) => {
-        if (init === undefined) {
-          message[name] = zeroValue;
-          return;
-        }
-        const value = init[name];
-        message[name] = value != null ? convert(value) : zeroValue;
-      };
-}
-
-function compileInitList(field: DescField & { fieldKind: "list" }): MemberInit {
-  const name = field.localName;
-  let convertItem: Converter | undefined;
-  if (field.listKind == "message") {
-    convertItem = compileConvertMessage(field);
-  } else if (field.scalar == ScalarType.BYTES) {
-    convertItem = toU8Arr;
-  }
-  return convertItem === undefined
-    ? (message, init) => {
-        if (init === undefined) {
-          message[name] = [];
-          return;
-        }
-        const value = init[name];
-        message[name] = value ?? [];
-      }
-    : (message, init) => {
-        if (init === undefined) {
-          message[name] = [];
-          return;
-        }
-        const value = init[name];
-        message[name] = Array.isArray(value)
-          ? value.map(convertItem)
-          : (value ?? []);
-      };
-}
-
-function compileInitMap(field: DescField & { fieldKind: "map" }): MemberInit {
-  const name = field.localName;
-  let convertValue: Converter | undefined;
-  if (field.mapKind == "message") {
-    convertValue = compileConvertMessage(field);
-  } else if (field.scalar == ScalarType.BYTES) {
-    convertValue = toU8Arr;
-  }
-  return convertValue === undefined
-    ? (message, init) => {
-        if (init === undefined) {
-          message[name] = {};
-          return;
-        }
-        const value = init[name];
-        // Object.create(null) would be desirable for the fresh map, but is
-        // unsupported by React:
-        // https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
-        message[name] = value ?? {};
-      }
-    : (message, init) => {
-        if (init === undefined) {
-          message[name] = {};
-          return;
-        }
-        const value = init[name];
-        if (value == null) {
-          message[name] = {};
-        } else if (isObject(value)) {
-          const convertedValues: Record<string, unknown> = {};
-          const keys = Object.keys(value);
-          for (let i = 0; i < keys.length; i++) {
-            const key = keys[i];
-            convertedValues[key] = convertValue(value[key]);
-          }
-          message[name] = convertedValues;
-        } else {
-          message[name] = value;
-        }
-      };
-}
-
-function compileInitOneof(oneof: DescOneof): MemberInit {
-  const name = oneof.localName;
+/**
+ * Compile the conversion of each case of a oneof group, keyed by case name.
+ */
+function compileConvertOneof(oneof: DescOneof): Map<string, Converter> {
   const converters = new Map<string, Converter>();
   for (const field of oneof.fields) {
     let convert: Converter | undefined;
@@ -283,28 +286,14 @@ function compileInitOneof(oneof: DescOneof): MemberInit {
     }
     converters.set(field.localName, convert ?? ((value) => value));
   }
-  return (message, init) => {
-    if (init === undefined) {
-      message[name] = { case: undefined };
-      return;
-    }
-    const oneofValue = init[name] as
-      | { case?: unknown; value?: unknown }
-      | null
-      | undefined;
-    if (oneofValue != null && oneofValue.case != null) {
-      const convert = converters.get(oneofValue.case as string);
-      if (convert !== undefined) {
-        message[name] = {
-          case: oneofValue.case,
-          value: convert(oneofValue.value),
-        };
-        return;
-      }
-    }
-    message[name] = { case: undefined };
-  };
+  return converters;
 }
+
+/**
+ * Converts a member value from a MessageInitShape to its message
+ * representation.
+ */
+type Converter = (value: unknown) => unknown;
 
 /**
  * Compile the conversion of an init value for a message field, a message
@@ -378,7 +367,7 @@ function needsPrototypeChain(desc: DescMessage): boolean {
  */
 function createZeroValue(
   field: DescField & { fieldKind: "scalar" | "enum" },
-): string | boolean | number | bigint | Uint8Array {
+): ScalarValue {
   const defaultValue = field.getDefaultValue();
   if (defaultValue !== undefined) {
     return field.fieldKind == "scalar" && field.longAsString

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -217,7 +217,7 @@ function compileInitMessage(desc: DescMessage): InitMessage {
           constant: undefined,
           convert:
             member.listKind == "message"
-              ? compileConvertMessage(member)
+              ? (compileConvertMessage(member) ?? ((value) => value))
               : member.scalar == ScalarType.BYTES
                 ? toU8Arr
                 : undefined,
@@ -231,7 +231,7 @@ function compileInitMessage(desc: DescMessage): InitMessage {
           constant: undefined,
           convert:
             member.mapKind == "message"
-              ? compileConvertMessage(member)
+              ? (compileConvertMessage(member) ?? ((value) => value))
               : member.scalar == ScalarType.BYTES
                 ? toU8Arr
                 : undefined,

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -166,14 +166,14 @@ function compileCreate(desc: DescMessage): CompiledCreate {
       }
     }
     if (init === undefined) {
-      for (const name of lists) {
-        message[name] = [];
+      for (let i = 0; i < lists.length; i++) {
+        message[lists[i]] = [];
       }
-      for (const name of maps) {
-        message[name] = {};
+      for (let i = 0; i < maps.length; i++) {
+        message[maps[i]] = {};
       }
-      for (const name of oneofs) {
-        message[name] = { case: undefined };
+      for (let i = 0; i < oneofs.length; i++) {
+        message[oneofs[i]] = { case: undefined };
       }
       return message as Message;
     }
@@ -312,7 +312,9 @@ function compileInitMap(field: DescField & { fieldKind: "map" }): MemberInit {
       message[name] = {};
     } else if (isObject(value)) {
       const convertedValues: Record<string, unknown> = {};
-      for (const key of Object.keys(value)) {
+      const keys = Object.keys(value);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
         convertedValues[key] = convertValue(value[key]);
       }
       message[name] = convertedValues;

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -107,13 +107,7 @@ type InitProperty = {
     }
 );
 
-/**
- * Compile the create function for this message type. It sets every property
- * of the message in a single walk over the compiled properties, so the switch
- * is the only dispatch. Every kind stores the zero value where the init has
- * no value for the property, which is why a missing or empty init produces a
- * zero message.
- */
+/* Compile the create function for this message type. */
 function compileCreate(desc: DescMessage): CompiledCreate {
   const typeName = desc.typeName;
   const { properties, prototype } = compileInitMessage(desc);

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -259,7 +259,7 @@ function compileInitImplicit(
   if (convert === undefined) {
     return (message, init) => {
       const value = init[name];
-      message[name] = value != null ? value : zeroValue;
+      message[name] = value ?? zeroValue;
     };
   }
   return (message, init) => {
@@ -279,17 +279,14 @@ function compileInitList(field: DescField & { fieldKind: "list" }): MemberInit {
   if (convertItem === undefined) {
     return (message, init) => {
       const value = init[name];
-      message[name] = value == null ? [] : value;
+      message[name] = value ?? [];
     };
   }
   return (message, init) => {
     const value = init[name];
-    message[name] =
-      value == null
-        ? []
-        : Array.isArray(value)
-          ? value.map(convertItem)
-          : value;
+    message[name] = Array.isArray(value)
+      ? value.map(convertItem)
+      : (value ?? []);
   };
 }
 
@@ -307,7 +304,7 @@ function compileInitMap(field: DescField & { fieldKind: "map" }): MemberInit {
       // Object.create(null) would be desirable for the fresh map, but is
       // unsupported by React:
       // https://react.dev/reference/react/use-server#serializable-parameters-and-return-values
-      message[name] = value == null ? {} : value;
+      message[name] = value ?? {};
     };
   }
   return (message, init) => {

--- a/packages/protobuf/src/create.ts
+++ b/packages/protobuf/src/create.ts
@@ -386,7 +386,16 @@ function compileConvertMessage(
     return undefined;
   }
   const messageDesc = field.message;
-  return (value) => (isObject(value) ? create(messageDesc, value) : value);
+  // Resolved on first use, not here: the message type can be this very field's
+  // parent, whose create function is still being compiled.
+  let compiled: CompiledCreate | undefined;
+  return (value) => {
+    if (!isObject(value) || isMessage(value, messageDesc)) {
+      return value;
+    }
+    compiled ??= compiledCreate(messageDesc);
+    return compiled(value);
+  };
 }
 
 // converts any ArrayLike<number> to Uint8Array if necessary.


### PR DESCRIPTION
Follow up to https://github.com/bufbuild/protobuf-es/pull/1491. We spend a lot of time interpreting descriptors when constructing new messages. This PR precomputes a list of init operations for each message descriptor.

| fixture           | create | fromJson | fromBinary |
|---------------------|--------|----------|------------|
| repeated-message       | -55.4% | -9.5%    | -19.3%     |
| map-message               | -53.9% | -9.6%    | -16.0%     |
| scalar                       | -52.2% | -8.0%    | -25.1%     |
| user-normal                     | -39.7% | -5.3%    | -7.1%      |
| repeated-scalar                    | -34.3% | 0.0%     | -3.2%      |
| map-scalar                            | -34.1% | -0.7%    | -4.2%      |
| user-tiny                                | -29.5% | -12.3%   | -13.2%     |
| general                                     | -22.4% | -2.3%    | -1.8%      |