### PR TITLE
Add plugin option `map_imports` to point imports at packages

### DIFF
--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -9,7 +9,7 @@ Reference pages cover exact generated shapes, plugin options, runtime types, and
 - [Generated code](/reference/generated-code/): file names, message shapes, enum generation, extension descriptors, and service schemas.
 - [Field types](/reference/generated-code/field-types/): scalar mappings, message fields, enum fields, repeated fields, map fields, and well-known type field shapes.
 - [Generated features](/reference/generated-code/features/): oneofs, proto2 groups, required fields, optional fields, services, reserved names, nested types, comments, and packages.
-- [Plugin options](/reference/plugin-options/): `target`, import extensions, CommonJS output, empty files, `ts_nocheck`, plugin version elision, JSON types, and Valid types.
+- [Plugin options](/reference/plugin-options/): `target`, import extensions, CommonJS output, empty files, `ts_nocheck`, plugin version elision, JSON types, map imports, and Valid types.
 
 ## Runtime
 

--- a/docs/src/content/docs/reference/plugin-options.md
+++ b/docs/src/content/docs/reference/plugin-options.md
@@ -67,7 +67,7 @@ The option takes the form `map_imports=<pattern>:<target>` and can be repeated. 
 - `**/` matches zero or more directories.
 - A trailing `/` matches every file in the directory and its subdirectories.
 
-`import_extension` only applies to imports of local files. Mapped imports always end in `_pb.js`, the file name of the generated code the package provides. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
+The target can also be a path relative to the output directory, for example to import from the output of another plugin. Relative targets are local files, so they receive the `import_extension` like any other local import. Package targets always end in `_pb.js`. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
 
 ## `js_import_style`
 

--- a/docs/src/content/docs/reference/plugin-options.md
+++ b/docs/src/content/docs/reference/plugin-options.md
@@ -67,7 +67,7 @@ The option takes the form `map_imports=<pattern>:<target>` and can be repeated. 
 - `**/` matches zero or more directories.
 - A trailing `/` matches every file in the directory and its subdirectories.
 
-The target can also be a path relative to the output directory, for example to import from the output of another plugin. Relative targets are local files, so they receive the `import_extension` like any other local import. Package targets always end in `_pb.js`. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
+Package imports always end in `_pb.js`. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
 
 ## `js_import_style`
 

--- a/docs/src/content/docs/reference/plugin-options.md
+++ b/docs/src/content/docs/reference/plugin-options.md
@@ -42,6 +42,33 @@ Use this option when your environment requires one:
 
 Using ECMAScript modules in Node.js typically requires `.js`. Deno typically requires `.ts`.
 
+## `map_imports`
+
+By default, generated code imports dependencies from the local output with a relative path. For example, the file generated for `foo/bar.proto` imports a message from `buf/validate/validate.proto` from `../buf/validate/validate_pb`.
+
+If a dependency is provided by a package instead, use `map_imports` to import it from there. For example, `@bufbuild/protovalidate` exports the code generated for `buf/validate/validate.proto`, so there is no need to generate it again:
+
+```yaml
+version: v2
+plugins:
+  - local: protoc-gen-es
+    out: src/gen
+    opt:
+      - target=ts
+      - map_imports=buf/validate/:@bufbuild/protovalidate/gen
+```
+
+With this option, `buf/validate/validate.proto` is imported from `@bufbuild/protovalidate/gen/buf/validate/validate_pb.js`.
+
+The option takes the form `map_imports=<pattern>:<target>` and can be repeated. The pattern is matched against the path of the Protobuf file, and the first matching pattern wins. The target is prepended to the path of the generated file. Patterns support a subset of glob:
+
+- `*` matches zero or more characters except `/`.
+- `**` matches zero or more characters, including `/`.
+- `**/` matches zero or more directories.
+- A trailing `/` matches every file in the directory and its subdirectories.
+
+`import_extension` only applies to imports of local files. Mapped imports always end in `_pb.js`, the file name of the generated code the package provides. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
+
 ## `js_import_style`
 
 By default, Protobuf-ES generates ECMAScript `import` and `export` statements.

