### PR TITLE
Render background for bundle-size

### DIFF
--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -8,6 +8,7 @@
       }
       ]]>
     </style>
+    <rect x="-10%" y="-10%" width="120%" height="120%" fill="#ffffff" />
     <g transform="translate(110,310)">
       <line y1="0" x2="700" stroke="black" />
       <text x="0" y="18" text-anchor="start">1 file</text>

--- a/packages/bundle-size/src/util.ts
+++ b/packages/bundle-size/src/util.ts
@@ -101,6 +101,7 @@ export function generateChart(lines: Chartline[]): string {
       }
       ]]>
     </style>
+    <rect x="-10%" y="-10%" width="120%" height="120%" fill="#ffffff" />
     <g transform="translate(110,310)">
       <line y1="0" x2="${xStep * sizes.length}" stroke="black" />
       ${sizes.map((size, index) => `<text x="${xStep * index}" y="18" text-anchor="start">${size} file${size > 1 ? "s" : ""}</text>`).join("\n")}


### PR DESCRIPTION
The bundle-size chart is not readable on GitHub with the dark theme enabled. This PR adds a white background for visibility.