### PR TITLE
Upgrade TypeScript target to ES2022

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   129,207 b |  64,864 b |   15,252 b |
-| Protobuf-ES         |     4 |   131,396 b |  66,370 b |   15,922 b |
-| Protobuf-ES         |     8 |   134,158 b |  68,141 b |   16,427 b |
-| Protobuf-ES         |    16 |   144,608 b |  76,124 b |   18,784 b |
-| Protobuf-ES         |    32 |   172,399 b |  98,144 b |   24,269 b |
+| Protobuf-ES         |     1 |   126,757 b |  63,418 b |   14,996 b |
+| Protobuf-ES         |     4 |   128,946 b |  64,924 b |   15,578 b |
+| Protobuf-ES         |     8 |   131,708 b |  66,695 b |   16,096 b |
+| Protobuf-ES         |    16 |   142,158 b |  74,678 b |   18,440 b |
+| Protobuf-ES         |    32 |   169,949 b |  96,697 b |   23,975 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.805859375 140,244.9083984375 280,243.47822265625 420,236.803125 560,221.26943359375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,247.530859375 140,245.8826171875 280,244.415625 420,237.77734375 560,222.10205078125">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.805859375" r="4" fill="#ffa600"><title>Protobuf-ES 14.89 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.9083984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.55 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.47822265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.04 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.803125" r="4" fill="#ffa600"><title>Protobuf-ES 18.34 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.26943359375" r="4" fill="#ffa600"><title>Protobuf-ES 23.7 KiB for 32 files</title></circle>
+<circle cx="0" cy="247.530859375" r="4" fill="#ffa600"><title>Protobuf-ES 14.64 KiB for 1 files</title></circle>
+<circle cx="140" cy="245.8826171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.21 KiB for 4 files</title></circle>
+<circle cx="280" cy="244.415625" r="4" fill="#ffa600"><title>Protobuf-ES 15.72 KiB for 8 files</title></circle>
+<circle cx="420" cy="237.77734375" r="4" fill="#ffa600"><title>Protobuf-ES 18.01 KiB for 16 files</title></circle>
+<circle cx="560" cy="222.10205078125" r="4" fill="#ffa600"><title>Protobuf-ES 23.41 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/from-json.ts
+++ b/packages/protobuf/src/from-json.ts
@@ -213,7 +213,6 @@ function readMessage(
     );
   } catch (e) {
     if (isFieldError(e)) {
-      // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
       throw new Error(`cannot decode ${e.field()} from JSON: ${e.message}`, {
         cause: e,
       });
@@ -1035,11 +1034,9 @@ function parseJsonString(jsonString: string, typeName: string) {
     json = JSON.parse(jsonString) as JsonValue;
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    throw new Error(
-      `cannot decode message ${typeName} from JSON: ${message}`,
-      // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
-      { cause: e },
-    );
+    throw new Error(`cannot decode message ${typeName} from JSON: ${message}`, {
+      cause: e,
+    });
   }
   checkDuplicateKeys(jsonString, typeName);
   return json;

--- a/packages/protobuf/src/txtpb/from-text.ts
+++ b/packages/protobuf/src/txtpb/from-text.ts
@@ -127,7 +127,6 @@ function parseText(
     if (isFieldError(e)) {
       throw new Error(
         `cannot decode ${e.field()} from text format: ${e.message}`,
-        // @ts-expect-error we use the ES2022 error CTOR option "cause" for better stack traces
         { cause: e },
       );
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,17 +1,9 @@
 {
   "compilerOptions": {
-    // We target ES2017, but require the Text Encoding API, globalThis, and
-    // optionally BigInt and AsyncIterable, see below.
-    "target": "es2017",
-    "lib": [
-      "ES2017",
-      // ES2020.BigInt for the bigint representation of 64-bit integers
-      // Note that these are only required for using bigint literals
-      // or the BigInt constructor function.
-      "ES2020.BigInt",
-      // AsyncIterable is required only for src/wire/size-delimited.ts.
-      "ES2018.AsyncIterable",
-    ],
+    "target": "es2022",
+    "lib": ["ES2022"],
+    // ES2022 defaults this to true; pin false to keep pre-ES2022 field semantics.
+    "useDefineForClassFields": false,
     "declaration": true,
     // Prevent tsc from picking up @types/node and others
     "types": [],


### PR DESCRIPTION
In line with our compat policy, this PR upgrades our target to ES2022. Along with reducing bundle size, this also speeds up some of our benchmarks (see https://github.com/bufbuild/protobuf-es/pull/1499).