--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -96,7 +96,7 @@ opt: map_imports=buf/validate/:@bufbuild/protovalidate/gen
 
 The option takes the form `map_imports=<pattern>:<target>` and can be repeated. The pattern is matched against the path of the Protobuf file, and the first matching pattern wins. The target is prepended to the path of the generated file, so `buf/validate/validate.proto` is imported from `@bufbuild/protovalidate/gen/buf/validate/validate_pb.js`. Patterns support `*` (any characters except `/`), `**` (any characters), `**/` (zero or more directories), and a trailing `/` (every file in the directory and its subdirectories).
 
-The target can also be a path relative to the output directory, for example to import from the output of another plugin. Relative targets are local files, so they receive the `import_extension` like any other local import. Package targets always end in `_pb.js`. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
+Package imports always end in `_pb.js`. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
 
 ### `js_import_style`
 

--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -96,7 +96,7 @@ opt: map_imports=buf/validate/:@bufbuild/protovalidate/gen
 
 The option takes the form `map_imports=<pattern>:<target>` and can be repeated. The pattern is matched against the path of the Protobuf file, and the first matching pattern wins. The target is prepended to the path of the generated file, so `buf/validate/validate.proto` is imported from `@bufbuild/protovalidate/gen/buf/validate/validate_pb.js`. Patterns support `*` (any characters except `/`), `**` (any characters), `**/` (zero or more directories), and a trailing `/` (every file in the directory and its subdirectories).
 
-`import_extension` only applies to imports of local files. Mapped imports always end in `_pb.js`, the file name of the generated code the package provides. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
+The target can also be a path relative to the output directory, for example to import from the output of another plugin. Relative targets are local files, so they receive the `import_extension` like any other local import. Package targets always end in `_pb.js`. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
 
 ### `js_import_style`
 

--- a/packages/protoc-gen-es/README.md
+++ b/packages/protoc-gen-es/README.md
@@ -86,6 +86,18 @@ By default, `protoc-gen-es` doesn't add file extensions to import paths. However
 - `import_extension=js`: Adds the `.js` extension.
 - `import_extension=ts`. Adds the `.ts` extension.
 
+### `map_imports`
+
+By default, `protoc-gen-es` imports dependencies from the local output. If a dependency is provided by a package instead—for example, `@bufbuild/protovalidate` exports the code generated for `buf/validate/validate.proto`—this option imports it from there:
+
+```yaml
+opt: map_imports=buf/validate/:@bufbuild/protovalidate/gen
+```
+
+The option takes the form `map_imports=<pattern>:<target>` and can be repeated. The pattern is matched against the path of the Protobuf file, and the first matching pattern wins. The target is prepended to the path of the generated file, so `buf/validate/validate.proto` is imported from `@bufbuild/protovalidate/gen/buf/validate/validate_pb.js`. Patterns support `*` (any characters except `/`), `**` (any characters), `**/` (zero or more directories), and a trailing `/` (every file in the directory and its subdirectories).
+
+`import_extension` only applies to imports of local files. Mapped imports always end in `_pb.js`, the file name of the generated code the package provides. Well-known types are always imported from `@bufbuild/protobuf/wkt`.
+
 ### `js_import_style`
 
 By default, `protoc-gen-es` generates ECMAScript `import` and `export` statements. For use cases where CommonJS is difficult to avoid, this option can be used to generate CommonJS `require()` calls. Possible values:

--- a/packages/protoplugin-test/src/map_imports.test.ts
+++ b/packages/protoplugin-test/src/map_imports.test.ts
@@ -130,9 +130,8 @@ void suite("map_imports", () => {
           f.print(f.importSchema(schema.files[0].messages[0]));
         },
       );
-      // The dependency is mapped and keeps the .js extension, because the
-      // exports of @scope/pkg are fixed when it is published. The local
-      // import gets the extension as usual.
+      // The dependency is mapped to a package and keeps the .js extension.
+      // The local import gets the extension as usual.
       assert.deepStrictEqual(lines, [
         'import { StatusSchema } from "@scope/pkg/google/rpc/status_pb.js";',
         `import { XSchema } from "./x_pb${ext}";`,
@@ -142,10 +141,48 @@ void suite("map_imports", () => {
       ]);
     });
   }
