### PR TITLE
Stop sharing the text encoding implementation via globalThis

### DIFF
--- a/docs/src/content/docs/guides/serialization.md
+++ b/docs/src/content/docs/guides/serialization.md
@@ -171,4 +171,5 @@ This format is compatible with the delimited message support in the C++, Java, G
 
 Protobuf-ES uses the WHATWG [Text Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API) to convert UTF-8 to and from binary.
 
-If your environment does not provide the API, call `configureTextEncoding()` from `@bufbuild/protobuf/wire` early during initialization and supply your own implementation.
+If your environment does not provide the API, install your own `TextEncoder` and `TextDecoder` implementations globally.
+We use `TextEncoder`'s methods `encode` and - optionally - `encodeInto`, as well as `TextDecoder`'s `fatal: true` constructor argument and its `decode` method.

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,566 b |  65,885 b |   15,644 b |
-| Protobuf-ES         |     4 |   134,755 b |  67,390 b |   16,324 b |
-| Protobuf-ES         |     8 |   137,517 b |  69,161 b |   16,867 b |
-| Protobuf-ES         |    16 |   147,967 b |  77,142 b |   19,147 b |
-| Protobuf-ES         |    32 |   175,758 b |  99,166 b |   24,644 b |
+| Protobuf-ES         |     1 |   132,566 b |  65,885 b |   15,622 b |
+| Protobuf-ES         |     4 |   134,755 b |  67,390 b |   16,348 b |
+| Protobuf-ES         |     8 |   137,517 b |  69,161 b |   16,828 b |
+| Protobuf-ES         |    16 |   147,967 b |  77,142 b |   19,128 b |
+| Protobuf-ES         |    32 |   175,758 b |  99,166 b |   24,639 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,566 b |  65,885 b |   15,622 b |
-| Protobuf-ES         |     4 |   134,755 b |  67,390 b |   16,348 b |
-| Protobuf-ES         |     8 |   137,517 b |  69,161 b |   16,828 b |
-| Protobuf-ES         |    16 |   147,967 b |  77,142 b |   19,128 b |
-| Protobuf-ES         |    32 |   175,758 b |  99,166 b |   24,639 b |
+| Protobuf-ES         |     1 |   132,565 b |  65,884 b |   15,649 b |
+| Protobuf-ES         |     4 |   134,754 b |  67,389 b |   16,323 b |
+| Protobuf-ES         |     8 |   137,516 b |  69,160 b |   16,847 b |
+| Protobuf-ES         |    16 |   147,966 b |  77,141 b |   19,147 b |
+| Protobuf-ES         |    32 |   175,757 b |  99,165 b |   24,618 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/README.md
+++ b/packages/bundle-size/README.md
@@ -16,11 +16,11 @@ usually do. We repeat this for an increasing number of files.
 
 | code generator      | files | bundle size |  minified | compressed |
 | ------------------- | ----: | ----------: | --------: | ---------: |
-| Protobuf-ES         |     1 |   132,514 b |  65,824 b |   15,654 b |
-| Protobuf-ES         |     4 |   134,703 b |  67,329 b |   16,301 b |
-| Protobuf-ES         |     8 |   137,465 b |  69,100 b |   16,859 b |
-| Protobuf-ES         |    16 |   147,915 b |  77,081 b |   19,137 b |
-| Protobuf-ES         |    32 |   175,706 b |  99,105 b |   24,648 b |
+| Protobuf-ES         |     1 |   132,566 b |  65,885 b |   15,644 b |
+| Protobuf-ES         |     4 |   134,755 b |  67,390 b |   16,324 b |
+| Protobuf-ES         |     8 |   137,517 b |  69,161 b |   16,867 b |
+| Protobuf-ES         |    16 |   147,967 b |  77,142 b |   19,147 b |
+| Protobuf-ES         |    32 |   175,758 b |  99,166 b |   24,644 b |
 | protobuf-javascript |     1 |   314,172 b | 244,057 b |   36,091 b |
 | protobuf-javascript |     4 |   340,189 b | 259,029 b |   37,458 b |
 | protobuf-javascript |     8 |   360,983 b | 270,606 b |   38,596 b |

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -44,14 +44,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.7580078125 140,243.701953125 280,242.342578125 420,235.82890625 560,220.22158203125002">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.68154296875 140,243.77275390625 280,242.28876953125 420,235.77509765625 560,220.2810546875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.7580078125" r="4" fill="#ffa600"><title>Protobuf-ES 15.26 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.701953125" r="4" fill="#ffa600"><title>Protobuf-ES 15.96 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.342578125" r="4" fill="#ffa600"><title>Protobuf-ES 16.43 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.82890625" r="4" fill="#ffa600"><title>Protobuf-ES 18.68 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.22158203125002" r="4" fill="#ffa600"><title>Protobuf-ES 24.06 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.68154296875" r="4" fill="#ffa600"><title>Protobuf-ES 15.28 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.77275390625" r="4" fill="#ffa600"><title>Protobuf-ES 15.94 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.28876953125" r="4" fill="#ffa600"><title>Protobuf-ES 16.45 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.77509765625" r="4" fill="#ffa600"><title>Protobuf-ES 18.7 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.2810546875" r="4" fill="#ffa600"><title>Protobuf-ES 24.04 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -44,14 +44,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.6673828125 140,243.83505859375 280,242.25478515625 420,235.80341796875 560,220.19609375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.695703125 140,243.769921875 280,242.23212890625 420,235.77509765625 560,220.207421875">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.6673828125" r="4" fill="#ffa600"><title>Protobuf-ES 15.29 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.83505859375" r="4" fill="#ffa600"><title>Protobuf-ES 15.92 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.25478515625" r="4" fill="#ffa600"><title>Protobuf-ES 16.46 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.80341796875" r="4" fill="#ffa600"><title>Protobuf-ES 18.69 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.19609375" r="4" fill="#ffa600"><title>Protobuf-ES 24.07 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.695703125" r="4" fill="#ffa600"><title>Protobuf-ES 15.28 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.769921875" r="4" fill="#ffa600"><title>Protobuf-ES 15.94 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.23212890625" r="4" fill="#ffa600"><title>Protobuf-ES 16.47 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.77509765625" r="4" fill="#ffa600"><title>Protobuf-ES 18.7 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.207421875" r="4" fill="#ffa600"><title>Protobuf-ES 24.07 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/bundle-size/chart.svg
+++ b/packages/bundle-size/chart.svg
@@ -44,14 +44,14 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.695703125 140,243.769921875 280,242.23212890625 420,235.77509765625 560,220.207421875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,245.7580078125 140,243.701953125 280,242.342578125 420,235.82890625 560,220.22158203125002">
     <title>Protobuf-ES</title>
   </polyline>
