### PR TITLE
Define descriptor toString instead of assigning it

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   130,558 b |  65,268 b |   15,369 b |
-| Protobuf-ES         |     4 |   132,747 b |  66,774 b |   16,043 b |
-| Protobuf-ES         |     8 |   135,509 b |  68,545 b |   16,603 b |
-| Protobuf-ES         |    16 |   145,959 b |  76,527 b |   18,863 b |
-| Protobuf-ES         |    32 |   173,750 b |  98,549 b |   24,412 b |
+| Protobuf-ES         |     1 |   130,687 b |  65,344 b |   15,414 b |
+| Protobuf-ES         |     4 |   132,876 b |  66,850 b |   16,088 b |
+| Protobuf-ES         |     8 |   135,638 b |  68,621 b |   16,619 b |
+| Protobuf-ES         |    16 |   146,088 b |  76,602 b |   18,913 b |
+| Protobuf-ES         |    32 |   173,879 b |  98,626 b |   24,437 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.47451171875 140,244.56572265625 280,242.97978515625 420,236.57939453125 560,220.864453125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.3470703125 140,244.43828125 280,242.93447265625 420,236.43779296875 560,220.79365234375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.47451171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.01 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.56572265625" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.97978515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.21 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.57939453125" r="4" fill="#ffa600"><title>Protobuf-ES 18.42 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.864453125" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.3470703125" r="4" fill="#ffa600"><title>Protobuf-ES 15.05 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.43828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.71 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.93447265625" r="4" fill="#ffa600"><title>Protobuf-ES 16.23 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.43779296875" r="4" fill="#ffa600"><title>Protobuf-ES 18.47 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.79365234375" r="4" fill="#ffa600"><title>Protobuf-ES 23.86 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -2182,26 +2182,6 @@ void suite("descriptor toString()", () => {
     extend Msg { optional int32 ext = 100; }
   `;
 
-  // Object.freeze(Object.prototype) is irreversible and would leak into every
-  // later test in this process.
-  function withNonWritableToString<T>(fn: () => T): T {
-    const original = Object.getOwnPropertyDescriptor(
-      Object.prototype,
-      "toString",
-    );
-    assert.ok(original);
-    Object.defineProperty(Object.prototype, "toString", {
-      ...original,
-      writable: false,
-      configurable: true,
-    });
-    try {
-      return fn();
-    } finally {
-      Object.defineProperty(Object.prototype, "toString", original);
-    }
-  }
-
   function describeAll(reg: FileRegistry): string[] {
     const msg = reg.getMessage("Msg");
     assert.ok(msg);
@@ -2232,14 +2212,26 @@ void suite("descriptor toString()", () => {
     );
   });
 
-  void test("works with non-writable Object.prototype.toString", async () => {
+  void test("works with non-writable Object.prototype.toString", async (t) => {
     const fileDescriptorSet = await compileFileDescriptorSet({
       "a.proto": protoSource,
     });
     const expected = describeAll(createFileRegistry(fileDescriptorSet));
-    const actual = withNonWritableToString(() =>
-      describeAll(createFileRegistry(fileDescriptorSet)),
+    // Object.freeze(Object.prototype) is irreversible and would leak into every
+    // later test in this process.
+    const original = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "toString",
     );
+    assert.ok(original);
+    Object.defineProperty(Object.prototype, "toString", {
+      ...original,
+      writable: false,
+    });
+    t.after(() =>
+      Object.defineProperty(Object.prototype, "toString", original),
+    );
+    const actual = describeAll(createFileRegistry(fileDescriptorSet));
     assert.deepStrictEqual(actual, expected);
   });
 });

--- a/packages/protobuf-test/src/registry.test.ts
+++ b/packages/protobuf-test/src/registry.test.ts
@@ -2171,3 +2171,75 @@ void suite("DescMethod", () => {
     });
   });
 });
+
+void suite("descriptor toString()", () => {
+  const protoSource = `
+    syntax="proto2";
+    message Msg {
+      optional int32 fld = 1;
+      extensions 100 to 200;
+    }
+    extend Msg { optional int32 ext = 100; }
+  `;
+
+  // Object.freeze(Object.prototype) is irreversible and would leak into every
+  // later test in this process.
+  function withNonWritableToString<T>(fn: () => T): T {
+    const original = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "toString",
+    );
+    assert.ok(original);
+    Object.defineProperty(Object.prototype, "toString", {
+      ...original,
+      writable: false,
+      configurable: true,
+    });
+    try {
+      return fn();
+    } finally {
+      Object.defineProperty(Object.prototype, "toString", original);
+    }
+  }
+
+  function describeAll(reg: FileRegistry): string[] {
+    const msg = reg.getMessage("Msg");
+    assert.ok(msg);
+    const ext = reg.getExtension("ext");
+    assert.ok(ext);
+    return [msg.fields[0].toString(), ext.toString()];
+  }
+
+  void test("describes a field and an extension", async () => {
+    const reg = createFileRegistry(
+      await compileFileDescriptorSet({ "a.proto": protoSource }),
+    );
+    assert.deepStrictEqual(describeAll(reg), [
+      "field Msg.fld",
+      "extension ext",
+    ]);
+  });
+
+  void test("is an enumerable own property", async () => {
+    const reg = createFileRegistry(
+      await compileFileDescriptorSet({ "a.proto": protoSource }),
+    );
+    const msg = reg.getMessage("Msg");
+    assert.ok(msg);
+    assert.strictEqual(
+      Object.getOwnPropertyDescriptor(msg.fields[0], "toString")?.enumerable,
+      true,
+    );
+  });
+
+  void test("works with non-writable Object.prototype.toString", async () => {
+    const fileDescriptorSet = await compileFileDescriptorSet({
+      "a.proto": protoSource,
+    });
+    const expected = describeAll(createFileRegistry(fileDescriptorSet));
+    const actual = withNonWritableToString(() =>
+      describeAll(createFileRegistry(fileDescriptorSet)),
+    );
+    assert.deepStrictEqual(actual, expected);
+  });
+});

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -860,7 +860,14 @@ function newField(
     field.oneof = undefined;
     field.typeName = typeName;
     field.jsonName = `[${typeName}]`; // option json_name is not allowed on extension fields
-    field.toString = () => `extension ${typeName}`;
+    // A plain assignment throws where built-in prototypes are frozen. The
+    // attributes below match what an assignment produces.
+    Object.defineProperty(field, "toString", {
+      value: () => `extension ${typeName}`,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
     const extendee = reg.getMessage(trimLeadingDot(proto.extendee));
     assert(
       extendee,
@@ -877,7 +884,12 @@ function newField(
       ? protoCamelCase(proto.name)
       : safeObjectProperty(protoCamelCase(proto.name));
     field.jsonName = proto.jsonName;
-    field.toString = () => `field ${parent.typeName}.${proto.name}`;
+    Object.defineProperty(field, "toString", {
+      value: () => `field ${parent.typeName}.${proto.name}`,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
   }
   const label: FieldDescriptorProto_Label = proto.label;
   const type: FieldDescriptorProto_Type = proto.type;

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -849,6 +849,7 @@ function newField(
     longAsString: false,
     getDefaultValue: undefined,
   };
+  let toStr: () => string;
   if (isExtension) {
     // extension field
     const file = parentOrFile.kind == "file" ? parentOrFile : parentOrFile.file;
@@ -860,14 +861,7 @@ function newField(
     field.oneof = undefined;
     field.typeName = typeName;
     field.jsonName = `[${typeName}]`; // option json_name is not allowed on extension fields
-    // A plain assignment throws where built-in prototypes are frozen. The
-    // attributes below match what an assignment produces.
-    Object.defineProperty(field, "toString", {
-      value: () => `extension ${typeName}`,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
+    toStr = () => `extension ${typeName}`;
     const extendee = reg.getMessage(trimLeadingDot(proto.extendee));
     assert(
       extendee,
@@ -884,13 +878,16 @@ function newField(
       ? protoCamelCase(proto.name)
       : safeObjectProperty(protoCamelCase(proto.name));
     field.jsonName = proto.jsonName;
-    Object.defineProperty(field, "toString", {
-      value: () => `field ${parent.typeName}.${proto.name}`,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
+    toStr = () => `field ${parent.typeName}.${proto.name}`;
   }
+  // A plain assignment throws where built-in prototypes are frozen. The
+  // attributes match what an assignment produces.
+  Object.defineProperty(field, "toString", {
+    value: toStr,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
   const label: FieldDescriptorProto_Label = proto.label;
   const type: FieldDescriptorProto_Type = proto.type;
   const jstype: FieldOptions_JSType | undefined = proto.options?.jstype;


### PR DESCRIPTION
We use Protobuf-ES as part of the license key system in the TinyMCE rich text editor. A customer embedded the editor in an environment that freezes the built-in JavaScript prototypes. In this frozen environment, Protobuf-ES throws an exception when attempting to create a file descriptor. The exception occurs at module load time before any of our code runs, so it cannot be caught. 

In Chrome, the exception `TypeError: Cannot assign to read only property 'toString' of object '#<Object>` is thrown. Firefox reports `"toString" is read-only`. Safari reports `Attempted to assign to readonly property`.

I found two locations in registry.ts that assign `toString`. The other seven descriptors define it in the object literal, so are safe. A frozen `Object.prototype.toString` is non-writable, so it throws in strict mode. `Object.defineProperty` creates the own property directly and is unaffected. The descriptor matches what assignment produces: `writable: true, enumerable: true, configurable: true`. `Object.keys` and spread behave as before.

The added tests cover string output and enumerability for non-frozen and frozen environments. The frozen-prototype test fails on main without the `defineProperty` fix.

Bundle size grows 236 b raw and 150 b minified. Compressed is unchanged within noise. The regenerated report is included.

Let me know if there is anything else I need to do for this PR.