+  for (const { option, ext } of [
+    { option: "none", ext: "" },
+    { option: "js", ext: ".js" },
+    { option: "ts", ext: ".ts" },
+  ]) {
+    void test(`should apply import_extension=${option} to relative target`, async () => {
+      const lines = await createTestPluginAndRun({
+        parameter: `target=ts,import_extension=${option},map_imports=google/rpc/:../other-out`,
+        proto: {
+          "foo/x.proto": `
+          syntax="proto3";
+          import "google/rpc/status.proto";
+          message X { google.rpc.Status s = 1; }
+          `,
+          "google/rpc/status.proto": `
+          syntax="proto3";
+          package google.rpc;
+          message Status {}
+          `,
+        },
+        filesToGenerate: ["foo/x.proto"],
+        generateTs(schema) {
+          const f = schema.generateFile("foo/x_pb.ts");
+          const field = schema.files[0].messages[0].fields[0];
+          assert.ok(field.fieldKind === "message");
+          f.print(f.importSchema(field.message));
+        },
+        returnLinesOfFirstFile: true,
+      });
+      // The target is relative to the output directory, and made relative to
+      // the importing file. It is a local file and gets the extension.
+      assert.strictEqual(
+        lines[0],
+        `import { StatusSchema } from "../../other-out/google/rpc/status_pb${ext}";`,
+      );
+    });
+  }
   void test("maps files being generated", async () => {
-    // Whether a file is part of the current invocation depends on how the
-    // compiler splits work across plugin invocations, so it must not affect
-    // the result. Patterns are expected to not match files being generated.
+    // While it could be nice to catch user error of overglobbing by excluding
+    // generated files from matches, because of potential parallel protobuf
+    // compilation, we don't have a reliable way of knowing generated files.
+    // This test ensures no one forgets and tries that trick.
     const lines = await testGenerate(
       "target=ts,map_imports=**:@scope/pkg",
       (f, schema) => {

--- a/packages/protoplugin-test/src/map_imports.test.ts
+++ b/packages/protoplugin-test/src/map_imports.test.ts
@@ -1,0 +1,266 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { suite, test } from "node:test";
+import * as assert from "node:assert";
+import type { GeneratedFile, Schema } from "@bufbuild/protoplugin";
+import { createTestPluginAndRun } from "./helpers.js";
+
+void suite("map_imports", () => {
+  void test("example works as documented", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:@scope/pkg",
+      (f, schema) => {
+        const Status = f.importShape(dep(schema).messages[0]);
+        const StatusSchema = f.importSchema(dep(schema).messages[0]);
+        f.print("export const s: ", Status, " = ", StatusSchema, ";");
+      },
+    );
+    assert.deepStrictEqual(lines, [
+      'import type { Status } from "@scope/pkg/google/rpc/status_pb.js";',
+      'import { StatusSchema } from "@scope/pkg/google/rpc/status_pb.js";',
+      "",
+      "export const s: Status = StatusSchema;",
+    ]);
+  });
+  for (const { pattern, matches } of [
+    { pattern: "google/rpc/status.proto", matches: true },
+    { pattern: "google/rpc/", matches: true },
+    { pattern: "google/", matches: true },
+    { pattern: "google/rpc/*", matches: true },
+    { pattern: "google/rpc/*.proto", matches: true },
+    { pattern: "google/rpc/**", matches: true },
+    { pattern: "google/**", matches: true },
+    { pattern: "**", matches: true },
+    { pattern: "**/status.proto", matches: true },
+    { pattern: "google/**/status.proto", matches: true },
+    { pattern: "**/*.proto", matches: true },
+    { pattern: "google/rpc", matches: false },
+    { pattern: "google/*", matches: false },
+    { pattern: "google/*.proto", matches: false },
+    { pattern: "google/rpc/status", matches: false },
+    { pattern: "google/rpc/s.atus.proto", matches: false },
+    { pattern: "rpc/", matches: false },
+    { pattern: "google/rpc/status.proto/", matches: false },
+  ]) {
+    void test(`pattern "${pattern}" ${matches ? "matches" : "does not match"} google/rpc/status.proto`, async () => {
+      const lines = await testGenerate(
+        `target=ts,map_imports=${pattern}:@scope/pkg`,
+        (f, schema) => {
+          f.print(f.importSchema(dep(schema).messages[0]));
+        },
+      );
+      assert.strictEqual(
+        lines[0],
+        matches
+          ? 'import { StatusSchema } from "@scope/pkg/google/rpc/status_pb.js";'
+          : 'import { StatusSchema } from "./google/rpc/status_pb";',
+      );
+    });
+  }
+  void test("first matching pattern wins", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:@first/pkg,map_imports=google/:@second/pkg",
+      (f, schema) => {
+        f.print(f.importSchema(dep(schema).messages[0]));
+      },
+    );
+    assert.strictEqual(
+      lines[0],
+      'import { StatusSchema } from "@first/pkg/google/rpc/status_pb.js";',
+    );
+  });
+  void test("maps file descriptor import", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:@scope/pkg",
+      (f, schema) => {
+        f.print(f.importSchema(dep(schema)));
+      },
+    );
+    assert.strictEqual(
+      lines[0],
+      'import { file_google_rpc_status } from "@scope/pkg/google/rpc/status_pb.js";',
+    );
+  });
+  void test("accepts target with colons", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:npm:@scope/pkg",
+      (f, schema) => {
+        f.print(f.importSchema(dep(schema).messages[0]));
+      },
+    );
+    assert.strictEqual(
+      lines[0],
+      'import { StatusSchema } from "npm:@scope/pkg/google/rpc/status_pb.js";',
+    );
+  });
+  void test("strips trailing slash from target", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:@scope/pkg/",
+      (f, schema) => {
+        f.print(f.importSchema(dep(schema).messages[0]));
+      },
+    );
+    assert.strictEqual(
+      lines[0],
+      'import { StatusSchema } from "@scope/pkg/google/rpc/status_pb.js";',
+    );
+  });
+  for (const { option, ext } of [
+    { option: "none", ext: "" },
+    { option: "js", ext: ".js" },
+    { option: "ts", ext: ".ts" },
+  ]) {
+    void test(`should not apply import_extension=${option} to mapped path`, async () => {
+      const lines = await testGenerate(
+        `target=ts,import_extension=${option},map_imports=google/rpc/:@scope/pkg`,
+        (f, schema) => {
+          f.print(f.importSchema(dep(schema).messages[0]));
+          f.print(f.importSchema(schema.files[0].messages[0]));
+        },
+      );
+      // The dependency is mapped and keeps the .js extension, because the
+      // exports of @scope/pkg are fixed when it is published. The local
+      // import gets the extension as usual.
+      assert.deepStrictEqual(lines, [
+        'import { StatusSchema } from "@scope/pkg/google/rpc/status_pb.js";',
+        `import { XSchema } from "./x_pb${ext}";`,
+        "",
+        "StatusSchema",
+        "XSchema",
+      ]);
+    });
+  }
+  void test("maps files being generated", async () => {
+    // Whether a file is part of the current invocation depends on how the
+    // compiler splits work across plugin invocations, so it must not affect
+    // the result. Patterns are expected to not match files being generated.
+    const lines = await testGenerate(
+      "target=ts,map_imports=**:@scope/pkg",
+      (f, schema) => {
+        f.print(f.importSchema(dep(schema).messages[0]));
+        f.print(f.importSchema(schema.files[0].messages[0]));
+      },
+    );
+    assert.deepStrictEqual(lines, [
+      'import { StatusSchema } from "@scope/pkg/google/rpc/status_pb.js";',
+      'import { XSchema } from "@scope/pkg/x_pb.js";',
+      "",
+      "StatusSchema",
+      "XSchema",
+    ]);
+  });
+  void test("does not map well-known types", async () => {
+    const lines = await createTestPluginAndRun({
+      proto: {
+        "x.proto": `
+        syntax="proto3";
+        import "google/protobuf/timestamp.proto";
+        message X { google.protobuf.Timestamp t = 1; }
+        `,
+      },
+      parameter: "target=ts,map_imports=google/:@scope/pkg",
+      generateAny(f, schema) {
+        const t = schema.files[0].messages[0].fields[0];
+        assert.ok(t.fieldKind === "message");
+        f.print(f.importSchema(t.message));
+      },
+      returnLinesOfFirstFile: true,
+    });
+    assert.strictEqual(
+      lines[0],
+      'import { TimestampSchema } from "@bufbuild/protobuf/wkt";',
+    );
+  });
+  void test("does not apply to import paths given as a string", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:@scope/pkg",
+      (f) => {
+        f.print(f.import("StatusSchema", "./google/rpc/status_pb.js"));
+      },
+    );
+    assert.strictEqual(
+      lines[0],
+      'import { StatusSchema } from "./google/rpc/status_pb";',
+    );
+  });
+  void test("applies before rewrite_imports", async () => {
+    const lines = await testGenerate(
+      "target=ts,map_imports=google/rpc/:@scope/pkg,rewrite_imports=@scope/pkg/google/rpc/status_pb.js:@other/pkg",
+      (f, schema) => {
+        f.print(f.importSchema(dep(schema).messages[0]));
+      },
+    );
+    assert.strictEqual(lines[0], 'import { StatusSchema } from "@other/pkg";');
+  });
+  for (const value of ["google/rpc/", ":@scope/pkg", "google/rpc/:"]) {
+    void test(`throws error for "${value}"`, async () => {
+      await assert.rejects(
+        async () => {
+          await testGenerate(`target=ts,map_imports=${value}`, (f) => {
+            f.print("x");
+          });
+        },
+        {
+          name: "PluginOptionError",
+          message: `invalid option "map_imports=${value}": must be in the form of <pattern>:<target>`,
+        },
+      );
+    });
+  }
+  void test("is available in options", async () => {
+    await testGenerate(
+      "target=ts,map_imports=google/rpc/:@scope/pkg,map_imports=foo/:@foo/pkg",
+      (f, schema) => {
+        assert.deepStrictEqual(schema.options.mapImports, [
+          { pattern: "google/rpc/", target: "@scope/pkg" },
+          { pattern: "foo/", target: "@foo/pkg" },
+        ]);
+        f.print("x");
+      },
+    );
+  });
+
+  function dep(schema: Schema) {
+    const file = schema.allFiles.find(
+      (f) => f.proto.name === "google/rpc/status.proto",
+    );
+    assert.ok(file !== undefined);
+    return file;
+  }
+
+  async function testGenerate(
+    parameter: string,
+    gen: (f: GeneratedFile, schema: Schema) => void,
+  ) {
+    return await createTestPluginAndRun({
+      parameter,
+      proto: {
+        "x.proto": `
+        syntax="proto3";
+        import "google/rpc/status.proto";
+        message X { google.rpc.Status s = 1; }
+        `,
+        "google/rpc/status.proto": `
+        syntax="proto3";
+        package google.rpc;
+        message Status {}
+        `,
+      },
+      filesToGenerate: ["x.proto"],
+      generateAny: gen,
+      returnLinesOfFirstFile: true,
+    });
+  }
+});

