### PR TITLE
Backfill `encodeUtf8Into` for backwards compat with `protobuf-es v2.13`

### DIFF
--- a/docs/src/content/docs/guides/serialization.md
+++ b/docs/src/content/docs/guides/serialization.md
@@ -172,3 +172,5 @@ This format is compatible with the delimited message support in the C++, Java, G
 Protobuf-ES uses the WHATWG [Text Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API) to convert UTF-8 to and from binary.
 
 If your environment does not provide the API, call `configureTextEncoding()` from `@bufbuild/protobuf/wire` early during initialization and supply your own implementation.
+
+Multiple copies of this library in the same JavaScript isolate share one codec via a singleton on `globalThis`. If an older copy (v2.13 and earlier) initialized that slot without `encodeUtf8Into`, `getTextEncoding()` backfills it.

--- a/packages/protobuf-test/src/wire/text-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/text-encoding.test.ts
@@ -17,7 +17,11 @@ import * as assert from "node:assert";
 import {
   getTextEncoding,
   configureTextEncoding,
+  BinaryWriter,
+  BinaryReader,
 } from "@bufbuild/protobuf/wire";
+
+const textEncodingSymbol = Symbol.for("@bufbuild/protobuf/text-encoding");
 
 void suite("getTextEncoding()", () => {
   void test("returns TextEncoding", () => {
@@ -161,5 +165,59 @@ void suite("configureTextEncoding()", () => {
       dest,
       new Uint8Array([1, 2, 3, 0, 0, 0, 0, 0, 0, 0]),
     );
+  });
+});
+
+void suite("protobuf-es v2.13 global singleton compatibility", () => {
+  let backup: ReturnType<typeof getTextEncoding>;
+  beforeEach(() => {
+    backup = getTextEncoding();
+  });
+  afterEach(() => {
+    configureTextEncoding(backup);
+  });
+
+  function installV213TextEncoding() {
+    // protobuf-es v2.13 getTextEncoding() adds a global singleton to
+    // `globalThis` but does not include `encodeUtf8Into`.
+    (
+      globalThis as typeof globalThis & {
+        [textEncodingSymbol]?: {
+          encodeUtf8: typeof backup.encodeUtf8;
+          decodeUtf8: typeof backup.decodeUtf8;
+          checkUtf8: typeof backup.checkUtf8;
+        };
+      }
+    )[textEncodingSymbol] = {
+      encodeUtf8: backup.encodeUtf8,
+      decodeUtf8: backup.decodeUtf8,
+      checkUtf8: backup.checkUtf8,
+    };
+  }
+
+  void test("getTextEncoding() backfills encodeUtf8Into", () => {
+    installV213TextEncoding();
+    const te = getTextEncoding();
+    assert.strictEqual(typeof te.encodeUtf8Into, "function");
+    const dest = new Uint8Array(10);
+    const { written } = te.encodeUtf8Into("hello 🌍", dest);
+    assert.strictEqual(written, 10);
+    assert.deepStrictEqual(
+      dest,
+      new Uint8Array([104, 101, 108, 108, 111, 32, 240, 159, 140, 141]),
+    );
+  });
+
+  void test("BinaryWriter.string() encodes non-ASCII", () => {
+    installV213TextEncoding();
+    const bytes = new BinaryWriter().string("hello 🌍").finish();
+    assert.strictEqual(new BinaryReader(bytes).string(), "hello 🌍");
+  });
+
+  void test("BinaryWriter.string() encodes ASCII longer than the fast path", () => {
+    installV213TextEncoding();
+    const longAscii = "a".repeat(40);
+    const bytes = new BinaryWriter().string(longAscii).finish();
+    assert.strictEqual(new BinaryReader(bytes).string(), longAscii);
   });
 });

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -60,6 +60,17 @@ export function configureTextEncoding(textEncoding: TextEncodingConfig): void {
   };
 }
 
+/**
+ * Returns the process-wide UTF-8 codec.
+ *
+ * Every copy of this library in the same JavaScript isolate shares one
+ * implementation via `Symbol.for("@bufbuild/protobuf/text-encoding")` on
+ * `globalThis`.
+ *
+ * v2.14's `BinaryWriter` requires `encodeUtf8Into` on thatobject; v2.13 and
+ * earlier initialize the slot without it. If an older copy won the race, **fill
+ * out the missing method** the same way `configureTextEncoding` does.
+ */
 export function getTextEncoding(): TextEncoding {
   const globals = globalThis as unknown as GlobalWithTextEncoding &
     GlobalWithTextEncoderDecoder;
@@ -106,12 +117,20 @@ export function getTextEncoding(): TextEncoding {
       };
     }
     configureTextEncoding(config);
+  } else {
+    const existing = globals[symbol];
+    if (existing && typeof existing.encodeUtf8Into !== "function") {
+      // An older copy of this library (v2.13 and earlier) already added the
+      // global singleton, but missing the `encodeUtf8Into` method. Re-run
+      // configureTextEncoding so encodeUtf8Into is emulated from encodeUtf8.
+      configureTextEncoding(existing);
+    }
   }
   return globals[symbol] as TextEncoding;
 }
 
 type GlobalWithTextEncoding = {
-  [symbol]?: TextEncoding;
+  [symbol]?: TextEncodingConfig;
 };
 
 type GlobalWithTextEncoderDecoder = {


### PR DESCRIPTION
This change is intended to fix a bug. Repro steps:

1. Launch a JS isolate (e.g., browser tab)
2. Load protobuf-es v2.13
3. Load protobuf-es v2.14
4. Attempt to use the v2.14 `BinaryWriter.string()`
5. Observe that `TypeError` was thrown

Explanation: protobuf-es v2.13 installs some functions onto `globalThis[Symbol.for("@bufbuild/protobuf/text-encoding")]`, but it does not install `encodeUtf8Into`. protobuf-es v2.14 assumes that if the singleton exists, it has `encodeUtf8Into`. This causes v2.14 to fail writes by throwing `TypeError`.

To fix: when grabbing the global singleton, check if the method is missing. If it's missing, backfill it.