### PR TITLE
Apply import_extension only to relative import paths

### DIFF
--- a/packages/protoplugin-test/src/import_extension.test.ts
+++ b/packages/protoplugin-test/src/import_extension.test.ts
@@ -94,6 +94,30 @@ void suite("import_extension", () => {
       "json",
     ]);
   });
+  for (const { option, ext } of [
+    { option: "none", ext: "" },
+    { option: "js", ext: ".js" },
+    { option: "ts", ext: ".ts" },
+  ]) {
+    void test(`should not touch npm package import with option ${option}`, async () => {
+      const lines = await testGenerate(
+        `target=ts,import_extension=${option}`,
+        (f) => {
+          const Foo = f.import("Foo", "foo/foo.js");
+          const Local = f.import("Local", "./local_pb.js");
+          f.print("console.log(", Foo, ", ", Local, ");");
+        },
+      );
+      // The extension of a published package is fixed. Only the import of
+      // generated code is modified.
+      assert.deepStrictEqual(lines, [
+        'import { Foo } from "foo/foo.js";',
+        `import { Local } from "./local_pb${ext}";`,
+        "",
+        "console.log(Foo, Local);",
+      ]);
+    });
+  }
 
   async function testGenerate(
     parameter: string,

--- a/packages/protoplugin-test/src/rewrite_imports.test.ts
+++ b/packages/protoplugin-test/src/rewrite_imports.test.ts
@@ -27,13 +27,41 @@ void suite("rewrite_imports", () => {
         f.print("console.log(", Bar, ", ", Baz, ");");
       },
     );
+    // import_extension only applies to relative paths - this plugin's own
+    // output. The rewritten paths keep the .js extension, even though the
+    // option defaults to "none", because the exports of @scope/pkg are fixed
+    // when it is published.
     assert.deepStrictEqual(lines, [
-      'import { Bar } from "@scope/pkg/foo/bar_pb";',
-      'import { Baz } from "@scope/pkg/foo/bar/baz_pb";',
+      'import { Bar } from "@scope/pkg/foo/bar_pb.js";',
+      'import { Baz } from "@scope/pkg/foo/bar/baz_pb.js";',
       "",
       "console.log(Bar, Baz);",
     ]);
   });
+  for (const { option, ext } of [
+    { option: "none", ext: "" },
+    { option: "js", ext: ".js" },
+    { option: "ts", ext: ".ts" },
+  ]) {
+    void test(`should not apply import_extension=${option} to rewritten path`, async () => {
+      const lines = await testGenerate(
+        `target=ts,import_extension=${option},rewrite_imports=./foo/**/*_pb.js:@scope/pkg`,
+        (f) => {
+          const Bar = f.import("Bar", "./foo/bar_pb.js");
+          const Local = f.import("Local", "./local_pb.js");
+          f.print("console.log(", Bar, ", ", Local, ");");
+        },
+      );
+      // Local does not match the pattern. It still gets the extension, which
+      // shows that the option applies to this plugin's own output as usual.
+      assert.deepStrictEqual(lines, [
+        'import { Bar } from "@scope/pkg/foo/bar_pb.js";',
+        `import { Local } from "./local_pb${ext}";`,
+        "",
+        "console.log(Bar, Local);",
+      ]);
+    });
+  }
   void test("should rewrite npm import to other package", async () => {
     const lines = await testGenerate(
       "target=ts,rewrite_imports=@scope/pkg:@other-scope/other-pkg",

--- a/packages/protoplugin/src/import-path.ts
+++ b/packages/protoplugin/src/import-path.ts
@@ -49,6 +49,12 @@ import type { ImportExtension } from "./parameter.js";
  *
  * With the target `@scope/pkg`, the import path `./foo/bar_pb.js` is
  * transformed to `@scope/pkg/foo/bar_pb.js`.
+ *
+ * Note that the plugin option `import_extension` only applies to relative
+ * import paths. Since the target is typically a npm package name, rewritten
+ * paths keep the .js extension. The exports of a package are fixed when it is
+ * published, and the extension chosen for local code generation must not
+ * change how a dependency is addressed.
  */
 export type RewriteImports = { pattern: string; target: string }[];
 
@@ -58,8 +64,8 @@ const cache = new WeakMap<
 >();
 
 /**
- * Apply import rewrites to the given import path, and change all .js extensions
- * to the given import extension.
+ * Apply import rewrites to the given import path, and change the .js extension
+ * of relative import paths to the given import extension.
  */
 export function rewriteImportPath(
   importPath: string,
@@ -87,7 +93,7 @@ export function rewriteImportPath(
       break;
     }
   }
-  if (importPath.endsWith(".js")) {
+  if (relativePathRE.test(importPath) && importPath.endsWith(".js")) {
     switch (importExtension) {
       case "none":
         return importPath.substring(0, importPath.length - 3);

--- a/packages/protoplugin/src/parameter.ts
+++ b/packages/protoplugin/src/parameter.ts
@@ -37,7 +37,7 @@ export interface EcmaScriptPluginOptions {
    */
   targets: Target[];
   /**
-   * Add an extension to every import: "js" or "ts".
+   * Add an extension to every relative import: "js" or "ts".
    *
    * The default is "none".
    */


### PR DESCRIPTION
The plugin option `import_extension` controls the file extension of generated imports. But it must only control the file extensions for generated code, not for code that is imported from published npm packages.

If a plugin generates an import from an npm package `import { Foo } from "foo/foo.js"`, the plugin option `import_extension=none` or `import_extension=ts` must not modify that import.