--- a/packages/protoplugin/src/index.ts
+++ b/packages/protoplugin/src/index.ts
@@ -29,6 +29,7 @@ export type {
   ImportExtension,
 } from "./parameter.js";
 export type { GeneratedFile, FileInfo } from "./generated-file.js";
+export type { MapImports } from "./map-imports.js";
 export type { ImportSymbol } from "./import-symbol.js";
 export { createImportSymbol } from "./import-symbol.js";
 export type { Printable } from "./printable.js";

--- a/packages/protoplugin/src/map-imports.ts
+++ b/packages/protoplugin/src/map-imports.ts
@@ -1,0 +1,122 @@
+// Copyright 2021-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A configuration for mapping imports of generated code to a package, for
+ * example a generated SDK published to a package registry.
+ *
+ * All plugins based on @bufbuild/protoplugin support the option
+ * "map_imports", which is parsed into this type. The option can be given
+ * multiple times, in the form of `map_imports=<pattern>:<target>`.
+ *
+ * The pattern is matched against the path of the Protobuf file, for example
+ * `google/rpc/status.proto`, using a reduced subset of glob:
+ * - `*` matches zero or more characters except `/`.
+ * - `**` matches zero or more characters, including `/`.
+ * - `**\/` (escaped for block comment!) matches zero or more path elements,
+ *   where an element is one or more characters with a trailing `/`.
+ * - A trailing `/` matches every file in the directory and its
+ *   subdirectories.
+ *
+ * The target is typically a npm package name, for example `@scope/pkg`.
+ *
+ * If a generated file imports from a Protobuf file matching one of the
+ * patterns, the import path is derived from the target instead of the local
+ * output, by prepending the target to the generated file path. The first
+ * matching pattern wins.
+ *
+ * For example, the option `map_imports=google/rpc/:@scope/pkg` imports
+ * `google/rpc/status.proto` from `@scope/pkg/google/rpc/status_pb.js`.
+ *
+ * Well-known types are always imported from the runtime package, unless they
+ * are generated, and are not subject to this option.
+ */
+export type MapImports = { pattern: string; target: string }[];
+
+const cache = new WeakMap<MapImports, { pattern: RegExp; target: string }[]>();
+
+/**
+ * Return the target for the given Protobuf file path, or undefined if none of
+ * the patterns match.
+ */
+export function mapImportTarget(
+  protoFileName: string,
+  mapImports: MapImports,
+): string | undefined {
+  let mi = cache.get(mapImports);
+  if (mi === undefined) {
+    mi = mapImports.map(({ pattern, target }) => {
+      return {
+        pattern: globToRegExp(pattern),
+        target: target.replace(/\/$/, ""),
+      };
+    });
+    cache.set(mapImports, mi);
+  }
+  for (const { pattern, target } of mi) {
+    if (pattern.test(protoFileName)) {
+      return target;
+    }
+  }
+  return undefined;
+}
+
+function globToRegExp(glob: string): RegExp {
+  const r: string[] = ["^"];
+  for (let i = 0; i < glob.length; i++) {
+    switch (glob[i]) {
+      case "*":
+        if (glob[i + 1] === "*") {
+          if (glob[i + 2] === "/") {
+            i += 2;
+            r.push("([^\\/]+\\/)*");
+            break;
+          }
+          i += 1;
+          r.push(".*");
+          break;
+        }
+        r.push("[^\\/]*");
+        break;
+      case "/":
+        if (i === glob.length - 1) {
+          // A trailing slash matches everything in the directory.
+          r.push("\\/.*");
+          break;
+        }
+        r.push("\\/");
+        break;
+      case ".":
+      case "+":
+      case "?":
+      case "^":
+      case "$":
+      case "{":
+      case "}":
+      case "(":
+      case ")":
+      case "|":
+      case "[":
+      case "]":
+      case "\\":
+        r.push("\\", glob[i]);
+        break;
+      default:
+        r.push(glob[i]);
+        break;
+    }
+  }
+  r.push("$");
+  return new RegExp(r.join(""));
+}

