### PR TITLE
Reorder hasOwnProperty for explicit-presence fields

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   130,558 b |  65,268 b |   15,369 b |
-| Protobuf-ES         |     4 |   132,747 b |  66,774 b |   16,043 b |
-| Protobuf-ES         |     8 |   135,509 b |  68,545 b |   16,603 b |
-| Protobuf-ES         |    16 |   145,959 b |  76,527 b |   18,863 b |
-| Protobuf-ES         |    32 |   173,750 b |  98,549 b |   24,412 b |
+| Protobuf-ES         |     1 |   130,603 b |  65,275 b |   15,389 b |
+| Protobuf-ES         |     4 |   132,792 b |  66,781 b |   16,028 b |
+| Protobuf-ES         |     8 |   135,554 b |  68,552 b |   16,578 b |
+| Protobuf-ES         |    16 |   146,004 b |  76,534 b |   18,886 b |
+| Protobuf-ES         |    32 |   173,795 b |  98,556 b |   24,363 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.47451171875 140,244.56572265625 280,242.97978515625 420,236.57939453125 560,220.864453125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.41787109375 140,244.608203125 280,243.0505859375 420,236.5142578125 560,221.00322265625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.47451171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.01 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.56572265625" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.97978515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.21 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.57939453125" r="4" fill="#ffa600"><title>Protobuf-ES 18.42 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.864453125" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.41787109375" r="4" fill="#ffa600"><title>Protobuf-ES 15.03 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.608203125" r="4" fill="#ffa600"><title>Protobuf-ES 15.65 KiB for 4 files</title></circle>
+<circle cx="280" cy="243.0505859375" r="4" fill="#ffa600"><title>Protobuf-ES 16.19 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.5142578125" r="4" fill="#ffa600"><title>Protobuf-ES 18.44 KiB for 16 files</title></circle>
+<circle cx="560" cy="221.00322265625" r="4" fill="#ffa600"><title>Protobuf-ES 23.79 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -165,15 +165,14 @@ function compileSingularField(field: DescFieldSingular): CompiledWriter {
         ? `cannot encode ${field} to binary: required field not set`
         : undefined;
     return (writer, opts, message) => {
-      const value = message[localName];
-      // Fields with explicit presence have properties on the prototype
-      // chain for default / zero values (except for proto3).
-      if (
-        value !== undefined &&
-        Object.prototype.hasOwnProperty.call(message, localName)
-      ) {
-        writeValue(writer, opts, value);
-      } else if (requiredError !== undefined) {
+      if (Object.prototype.hasOwnProperty.call(message, localName)) {
+        const value = message[localName];
+        if (value !== undefined) {
+          writeValue(writer, opts, value);
+          return;
+        }
+      }
+      if (requiredError !== undefined) {
         throw new Error(requiredError);
       }
     };


### PR DESCRIPTION
This doesn't move any numbers on our current benchmarks. But let's name the two checks:

- H = `Object.prototype.hasOwnProperty.call(message, localName)`
- M = `message[localName] != undefined` 

Then:

- For absent message fields, any syntax: `M` gets replaced with `H` (no effect)
- For absent scalars on proto3: `M` gets replaced with `H` (no effect)
- For absent scalars on proto2 / editions: `M+H` gets replaced with `H` (big win)
- For own properties that are explicitly marked as `undefined`: `M` becomes `M+H` (big loss)

Not sure if this is a clean win, but I think absent scalars are more common that explicit `undefined` properties.