### PR TITLE
Add ASCII fast paths

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   131,710 b |  65,479 b |   15,513 b |
-| Protobuf-ES         |     4 |   133,899 b |  66,984 b |   16,187 b |
-| Protobuf-ES         |     8 |   136,661 b |  68,755 b |   16,710 b |
-| Protobuf-ES         |    16 |   147,111 b |  76,736 b |   19,016 b |
-| Protobuf-ES         |    32 |   174,902 b |  98,760 b |   24,516 b |
+| Protobuf-ES         |     1 |   132,514 b |  65,824 b |   15,654 b |
+| Protobuf-ES         |     4 |   134,703 b |  67,329 b |   16,301 b |
+| Protobuf-ES         |     8 |   137,465 b |  69,100 b |   16,859 b |
+| Protobuf-ES         |    16 |   147,915 b |  77,081 b |   19,137 b |
+| Protobuf-ES         |    32 |   175,706 b |  99,105 b |   24,648 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -43,14 +43,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,246.06669921875 140,244.15791015625 280,242.6767578125 420,236.14609375 560,220.569921875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.6673828125 140,243.83505859375 280,242.25478515625 420,235.80341796875 560,220.19609375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="246.06669921875" r="4" fill="#ffa600"><title>Protobuf-ES 15.15 KiB for 1 files</title></circle>
-<circle cx="140" cy="244.15791015625" r="4" fill="#ffa600"><title>Protobuf-ES 15.81 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.6767578125" r="4" fill="#ffa600"><title>Protobuf-ES 16.32 KiB for 8 files</title></circle>
-<circle cx="420" cy="236.14609375" r="4" fill="#ffa600"><title>Protobuf-ES 18.57 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.569921875" r="4" fill="#ffa600"><title>Protobuf-ES 23.94 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.6673828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.29 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.83505859375" r="4" fill="#ffa600"><title>Protobuf-ES 15.92 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.25478515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.46 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.80341796875" r="4" fill="#ffa600"><title>Protobuf-ES 18.69 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.19609375" r="4" fill="#ffa600"><title>Protobuf-ES 24.07 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -299,9 +299,28 @@ export class BinaryWriter {
     if (typeof value !== "string") {
       value = String(value);
     }
+    const len = value.length;
+
+    // Fast path for ASCII.
+    if (len <= ASCII_MAX_LENGTH) {
+      this.ensureCapacity(len + 1);
+      const ascii = this.buffer;
+      let pos = this.pos;
+      ascii[pos++] = len;
+      let i = 0;
+      for (; i < len; i++) {
+        const code = value.charCodeAt(i);
+        if (code > 0x7f) break;
+        ascii[pos++] = code;
+      }
+      if (i == len) {
+        this.pos = pos;
+        return this;
+      }
+    }
+
     // encodeUtf8Into needs the full-length buffer upfront. The length prefix
     // can be upto 5 bytes, and a UTF-16 code unit takes at most 3 UTF-8 bytes.
-    const len = value.length;
     this.ensureCapacity(len * 3 + 5);
 
     // The length prefix goes first, but the byte length is only known after
@@ -509,6 +528,12 @@ const EMPTY_BUFFER = new Uint8Array(0) as Uint8Array<ArrayBuffer>;
  * fixed-width write first grows the buffer, which replaces this view.
  */
 const EMPTY_VIEW = new DataView(EMPTY_BUFFER.buffer);
+
+/**
+ * Longest string on the ASCII fast paths. Must stay below 0x80, so
+ * that the writer's length prefix always fits a single varint byte.
+ */
+const ASCII_MAX_LENGTH = 32;
 
 /**
  * Number of bytes needed to encode `value` as an unsigned 32-bit varint.
@@ -755,7 +780,23 @@ export class BinaryReader {
    * `strict` is true, throw on invalid UTF-8 instead of substituting U+FFFD.
    */
   string(strict?: boolean): string {
-    return this.decodeUtf8(this.bytes(), strict);
+    const bytes = this.bytes();
+    const len = bytes.length;
+
+    // Fast path for ASCII.
+    if (len <= ASCII_MAX_LENGTH) {
+      const codes = new Array<number>(len);
+      for (let i = 0; i < len; i++) {
+        const byte = bytes[i];
+        if (byte > 0x7f) {
+          return this.decodeUtf8(bytes, strict);
+        }
+        codes[i] = byte;
+      }
+      return String.fromCharCode.apply(String, codes);
+    }
+
+    return this.decodeUtf8(bytes, strict);
   }
 }
 


### PR DESCRIPTION
Calling TextEncoder functions incurs a fixed cost, below which it is much cheaper to execute code in JS itself. This PR bets on most small strings being pure ASCII:

| case                        | delta  |
|-------------------------------|--------|
| BinaryWriter/string-ascii       | -69.6% |
| BinaryReader/string-ascii         | -43.9% |
| toBinary/user-normal                 | -42.0% |
| fromBinary/user-normal                  | -29.2% |
| toBinary/general                           | -17.3% |
| fromBinary/general                            | -5.4%  |
| BinaryWriter/string-utf8                         | +6.5%  |
| BinaryReader/string-utf8                            | +6.1%  |