### PR TITLE
Reuse BinaryWriter in toBinary()

### DIFF
--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,514 b |  65,824 b |   15,654 b |
-| Protobuf-ES         |     4 |   134,703 b |  67,329 b |   16,301 b |
-| Protobuf-ES         |     8 |   137,465 b |  69,100 b |   16,859 b |
-| Protobuf-ES         |    16 |   147,915 b |  77,081 b |   19,137 b |
-| Protobuf-ES         |    32 |   175,706 b |  99,105 b |   24,648 b |
+| Protobuf-ES         |     1 |   132,831 b |  65,927 b |   15,674 b |
+| Protobuf-ES         |     4 |   135,020 b |  67,431 b |   16,341 b |
+| Protobuf-ES         |     8 |   137,782 b |  69,202 b |   16,876 b |
+| Protobuf-ES         |    16 |   148,232 b |  77,185 b |   19,182 b |
+| Protobuf-ES         |    32 |   176,023 b |  99,208 b |   24,637 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -44,14 +44,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.6673828125 140,243.83505859375 280,242.25478515625 420,235.80341796875 560,220.19609375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.6107421875 140,243.72177734375 280,242.206640625 420,235.6759765625 560,220.22724609375">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.6673828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.29 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.83505859375" r="4" fill="#ffa600"><title>Protobuf-ES 15.92 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.25478515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.46 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.80341796875" r="4" fill="#ffa600"><title>Protobuf-ES 18.69 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.19609375" r="4" fill="#ffa600"><title>Protobuf-ES 24.07 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.6107421875" r="4" fill="#ffa600"><title>Protobuf-ES 15.31 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.72177734375" r="4" fill="#ffa600"><title>Protobuf-ES 15.96 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.206640625" r="4" fill="#ffa600"><title>Protobuf-ES 16.48 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.6759765625" r="4" fill="#ffa600"><title>Protobuf-ES 18.73 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.22724609375" r="4" fill="#ffa600"><title>Protobuf-ES 24.06 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf/src/to-binary.ts
+++ b/packages/protobuf/src/to-binary.ts
@@ -54,18 +54,26 @@ function makeWriteOptions(
   return options ? { ...writeDefaults, ...options } : writeDefaults;
 }
 
+/** A writer reused between toBinary calls. */
+let sharedWriter: BinaryWriter | undefined;
+
 export function toBinary<Desc extends DescMessage>(
   schema: Desc,
   message: MessageShape<Desc>,
   options?: Partial<BinaryWriteOptions>,
 ): Uint8Array<ArrayBuffer> {
-  const writer = new BinaryWriter();
+  const writer = sharedWriter ?? new BinaryWriter();
+  // Guard against re-entry. While this should never happen under normal
+  // circumstances, we do use String(value) which may call user code.
+  sharedWriter = undefined;
   compiledWriter(schema)(
     writer,
     makeWriteOptions(options),
     message as Record<string, unknown>,
   );
-  return writer.finish();
+  const bytes = writer.finish();
+  sharedWriter = writer;
+  return bytes;
 }
 
 /**

--- a/packages/protobuf/src/wire/binary-encoding.ts
+++ b/packages/protobuf/src/wire/binary-encoding.ts
@@ -165,6 +165,10 @@ export class BinaryWriter {
     const result = this.buffer.slice(0, this.pos);
     this.pos = 0;
     this.stackPos = [];
+    if (this.buffer.length > MAX_RETAINED_SIZE) {
+      this.buffer = EMPTY_BUFFER;
+      this.viewCache = EMPTY_VIEW;
+    }
     return result;
   }
 
@@ -508,6 +512,12 @@ export class BinaryWriter {
  * Capacity of the buffer allocated by the first write..
  */
 const INITIAL_SIZE = 128;
+
+/**
+ * Buffer capacity above which a writer releases its buffer in finish()
+ * instead of retaining it for reuse.
+ */
+const MAX_RETAINED_SIZE = 64 * 1024;
 
 /**
  * Bytes `fork()` reserves for the length prefix, betting that the payload will


### PR DESCRIPTION
Reusing the `BinaryWriter` between calls significantly speeds up `toBinary()`.

| case              | main ops/s | branch ops/s | median delta |
|---------------------|------------|---------------|--------------|
| user-tiny             | 3,371,151  | 5,010,427     | +48.6%       |
| scalar                   | 1,312,346  | 1,949,876     | +48.6%       |
| repeated-scalar             | 427,492    | 607,573       | +42.1%       |
| map-scalar                     | 194,082    | 249,383       | +28.5%       |
| user-normal                       | 1,588,382  | 1,915,175     | +20.6%       |
| general                              | 14,793     | 15,872        | +7.3%        |
| repeated-message                        | 2,162      | 2,173         | +0.5%        |
| map-message                                | 1,742      | 1,754         | +0.7%        |