### PR TITLE
Fix byte size estimate in base64 fallback

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   129,207 b |  64,864 b |   15,252 b |
-| Protobuf-ES         |     4 |   131,396 b |  66,370 b |   15,922 b |
-| Protobuf-ES         |     8 |   134,158 b |  68,141 b |   16,427 b |
-| Protobuf-ES         |    16 |   144,608 b |  76,124 b |   18,784 b |
-| Protobuf-ES         |    32 |   172,399 b |  98,144 b |   24,269 b |
+| Protobuf-ES         |     1 |   129,086 b |  64,809 b |   15,268 b |
+| Protobuf-ES         |     4 |   131,275 b |  66,315 b |   15,893 b |
+| Protobuf-ES         |     8 |   134,037 b |  68,086 b |   16,439 b |
+| Protobuf-ES         |    16 |   144,487 b |  76,069 b |   18,745 b |
+| Protobuf-ES         |    32 |   172,278 b |  98,089 b |   24,219 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.805859375 140,244.9083984375 280,243.47822265625 420,236.803125 560,221.26943359375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.760546875 140,244.99052734375 280,243.44423828125 420,236.91357421875 560,221.41103515625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.805859375" r="4" fill="#ffa600"><title>Protobuf-ES 14.89 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.9083984375" r="4" fill="#ffa600"><title>Protobuf-ES 15.55 KiB for 4 files</title></circle>
-<circle cx="280" cy="243.47822265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.04 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.803125" r="4" fill="#ffa600"><title>Protobuf-ES 18.34 KiB for 16 files</title></circle>
-<circle cx="560" cy="221.26943359375" r="4" fill="#ffa600"><title>Protobuf-ES 23.7 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.760546875" r="4" fill="#ffa600"><title>Protobuf-ES 14.91 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.99052734375" r="4" fill="#ffa600"><title>Protobuf-ES 15.52 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.44423828125" r="4" fill="#ffa600"><title>Protobuf-ES 16.05 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.91357421875" r="4" fill="#ffa600"><title>Protobuf-ES 18.31 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.41103515625" r="4" fill="#ffa600"><title>Protobuf-ES 23.65 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf-test/src/wire/base64-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/base64-encoding.test.ts
@@ -211,8 +211,9 @@ void suite("base64Decode()", () => {
     "c3VyZQ==\tc3VyZQ==",
     "c3VyZQ==\rc3VyZQ==",
     "c3VyZQ== c3VyZQ==",
+    "c3VyZXN1cmU==",
   ]) {
-    void test(`allows inner padding in ${b64}`, () => {
+    void test(`allows padding in ${b64}`, () => {
       assert.deepStrictEqual(
         base64Decode(b64),
         new TextEncoder().encode("suresure"),

--- a/packages/protobuf-test/src/wire/base64-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/base64-encoding.test.ts
@@ -211,12 +211,24 @@ void suite("base64Decode()", () => {
     "c3VyZQ==\tc3VyZQ==",
     "c3VyZQ==\rc3VyZQ==",
     "c3VyZQ== c3VyZQ==",
-    "c3VyZXN1cmU==",
   ]) {
-    void test(`allows padding in ${b64}`, () => {
+    void test(`allows inner padding in ${b64}`, () => {
       assert.deepStrictEqual(
         base64Decode(b64),
         new TextEncoder().encode("suresure"),
+      );
+    });
+  }
+  for (const [b64, expected] of [
+    ["c3Vy=", "sur"],
+    ["c3Vy==", "sur"],
+    ["c3VyZS4==", "sure."],
+    ["c3VyZXN1cmU==", "suresure"],
+  ]) {
+    void test(`allows excess padding in ${b64}`, () => {
+      assert.deepStrictEqual(
+        base64Decode(b64),
+        new TextEncoder().encode(expected),
       );
     });
   }

--- a/packages/protobuf/src/wire/base64-encoding.ts
+++ b/packages/protobuf/src/wire/base64-encoding.ts
@@ -41,11 +41,8 @@ export function base64Decode(base64Str: string): Uint8Array<ArrayBuffer> {
     }
   }
   const table = getDecodeTable();
-  // estimate byte size, not accounting for inner padding and whitespace
-  let es = (base64Str.length * 3) / 4;
-  if (base64Str[base64Str.length - 2] == "=") es -= 2;
-  else if (base64Str[base64Str.length - 1] == "=") es -= 1;
-
+  // estimate byte size
+  const es = (base64Str.length * 3) / 4;
   let bytes = new Uint8Array(es),
     bytePos = 0, // position in byte array
     groupPos = 0, // position in base64 group


### PR DESCRIPTION
Correctness fix - for certain poorly formed inputs, the handwritten impl of base64 may underallocate the buffer, missing a byte in the end.