--- a/packages/protoplugin/src/map-imports.ts
+++ b/packages/protoplugin/src/map-imports.ts
@@ -44,7 +44,22 @@
  */
 export type MapImports = { pattern: string; target: string }[];
 
-const cache = new WeakMap<MapImports, { pattern: RegExp; target: string }[]>();
+/**
+ * Patterns of `MapImports` compiled to regular expressions to read during codegen.
+ */
+export type CompiledMapImports = { pattern: RegExp; target: string }[];
+
+/**
+ * Compile the patterns of the given `MapImports`.
+ */
+export function compileMapImports(mapImports: MapImports): CompiledMapImports {
+  return mapImports.map(({ pattern, target }) => {
+    return {
+      pattern: globToRegExp(pattern),
+      target: target.endsWith("/") ? target.slice(0, -1) : target,
+    };
+  });
+}
 
 /**
  * Return the target for the given Protobuf file path, or undefined if none of
@@ -52,19 +67,9 @@ const cache = new WeakMap<MapImports, { pattern: RegExp; target: string }[]>();
  */
 export function mapImportTarget(
   protoFileName: string,
-  mapImports: MapImports,
+  mapImports: CompiledMapImports,
 ): string | undefined {
-  let mi = cache.get(mapImports);
-  if (mi === undefined) {
-    mi = mapImports.map(({ pattern, target }) => {
-      return {
-        pattern: globToRegExp(pattern),
-        target: target.replace(/\/$/, ""),
-      };
-    });
-    cache.set(mapImports, mi);
-  }
-  for (const { pattern, target } of mi) {
+  for (const { pattern, target } of mapImports) {
     if (pattern.test(protoFileName)) {
       return target;
     }

--- a/packages/protoplugin/src/names.ts
+++ b/packages/protoplugin/src/names.ts
@@ -48,8 +48,6 @@ export function generateFilePath(
   ) {
     return wktFrom;
   }
-  // The plugin option map_imports may provide the generated code for this
-  // file from a different location.
   const target = mapImportTarget(file.proto.name, mapImports);
   if (target !== undefined) {
     return target + "/" + file.name + "_pb.js";

--- a/packages/protoplugin/src/names.ts
+++ b/packages/protoplugin/src/names.ts
@@ -22,6 +22,7 @@ import type {
 import { wktPublicImportPaths } from "@bufbuild/protobuf/codegenv2";
 import { nestedTypes } from "@bufbuild/protobuf/reflect";
 import { safeIdentifier } from "./safe-identifier.js";
+import { type MapImports, mapImportTarget } from "./map-imports.js";
 
 /**
  * Return a file path for the give file descriptor.
@@ -30,6 +31,7 @@ export function generateFilePath(
   file: DescFile,
   bootstrapWkt: boolean,
   filesToGenerate: DescFile[],
+  mapImports: MapImports,
 ): string {
   // Well-known types are published with the runtime package. We usually want
   // the generated code to import them from the runtime package, with the
@@ -45,6 +47,13 @@ export function generateFilePath(
     !filesToGenerate.find((f) => f.name === file.name)
   ) {
     return wktFrom;
+  }
+  // Generated code for a dependency may be provided by a package instead of
+  // the local output. The path within the package is fixed when it is
+  // published, so we keep the .js extension.
+  const target = mapImportTarget(file.proto.name, mapImports);
+  if (target !== undefined) {
+    return target + "/" + file.name + "_pb.js";
   }
   return "./" + file.name + "_pb.js";
 }

--- a/packages/protoplugin/src/names.ts
+++ b/packages/protoplugin/src/names.ts
@@ -22,7 +22,7 @@ import type {
 import { wktPublicImportPaths } from "@bufbuild/protobuf/codegenv2";
 import { nestedTypes } from "@bufbuild/protobuf/reflect";
 import { safeIdentifier } from "./safe-identifier.js";
-import { type MapImports, mapImportTarget } from "./map-imports.js";
+import { type CompiledMapImports, mapImportTarget } from "./map-imports.js";
 
 /**
  * Return a file path for the give file descriptor.
@@ -31,7 +31,7 @@ export function generateFilePath(
   file: DescFile,
   bootstrapWkt: boolean,
   filesToGenerate: DescFile[],
-  mapImports: MapImports,
+  mapImports: CompiledMapImports,
 ): string {
   // Well-known types are published with the runtime package. We usually want
   // the generated code to import them from the runtime package, with the
@@ -48,9 +48,8 @@ export function generateFilePath(
   ) {
     return wktFrom;
   }
-  // Generated code for a dependency may be provided by a package instead of
-  // the local output. The path within the package is fixed when it is
-  // published, so we keep the .js extension.
+  // The plugin option map_imports may provide the generated code for this
+  // file from a different location.
   const target = mapImportTarget(file.proto.name, mapImports);
   if (target !== undefined) {
     return target + "/" + file.name + "_pb.js";

--- a/packages/protoplugin/src/parameter.ts
+++ b/packages/protoplugin/src/parameter.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import type { RewriteImports } from "./import-path.js";
+import type { MapImports } from "./map-imports.js";
 import { PluginOptionError } from "./error.js";
 
 /**
@@ -72,6 +73,13 @@ export interface EcmaScriptPluginOptions {
    */
   bootstrapWkt: boolean;
   /**
+   * Import generated code for Protobuf files matching a pattern from a
+   * package instead of the local output. See `MapImports` for details.
+   *
+   * The default is an empty list.
+   */
+  mapImports: MapImports;
+  /**
    * @private
    */
   rewriteImports: RewriteImports;
@@ -99,6 +107,7 @@ export function parseParameter<T extends object>(
   let bootstrapWkt = false;
   let keepEmptyFiles = false;
   const rewriteImports: RewriteImports = [];
+  const mapImports: MapImports = [];
   let importExtension: ImportExtension = "none";
   let jsImportStyle: "module" | "legacy_commonjs" = "module";
   const extraParameters: {
@@ -188,6 +197,20 @@ export function parseParameter<T extends object>(
         sanitize = true;
         break;
       }
+      case "map_imports": {
+        const i = value.indexOf(":");
+        if (i < 1 || i === value.length - 1) {
+          throw new PluginOptionError(
+            raw,
+            "must be in the form of <pattern>:<target>",
+          );
+        }
+        mapImports.push({
+          pattern: value.substring(0, i),
+          target: value.substring(i + 1),
+        });
+        break;
+      }
       case "import_extension": {
         switch (value) {
           case "none":
@@ -253,6 +276,7 @@ export function parseParameter<T extends object>(
     elidePluginVersion,
     bootstrapWkt,
     rewriteImports,
+    mapImports,
     importExtension,
     jsImportStyle,
     keepEmptyFiles,

--- a/packages/protoplugin/src/schema.ts
+++ b/packages/protoplugin/src/schema.ts
@@ -55,6 +55,7 @@ import {
   generatedValidTypeName,
 } from "./names.js";
 import { createRuntimeImports } from "./runtime-imports.js";
+import { compileMapImports } from "./map-imports.js";
 
 /**
  * Schema describes the files and types that the plugin is requested to
@@ -122,6 +123,7 @@ export function createSchema<T extends object>(
   let target: Target | undefined;
   const generatedFiles: GeneratedFileController[] = [];
   const runtime = createRuntimeImports(parameter.parsed.bootstrapWkt);
+  const mapImports = compileMapImports(parameter.parsed.mapImports);
   const resolveDescImport: ResolveDescImportFn = (desc, typeOnly) =>
     createImportSymbol(
       generatedDescName(desc),
@@ -129,7 +131,7 @@ export function createSchema<T extends object>(
         desc.kind == "file" ? desc : desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
-        parameter.parsed.mapImports,
+        mapImports,
       ),
       typeOnly,
     );
@@ -140,7 +142,7 @@ export function createSchema<T extends object>(
         desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
-        parameter.parsed.mapImports,
+        mapImports,
       ),
       true,
     );
@@ -151,7 +153,7 @@ export function createSchema<T extends object>(
         desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
-        parameter.parsed.mapImports,
+        mapImports,
       ),
       true,
     );
@@ -162,7 +164,7 @@ export function createSchema<T extends object>(
         desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
-        parameter.parsed.mapImports,
+        mapImports,
       ),
       true,
     );

--- a/packages/protoplugin/src/schema.ts
+++ b/packages/protoplugin/src/schema.ts
@@ -129,6 +129,7 @@ export function createSchema<T extends object>(
         desc.kind == "file" ? desc : desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
+        parameter.parsed.mapImports,
       ),
       typeOnly,
     );
@@ -139,6 +140,7 @@ export function createSchema<T extends object>(
         desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
+        parameter.parsed.mapImports,
       ),
       true,
     );
@@ -149,6 +151,7 @@ export function createSchema<T extends object>(
         desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
+        parameter.parsed.mapImports,
       ),
       true,
     );
@@ -159,6 +162,7 @@ export function createSchema<T extends object>(
         desc.file,
         parameter.parsed.bootstrapWkt,
         filesToGenerate,
+        parameter.parsed.mapImports,
       ),
       true,
     );


### PR DESCRIPTION
This adds `map_imports`, an option to point imported `.proto` files to a different location then the default relative path from the output directory. This notably allows importing from external libraries published to NPM. 

For example, if your proto imports `buf/validate/validate.proto` to add validation annotations, you can use the following configuration that matches on the `buf/validate/` prefix to have generated code import from the `@bufbuild/protovalidate` package, avoiding needing `require_imports` to compile a duplicate copy of the validate.proto gencode.

```yaml
version: v2
plugins:
  - local: protoc-gen-es
    out: src/gen
    opt:
      - target=ts
      - map_imports=buf/validate/:@bufbuild/protovalidate/gen
```