-<circle cx="0" cy="245.695703125" r="4" fill="#ffa600"><title>Protobuf-ES 15.28 KiB for 1 files</title></circle>
-<circle cx="140" cy="243.769921875" r="4" fill="#ffa600"><title>Protobuf-ES 15.94 KiB for 4 files</title></circle>
-<circle cx="280" cy="242.23212890625" r="4" fill="#ffa600"><title>Protobuf-ES 16.47 KiB for 8 files</title></circle>
-<circle cx="420" cy="235.77509765625" r="4" fill="#ffa600"><title>Protobuf-ES 18.7 KiB for 16 files</title></circle>
-<circle cx="560" cy="220.207421875" r="4" fill="#ffa600"><title>Protobuf-ES 24.07 KiB for 32 files</title></circle>
+<circle cx="0" cy="245.7580078125" r="4" fill="#ffa600"><title>Protobuf-ES 15.26 KiB for 1 files</title></circle>
+<circle cx="140" cy="243.701953125" r="4" fill="#ffa600"><title>Protobuf-ES 15.96 KiB for 4 files</title></circle>
+<circle cx="280" cy="242.342578125" r="4" fill="#ffa600"><title>Protobuf-ES 16.43 KiB for 8 files</title></circle>
+<circle cx="420" cy="235.82890625" r="4" fill="#ffa600"><title>Protobuf-ES 18.68 KiB for 16 files</title></circle>
+<circle cx="560" cy="220.22158203125002" r="4" fill="#ffa600"><title>Protobuf-ES 24.06 KiB for 32 files</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,187.78916015624998 140,183.9177734375 280,180.694921875 420,160.52802734374998 560,76.125">

