### PR TITLE
Use setFromBase64 instead of fromBase64

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   131,110 b |  65,502 b |   15,443 b |
-| Protobuf-ES         |     4 |   133,299 b |  67,008 b |   16,130 b |
-| Protobuf-ES         |     8 |   136,061 b |  68,779 b |   16,654 b |
-| Protobuf-ES         |    16 |   146,511 b |  76,761 b |   18,957 b |
-| Protobuf-ES         |    32 |   174,302 b |  98,783 b |   24,504 b |
+| Protobuf-ES         |     1 |   130,957 b |  65,428 b |   15,488 b |
+| Protobuf-ES         |     4 |   133,146 b |  66,934 b |   16,107 b |
+| Protobuf-ES         |     8 |   135,908 b |  68,705 b |   16,628 b |
+| Protobuf-ES         |    16 |   146,358 b |  76,687 b |   18,918 b |
+| Protobuf-ES         |    32 |   174,149 b |  98,709 b |   24,459 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   130,558 b |  65,268 b |   15,369 b |
-| Protobuf-ES         |     4 |   132,747 b |  66,774 b |   16,043 b |
-| Protobuf-ES         |     8 |   135,509 b |  68,545 b |   16,603 b |
-| Protobuf-ES         |    16 |   145,959 b |  76,527 b |   18,863 b |
-| Protobuf-ES         |    32 |   173,750 b |  98,549 b |   24,412 b |
+| Protobuf-ES         |     1 |   131,110 b |  65,502 b |   15,443 b |
+| Protobuf-ES         |     4 |   133,299 b |  67,008 b |   16,130 b |
+| Protobuf-ES         |     8 |   136,061 b |  68,779 b |   16,654 b |
+| Protobuf-ES         |    16 |   146,511 b |  76,761 b |   18,957 b |
+| Protobuf-ES         |    32 |   174,302 b |  98,783 b |   24,504 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.26494140625 140,244.3193359375 280,242.8353515625 420,236.31318359375 560,220.60390625000002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.1375 140,244.38447265625 280,242.908984375 420,236.4236328125 560,220.73134765625">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.26494140625" r="4" fill="#ffa600"><title>Protobuf-ES 15.08 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.3193359375" r="4" fill="#ffa600"><title>Protobuf-ES 15.75 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.8353515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.26 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.31318359375" r="4" fill="#ffa600"><title>Protobuf-ES 18.51 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.60390625000002" r="4" fill="#ffa600"><title>Protobuf-ES 23.93 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.1375" r="4" fill="#ffa600"><title>Protobuf-ES 15.13 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.38447265625" r="4" fill="#ffa600"><title>Protobuf-ES 15.73 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.908984375" r="4" fill="#ffa600"><title>Protobuf-ES 16.24 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.4236328125" r="4" fill="#ffa600"><title>Protobuf-ES 18.47 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.73134765625" r="4" fill="#ffa600"><title>Protobuf-ES 23.89 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.47451171875 140,244.56572265625 280,242.97978515625 420,236.57939453125 560,220.864453125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.26494140625 140,244.3193359375 280,242.8353515625 420,236.31318359375 560,220.60390625000002">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.47451171875" r="4" fill="#ffa600"><title>Protobuf-ES 15.01 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.56572265625" r="4" fill="#ffa600"><title>Protobuf-ES 15.67 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.97978515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.21 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.57939453125" r="4" fill="#ffa600"><title>Protobuf-ES 18.42 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.864453125" r="4" fill="#ffa600"><title>Protobuf-ES 23.84 KiB for 32 files</title></circle>
+<circle cx="0" cy="246.26494140625" r="4" fill="#ffa600"><title>Protobuf-ES 15.08 KiB for 1 files</title></circle>
+<circle cx="140" cy="244.3193359375" r="4" fill="#ffa600"><title>Protobuf-ES 15.75 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.8353515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.26 KiB for 8 files</title></circle>
+<circle cx="420" cy="236.31318359375" r="4" fill="#ffa600"><title>Protobuf-ES 18.51 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.60390625000002" r="4" fill="#ffa600"><title>Protobuf-ES 23.93 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/wire/base64-encoding.ts
+++ b/packages/protobuf/src/wire/base64-encoding.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Native Uint8Array.fromBase64, if the runtime provides it.
-const nativeUint8ArrayFromBase64 = (
-  Uint8Array as Partial<{
-    fromBase64(base64Str: string): Uint8Array<ArrayBuffer>;
+// Native Uint8Array.prototype.setFromBase64, if the runtime provides it.
+const nativeSetFromBase64 = (
+  Uint8Array.prototype as Partial<{
+    setFromBase64(base64Str: string): { read: number; written: number };
   }>
-).fromBase64;
+).setFromBase64;
 
 /**
  * Decodes a base64 string to a byte array.
@@ -31,20 +31,44 @@ const nativeUint8ArrayFromBase64 = (
  *   no padding
  */
 export function base64Decode(base64Str: string): Uint8Array<ArrayBuffer> {
-  if (nativeUint8ArrayFromBase64) {
+  const len = base64Str.length;
+  let size = (len >> 2) * 3;
+  switch (len & 3) {
+    case 0:
+      if (len > 0 && base64Str.charCodeAt(len - 1) == 61 /* = */) {
+        size -= base64Str.charCodeAt(len - 2) == 61 ? 2 : 1;
+      }
+      break;
+    case 2:
+      size += 1; // unpadded tail, one extra byte
+      break;
+    case 3:
+      size += 2; // unpadded tail, two extra bytes
+      break;
+  }
+
+  const bytes = new Uint8Array(size);
+  let written = -1;
+  if (nativeSetFromBase64) {
     try {
-      return nativeUint8ArrayFromBase64(base64Str);
+      const result = nativeSetFromBase64.call(bytes, base64Str);
+      if (result.read == len) {
+        written = result.written;
+      }
     } catch {
-      // The native decoder rejects base64url and inner padding, which we
-      // accept. Fall through to the implementation below, which is lenient,
-      // and raises our own error for genuinely invalid input.
+      // The native decoder rejects base64url and inner padding, which we accept.
     }
   }
+  if (written < 0) {
+    written = setFromBase64(bytes, base64Str);
+  }
+  return written == size ? bytes : bytes.subarray(0, written);
+}
+
+/** Writes into `bytes` from index 0 and returns the number of bytes written. */
+function setFromBase64(bytes: Uint8Array, base64Str: string): number {
   const table = getDecodeTable();
-  // estimate byte size
-  const es = (base64Str.length * 3) / 4;
-  let bytes = new Uint8Array(es),
-    bytePos = 0, // position in byte array
+  let bytePos = 0, // position in byte array
     groupPos = 0, // position in base64 group
     b: number, // current byte
     p = 0; // previous byte
@@ -86,7 +110,7 @@ export function base64Decode(base64Str: string): Uint8Array<ArrayBuffer> {
     }
   }
   if (groupPos == 1) throw Error("invalid base64 string");
-  return bytes.subarray(0, bytePos);
+  return bytePos;
 }
 
 // Native Uint8Array.prototype.toBase64, if the runtime provides it.
@@ -94,7 +118,7 @@ type ToBase64Options = {
   readonly alphabet?: "base64" | "base64url";
   readonly omitPadding?: boolean;
 };
-const nativeUint8ArrayToBase64 = (
+const nativeToBase64 = (
   Uint8Array.prototype as Partial<{
     toBase64(options?: ToBase64Options): string;
   }>
@@ -123,8 +147,8 @@ export function base64Encode(
   bytes: Uint8Array,
   encoding: Base64Encoding = "std",
 ) {
-  if (nativeUint8ArrayToBase64) {
-    return nativeUint8ArrayToBase64.call(bytes, toBase64OptionsMap[encoding]);
+  if (nativeToBase64) {
+    return nativeToBase64.call(bytes, toBase64OptionsMap[encoding]);
   }
   const table = getEncodeTable(encoding);
   const pad = encoding == "std";

--- a/packages/protobuf/src/wire/base64-encoding.ts
+++ b/packages/protobuf/src/wire/base64-encoding.ts
@@ -32,19 +32,11 @@ const nativeSetFromBase64 = (
  */
 export function base64Decode(base64Str: string): Uint8Array<ArrayBuffer> {
   const len = base64Str.length;
-  let size = (len >> 2) * 3;
-  switch (len & 3) {
-    case 0:
-      if (len > 0 && base64Str.charCodeAt(len - 1) == 61 /* = */) {
-        size -= base64Str.charCodeAt(len - 2) == 61 ? 2 : 1;
-      }
-      break;
-    case 2:
-      size += 1; // unpadded tail, one extra byte
-      break;
-    case 3:
-      size += 2; // unpadded tail, two extra bytes
-      break;
+  // Decoded size, assuming a well-formed string: three bytes per group of
+  // four characters, minus one byte for each padding character.
+  let size = len - ((len + 3) >> 2);
+  if ((len & 3) == 0 && base64Str[len - 1] == "=") {
+    size -= base64Str[len - 2] == "=" ? 2 : 1;
   }
 
   const bytes = new Uint8Array(size);


### PR DESCRIPTION
It turns out `setFromBase64` is quite a bit faster than `fromBase64`, likely because it writes to a temporary buffer and copies to an exact sized buffer on completion.

| case              | main ns/op | branch ns/op | median delta |
|---------------------|-------------|---------------|--------------|
| fromJson/general               | 155,205     | 127,223       | -18.03%      |
| fromJson/scalar                   | 1,547       | 1,415         | -8.54%       |
| fromJson/repeated-message           | 1,634,885   | 1,510,323     | -7.62%       |
| fromJson/map-message                   | 1,735,116   | 1,637,511     | -5.63%       |

Since the `fromBase64` API already does return subarrays, we don't need to do that copy. However, I added code to attempt to compute the _exact_ output size, which should help us avoid allocating the subarray in most cases.