--- a/packages/protobuf-test/src/wire/text-encoding.test.ts
+++ b/packages/protobuf-test/src/wire/text-encoding.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite, test, beforeEach, afterEach } from "node:test";
+import { suite, test, beforeEach, afterEach, after } from "node:test";
 import * as assert from "node:assert";
 import {
   getTextEncoding,
@@ -68,6 +68,24 @@ void suite("getTextEncoding()", () => {
       const ok = getTextEncoding().checkUtf8(invalid);
       assert.strictEqual(ok, false);
     });
+  });
+  void test("does not read the singleton of v2.13 and earlier", () => {
+    // Up to v2.14, the codec was shared between every copy of the library
+    // through a singleton on `globalThis`.
+    const legacySymbol = Symbol.for("@bufbuild/protobuf/text-encoding");
+    const globalsWithSingleton = globalThis as typeof globalThis & {
+      [legacySymbol]?: unknown;
+    };
+
+    after(() => {
+      delete globalsWithSingleton[legacySymbol];
+    });
+    globalsWithSingleton[legacySymbol] = {
+      checkUtf8() {
+        throw new Error();
+      },
+    };
+    assert.ok(getTextEncoding().checkUtf8(""));
   });
 });
 

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -71,7 +71,7 @@ export function configureTextEncoding(textEncoding: TextEncodingConfig): void {
 export function getTextEncoding(): TextEncoding {
   if (!te) {
     const globals = globalThis as unknown as GlobalWithTextEncoderDecoder;
-    if (!globals.TextEncoder || !globals.TextDecoder) {
+    if (!globals.TextEncoder || !globals.TextEncoder) {
       throw new Error(
         "Encoding API missing - install TextEncoder and TextDecoder on globalThis",
       );

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -71,9 +71,9 @@ export function configureTextEncoding(textEncoding: TextEncodingConfig): void {
 export function getTextEncoding(): TextEncoding {
   if (!te) {
     const globals = globalThis as unknown as GlobalWithTextEncoderDecoder;
-    if (!globals.TextEncoder || !globals.TextEncoder) {
+    if (!globals.TextEncoder || !globals.TextDecoder) {
       throw new Error(
-        "Encoding API missing - install TextEncoder and TextDecoder on globalThis",
+        "encoding API missing: install TextEncoder and TextDecoder on globalThis",
       );
     }
     const textEncoder = new globals.TextEncoder();

--- a/packages/protobuf/src/wire/text-encoding.ts
+++ b/packages/protobuf/src/wire/text-encoding.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const symbol = Symbol.for("@bufbuild/protobuf/text-encoding");
+let te: TextEncoding | undefined;
 
 interface TextEncoding {
   /**
@@ -41,8 +41,14 @@ type TextEncodingConfig = Omit<TextEncoding, "encodeUtf8Into"> &
 /**
  * Protobuf-ES requires the Text Encoding API to convert UTF-8 from and to
  * binary. This WHATWG API is widely available, but it is not part of the
- * ECMAScript standard. On runtimes where it is not available, use this
- * function to provide your own implementation.
+ * ECMAScript standard. This function used to be the way to supply an
+ * implementation on runtimes that do not provide one.
+ *
+ * It only configures the copy of the library it is imported from. To provide
+ * the encoding API for every copy of Protobuf-ES in an isolate, install
+ * `TextEncoder` (with the methods `encode` and optionally `encodeInto`) and
+ * `TextDecoder` (with the `fatal: true` constructor argument and the `decode`
+ * method) on `globalThis`.
  *
  * Providing `encodeUtf8Into` is optional for backwards compatibility. If it
  * is omitted, we emulate it with a wrapper that calls `encodeUtf8`.
@@ -50,9 +56,11 @@ type TextEncodingConfig = Omit<TextEncoding, "encodeUtf8Into"> &
  * Note that the Text Encoding API does not provide a way to validate UTF-8.
  * Our implementation uses String.prototype.isWellFormed, and falls back
  * to use encodeURIComponent().
+ *
+ * @deprecated Install `TextEncoder` and `TextDecoder` on `globalThis` instead.
  */
 export function configureTextEncoding(textEncoding: TextEncodingConfig): void {
-  (globalThis as GlobalWithTextEncoding)[symbol] = {
+  te = {
     ...textEncoding,
     encodeUtf8Into:
       textEncoding.encodeUtf8Into ??
@@ -61,9 +69,13 @@ export function configureTextEncoding(textEncoding: TextEncodingConfig): void {
 }
 
 export function getTextEncoding(): TextEncoding {
-  const globals = globalThis as unknown as GlobalWithTextEncoding &
-    GlobalWithTextEncoderDecoder;
-  if (!globals[symbol]) {
+  if (!te) {
+    const globals = globalThis as unknown as GlobalWithTextEncoderDecoder;
+    if (!globals.TextEncoder || !globals.TextDecoder) {
+      throw new Error(
+        "Encoding API missing - install TextEncoder and TextDecoder on globalThis",
+      );
+    }
     const textEncoder = new globals.TextEncoder();
     const textDecoder = new globals.TextDecoder();
     let textDecoderStrict: typeof textDecoder | undefined;
@@ -107,12 +119,8 @@ export function getTextEncoding(): TextEncoding {
     }
     configureTextEncoding(config);
   }
-  return globals[symbol] as TextEncoding;
+  return te as TextEncoding;
 }
-
-type GlobalWithTextEncoding = {
-  [symbol]?: TextEncoding;
-};
 
 type GlobalWithTextEncoderDecoder = {
   TextEncoder: {


### PR DESCRIPTION
V2 of `@bufbuild/protobuf` introduced a facade for the Text Encoding API. The purpose was to make it easier to bring your own implementation in environments that don't have it.

The implementation is kept in a singleton on `globalThis`, shared by every copy of the library. Unfortunately, that made the shape of the implementation an undeclared contract between versions, and we have accidentally broken it twice:

- v2.12 added the `strict` argument to `decodeUtf8`
- v2.14 added `encodeUtf8Into`

When more than one copy of `@bufbuild/protobuf` is loaded, whichever copy initializes first wins the slot on the singleton, binding the implementation for every copy that comes after. A newer copy then runs on an implementation built against an older interface, ignoring `strict` or throwing a TypeError on a missing `encodeUtf8Into`.

To fix this issue, we're changing the facade to stop keeping state on `globalThis`. Every copy of `@bufbuild/protobuf` gets its own implementation now, which guarantees that it always works as intended.

We're also deprecating the function `configureTextEncoding`. While it's still possible to bring your own Text Encoding implementation via the function, it will only install your implementation for the copy it is imported from. To provide the Text Encoding API globally, we recommend installing `TextEncoder` (with the methods `encode` and optionally `encodeInto`) and `TextDecoder` (with the `fatal: true` constructor argument and the `decode` method) on `globalThis` instead.

Thanks to @alexandercampbell-wk and @e2digital-eurostar for the report in #1516.
